### PR TITLE
perf(landing): lazy-load Lenis on landing

### DIFF
--- a/src/components/layout/PublicChrome.tsx
+++ b/src/components/layout/PublicChrome.tsx
@@ -2,9 +2,10 @@
 
 import { useEffect } from 'react';
 import { usePathname } from 'next/navigation';
-import Lenis from 'lenis';
 import { WhatsAppWidget } from './WhatsAppWidget';
 import type { ReactNode } from 'react';
+
+type LenisInstance = { raf: (time: number) => void; destroy: () => void };
 
 const PORTAL_PREFIXES = ['/admin', '/marcas', '/creadores', '/giveaways', '/c/'];
 const LOGIN_SUFFIXES = ['/login'];
@@ -44,20 +45,28 @@ export function PublicChrome({ nav, footer, children }: PublicChromeProps) {
 
   useEffect(() => {
     if (isPortal) return;
-    const lenis = new Lenis({
-      duration: 1.2,
-      easing: (t) => Math.min(1, 1.001 - Math.pow(2, -10 * t)),
-      smoothWheel: true,
-    });
-    let rafId: number;
-    function raf(time: number) {
-      lenis.raf(time);
+    let cancelled = false;
+    let rafId = 0;
+    let lenis: LenisInstance | null = null;
+
+    import('lenis').then(({ default: Lenis }) => {
+      if (cancelled) return;
+      lenis = new Lenis({
+        duration: 1.2,
+        easing: (t: number) => Math.min(1, 1.001 - Math.pow(2, -10 * t)),
+        smoothWheel: true,
+      });
+      const raf = (time: number) => {
+        lenis?.raf(time);
+        rafId = requestAnimationFrame(raf);
+      };
       rafId = requestAnimationFrame(raf);
-    }
-    rafId = requestAnimationFrame(raf);
+    });
+
     return () => {
-      cancelAnimationFrame(rafId);
-      lenis.destroy();
+      cancelled = true;
+      if (rafId) cancelAnimationFrame(rafId);
+      lenis?.destroy();
     };
   }, [isPortal]);
 


### PR DESCRIPTION
Closes #14

## Summary
Removes `lenis` from the initial public-route bundle by converting the top-level `import Lenis from 'lenis'` in `PublicChrome.tsx` into a dynamic `import('lenis')` inside the existing `useEffect`. Smooth-scroll behavior on the landing is unchanged — just deferred until after hydration.

## Implementation notes
- Top-level `import Lenis from 'lenis'` removed; module is now loaded inside the effect.
- Added a `LenisInstance` structural type so we can hold a reference without importing the lib at module scope.
- Cleanup-vs-resolve race handled with a `cancelled` flag and locals captured in the effect closure: if the component unmounts before `import('lenis')` resolves, the `.then(...)` callback bails out without instantiating Lenis. If it resolves first, the cleanup still calls `lenis?.destroy()` and `cancelAnimationFrame` correctly.
- Master's JSDoc header is preserved verbatim.
- Only `src/components/layout/PublicChrome.tsx` is touched.

## Validation
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint src/components/layout/PublicChrome.tsx` clean
- [ ] Manual: smooth-scroll still works on landing
- [ ] `next build` shows Lenis no longer in main initial chunk