### PR TITLE
a11y(landing): TalentCard focus-visible ring + aria-label

### DIFF
--- a/src/features/talents-public/components/TalentCard.tsx
+++ b/src/features/talents-public/components/TalentCard.tsx
@@ -29,7 +29,8 @@ export function TalentCard({ talent, onOpen, priority = false }: TalentCardProps
   return (
     <button
       onClick={onOpen}
-      className="group text-left w-full rounded-2xl overflow-hidden border border-sp-border bg-white hover:shadow-xl transition-all hover:-translate-y-0.5 focus:outline-none"
+      aria-label={`Ver perfil de ${talent.name}`}
+      className="group text-left w-full rounded-2xl overflow-hidden border border-sp-border bg-white hover:shadow-xl transition-all hover:-translate-y-0.5 focus-visible:ring-2 focus-visible:ring-sp-orange focus-visible:ring-offset-2"
     >
       {/* Photo / Gradient fallback */}
       <div className="relative h-52 overflow-hidden" style={{ background: grad }}>


### PR DESCRIPTION
Closes #16

## Summary
- Replaced `focus:outline-none` with `focus-visible:ring-2 focus-visible:ring-sp-orange focus-visible:ring-offset-2` so keyboard users get a visible orange focus ring without affecting mouse interaction.
- Added `aria-label={\`Ver perfil de ${talent.name}\`}` so screen readers announce a meaningful action instead of reading the entire card content.

## Rejected from PR #10
- Did NOT swap `<button>` for `<div role=\"button\">` + manual `onKeyDown`. Native `<button>` is strictly more accessible (Enter/Space, focus, form-semantics, AT exposure all free).
- Kept master's `priority` prop and its forwarding to `<Image>` intact.

## Test plan
- [ ] Tab through cards on `/` → visible orange focus ring on the focused card
- [ ] Screen reader announces "Ver perfil de [nombre]" on focus
- [ ] DOM inspector confirms element is still `<button>`
- [ ] First card still gets `priority` on its `<Image>`
- [x] `npx tsc --noEmit` passes
- [x] `npx eslint` passes