### PR TITLE
feat(ui): roster en cards cuadradas + kanban visual mejorado

### DIFF
--- a/src/features/admin/talents/components/InfluencerCardsView.parts.tsx
+++ b/src/features/admin/talents/components/InfluencerCardsView.parts.tsx
@@ -103,74 +103,63 @@ export function TalentCard({ creator, verticals }: CardProps): React.ReactElemen
 
   return (
     <m.div
-      whileHover={{ y: -4, scale: 1.02 }}
-      transition={{ type: 'spring', stiffness: 300, damping: 20 }}
+      whileHover={{ y: -3, boxShadow: '0 8px 24px rgba(0,0,0,0.12)' }}
+      transition={{ type: 'spring', stiffness: 400, damping: 25 }}
       onClick={handleClick}
       onKeyDown={handleKeyDown}
       role="button"
       tabIndex={0}
       aria-label={`Ver perfil de ${creator.name}`}
-      className="relative rounded-2xl bg-sp-admin-card border border-sp-admin-border overflow-hidden flex flex-col cursor-pointer focus-visible:outline-2 focus-visible:outline-sp-admin-accent focus-visible:outline-offset-2"
+      className="relative rounded-xl bg-sp-admin-card shadow-[0_1px_3px_rgba(0,0,0,0.06)] overflow-hidden flex flex-col cursor-pointer focus-visible:outline-2 focus-visible:outline-sp-admin-accent focus-visible:outline-offset-2"
     >
-      {/* Status badge — top right */}
-      <div className="absolute top-3 right-3 z-10">
-        <StateBadge tone={tone} variant="soft">
-          {statusLabel}
-        </StateBadge>
-      </div>
-
-      {/* Avatar area */}
-      <div className="flex flex-col items-center pt-8 pb-4 px-4 gap-3">
+      {/* Foto cuadrada centrada en cara */}
+      <div
+        className="relative aspect-square w-full overflow-hidden"
+        style={{ background: `linear-gradient(135deg, ${creator.gradientC1}, ${creator.gradientC2})` }}
+      >
         <Avatar creator={creator} />
 
-        {/* Name + slug */}
-        <div className="text-center min-w-0 w-full">
-          <p className="font-bold text-sp-admin-text truncate text-sm leading-tight">
-            {creator.name}
-          </p>
-          <p className="text-[11px] text-sp-admin-muted truncate mt-0.5">
-            @{creator.slug}
-          </p>
+        {/* Status badge */}
+        <div className="absolute top-2 right-2 z-10">
+          <StateBadge tone={tone} variant="soft">{statusLabel}</StateBadge>
         </div>
 
-        {/* Platform chips */}
-        {platformChips.length > 0 && (
-          <div className="flex flex-wrap justify-center gap-1">
-            {platformChips.map((chip) => (
-              <StateBadge key={chip} tone="info" variant="dot">
-                {chip}
-              </StateBadge>
-            ))}
+        {/* País */}
+        {creator.creatorCountry && (
+          <div className="absolute top-2 left-2 z-10">
+            <span className="text-[9px] font-bold uppercase tracking-wider text-white bg-black/30 backdrop-blur-sm rounded px-1.5 py-0.5">
+              {creator.creatorCountry}
+            </span>
           </div>
         )}
 
-        {/* Total followers */}
-        <div className="text-center">
-          {totalFollowers !== null ? (
-            <>
-              <p className="text-2xl font-black text-sp-admin-text tabular-nums leading-none">
-                {totalFollowers}
-              </p>
-              <p className="text-[10px] text-sp-admin-muted uppercase tracking-wider mt-0.5">
-                seguidores
-              </p>
-            </>
-          ) : (
-            <p className="text-2xl font-black text-sp-admin-muted leading-none">—</p>
-          )}
-        </div>
+        {/* Total followers — overlay inferior */}
+        {totalFollowers !== null && (
+          <div className="absolute bottom-0 inset-x-0 bg-gradient-to-t from-black/60 to-transparent px-3 py-2">
+            <p className="text-base font-black text-white tabular-nums leading-none">{totalFollowers}</p>
+            <p className="text-[8px] text-white/70 uppercase tracking-wide">seguidores</p>
+          </div>
+        )}
+      </div>
+
+      {/* Info compacta */}
+      <div className="px-3 pt-2 pb-1">
+        <p className="font-bold text-[12px] text-sp-admin-text truncate leading-tight">{creator.name}</p>
+        {creator.game && <p className="text-[10px] text-sp-admin-muted truncate">{creator.game}</p>}
+
+        {/* Platform chips — max 2 */}
+        {platformChips.length > 0 && (
+          <div className="flex flex-wrap gap-1 mt-1.5">
+            {platformChips.slice(0, 2).map((chip) => (
+              <StateBadge key={chip} tone="info" variant="dot">{chip}</StateBadge>
+            ))}
+          </div>
+        )}
       </div>
 
       {/* Footer */}
-      <div className="border-t border-sp-admin-border px-4 py-2.5 flex items-center justify-between gap-2 mt-auto">
-        <span className="text-[10px] text-sp-admin-muted truncate">
-          {creator.role}{creator.game ? ` · ${creator.game}` : ''}
-        </span>
-        {creator.creatorCountry && (
-          <span className="shrink-0 text-[10px] uppercase tracking-wider font-mono font-semibold text-sp-admin-muted border border-sp-admin-border rounded px-1.5 py-0.5">
-            {creator.creatorCountry}
-          </span>
-        )}
+      <div className="border-t border-sp-admin-border/60 px-3 py-1.5 mt-auto">
+        <span className="text-[9px] text-sp-admin-muted truncate block">{creator.role}</span>
       </div>
     </m.div>
   );
@@ -185,26 +174,19 @@ type AvatarProps = {
 function Avatar({ creator }: AvatarProps): React.ReactElement {
   if (creator.photoUrl) {
     return (
-      <div className="relative w-20 h-20 rounded-full overflow-hidden shrink-0 ring-2 ring-sp-admin-border">
-        <Image
-          src={creator.photoUrl}
-          alt={creator.name}
-          fill
-          className="object-cover"
-          sizes="80px"
-        />
-      </div>
+      <Image
+        src={creator.photoUrl}
+        alt={creator.name}
+        fill
+        className="object-cover object-top"
+        sizes="(max-width: 640px) 50vw, (max-width: 1024px) 25vw, 20vw"
+      />
     );
   }
 
   return (
-    <div
-      className="w-20 h-20 rounded-full shrink-0 flex items-center justify-center ring-2 ring-sp-admin-border"
-      style={{
-        background: `linear-gradient(135deg, ${creator.gradientC1}, ${creator.gradientC2})`,
-      }}
-    >
-      <span className="font-display text-2xl font-black text-white/90 select-none">
+    <div className="absolute inset-0 flex items-center justify-center">
+      <span className="font-display text-4xl font-black text-white/90 select-none">
         {creator.initials}
       </span>
     </div>

--- a/src/features/admin/talents/components/InfluencerCardsView.tsx
+++ b/src/features/admin/talents/components/InfluencerCardsView.tsx
@@ -67,57 +67,53 @@ export function InfluencerCardsView({ creators, verticalsByTalent }: Props): Rea
     return { active, available, inactive };
   }, [creators]);
 
+  const INPUT_CLS = 'h-8 rounded-lg border border-sp-admin-border bg-white px-3 text-[12px] text-sp-admin-text placeholder:text-sp-admin-muted/60 focus:outline-none focus:border-sp-admin-accent/50';
+
   return (
-    <div className="space-y-5">
-      {/* Filters */}
-      <div className="flex flex-wrap items-center gap-3 rounded-2xl bg-sp-admin-card border border-sp-admin-border p-4">
+    <div className="space-y-4">
+      {/* KPIs de estado — clicables como filtros */}
+      <div className="grid grid-cols-3 gap-2">
+        {[
+          { label: 'Activos',     value: counts.active,    color: '#16a34a', filter: 'active' as TalentStatus },
+          { label: 'Disponibles', value: counts.available, color: '#5b9bd5', filter: 'available' as TalentStatus },
+          { label: 'Inactivos',   value: counts.inactive,  color: '#72728a', filter: 'inactive' as TalentStatus },
+        ].map((s) => (
+          <button
+            key={s.label}
+            type="button"
+            onClick={() => setStatusFilter(statusFilter === s.filter ? 'all' : s.filter)}
+            className={`rounded-lg bg-sp-admin-card shadow-[0_1px_3px_rgba(0,0,0,0.06)] overflow-hidden text-left hover:shadow-md transition-shadow ${statusFilter === s.filter ? 'ring-1 ring-sp-admin-accent/40' : ''}`}
+          >
+            <div className="h-[2px]" style={{ background: s.color }} />
+            <div className="px-4 py-3">
+              <p className="text-[9px] font-bold uppercase tracking-wide text-sp-admin-muted">{s.label}</p>
+              <p className="text-xl font-bold mt-0.5" style={{ color: s.color }}>{s.value}</p>
+            </div>
+          </button>
+        ))}
+      </div>
+
+      {/* Filtros */}
+      <div className="flex flex-wrap items-center gap-2">
         <input
           type="search"
           value={search}
           onChange={(e) => setSearch(e.target.value)}
-          placeholder="Buscar por nombre..."
-          className="min-w-[220px] flex-1 rounded-xl border border-sp-admin-border bg-sp-admin-bg px-3 py-2 text-sm text-sp-admin-text outline-none focus:border-sp-admin-accent transition-colors"
+          placeholder="Buscar influencer…"
+          className={`${INPUT_CLS} flex-1 min-w-[180px]`}
         />
-
-        <select
-          value={statusFilter}
-          onChange={(e) => setStatusFilter(e.target.value as TalentStatus | 'all')}
-          className="rounded-xl border border-sp-admin-border bg-sp-admin-bg px-3 py-2 text-sm text-sp-admin-text"
-        >
-          <option value="all">Todos ({creators.length})</option>
-          <option value="active">Activos ({counts.active})</option>
-          <option value="available">Disponibles ({counts.available})</option>
-          <option value="inactive">Inactivos ({counts.inactive})</option>
-        </select>
-
-        <select
-          value={verticalFilter}
-          onChange={(e) => setVerticalFilter(e.target.value as TalentVertical | '')}
-          className="rounded-xl border border-sp-admin-border bg-sp-admin-bg px-3 py-2 text-sm text-sp-admin-text"
-        >
+        <select value={verticalFilter} onChange={(e) => setVerticalFilter(e.target.value as TalentVertical | '')} className={INPUT_CLS}>
           <option value="">Todos los sectores</option>
-          {TALENT_VERTICALS.map((v) => (
-            <option key={v} value={v}>{TALENT_VERTICAL_LABELS[v]}</option>
-          ))}
+          {TALENT_VERTICALS.map((v) => <option key={v} value={v}>{TALENT_VERTICAL_LABELS[v]}</option>)}
         </select>
-
-        <select
-          value={platformFilter}
-          onChange={(e) => setPlatformFilter(e.target.value)}
-          className="rounded-xl border border-sp-admin-border bg-sp-admin-bg px-3 py-2 text-sm text-sp-admin-text"
-        >
-          <option value="">Todas plataformas</option>
-          {platforms.map((p) => (
-            <option key={p} value={p}>{PLATFORM_LABELS[p] ?? p}</option>
-          ))}
+        <select value={platformFilter} onChange={(e) => setPlatformFilter(e.target.value)} className={INPUT_CLS}>
+          <option value="">Todas las plataformas</option>
+          {platforms.map((p) => <option key={p} value={p}>{PLATFORM_LABELS[p] ?? p}</option>)}
         </select>
-
-        <span className="text-xs text-sp-admin-muted tabular-nums ml-auto">
-          {filtered.length} / {creators.length}
-        </span>
+        <span className="text-[11px] text-sp-admin-muted tabular-nums ml-auto">{filtered.length} de {creators.length}</span>
       </div>
 
-      {/* Grid / Empty state */}
+      {/* Grid — más columnas para cards más pequeñas */}
       {filtered.length === 0 ? (
         creators.length === 0 ? (
           <EmptyState
@@ -125,29 +121,18 @@ export function InfluencerCardsView({ creators, verticalsByTalent }: Props): Rea
             title="Sin talentos"
             description="Importa talentos para empezar"
             action={
-              <button
-                type="button"
-                className="inline-flex items-center gap-2 rounded-xl bg-sp-admin-accent px-4 py-2 text-sm font-semibold text-white hover:opacity-90 transition-opacity cursor-pointer"
-              >
+              <button type="button" className="inline-flex items-center gap-2 rounded-xl bg-sp-admin-accent px-4 py-2 text-sm font-semibold text-white hover:opacity-90 transition-opacity cursor-pointer">
                 Importar
               </button>
             }
           />
         ) : (
-          <EmptyState
-            variant="no-results"
-            title="Sin resultados"
-            description="Prueba con otros filtros"
-          />
+          <EmptyState variant="no-results" title="Sin resultados" description="Prueba con otros filtros" />
         )
       ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3">
           {filtered.map((c) => (
-            <TalentCard
-              key={c.id}
-              creator={c}
-              verticals={verticalsByTalent[c.id] ?? []}
-            />
+            <TalentCard key={c.id} creator={c} verticals={verticalsByTalent[c.id] ?? []} />
           ))}
         </div>
       )}

--- a/src/features/admin/tasks/components/TaskKanban.tsx
+++ b/src/features/admin/tasks/components/TaskKanban.tsx
@@ -16,10 +16,10 @@ type Props = {
   readonly onOpenAction: (task: CrmTask) => void;
 };
 
-const COLUMNS: ReadonlyArray<{ readonly status: CrmTaskStatus; readonly label: string; readonly accent: string }> = [
-  { status: 'pendiente', label: 'Pendiente', accent: 'border-l-blue-500/60' },
-  { status: 'en_progreso', label: 'En progreso', accent: 'border-l-amber-500/60' },
-  { status: 'completada', label: 'Completada', accent: 'border-l-emerald-500/60' },
+const COLUMNS: ReadonlyArray<{ readonly status: CrmTaskStatus; readonly label: string; readonly color: string }> = [
+  { status: 'pendiente',  label: 'Pendiente',  color: '#5b9bd5' },
+  { status: 'en_progreso', label: 'En progreso', color: '#f59e0b' },
+  { status: 'completada', label: 'Completada',  color: '#16a34a' },
 ];
 
 const PRIORITY_DOT: Record<CrmTaskPriority, string> = {
@@ -76,15 +76,28 @@ export function TaskKanban({ tasks, users, relatedLabels, onOpenAction }: Props)
             onDragOver={(e) => { e.preventDefault(); setHoverCol(col.status); }}
             onDragLeave={() => setHoverCol((prev) => (prev === col.status ? null : prev))}
             onDrop={() => handleDrop(col.status)}
-            className={`rounded-2xl border bg-sp-admin-card p-4 min-h-[400px] transition-colors ${isHover ? 'border-sp-admin-accent bg-sp-admin-accent/5' : 'border-sp-admin-border'}`}
+            className={`rounded-xl overflow-hidden shadow-[0_1px_3px_rgba(0,0,0,0.06)] transition-all ${
+              isHover ? 'ring-1 ring-sp-admin-accent shadow-[0_4px_16px_rgba(245,99,42,0.12)]' : ''
+            }`}
           >
-            <div className={`flex items-center justify-between mb-3 pb-2 border-b border-sp-admin-border/60 border-l-4 pl-3 -mx-1 ${col.accent}`}>
-              <h3 className="text-xs font-bold uppercase tracking-wider text-sp-admin-text">{col.label}</h3>
-              <span className="text-xs tabular-nums text-sp-admin-muted">{items.length}</span>
+            {/* Column header con color */}
+            <div className="bg-sp-admin-card border-b border-sp-admin-border px-4 py-3 flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <div className="w-2 h-2 rounded-full" style={{ background: col.color }} />
+                <h3 className="text-[11px] font-bold uppercase tracking-[0.18em] text-sp-admin-muted">{col.label}</h3>
+              </div>
+              <span className="text-[11px] font-bold tabular-nums px-2 py-0.5 rounded-full"
+                style={{ color: col.color, background: `${col.color}14` }}>
+                {items.length}
+              </span>
             </div>
-            <div className="space-y-2">
+
+            {/* Task cards */}
+            <div className="bg-sp-admin-bg/60 p-3 min-h-[400px] space-y-2">
               {items.length === 0 ? (
-                <p className="text-xs italic text-sp-admin-muted text-center py-6">Suelta tareas aquí.</p>
+                <div className="flex items-center justify-center h-20 border-2 border-dashed border-sp-admin-border rounded-lg">
+                  <p className="text-[10px] text-sp-admin-muted/60">Suelta tareas aquí</p>
+                </div>
               ) : (
                 items.map((t) => {
                   const owner = usersById.get(t.ownerId);
@@ -100,32 +113,44 @@ export function TaskKanban({ tasks, users, relatedLabels, onOpenAction }: Props)
                       onDragStart={() => setDraggingId(t.id)}
                       onDragEnd={() => { setDraggingId(null); setHoverCol(null); }}
                       onClick={() => onOpenAction(t)}
-                      className={`group rounded-xl bg-sp-admin-bg border border-sp-admin-border p-3 cursor-grab active:cursor-grabbing hover:border-sp-admin-accent/50 transition-colors ${draggingId === t.id ? 'opacity-50' : ''}`}
+                      className={`rounded-lg bg-sp-admin-card border border-sp-admin-border p-3 cursor-grab active:cursor-grabbing hover:border-sp-admin-accent/40 hover:shadow-sm transition-all ${
+                        draggingId === t.id ? 'opacity-40 scale-95' : ''
+                      }`}
                     >
-                      <div className="flex items-start gap-2 mb-2">
+                      {/* Título + prioridad */}
+                      <div className="flex items-start gap-2">
                         <span className={`shrink-0 w-2 h-2 rounded-full mt-1.5 ${PRIORITY_DOT[t.priority]}`} />
-                        <p className={`text-sm font-medium flex-1 ${t.status === 'completada' ? 'text-sp-admin-muted line-through' : 'text-sp-admin-text'}`}>
-                          {t.title}
-                        </p>
+                        <p className={`text-[12px] font-medium flex-1 leading-snug ${
+                          t.status === 'completada' ? 'text-sp-admin-muted line-through' : 'text-sp-admin-text'
+                        }`}>{t.title}</p>
                       </div>
-                      <div className="flex items-center justify-between flex-wrap gap-1">
-                        <span className="text-[10px] uppercase tracking-wider text-sp-admin-muted">{t.category}</span>
+                      {/* Categoría + fecha + recurrencia */}
+                      <div className="flex items-center justify-between flex-wrap gap-1 mt-2">
+                        {t.category && (
+                          <span className="text-[9px] font-bold uppercase tracking-wide text-sp-admin-muted bg-sp-admin-hover border border-sp-admin-border px-1.5 py-0.5 rounded-full">
+                            {t.category}
+                          </span>
+                        )}
                         {t.recurrenceTemplateId !== null && t.recurrence && <RecurrenceBadge frequency={t.recurrence} />}
                         {t.dueDate && (
-                          <span className={`text-[10px] tabular-nums px-1.5 py-0.5 rounded ${overdue ? 'bg-red-500/15 text-red-400' : 'text-sp-admin-muted'}`}>
-                            {t.dueDate.slice(5)}
+                          <span className={`text-[10px] tabular-nums font-semibold px-1.5 py-0.5 rounded-full ml-auto ${
+                            overdue ? 'bg-red-50 text-red-600 border border-red-200' : 'text-sp-admin-muted'
+                          }`}>
+                            {overdue ? '⚠ ' : ''}{t.dueDate.slice(5)}
                           </span>
                         )}
                       </div>
+                      {/* Entidad relacionada */}
                       {related && (
                         <div className="mt-2">
-                          <span className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold border ${RELATED_BG[related.type] ?? ''} truncate max-w-full`} title={related.label}>
+                          <span className={`inline-flex items-center px-1.5 py-0.5 rounded-full text-[9px] font-semibold border ${RELATED_BG[related.type] ?? ''} truncate max-w-full`}>
                             {related.label}
                           </span>
                         </div>
                       )}
+                      {/* Owner */}
                       {owner && (
-                        <div className="mt-2 flex items-center gap-1.5">
+                        <div className="mt-2 flex items-center gap-1.5 pt-2 border-t border-sp-admin-border/40">
                           <Avatar userId={owner.id} name={owner.name} size="sm" />
                           <span className="text-[10px] text-sp-admin-muted">{owner.name}</span>
                         </div>

--- a/src/features/admin/tasks/components/TaskWorkspace.tsx
+++ b/src/features/admin/tasks/components/TaskWorkspace.tsx
@@ -24,10 +24,22 @@ type Props = {
 
 type ViewMode = 'list' | 'kanban' | 'calendar';
 
-const VIEWS: ReadonlyArray<{ readonly key: ViewMode; readonly label: string; readonly icon: string }> = [
-  { key: 'list', label: 'Lista', icon: '☰' },
-  { key: 'kanban', label: 'Kanban', icon: '▦' },
-  { key: 'calendar', label: 'Calendario', icon: '📅' },
+const VIEWS: ReadonlyArray<{ readonly key: ViewMode; readonly label: string; readonly icon: React.ReactNode }> = [
+  { key: 'list', label: 'Lista', icon: (
+    <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" aria-hidden>
+      <line x1="2" y1="3" x2="11" y2="3"/><line x1="2" y1="6.5" x2="11" y2="6.5"/><line x1="2" y1="10" x2="7" y2="10"/>
+    </svg>
+  )},
+  { key: 'kanban', label: 'Kanban', icon: (
+    <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" aria-hidden>
+      <rect x="1" y="2" width="3" height="9" rx="1"/><rect x="5" y="2" width="3" height="6" rx="1"/><rect x="9" y="2" width="3" height="7.5" rx="1"/>
+    </svg>
+  )},
+  { key: 'calendar', label: 'Calendario', icon: (
+    <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" aria-hidden>
+      <rect x="1" y="2" width="11" height="10" rx="1.5"/><line x1="1" y1="5" x2="12" y2="5"/><line x1="4" y1="1" x2="4" y2="3.5"/><line x1="9" y1="1" x2="9" y2="3.5"/>
+    </svg>
+  )},
 ];
 
 /**
@@ -56,24 +68,54 @@ export function TaskWorkspace(props: Props): React.ReactElement {
 
   const activeIdParam = searchParams.get('t');
 
+  const pending    = props.tasks.filter((t) => t.status === 'pendiente').length;
+  const inProgress = props.tasks.filter((t) => t.status === 'en_progreso').length;
+  const done       = props.tasks.filter((t) => t.status === 'completada').length;
+  const overdue    = props.tasks.filter((t) => t.status !== 'completada' && t.dueDate !== null && new Date(t.dueDate) < new Date()).length;
+
   return (
     <div className="space-y-4">
-      <div className="flex items-center justify-end">
-        <div className="inline-flex rounded-full bg-sp-admin-card border border-sp-admin-border p-0.5">
+      {/* KPIs de la semana */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+        {[
+          { label: 'Pendientes',  value: pending,    color: '#72728a' },
+          { label: 'En curso',    value: inProgress, color: '#f59e0b' },
+          { label: 'Completadas', value: done,       color: '#16a34a' },
+          { label: 'Vencidas',    value: overdue,    color: overdue > 0 ? '#ef4444' : '#72728a' },
+        ].map((s) => (
+          <div key={s.label} className="rounded-lg bg-sp-admin-card shadow-[0_1px_3px_rgba(0,0,0,0.06)] overflow-hidden">
+            <div className="h-[2px]" style={{ background: s.color }} />
+            <div className="px-4 py-3">
+              <p className="text-[9px] font-bold uppercase tracking-wide text-sp-admin-muted">{s.label}</p>
+              <p className="text-xl font-bold mt-0.5" style={{ color: s.color }}>{s.value}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Toolbar: semana + view switcher */}
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-[11px] text-sp-admin-muted hidden sm:block tabular-nums">
+          {props.tasks.length} {props.tasks.length === 1 ? 'tarea' : 'tareas'} · {props.weekLabel}
+        </p>
+        <div className="flex items-center gap-0.5 bg-sp-admin-card border border-sp-admin-border rounded-lg p-0.5 shadow-[0_1px_2px_rgba(0,0,0,0.04)]">
           {VIEWS.map((v) => {
             const isActive = view === v.key;
             return (
               <button
                 key={v.key}
                 type="button"
+                title={v.label}
                 onClick={() => {
-                  // Si veníamos de list con ?t=xx, limpiar ese param al cambiar de vista
                   if (activeIdParam && v.key !== 'list') router.replace(pathname, { scroll: false });
                   setView(v.key);
                 }}
-                className={`px-3 py-1.5 rounded-full text-xs font-semibold transition-colors cursor-pointer ${isActive ? 'bg-sp-admin-accent text-sp-admin-bg' : 'text-sp-admin-muted hover:text-sp-admin-text'}`}
+                className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-[11px] font-semibold transition-all cursor-pointer ${
+                  isActive ? 'bg-sp-admin-accent text-white shadow-sm' : 'text-sp-admin-muted hover:text-sp-admin-text hover:bg-sp-admin-hover'
+                }`}
               >
-                <span className="mr-1.5">{v.icon}</span>{v.label}
+                {v.icon}
+                <span className="hidden sm:inline">{v.label}</span>
               </button>
             );
           })}


### PR DESCRIPTION
## Resumen

Mejoras visuales puras sobre el CRM — sin cambios de lógica ni schema. Todos los cambios están en la capa de presentación.

## Cambios

### Influencer Cards (`InfluencerCardsView` + `InfluencerCardsView.parts`)
- **Foto cuadrada** (`aspect-square`, `object-cover object-top`) centrada en la cara del influencer
- **Grid más denso**: 2 → 3 → 4 → 5 → 6 columnas según breakpoint (cards más pequeñas y visuales)
- **KPIs clickeables** arriba: Activos / Disponibles / Inactivos como filtros rápidos
- Seguidores y país como **overlay** sobre la foto (no ocupan espacio adicional)
- Filtros inline compactos sin caja wrapper pesada
- Card con footer mínimo: nombre, juego, chips de plataforma

### TaskWorkspace
- **4 KPIs** de la semana en la parte superior: pendientes / en curso / completadas / vencidas
- View switcher con **iconos SVG** en lugar de emojis
- Toolbar con semana label a la izquierda y switcher a la derecha

### TaskKanban
- Columnas con **header coloreado** (azul/ámbar/verde según estado)
- Contador de tareas estilizado con el color de la columna
- Cards con mejor jerarquía visual: título, categoría como pill, fecha vencida en rojo
- Área drop con fondo diferenciado
- Animación de arrastre suave (opacity + scale)

## Test plan
- [ ] `/admin/talents` — verificar que las cards muestran foto cuadrada centrada en cara
- [ ] `/admin/talents` — filtros de estado clicables funcionan
- [ ] `/admin/tareas` — KPIs de semana correctos
- [ ] `/admin/tareas` → vista Kanban — columnas con colores y drag & drop funciona
- [ ] TypeScript sin errores (`npx tsc --noEmit`)
- [ ] Todas las rutas responden 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)