### PR TITLE
ci: make Playwright manual-only

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,6 +3,16 @@ name: E2E Tests
 on:
   pull_request:
     branches: [master]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'audit/**'
+      - '.claude/**'
+      - '.agents/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.gitignore'
+      - '.editorconfig'
+      - 'LICENSE'
 
 concurrency:
   group: e2e-${{ github.ref }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,18 +1,7 @@
 name: E2E Tests
 
 on:
-  pull_request:
-    branches: [master]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'audit/**'
-      - '.claude/**'
-      - '.agents/**'
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.gitignore'
-      - '.editorconfig'
-      - 'LICENSE'
+  workflow_dispatch:
 
 concurrency:
   group: e2e-${{ github.ref }}


### PR DESCRIPTION
## Summary
Removes the per-PR Playwright trigger and switches the workflow to `workflow_dispatch:` only. Manual invocation from the Actions tab still works; PRs and pushes no longer trigger e2e.

## Why
Playwright was consistently flaky and slow on PRs (5-10 min, with the auth-related Better Auth invalid-email error tripping the suite). It was blocking review velocity. We can iterate on stability separately and re-enable per-PR runs (or move to nightly) once the suite is reliable.

## What changed
- `.github/workflows/e2e.yml`: replace `pull_request:` trigger (and the prior `paths-ignore` block this PR initially proposed) with `workflow_dispatch:` only.

## Out of scope (follow-ups)
- Stabilize Playwright (auth flow, fixtures) and re-enable on PR — possibly with the path filters originally drafted here.
- Nightly run against `master` so we still catch drift even without per-PR runs.

## Test plan
- [ ] After merge, the next PR opens with no Playwright check
- [ ] `Actions` tab still shows the "E2E Tests" workflow with a "Run workflow" button