### PR TITLE
feat(auth): bypass admin auth in development

### DIFF
--- a/src/lib/auth-guard.ts
+++ b/src/lib/auth-guard.ts
@@ -18,6 +18,11 @@ type SessionWithRole = {
 
 export async function requireRole(role: Role, loginPath: string): Promise<SessionWithRole> {
   const safePath = ALLOWED_LOGIN_PATHS.has(loginPath) ? loginPath : '/';
+
+  if (process.env.NODE_ENV === 'development') {
+    return { user: { id: 'dev', email: 'dev@localhost', name: 'Dev', role } };
+  }
+
   const session = await auth.api.getSession({ headers: await headers() });
 
   if (!session) {


### PR DESCRIPTION
## Summary
- Salta el check de autenticación en `requireRole` cuando `NODE_ENV=development`
- Permite entrar a `/admin` en localhost sin contraseña
- En producción el comportamiento sigue siendo el mismo

## Test plan
- [ ] Verificar que `/admin` en localhost carga sin pedir login
- [ ] Verificar que en producción sigue requiriendo autenticación

🤖 Generated with [Claude Code](https://claude.com/claude-code)