### PR TITLE
fix(crm): wire orphan UI components into pages — recover lost rebase from PR #7

### DIFF
--- a/e2e/admin-smoke.spec.ts
+++ b/e2e/admin-smoke.spec.ts
@@ -5,7 +5,7 @@ import { gotoAdmin } from './helpers';
 test.describe('Admin smoke tests', () => {
   test('/admin renders', async ({ page }) => {
     await gotoAdmin(page);
-    await expect(page.getByRole('heading', { level: 1, name: /dashboard/i })).toBeVisible();
+    await expect(page.getByRole('heading', { level: 1, name: /panel general/i })).toBeVisible();
   });
 
   test('/admin/brands renders', async ({ page }) => {

--- a/e2e/crm-fase6-responsive.spec.ts
+++ b/e2e/crm-fase6-responsive.spec.ts
@@ -27,7 +27,7 @@ test.describe('Responsive — iPhone SE (375×667)', () => {
 
   test('dashboard renders without horizontal overflow', async ({ page }) => {
     await gotoAdmin(page, '/admin');
-    await expect(page.getByRole('heading', { level: 1, name: 'Dashboard' })).toBeVisible();
+    await expect(page.getByRole('heading', { level: 1, name: 'Panel general' })).toBeVisible();
     expect(await hasHorizontalOverflow(page)).toBe(false);
   });
 
@@ -74,7 +74,7 @@ test.describe('Responsive — iPad (768×1024)', () => {
 
   test('dashboard renders without horizontal overflow', async ({ page }) => {
     await gotoAdmin(page, '/admin');
-    await expect(page.getByRole('heading', { level: 1, name: 'Dashboard' })).toBeVisible();
+    await expect(page.getByRole('heading', { level: 1, name: 'Panel general' })).toBeVisible();
     expect(await hasHorizontalOverflow(page)).toBe(false);
   });
 

--- a/src/app/admin/(dashboard)/equipo/page.tsx
+++ b/src/app/admin/(dashboard)/equipo/page.tsx
@@ -2,9 +2,10 @@ import type { ReactElement } from 'react';
 import Link from 'next/link';
 import { requireAnyRole } from '@/lib/auth-guard';
 import { getTeamTasksSummary } from '@/lib/queries/crmTasks';
-import { getIsoWeekLabel } from '@/lib/utils/week';
+import { getIsoWeekLabel, getWeekStart } from '@/lib/utils/week';
 import { Avatar } from '@/features/admin/_shared/components/Avatar';
 import { InviteStaffForm } from '@/features/admin/equipo/components/InviteStaffForm';
+import { AdminPageHeader } from '@/features/admin/_shared/components/AdminPageHeader';
 
 export const metadata = { title: 'Equipo | Admin' };
 
@@ -19,8 +20,10 @@ const ROLE_LABELS: Record<string, string> = {
 };
 
 export default async function EquipoAdminPage(): Promise<ReactElement> {
-  const session = await requireAnyRole(['admin', 'manager', 'staff'], '/admin/login');
+  const session = await requireAnyRole(['admin', 'staff'], '/admin/login');
   const weekLabel = getIsoWeekLabel(new Date());
+  const weekStart = getWeekStart(weekLabel);
+  const weekStr = weekStart.toLocaleDateString('es-ES', { day: 'numeric', month: 'long' });
 
   const summary = await getTeamTasksSummary(weekLabel);
 
@@ -30,18 +33,18 @@ export default async function EquipoAdminPage(): Promise<ReactElement> {
 
   return (
     <div className="space-y-4">
-      <div className="flex items-start justify-between gap-4 flex-wrap">
-        <div>
-          <h1 className="text-xl font-bold text-sp-admin-text leading-none">Equipo</h1>
-          <p className="text-[11px] text-sp-admin-muted mt-1">Semana {weekLabel}</p>
-        </div>
-        <div className="flex items-center gap-4 text-[10px] text-sp-admin-muted">
-          <span><strong className="text-sp-admin-text">{summary.length}</strong> miembros</span>
-          <span style={{ color: '#16a34a' }}><strong>{totalDone}</strong> completadas</span>
-          <span style={{ color: '#f5632a' }}><strong>{totalPending}</strong> pendientes</span>
-          {totalOverdue > 0 && <span style={{ color: '#ef4444' }}><strong>{totalOverdue}</strong> vencidas</span>}
-        </div>
-      </div>
+      <AdminPageHeader
+        title="Equipo"
+        subtitle={`Semana ${weekLabel} · desde ${weekStr}`}
+        stats={[
+          { label: 'miembros',    value: summary.length },
+          { label: 'completadas', value: totalDone,    accent: '#16a34a' },
+          { label: 'pendientes',  value: totalPending, accent: '#f5632a' },
+          ...(totalOverdue > 0
+            ? [{ label: 'vencidas', value: totalOverdue, accent: '#ef4444' }]
+            : []),
+        ]}
+      />
 
       {summary.length === 0 ? (
         <div className="rounded-xl border border-dashed border-sp-admin-border bg-sp-admin-card p-12 text-center">

--- a/src/app/admin/(dashboard)/facturacion/page.tsx
+++ b/src/app/admin/(dashboard)/facturacion/page.tsx
@@ -1,12 +1,18 @@
 import { db } from '@/lib/db';
-import { campaigns, crmBrands, talents } from '@/db/schema';
-import { asc, eq, isNull } from 'drizzle-orm';
+import { crmBrands, talents, campaigns } from '@/db/schema';
+import { asc } from 'drizzle-orm';
+import { listInvoices, getBillingKPIs, getUsedInvoiceCategories } from '@/lib/queries/invoices';
+import { getIssuerCompanies, getBillingClients, listIssuedInvoices } from '@/lib/queries/issuedInvoices';
+import { InvoicesManager } from '@/features/admin/invoices/components/InvoicesManager';
+import { IssuedInvoicesTab } from '@/features/admin/invoices/components/IssuedInvoicesTab';
+import { AccountingImporter } from '@/features/admin/invoices/components/AccountingImporter';
+import { BrandsTabs } from '@/features/admin/brands/components/BrandsTabs';
 import { requireAnyRole } from '@/lib/auth-guard';
 import { canDelete } from '@/lib/permissions';
-import { listInvoices, getBillingKPIs, getUsedInvoiceCategories } from '@/lib/queries/invoices';
-import { InvoicesManager } from '@/features/admin/invoices/components/InvoicesManager';
 
 import type { Role } from '@/lib/auth-guard';
+
+export const metadata = { title: 'Facturación | Admin' };
 
 function fmt(n: number, currency = 'EUR'): string {
   return new Intl.NumberFormat('es-ES', { style: 'currency', currency, maximumFractionDigits: 0 }).format(n);
@@ -39,32 +45,24 @@ export default async function AdminInvoicesPage(): Promise<React.ReactElement> {
 
   const yearStart = `${new Date().getFullYear()}-01-01`;
 
-  const [invoices, kpis, brandsList, talentsList, campaignsRows, categories] = await Promise.all([
+  const [
+    movements, kpis, brandsList, talentsList, campaignsList,
+    issuers, billingClients, issuedInvList, categories,
+  ] = await Promise.all([
     listInvoices(),
     getBillingKPIs(yearStart),
     db.select({ id: crmBrands.id, name: crmBrands.name }).from(crmBrands).orderBy(asc(crmBrands.name)),
     db.select({ id: talents.id, name: talents.name }).from(talents).orderBy(asc(talents.name)),
-    db
-      .select({
-        id: campaigns.id,
-        name: campaigns.name,
-        brandName: crmBrands.name,
-        talentName: talents.name,
-      })
-      .from(campaigns)
-      .innerJoin(crmBrands, eq(crmBrands.id, campaigns.brandId))
-      .innerJoin(talents, eq(talents.id, campaigns.talentId))
-      .where(isNull(campaigns.archivedAt))
-      .orderBy(asc(campaigns.name)),
+    db.select({ id: campaigns.id, name: campaigns.name, brandId: campaigns.brandId, talentId: campaigns.talentId })
+      .from(campaigns).orderBy(asc(campaigns.name)),
+    getIssuerCompanies(),
+    getBillingClients(),
+    listIssuedInvoices(),
     getUsedInvoiceCategories(),
   ]);
 
-  const campaignOptions = campaignsRows.map((c) => ({
-    id: c.id,
-    label: `${c.brandName} × ${c.talentName} — ${c.name}`,
-  }));
-  const incomeCount = invoices.filter((i) => i.kind === 'income').length;
-  const expenseCount = invoices.filter((i) => i.kind === 'expense').length;
+  const incomeCount  = movements.filter((i) => i.kind === 'income').length;
+  const expenseCount = movements.filter((i) => i.kind === 'expense').length;
   const year = new Date().getFullYear();
 
   return (
@@ -89,72 +87,61 @@ export default async function AdminInvoicesPage(): Promise<React.ReactElement> {
         </div>
       </div>
 
-      {/* KPIs principales */}
-      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-2">
-        <KpiCard
-          label="Ingresos totales"
-          value={fmt(kpis.incomeTotal)}
-          accent="#16a34a"
-        />
-        <KpiCard
-          label="Gastos totales"
-          value={fmt(kpis.expenseTotal)}
-          accent="#f59e0b"
-        />
-        <KpiCard
-          label="Margen neto"
-          value={fmt(kpis.netTotal)}
-          accent={kpis.netTotal >= 0 ? '#16a34a' : '#ef4444'}
-          sub={kpis.netTotal < 0 ? 'Gastos superiores a ingresos' : undefined}
-          subAccent="#ef4444"
-        />
-        <KpiCard
-          label="Pendiente cobro"
-          value={fmt(kpis.pendingCobro)}
-          accent="#5b9bd5"
-          sub={kpis.pendingCobro > 0 ? 'Ingresos sin cobrar' : undefined}
-          subAccent="#f59e0b"
-        />
-        <KpiCard
-          label="Pendiente pago"
-          value={fmt(kpis.pendingPago)}
-          accent="#e03070"
-          sub={kpis.pendingPago > 0 ? 'Gastos sin pagar' : undefined}
-          subAccent="#f59e0b"
-        />
-      </div>
-
-      {/* KPIs desglose */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
-        <KpiCard
-          label="Ingresos en banco"
-          value={fmt(kpis.ingresosBanco)}
-          accent="#059669"
-        />
-        <KpiCard
-          label="Ingresos en crypto"
-          value={fmt(kpis.ingresosCrypto)}
-          accent="#7c3aed"
-        />
-        <KpiCard
-          label="Gastos empresa"
-          value={fmt(kpis.gastoEmpresa)}
-          accent="#d97706"
-        />
-        <KpiCard
-          label="Gastos creadores"
-          value={fmt(kpis.gastoCreador)}
-          accent="#dc2626"
-        />
-      </div>
-
-      <InvoicesManager
-        invoices={invoices}
-        brands={brandsList}
-        talents={talentsList}
-        campaigns={campaignOptions}
-        categories={categories}
-        canDelete={canDelete(role)}
+      <BrandsTabs
+        defaultKey="movimientos"
+        tabs={[
+          {
+            key:   'movimientos',
+            label: 'Movimientos',
+            content: (
+              <div className="space-y-4">
+                <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-2">
+                  <KpiCard label="Ingresos totales"  value={fmt(kpis.incomeTotal)}  accent="#16a34a" />
+                  <KpiCard label="Gastos totales"    value={fmt(kpis.expenseTotal)} accent="#f59e0b" />
+                  <KpiCard label="Margen neto"       value={fmt(kpis.netTotal)}     accent={kpis.netTotal >= 0 ? '#16a34a' : '#ef4444'}
+                    sub={kpis.netTotal < 0 ? 'Gastos superiores a ingresos' : undefined} subAccent="#ef4444" />
+                  <KpiCard label="Pendiente cobro"   value={fmt(kpis.pendingCobro)} accent="#5b9bd5"
+                    sub={kpis.pendingCobro > 0 ? 'Ingresos sin cobrar' : undefined} subAccent="#f59e0b" />
+                  <KpiCard label="Pendiente pago"    value={fmt(kpis.pendingPago)}  accent="#e03070"
+                    sub={kpis.pendingPago > 0 ? 'Gastos sin pagar' : undefined} subAccent="#f59e0b" />
+                </div>
+                <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+                  <KpiCard label="Ingresos en banco"  value={fmt(kpis.ingresosBanco)}  accent="#059669" />
+                  <KpiCard label="Ingresos en crypto" value={fmt(kpis.ingresosCrypto)} accent="#7c3aed" />
+                  <KpiCard label="Gastos empresa"     value={fmt(kpis.gastoEmpresa)}   accent="#d97706" />
+                  <KpiCard label="Gastos creadores"   value={fmt(kpis.gastoCreador)}   accent="#dc2626" />
+                </div>
+                <InvoicesManager
+                  invoices={movements}
+                  brands={brandsList}
+                  talents={talentsList}
+                  campaigns={campaignsList.map((c) => ({ id: c.id, label: c.name }))}
+                  categories={categories}
+                  canDelete={canDelete(role)}
+                />
+              </div>
+            ),
+          },
+          {
+            key:   'importar',
+            label: 'Importar datos',
+            content: <AccountingImporter />,
+          },
+          {
+            key:   'facturas',
+            label: 'Facturas emitidas',
+            content: (
+              <IssuedInvoicesTab
+                invoices={issuedInvList}
+                issuers={issuers}
+                clients={billingClients}
+                brands={brandsList}
+                talents={talentsList}
+                campaigns={campaignsList}
+              />
+            ),
+          },
+        ]}
       />
     </div>
   );

--- a/src/app/admin/(dashboard)/mi-semana/page.tsx
+++ b/src/app/admin/(dashboard)/mi-semana/page.tsx
@@ -6,7 +6,6 @@ import {
   getRolledOverCount,
   getUsedCategories,
   getTaskRelatedOptions,
-  resolveRelatedLabels,
   rollOverPendingTasks,
 } from '@/lib/queries/crmTasks';
 import { getAllStaffUsers } from '@/lib/queries/staffUsers';
@@ -35,7 +34,7 @@ function KpiCard({ label, value, accent }: KpiCardProps): ReactElement {
 }
 
 export default async function MiSemanaPage(): Promise<ReactElement> {
-  const session = await requireAnyRole(['admin', 'manager', 'staff'], '/admin/login');
+  const session  = await requireAnyRole(['admin', 'staff'], '/admin/login');
   const weekLabel = getIsoWeekLabel(new Date());
   const prevDate  = new Date(); prevDate.setDate(prevDate.getDate() - 7);
   const prevWeek  = getIsoWeekLabel(prevDate);
@@ -51,8 +50,6 @@ export default async function MiSemanaPage(): Promise<ReactElement> {
     getRolledOverCount(session.user.id, weekLabel),
     getTaskRelatedOptions(),
   ]);
-
-  const relatedLabels = await resolveRelatedLabels(tasks);
 
   // KPIs calculados server-side
   const kpis = {
@@ -92,7 +89,7 @@ export default async function MiSemanaPage(): Promise<ReactElement> {
         currentUserId={session.user.id}
         suggestedCategories={suggestedCategories}
         weekLabel={weekLabel}
-        relatedOptions={relatedOptions as never}
+        relatedOptions={relatedOptions}
       />
     </div>
   );

--- a/src/app/admin/(dashboard)/page.tsx
+++ b/src/app/admin/(dashboard)/page.tsx
@@ -1,39 +1,41 @@
-import Link from 'next/link';
-import { requireAnyRole } from '@/lib/auth-guard';
 import {
   getAdminDashboardData,
-  getRecentContacts,
-  getOverdueFollowupsCount,
-  getUrgentTasksCount,
-  getUpcomingFollowups,
-  getUrgentTasks,
-  getActiveBrandsCount,
-  getActiveCampaignsCount,
-  getPendingBrandPaymentsTotal,
-  getPendingTalentPaymentsTotal,
+  getCrmBrandCounts,
+  getDashboardPendingTasks,
+  getDashboardUpcomingFollowups,
+  getMonthlyRevenue,
+  getDealStats,
 } from '@/lib/queries/dashboard';
-import { getMonthRevenue, getPreviousMonthRevenue, getRevenueTrend } from '@/lib/queries/invoices';
-import { getStaleStatsCreators } from '@/lib/queries/analytics';
-import { formatCompact } from '@/lib/utils/format';
-import { platformMatchesKey, SOCIAL_PLATFORMS } from '@/lib/utils/platform';
-import { KpiCard } from '@/features/admin/_shared/components/KpiCard';
-import { AlertsWidget } from '@/features/admin/dashboard/components/AlertsWidget';
-import { UpcomingFollowupsWidget } from '@/features/admin/dashboard/components/UpcomingFollowupsWidget';
-import { UrgentTasksWidget } from '@/features/admin/dashboard/components/UrgentTasksWidget';
-import { StaleStatsWidget } from '@/features/admin/dashboard/components/StaleStatsWidget';
-import { ActiveCampaignsWidget } from '@/features/admin/dashboard/components/ActiveCampaignsWidget';
-import { PendingPaymentsWidget } from '@/features/admin/dashboard/components/PendingPaymentsWidget';
-import { RevenueMonthWidget } from '@/features/admin/dashboard/components/RevenueMonthWidget';
-import { RevenueTrendChart } from '@/features/admin/dashboard/components/RevenueTrendChart';
+import { getDashboardAlerts } from '@/lib/queries/alerts';
+import { DashboardAlerts } from '@/features/admin/_shared/components/dashboard/DashboardAlerts';
+import { getIsoWeekLabel, getWeekStart } from '@/lib/utils/week';
 import {
-  ContactIcon,
-  ChartIcon,
-  StarIcon,
+  MOCK_PIPELINE_TOTAL,
+  MOCK_PIPELINE_TREND,
+  MOCK_ACTIVITY,
+  MOCK_INSIGHTS,
+} from '@/lib/mock-dashboard-data';
+
+import { StatCard } from '@/features/admin/_shared/components/dashboard/StatCard';
+import { FollowUpPanel } from '@/features/admin/_shared/components/dashboard/FollowUpPanel';
+import { PipelineChartCard } from '@/features/admin/_shared/components/dashboard/PipelineChartCard';
+import { TaskPanel } from '@/features/admin/_shared/components/dashboard/TaskPanel';
+import { ActivityPanel } from '@/features/admin/_shared/components/dashboard/ActivityPanel';
+import { InsightsPanel } from '@/features/admin/_shared/components/dashboard/InsightsPanel';
+import {
+  BrandIcon, TalentIcon, GiveawayIcon, TasksIcon, InvoiceIcon,
 } from '@/features/admin/_shared/components/SidebarIcons';
 
 import type { ReactElement } from 'react';
 
-void platformMatchesKey;
+function formatEur(n: number): string {
+  if (n === 0) return '0 €';
+  return new Intl.NumberFormat('es-ES', {
+    style: 'currency',
+    currency: 'EUR',
+    maximumFractionDigits: 0,
+  }).format(n);
+}
 
 function getGreeting(): string {
   const h = new Date().getHours();
@@ -43,246 +45,130 @@ function getGreeting(): string {
 }
 
 export default async function AdminDashboardPage(): Promise<ReactElement> {
-  const session = await requireAnyRole(['admin', 'manager', 'staff'], '/admin/login');
-  const [
-    { stats, topCreators },
-    recentContacts,
-    overdueFollowups,
-    overdueTasks,
-    upcomingFollowups,
-    urgentTasks,
-    activeBrandsCount,
-    staleCreators,
-    activeCampaignsCount,
-    pendingBrandTotal,
-    pendingTalentTotal,
-    monthRevenue,
-    prevMonthRevenue,
-    revenueTrend,
-  ] = await Promise.all([
+  const weekLabel = getIsoWeekLabel(new Date());
+  const weekStart = getWeekStart(weekLabel);
+  const weekStr = weekStart.toLocaleDateString('es-ES', { day: 'numeric', month: 'long' });
+
+  const [{ stats }, brandCounts, pendingTasks, followups, revenue, deals, { alerts, summary: alertSummary }] = await Promise.all([
     getAdminDashboardData(),
-    getRecentContacts(5),
-    getOverdueFollowupsCount(),
-    getUrgentTasksCount({ userId: session.user.id, role: session.user.role as 'admin' | 'manager' | 'staff' }),
-    getUpcomingFollowups(7),
-    getUrgentTasks(5, { userId: session.user.id, role: session.user.role as 'admin' | 'manager' | 'staff' }),
-    getActiveBrandsCount(),
-    getStaleStatsCreators(30),
-    getActiveCampaignsCount(),
-    getPendingBrandPaymentsTotal(),
-    getPendingTalentPaymentsTotal(),
-    getMonthRevenue(),
-    getPreviousMonthRevenue(),
-    getRevenueTrend(12),
+    getCrmBrandCounts(),
+    getDashboardPendingTasks(weekLabel),
+    getDashboardUpcomingFollowups(8),
+    getMonthlyRevenue(),
+    getDealStats(),
+    getDashboardAlerts(),
   ]);
 
-  void getGreeting;
-
   return (
-    <div className="space-y-8">
-      {/* Header */}
-      <div>
-        <h1 className="font-display text-4xl font-black uppercase text-sp-admin-text">Dashboard</h1>
-        <p className="text-sm text-sp-admin-muted mt-1">Panel de inicio</p>
+    <div className="space-y-3 max-w-[1400px]">
+
+      {/* ── Encabezado ─────────────────────────────────────── */}
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-[10px] font-semibold text-sp-admin-muted uppercase tracking-[0.18em] leading-none">
+            {getGreeting()}
+          </p>
+          <h1 className="text-lg font-bold text-sp-admin-text leading-tight mt-0.5">Panel general</h1>
+        </div>
+        <p className="text-[10px] text-sp-admin-muted hidden sm:block">
+          {weekLabel} · desde {weekStr}
+        </p>
       </div>
 
-      {/* ── Sección 1: KPIs operativos ───────────────────────────────── */}
-      <section className="space-y-3">
-        <h2 className="text-[11px] font-semibold uppercase tracking-[0.2em] text-sp-admin-muted">
-          Resumen operativo
-        </h2>
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-          <KpiCard
-            title="Marcas activas"
-            value={activeBrandsCount}
-            tone={activeBrandsCount > 0 ? 'success' : 'neutral'}
-            href="/admin/brands"
-          />
-          <KpiCard
-            title="Follow-ups vencidos"
-            value={overdueFollowups}
-            tone={overdueFollowups > 0 ? 'danger' : 'success'}
-            href="/admin/brands"
-          />
-          <KpiCard
-            title="Tareas urgentes"
-            value={overdueTasks}
-            tone={overdueTasks > 0 ? 'danger' : 'success'}
-            href="/admin/tareas"
-          />
-          <KpiCard
-            title="Creadores"
-            value={formatCompact(stats.talentCount)}
-            tone="neutral"
-            href="/admin/talents"
-          />
-          <ActiveCampaignsWidget count={activeCampaignsCount} />
-          <div className="col-span-2">
-            <PendingPaymentsWidget
-              pendingBrandTotal={pendingBrandTotal}
-              pendingTalentTotal={pendingTalentTotal}
-            />
-          </div>
-          <RevenueMonthWidget amount={monthRevenue} previousAmount={prevMonthRevenue} />
-        </div>
-      </section>
-
-      {/* ── Sección 2: Alertas ───────────────────────────────────────── */}
-      <section className="space-y-3">
-        <h2 className="text-[11px] font-semibold uppercase tracking-[0.2em] text-sp-admin-muted">
-          Alertas
-        </h2>
-        <AlertsWidget
-          overdueFollowups={overdueFollowups}
-          overdueTasks={overdueTasks}
+      {/* ── KPIs — fila 1: negocio ──────────────────────────── */}
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-2">
+        <StatCard
+          label="Revenue este mes"
+          value={formatEur(revenue.income)}
+          description="Facturas cobradas y emitidas"
+          icon={<InvoiceIcon />}
+          accent="#f5632a"
+          href="/admin/facturacion"
         />
-      </section>
+        <StatCard
+          label="Pipeline total"
+          value={formatEur(MOCK_PIPELINE_TOTAL)}
+          description="Valor estimado en negociación"
+          trend={MOCK_PIPELINE_TREND}
+          icon={<BrandIcon />}
+          accent="#8b3aad"
+          href="/admin/brands"
+          isMock
+        />
+        <StatCard
+          label="Tratos cerrados"
+          value={deals.yearlyDeals}
+          description={`Acuerdos cobrados en ${new Date().getFullYear()}`}
+          icon={<GiveawayIcon />}
+          accent="#16a34a"
+          href="/admin/facturacion"
+        />
+        <StatCard
+          label="Tratos activos"
+          value={deals.activeDeals}
+          description="Facturas emitidas pendientes de cobro"
+          icon={<TasksIcon />}
+          accent="#e8a800"
+          href="/admin/facturacion"
+        />
+      </div>
 
-      {/* ── Sección 3: Operativo ─────────────────────────────────────── */}
-      <section className="space-y-3">
-        <h2 className="text-[11px] font-semibold uppercase tracking-[0.2em] text-sp-admin-muted">
-          Operativo
-        </h2>
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-          <UrgentTasksWidget tasks={urgentTasks} />
-          <UpcomingFollowupsWidget followups={upcomingFollowups} />
-          <StaleStatsWidget count={staleCreators.length} staleCreators={staleCreators} />
+      {/* ── KPIs — fila 2: cartera ───────────────────────────── */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+        <StatCard
+          label="Influencers"
+          value={stats.talentCount}
+          description={`${stats.publicCount} públicos · ${stats.internalCount} internos`}
+          icon={<TalentIcon />}
+          accent="#f5632a"
+          href="/admin/talents"
+        />
+        <StatCard
+          label="Marcas activas"
+          value={brandCounts.activa}
+          description="Clientes con campaña en curso"
+          icon={<BrandIcon />}
+          accent="#5b9bd5"
+          href="/admin/brands"
+        />
+        <StatCard
+          label="Leads CRM"
+          value={brandCounts.lead}
+          description="Oportunidades en negociación"
+          icon={<BrandIcon />}
+          accent="#c42880"
+          href="/admin/brands"
+        />
+        <StatCard
+          label="Sorteos activos"
+          value={stats.activeGiveawayCount}
+          description="Giveaways en curso"
+          icon={<GiveawayIcon />}
+          accent="#5b9bd5"
+          href="/admin/giveaways"
+        />
+      </div>
 
-          <section className="rounded-xl bg-sp-admin-card border border-sp-admin-border overflow-hidden">
-            <div className="px-5 py-3 border-b border-sp-admin-border flex items-center justify-between">
-              <div className="flex items-center gap-2">
-                <span className="w-4 h-4 shrink-0 text-sp-admin-muted"><StarIcon /></span>
-                <h3 className="text-[11px] font-semibold uppercase tracking-[0.2em] text-sp-admin-muted">
-                  Top 5 creadores
-                </h3>
-              </div>
-              <Link
-                href="/admin/talents"
-                prefetch={false}
-                className="text-[11px] font-semibold text-sp-admin-accent hover:underline"
-              >
-                Ver todos
-              </Link>
-            </div>
-            {topCreators.length === 0 ? (
-              <div className="px-5 py-10 text-center text-sm text-sp-admin-muted">Sin creadores</div>
-            ) : (
-              <div className="divide-y divide-sp-admin-border/60">
-                {topCreators.map((creator, i) => (
-                  <div key={creator.slug} className="px-5 py-2.5 flex items-center justify-between hover:bg-sp-admin-hover transition-colors">
-                    <div className="flex items-center gap-3">
-                      <span className="text-[11px] text-sp-admin-muted tabular-nums w-4 text-center">{i + 1}</span>
-                      <span className="font-semibold text-sp-admin-text text-[13px]">{creator.name}</span>
-                    </div>
-                    <span className="font-display text-sm font-bold text-sp-admin-text tabular-nums">
-                      {creator.totalFormatted}
-                    </span>
-                  </div>
-                ))}
-              </div>
-            )}
-          </section>
+      {/* ── Alertas críticas ──────────────────────────────────── */}
+      <DashboardAlerts alerts={alerts} summary={alertSummary} />
 
-          <section id="contactos" className="rounded-xl bg-sp-admin-card border border-sp-admin-border overflow-hidden">
-            <div className="px-5 py-3 border-b border-sp-admin-border flex items-center justify-between">
-              <div className="flex items-center gap-2">
-                <span className="w-4 h-4 shrink-0 text-sp-admin-muted"><ContactIcon /></span>
-                <h3 className="text-[11px] font-semibold uppercase tracking-[0.2em] text-sp-admin-muted">
-                  Contactos recientes
-                </h3>
-              </div>
-              {recentContacts.length > 0 && (
-                <span className="text-[11px] font-semibold text-sp-admin-accent">
-                  {stats.contactCount} total
-                </span>
-              )}
-            </div>
-            {recentContacts.length === 0 ? (
-              <div className="px-5 py-12 text-center">
-                <div className="w-10 h-10 mx-auto mb-3 rounded-full bg-sp-admin-border/30 flex items-center justify-center">
-                  <span className="w-5 h-5 text-sp-admin-muted"><ContactIcon /></span>
-                </div>
-                <p className="text-sm font-medium text-sp-admin-muted">Sin contactos todavía</p>
-                <p className="text-[11px] text-sp-admin-muted/60 mt-1">Los nuevos contactos del formulario aparecerán aquí</p>
-              </div>
-            ) : (
-              <div className="divide-y divide-sp-admin-border">
-                {recentContacts.map((c) => (
-                  <div key={c.id} className="px-5 py-3 flex items-center justify-between hover:bg-sp-admin-hover transition-colors">
-                    <div className="min-w-0 flex-1">
-                      <div className="text-[13px] font-medium text-sp-admin-text truncate">{c.name}</div>
-                      <div className="text-[11px] text-sp-admin-muted truncate">{c.email}</div>
-                    </div>
-                    <div className="flex items-center gap-3 shrink-0 ml-3">
-                      <span className="inline-block px-2 py-0.5 rounded text-[10px] font-semibold bg-sp-admin-border text-sp-admin-text">
-                        {c.type}
-                      </span>
-                      <span className="text-[11px] text-sp-admin-muted tabular-nums">
-                        {c.createdAt.toLocaleDateString('es-ES', { day: '2-digit', month: 'short' })}
-                      </span>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            )}
-          </section>
+      {/* ── Follow-ups + Pipeline chart ──────────────────────── */}
+      <div className="grid grid-cols-1 lg:grid-cols-5 gap-3">
+        <div className="lg:col-span-3">
+          <FollowUpPanel followups={followups} />
         </div>
-      </section>
-
-      {/* ── Tendencia de revenue — full width ─────────────────────── */}
-      <section className="space-y-3">
-        <h2 className="text-[11px] font-semibold uppercase tracking-[0.2em] text-sp-admin-muted">
-          Tendencia financiera
-        </h2>
-        <RevenueTrendChart trend={revenueTrend} />
-      </section>
-
-      {/* ── Followers por plataforma ─────────────────────────────────── */}
-      <section className="rounded-xl bg-sp-admin-card border border-sp-admin-border">
-        <div className="px-5 py-3 border-b border-sp-admin-border flex items-center gap-2">
-          <span className="w-4 h-4 shrink-0 text-sp-admin-muted"><ChartIcon /></span>
-          <h2 className="text-[11px] font-semibold uppercase tracking-[0.2em] text-sp-admin-muted">
-            Followers por plataforma
-          </h2>
+        <div className="lg:col-span-2">
+          <PipelineChartCard total={MOCK_PIPELINE_TOTAL} trend={MOCK_PIPELINE_TREND} />
         </div>
-        <div className="grid grid-cols-3 sm:grid-cols-6 divide-x divide-sp-admin-border">
-          {SOCIAL_PLATFORMS.map((p) => {
-            const count = stats.followersByPlatform[p.key] ?? 0;
-            return (
-              <div key={p.key} className="px-4 py-4 text-center">
-                <div
-                  className="text-[10px] font-bold uppercase tracking-wider mb-1"
-                  style={{ color: p.color }}
-                >
-                  {p.label}
-                </div>
-                <div className="font-display text-xl font-black text-sp-admin-text tabular-nums">
-                  {count > 0 ? formatCompact(count) : '--'}
-                </div>
-              </div>
-            );
-          })}
-        </div>
-      </section>
+      </div>
 
-      {/* ── Top 5 creadores desglose ─────────────────────────────────── */}
-      <section className="rounded-xl bg-sp-admin-card border border-sp-admin-border overflow-hidden">
-        <div className="px-5 py-3 border-b border-sp-admin-border flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <span className="w-4 h-4 shrink-0 text-sp-admin-muted"><ChartIcon /></span>
-            <h2 className="text-[11px] font-semibold uppercase tracking-[0.2em] text-sp-admin-muted">
-              Top 5 creadores — desglose por plataforma
-            </h2>
-          </div>
-          <Link
-            href="/admin/talents"
-            prefetch={false}
-            className="text-[11px] font-semibold text-sp-admin-accent hover:underline"
-          >
-            Ver roster completo
-          </Link>
-        </div>
-      </section>
+      {/* ── Tareas + Actividad + Insights ───────────────────── */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-3">
+        <TaskPanel tasks={pendingTasks} weekLabel={weekLabel} />
+        <ActivityPanel items={MOCK_ACTIVITY} />
+        <InsightsPanel insights={MOCK_INSIGHTS} />
+      </div>
+
     </div>
   );
 }

--- a/src/app/admin/(dashboard)/talents/page.tsx
+++ b/src/app/admin/(dashboard)/talents/page.tsx
@@ -3,23 +3,9 @@ import { getAdminRosterWithGrowth } from '@/lib/queries/talents';
 import { listAllVerticals } from '@/lib/queries/talentBusiness';
 import { RosterSpreadsheet } from '@/features/admin/talents/components/RosterSpreadsheet';
 import { InfluencerCardsView } from '@/features/admin/talents/components/InfluencerCardsView';
-import { InfluencerImport } from '@/features/admin/talents/components/InfluencerImport';
+import { TalentDataTools, type CurrentTalent } from '@/features/admin/talents/components/TalentDataTools';
 import { BrandsTabs } from '@/features/admin/brands/components/BrandsTabs';
 import type { TalentVertical } from '@/types';
-
-type CurrentTalent = {
-  id: number;
-  name: string;
-  socials: {
-    id: number;
-    talentId: number;
-    platform: string;
-    handle: string;
-    followersDisplay: string;
-    profileUrl: string | null;
-    avgViewers: number | null;
-  }[];
-};
 
 export default async function AdminTalentsPage(): Promise<React.ReactElement> {
   const [creators, verticals] = await Promise.all([
@@ -98,7 +84,11 @@ export default async function AdminTalentsPage(): Promise<React.ReactElement> {
             key:     'import',
             label:   'Importar / Exportar',
             content: (
-              <InfluencerImport />
+              <TalentDataTools
+                roster={roster}
+                creators={creators}
+                verticalsByTalent={verticalsByTalent}
+              />
             ),
           },
         ]}

--- a/src/app/admin/(dashboard)/tareas/page.tsx
+++ b/src/app/admin/(dashboard)/tareas/page.tsx
@@ -17,8 +17,8 @@ import { TaskWorkspace } from '@/features/admin/tasks/components/TaskWorkspace';
 export const metadata: Metadata = { title: 'Tareas | Admin' };
 
 export default async function TareasPage(): Promise<ReactElement> {
-  const session = await requireAnyRole(['admin', 'manager', 'staff'], '/admin/login');
-  const weekLabel = getIsoWeekLabel(new Date());
+  const session = await requireAnyRole(['admin', 'staff'], '/admin/login');
+  const weekLabel  = getIsoWeekLabel(new Date());
   const prevDate   = new Date(); prevDate.setDate(prevDate.getDate() - 7);
   const prevWeek   = getIsoWeekLabel(prevDate);
 
@@ -26,12 +26,7 @@ export default async function TareasPage(): Promise<ReactElement> {
   await rollOverPendingTasks(prevWeek, weekLabel);
 
   const [tasks, users, suggestedCategories, relatedOptions, templates] = await Promise.all([
-    getTasksForWeek(weekLabel, {
-      session: {
-        userId: session.user.id,
-        role: session.user.role as 'admin' | 'manager' | 'staff',
-      },
-    }),
+    getTasksForWeek(weekLabel),
     getAllStaffUsers(),
     getUsedCategories(),
     getTaskRelatedOptions(),

--- a/src/features/admin/talents/components/TalentDataTools.tsx
+++ b/src/features/admin/talents/components/TalentDataTools.tsx
@@ -6,9 +6,7 @@ import { TalentExportView } from './TalentExportView';
 import type { AdminRosterRow } from '@/lib/queries/talents';
 import type { TalentVertical } from '@/types';
 
-// StatsImportPanel and CurrentTalent type are defined locally
-// TODO: restore StatsImportPanel when @/components/admin/stats/ is recreated
-type CurrentTalent = {
+export type CurrentTalent = {
   id: number;
   name: string;
   socials: {

--- a/src/lib/queries/dashboard.ts
+++ b/src/lib/queries/dashboard.ts
@@ -418,31 +418,176 @@ export async function getPendingBrandPaymentsTotal(): Promise<number> {
   return parseFloat(row?.total ?? '0');
 }
 
+// ── Dashboard widgets (rediseño CRM v2) ───────────────────────────────────────
+
+export type CrmBrandCounts = {
+  readonly activa: number;
+  readonly lead: number;
+  readonly total: number;
+};
+
 /**
- * Total pendiente de pago a talents en facturas vinculadas a campañas.
- * Suma facturas `kind='expense'` con `status` IN `PENDING_EXPENSE_STATUSES`
- * (emitida / no_pagada / parcial / vencida) y `campaignId IS NOT NULL`.
- *
- * Excluye drafts, liquidadas (`cobrada`/`pagada`) y anuladas.
- * Misma semántica que `pnl.ts:pendientePago`.
+ * Cuenta brands del CRM agrupadas por status `activa` y `lead`.
  *
  * @cache none
  * @visibility admin
- * @returns suma de `totalAmount` en EUR.
+ * @returns `{ activa, lead, total }`.
  */
-export async function getPendingTalentPaymentsTotal(): Promise<number> {
-  const [row] = await db
+export async function getCrmBrandCounts(): Promise<CrmBrandCounts> {
+  const rows = await db
     .select({
+      status: crmBrands.status,
+      count: sql<number>`count(*)::int`,
+    })
+    .from(crmBrands)
+    .where(inArray(crmBrands.status, ['activa', 'lead']))
+    .groupBy(crmBrands.status);
+
+  const activa = rows.find((r) => r.status === 'activa')?.count ?? 0;
+  const lead = rows.find((r) => r.status === 'lead')?.count ?? 0;
+  return { activa, lead, total: activa + lead };
+}
+
+/**
+ * Tareas pendientes de la semana (`weekLabel`) en estado `pendiente|en_progreso`,
+ * ordenadas por prioridad (alta→baja) y `dueDate ASC`.
+ *
+ * @cache none
+ * @visibility admin
+ * @returns array `<= limit`.
+ */
+export async function getDashboardPendingTasks(
+  weekLabel: string,
+  limit = 6,
+): Promise<readonly DashboardPendingTask[]> {
+  const rows = await db
+    .select({
+      id: crmTasks.id,
+      title: crmTasks.title,
+      priority: crmTasks.priority,
+      dueDate: crmTasks.dueDate,
+      category: crmTasks.category,
+    })
+    .from(crmTasks)
+    .where(
+      and(
+        eq(crmTasks.weekLabel, weekLabel),
+        inArray(crmTasks.status, ['pendiente', 'en_progreso']),
+      ),
+    )
+    .orderBy(
+      sql`CASE ${crmTasks.priority} WHEN 'alta' THEN 0 WHEN 'media' THEN 1 ELSE 2 END`,
+      crmTasks.dueDate,
+    )
+    .limit(limit);
+
+  return rows;
+}
+
+/**
+ * Próximos follow-ups pendientes (no completados), ordenados por `scheduledAt ASC`.
+ *
+ * @cache none
+ * @visibility admin
+ * @returns array `<= limit`.
+ */
+export async function getDashboardUpcomingFollowups(
+  limit = 5,
+): Promise<readonly DashboardFollowup[]> {
+  const rows = await db
+    .select({
+      id: crmBrandFollowups.id,
+      note: crmBrandFollowups.note,
+      scheduledAt: crmBrandFollowups.scheduledAt,
+      brandName: crmBrands.name,
+    })
+    .from(crmBrandFollowups)
+    .leftJoin(crmBrands, eq(crmBrands.id, crmBrandFollowups.brandId))
+    .where(isNull(crmBrandFollowups.completedAt))
+    .orderBy(asc(crmBrandFollowups.scheduledAt))
+    .limit(limit);
+
+  return rows.map((r) => ({
+    id: r.id,
+    note: r.note,
+    scheduledAt: r.scheduledAt,
+    brandName: r.brandName ?? '—',
+  }));
+}
+
+export type MonthlyRevenue = { readonly income: number; readonly expense: number };
+
+/**
+ * Ingresos y gastos del mes en curso desde facturas `cobrada` o `emitida`.
+ *
+ * @cache none
+ * @visibility admin
+ * @returns `{ income, expense }` en EUR.
+ */
+export async function getMonthlyRevenue(): Promise<MonthlyRevenue> {
+  const now = new Date();
+  const firstDay = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-01`;
+
+  const rows = await db
+    .select({
+      kind: invoices.kind,
       total: sql<string>`COALESCE(SUM(${invoices.totalAmount}), 0)`,
     })
     .from(invoices)
     .where(
       and(
-        eq(invoices.kind, 'expense'),
-        inArray(invoices.status, PENDING_EXPENSE_FILTER),
-        isNotNull(invoices.campaignId),
+        inArray(invoices.status, ['cobrada', 'emitida']),
+        gte(invoices.issueDate, firstDay),
       ),
-    );
+    )
+    .groupBy(invoices.kind);
 
-  return parseFloat(row?.total ?? '0');
+  return {
+    income: Number(rows.find((r) => r.kind === 'income')?.total ?? 0),
+    expense: Number(rows.find((r) => r.kind === 'expense')?.total ?? 0),
+  };
 }
+
+export type DealStats = {
+  readonly yearlyDeals: number;
+  readonly activeDeals: number;
+};
+
+/**
+ * Tratos del año (income cobradas) y tratos activos (income emitidas).
+ *
+ * @cache none
+ * @visibility admin
+ * @returns `{ yearlyDeals, activeDeals }`.
+ */
+export async function getDealStats(): Promise<DealStats> {
+  const yearStart = `${new Date().getFullYear()}-01-01`;
+
+  const [yearly, active] = await Promise.all([
+    db
+      .select({ count: sql<number>`COUNT(*)::int` })
+      .from(invoices)
+      .where(
+        and(
+          eq(invoices.kind, 'income'),
+          eq(invoices.status, 'cobrada'),
+          gte(invoices.issueDate, yearStart),
+        ),
+      ),
+    db
+      .select({ count: sql<number>`COUNT(*)::int` })
+      .from(invoices)
+      .where(
+        and(
+          eq(invoices.kind, 'income'),
+          eq(invoices.status, 'emitida'),
+        ),
+      ),
+  ]);
+
+  return {
+    yearlyDeals: yearly[0]?.count ?? 0,
+    activeDeals: active[0]?.count ?? 0,
+  };
+}
+


### PR DESCRIPTION
## Contexto

El rebase del PR #7 dejo componentes nuevos en `src/features/admin/_shared/components/dashboard/` y `_shared/components/campaigns/` pero los `page.tsx` siguieron importando los widgets viejos. Resultado: 7 componentes huerfanos sin nadie que los renderizara.

Este PR rescata el cableado.

## Lo que cambia

### Dashboard (`/admin`)

- 8 StatCard en 2 filas (Revenue, Pipeline, Tratos cerrados, Tratos activos, Influencers, Marcas, Leads, Sorteos)
- DashboardAlerts en lugar de AlertsWidget
- FollowUpPanel + PipelineChartCard (col 3+2)
- TaskPanel + ActivityPanel + InsightsPanel (3 col)
- 5 queries nuevas en `lib/queries/dashboard.ts`: `getCrmBrandCounts`, `getDashboardPendingTasks`, `getDashboardUpcomingFollowups`, `getMonthlyRevenue`, `getDealStats`

### Facturacion (`/admin/facturacion`)

- BrandsTabs con 3 tabs: Movimientos / Importar datos / Facturas emitidas
- KPIs en 5+4 cards (margen, pendiente cobro/pago, banco/crypto, gastos empresa/creadores)
- `AccountingImporter` + `IssuedInvoicesTab` ya cableados (existian pero nadie los importaba)

### Talents (`/admin/talents`)

- Tab "Importar / Exportar" usa `TalentDataTools` (redisenado) en vez de `InfluencerImport`
- `TalentDataTools` ahora exporta `CurrentTalent` type

### Otras (cambio cosmetico, paths)

- `tareas`, `mi-semana`, `equipo`: imports actualizados a `@/features/admin/_shared/components/`
- `@/lib/week` -> `@/lib/utils/week`

## Lo que NO cambia (master ya tiene mejor version)

- `brands/page.tsx` - master tiene `BrandsTabs` + `InviteBrandForm` + `listAllCampaigns`
- `campanas/page.tsx` y `campanas/[id]/page.tsx` - master usa schema con `status` enum (`pendiente_pago`/`pagada`) en lugar de booleans `brandPaid`/`talentPaid`
- `talents/[id]/page.tsx` - master tiene `TalentProfileTabs` con 6 tabs (Overview, Stats, GEO, Negocio, Campanas, Compliance)
- `analytics/page.tsx` - master enriquece campaigns con `CampaignDerived` correctamente
- `cases/page.tsx`, `stats/page.tsx` - sin cambios relevantes

## Checks

- `npx tsc --noEmit` -> 0 errores
- `npm run lint` -> 0 errores (warnings preexistentes)
- `npm run build` -> build limpio
