### PR TITLE
feat(crm): inline talent actions + status pill wiring

### DIFF
--- a/src/app/admin/(dashboard)/talents/actions.ts
+++ b/src/app/admin/(dashboard)/talents/actions.ts
@@ -1,10 +1,11 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
-import { requireAnyRole } from '@/lib/auth-guard';
+import { requireAnyRole, type Role } from '@/lib/auth-guard';
+import { assertCanDelete } from '@/lib/permissions';
 import { db } from '@/lib/db';
 import { talents, talentSocials } from '@/db/schema';
-import { sql } from 'drizzle-orm';
+import { eq, sql } from 'drizzle-orm';
 import { initialsOf, slugify } from '@/lib/utils/import-utils';
 
 type ActionState = { readonly success: boolean; readonly error?: string };
@@ -94,5 +95,77 @@ export async function createTalentAction(
   } catch (err) {
     const msg = err instanceof Error ? err.message : 'unknown';
     return { success: false, error: `Error al crear talent: ${msg}` };
+  }
+}
+
+export async function deleteTalentAction(formData: FormData): Promise<void> {
+  const session = await requireAnyRole(['admin', 'manager', 'staff'], '/admin/login');
+  assertCanDelete(session.user.role as Role);
+  const id = Number(formData.get('id'));
+  if (!id) return;
+  await db.delete(talents).where(eq(talents.id, id));
+  revalidatePath('/admin/talents');
+  revalidatePath('/');
+}
+
+export async function updateTalentBioAction(formData: FormData): Promise<void> {
+  await requireAnyRole(['admin', 'manager', 'staff'], '/admin/login');
+  const id = Number(formData.get('id'));
+  const bio = String(formData.get('bio') ?? '');
+  if (!id || !bio) return;
+  await db.update(talents).set({ bio }).where(eq(talents.id, id));
+  revalidatePath('/admin/talents');
+  revalidatePath('/');
+}
+
+const STATUS_VALUES = ['active', 'available', 'inactive'] as const;
+type TalentStatus = (typeof STATUS_VALUES)[number];
+
+export async function setTalentStatusAction(
+  talentId: number,
+  status: TalentStatus,
+): Promise<ActionState> {
+  await requireAnyRole(['admin', 'manager', 'staff'], '/admin/login');
+  if (!STATUS_VALUES.includes(status)) return { success: false, error: 'Estado inválido' };
+  if (!talentId) return { success: false, error: 'ID inválido' };
+  try {
+    await db.update(talents).set({ status }).where(eq(talents.id, talentId));
+    revalidatePath('/admin/talents');
+    revalidatePath('/');
+    return { success: true };
+  } catch (err) {
+    console.error('[admin] setTalentStatus error:', err);
+    return { success: false, error: 'Error al actualizar estado' };
+  }
+}
+
+type GeoEntry = { country: string; pct: number };
+
+export async function updateSocialGeoAction(
+  socialId: number,
+  topGeos: readonly GeoEntry[],
+): Promise<ActionState> {
+  await requireAnyRole(['admin', 'manager', 'staff'], '/admin/login');
+  if (!socialId) return { success: false, error: 'ID inválido' };
+
+  const cleaned: GeoEntry[] = [];
+  for (const entry of topGeos) {
+    if (typeof entry?.country !== 'string' || typeof entry?.pct !== 'number') continue;
+    const country = entry.country.trim().toUpperCase().slice(0, 3);
+    if (!country) continue;
+    const pct = Math.max(0, Math.min(100, Math.round(entry.pct * 10) / 10));
+    cleaned.push({ country, pct });
+  }
+
+  try {
+    await db
+      .update(talentSocials)
+      .set({ topGeos: cleaned.length > 0 ? cleaned : null })
+      .where(eq(talentSocials.id, socialId));
+    revalidatePath('/admin/talents');
+    return { success: true };
+  } catch (err) {
+    console.error('[admin] updateSocialGeo error:', err);
+    return { success: false, error: 'Error al guardar geo' };
   }
 }

--- a/src/features/admin/talents/components/InfluencerCardsView.parts.tsx
+++ b/src/features/admin/talents/components/InfluencerCardsView.parts.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import Image from 'next/image';
-import { useMemo } from 'react';
+import { useMemo, useState, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
 import * as m from 'motion/react-client';
 import { StateBadge } from '@/features/admin/_shared/components/StateBadge';
 import { parseFollowers, formatCompact } from '@/lib/utils/format';
 import { TALENT_VERTICAL_LABELS } from '@/lib/schemas/talentBusiness';
+import { setTalentStatusAction } from '@/app/admin/(dashboard)/talents/actions';
 import type { AdminRosterRow } from '@/lib/queries/talents';
 import type { TalentVertical } from '@/types';
 import type { Tone } from '@/features/admin/_shared/components/StateBadge';
@@ -48,6 +49,13 @@ export const PLATFORM_LABELS: Record<string, string> = {
 
 // ── Card ─────────────────────────────────────────────────────────────
 
+const STATUS_CYCLE: readonly TalentStatus[] = ['active', 'available', 'inactive'];
+
+function nextStatus(current: TalentStatus): TalentStatus {
+  const idx = STATUS_CYCLE.indexOf(current);
+  return STATUS_CYCLE[(idx + 1) % STATUS_CYCLE.length] ?? 'active';
+}
+
 type CardProps = {
   readonly creator: AdminRosterRow;
   readonly verticals: readonly TalentVertical[];
@@ -55,11 +63,35 @@ type CardProps = {
 
 export function TalentCard({ creator, verticals }: CardProps): React.ReactElement {
   const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [optimisticStatus, setOptimisticStatus] = useState<TalentStatus>(creator.status as TalentStatus);
 
-  // Resolve status: prefer audienceStatus if set, fall back to status
-  const displayStatus: string = creator.audienceStatus ?? creator.status;
+  // Resolve status: prefer audienceStatus if set, fall back to optimistic status
+  const displayStatus: string = creator.audienceStatus ?? optimisticStatus;
   const tone: Tone = STATUS_TONE[displayStatus] ?? 'neutral';
   const statusLabel: string = STATUS_LABELS[displayStatus] ?? displayStatus;
+  const isPillClickable = !creator.audienceStatus;
+
+  const handleStatusClick = (e: React.MouseEvent | React.KeyboardEvent): void => {
+    e.stopPropagation();
+    e.preventDefault();
+    const next = nextStatus(optimisticStatus);
+    setOptimisticStatus(next);
+    startTransition(async () => {
+      const res = await setTalentStatusAction(creator.id, next);
+      if (!res.success) {
+        setOptimisticStatus(creator.status as TalentStatus);
+      } else {
+        router.refresh();
+      }
+    });
+  };
+
+  const handleStatusKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>): void => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      handleStatusClick(e);
+    }
+  };
 
   // Platform chips: from socials (up to 3)
   const platformChips = useMemo(() => {
@@ -119,9 +151,22 @@ export function TalentCard({ creator, verticals }: CardProps): React.ReactElemen
       >
         <Avatar creator={creator} />
 
-        {/* Status badge */}
+        {/* Status badge — clickable cycles status when no audienceStatus override */}
         <div className="absolute top-2 right-2 z-10">
-          <StateBadge tone={tone} variant="soft">{statusLabel}</StateBadge>
+          {isPillClickable ? (
+            <button
+              type="button"
+              onClick={handleStatusClick}
+              onKeyDown={handleStatusKeyDown}
+              disabled={isPending}
+              aria-label={`Cambiar estado: ${statusLabel}`}
+              className="cursor-pointer rounded-full focus-visible:outline-2 focus-visible:outline-sp-admin-accent focus-visible:outline-offset-2 disabled:opacity-60"
+            >
+              <StateBadge tone={tone} variant="soft">{statusLabel}</StateBadge>
+            </button>
+          ) : (
+            <StateBadge tone={tone} variant="soft">{statusLabel}</StateBadge>
+          )}
         </div>
 
         {/* País */}


### PR DESCRIPTION
Closes #11

## Summary
- Adds 4 server actions to `src/app/admin/(dashboard)/talents/actions.ts` (ported from PR #10, adapted to master's auth pattern):
  - `deleteTalentAction` — `requireAnyRole(['admin','manager','staff'])` + `assertCanDelete` (admin-only delete)
  - `updateTalentBioAction` — `requireAnyRole(['admin','manager','staff'])`
  - `setTalentStatusAction(talentId, status)` — runtime-validated against `['active','available','inactive']`
  - `updateSocialGeoAction(socialId, topGeos)` — clamps pct 0-100, uppercases country to 3 chars
- Wires the status pill in `InfluencerCardsView.parts.tsx`:
  - Pill becomes a `<button>` that cycles `active → available → inactive` on click
  - Uses `useTransition` + optimistic state; rolls back on failure
  - `e.stopPropagation()` + `e.preventDefault()` prevent the card-level click from firing
  - When `audienceStatus` is set the pill stays read-only (out of scope for this action)
  - `router.refresh()` after success so the parent server tree reflects the new value

## Auth deviations from PR #10
PR #10 used `requireRole('admin', '/admin/login')` for all four actions. Master convention is `requireAnyRole(['admin','manager','staff'])` for edits and `assertCanDelete` for deletes — applied accordingly per CLAUDE.md and `src/lib/permissions.ts`.

## DB impact
None. Uses existing columns (`talents.status`, `talents.bio`, `talentSocials.topGeos`).

## Validation
- `npx tsc --noEmit` — clean
- `npx eslint` on the two changed files — clean (the only warnings reported in the wider folder are pre-existing in `AddTalentModal.tsx` and `TalentExportView.tsx`, untouched here)

## Test plan
- [ ] Open `/admin/talents`
- [ ] Click a status pill on a card without `audienceStatus`; verify it cycles and persists after refresh
- [ ] Confirm the click does not navigate to the talent detail page
- [ ] Confirm cards with `audienceStatus` still render as read-only