### PR TITLE
feat(crm): wire contract tab into campaign detail

### DIFF
--- a/src/app/admin/(dashboard)/campanas/[id]/page.tsx
+++ b/src/app/admin/(dashboard)/campanas/[id]/page.tsx
@@ -6,6 +6,10 @@ import { requireAnyRole } from '@/lib/auth-guard';
 import { getCampaignWithRelations } from '@/lib/queries/campaigns';
 import { listFilesByEntity } from '@/lib/queries/files';
 import { listDeliverablesByCampaign } from '@/lib/queries/deliverables';
+import { getContractByCampaign } from '@/lib/queries/contracts';
+import { listContractTemplates } from '@/lib/queries/contractTemplates';
+import { getIssuerCompanies, listIssuedInvoicesByDeal } from '@/lib/queries/issuedInvoices';
+import { buildContractVars } from '@/lib/contractVariables';
 import { db } from '@/lib/db';
 import { invoices, user as userTable } from '@/db/schema';
 import { listCrmBrands, getBrandContacts } from '@/lib/queries/crmBrands';
@@ -27,27 +31,45 @@ export default async function CampaignDetailPage({
   const session = await requireAnyRole(['admin', 'manager', 'staff'], '/admin/login');
   const role = session.user.role as Role;
   const isManager = role === 'manager';
+  const isAdmin = role === 'admin';
 
-  const [campaign, campaignFiles, campaignInvoices, campaignDeliverables, crmBrandsList, allTalents, staffUsers] =
-    await Promise.all([
-      getCampaignWithRelations(campaignId),
-      listFilesByEntity('campaign', campaignId),
-      db
-        .select()
-        .from(invoices)
-        .where(eq(invoices.campaignId, campaignId))
-        .orderBy(invoices.issueDate),
-      listDeliverablesByCampaign(campaignId),
-      listCrmBrands(),
-      getAllTalents(),
-      db
-        .select({ id: userTable.id, name: userTable.name })
-        .from(userTable)
-        .where(inArray(userTable.role, ['admin', 'manager', 'staff']))
-        .orderBy(userTable.name),
-    ]);
+  const [
+    campaign,
+    campaignFiles,
+    campaignInvoices,
+    campaignDeliverables,
+    crmBrandsList,
+    allTalents,
+    staffUsers,
+    contract,
+    contractTemplates,
+    issuedInvoices,
+    issuerCompanies,
+  ] = await Promise.all([
+    getCampaignWithRelations(campaignId),
+    listFilesByEntity('campaign', campaignId),
+    db
+      .select()
+      .from(invoices)
+      .where(eq(invoices.campaignId, campaignId))
+      .orderBy(invoices.issueDate),
+    listDeliverablesByCampaign(campaignId),
+    listCrmBrands(),
+    getAllTalents(),
+    db
+      .select({ id: userTable.id, name: userTable.name })
+      .from(userTable)
+      .where(inArray(userTable.role, ['admin', 'manager', 'staff']))
+      .orderBy(userTable.name),
+    getContractByCampaign(campaignId),
+    listContractTemplates(),
+    listIssuedInvoicesByDeal(campaignId),
+    getIssuerCompanies(),
+  ]);
 
   if (!campaign) notFound();
+
+  const contractVars = buildContractVars(campaign);
 
   // Load contacts for each brand (for the drawer's contact select)
   const contactsByBrand: Record<number, readonly CrmBrandContact[]> = {};
@@ -76,10 +98,16 @@ export default async function CampaignDetailPage({
         campaignInvoices={campaignInvoices}
         campaignDeliverables={campaignDeliverables}
         isManager={isManager}
+        isAdmin={isAdmin}
         brands={brands}
         talents={talents}
         staffUsers={staffUsers}
         contactsByBrand={contactsByBrand}
+        contract={contract}
+        contractTemplates={contractTemplates}
+        contractVars={contractVars}
+        issuedInvoices={issuedInvoices}
+        issuerCompanies={issuerCompanies}
       />
     </div>
   );

--- a/src/features/admin/_shared/components/campaigns/ContractGenerator.tsx
+++ b/src/features/admin/_shared/components/campaigns/ContractGenerator.tsx
@@ -4,7 +4,7 @@ import { useActionState, useMemo, useState } from 'react';
 import { saveGeneratedContractAction } from '@/app/admin/(dashboard)/campanas/generate-contract-action';
 import { fillTemplate, AVAILABLE_VARIABLES } from '@/lib/contractVariables';
 import type { ContractTemplate } from '@/lib/queries/contractTemplates';
-import type { CampaignWithRelations } from '@/types';
+import type { CampaignWithRelations } from '@/lib/queries/campaigns';
 
 type Props = {
   readonly campaign:  CampaignWithRelations;

--- a/src/features/admin/_shared/components/campaigns/ContractTab.tsx
+++ b/src/features/admin/_shared/components/campaigns/ContractTab.tsx
@@ -10,7 +10,7 @@ import {
 import type { ContractWithSigners, SignerRole } from '@/types';
 import type { ContractTemplate } from '@/lib/queries/contractTemplates';
 import { ContractGenerator } from './ContractGenerator';
-import type { CampaignWithRelations } from '@/types';
+import type { CampaignWithRelations } from '@/lib/queries/campaigns';
 
 type Props = {
   readonly campaignId: number;

--- a/src/features/admin/campaigns/components/CampaignDetailTabs.tsx
+++ b/src/features/admin/campaigns/components/CampaignDetailTabs.tsx
@@ -10,6 +10,8 @@ import { CampaignFiles } from '@/features/admin/campaigns/components/CampaignFil
 import { CampaignDrawer } from '@/features/admin/campaigns/components/CampaignDrawer';
 import { CampaignCnmcChecklist } from '@/features/admin/campaigns/components/CampaignCnmcChecklist';
 import { CampaignDeliverables } from '@/features/admin/campaigns/components/CampaignDeliverables';
+import { ContractTab } from '@/features/admin/_shared/components/campaigns/ContractTab';
+import { DealInvoicePanel } from '@/features/admin/_shared/components/campaigns/DealInvoicePanel';
 import { CAMPAIGN_STATUS_LABELS } from '@/lib/schemas/campaign';
 import { archiveCampaignAction } from '@/app/admin/(dashboard)/campanas/actions';
 
@@ -17,16 +19,25 @@ import type { Tone } from '@/features/admin/_shared/components/StateBadge';
 import type { CampaignWithRelations } from '@/lib/queries/campaigns';
 import type { DeliverableWithComments } from '@/lib/queries/deliverables';
 import type { CampaignStatus } from '@/lib/schemas/campaign';
-import type { FileRecord, Invoice, CrmBrandContact } from '@/types';
+import type { ContractTemplate } from '@/lib/queries/contractTemplates';
+import type {
+  ContractWithSigners,
+  FileRecord,
+  Invoice,
+  CrmBrandContact,
+  IssuedInvoiceWithRelations,
+  IssuerCompany,
+} from '@/types';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
-type Tab = 'resumen' | 'pagos' | 'archivos' | 'notas' | 'deliverables';
+type Tab = 'resumen' | 'pagos' | 'archivos' | 'notas' | 'deliverables' | 'contratos';
 
 const TABS: { id: Tab; label: string }[] = [
   { id: 'resumen', label: 'Resumen' },
   { id: 'pagos', label: 'Pagos' },
   { id: 'deliverables', label: 'Deliverables' },
+  { id: 'contratos', label: 'Contratos' },
   { id: 'archivos', label: 'Archivos' },
   { id: 'notas', label: 'Notas' },
 ];
@@ -52,10 +63,16 @@ type Props = {
   readonly campaignInvoices: readonly Invoice[];
   readonly campaignDeliverables: readonly DeliverableWithComments[];
   readonly isManager: boolean;
+  readonly isAdmin: boolean;
   readonly brands: readonly BrandOption[];
   readonly talents: readonly TalentOption[];
   readonly staffUsers: readonly StaffOption[];
   readonly contactsByBrand: Readonly<Record<number, readonly CrmBrandContact[]>>;
+  readonly contract: ContractWithSigners | null;
+  readonly contractTemplates: readonly ContractTemplate[];
+  readonly contractVars: Readonly<Record<string, string>>;
+  readonly issuedInvoices: readonly IssuedInvoiceWithRelations[];
+  readonly issuerCompanies: readonly IssuerCompany[];
 };
 
 // ── Main component ─────────────────────────────────────────────────────────────
@@ -73,10 +90,16 @@ export function CampaignDetailTabs({
   campaignInvoices,
   campaignDeliverables,
   isManager,
+  isAdmin,
   brands,
   talents,
   staffUsers,
   contactsByBrand,
+  contract,
+  contractTemplates,
+  contractVars,
+  issuedInvoices,
+  issuerCompanies,
 }: Props): React.ReactElement {
   const router = useRouter();
   const [, startTransition] = useTransition();
@@ -194,6 +217,26 @@ export function CampaignDetailTabs({
             deliverables={campaignDeliverables}
             isManager={isManager}
           />
+        )}
+
+        {activeTab === 'contratos' && (
+          <div className="space-y-6">
+            <ContractTab
+              campaignId={campaign.id}
+              contract={contract}
+              isAdmin={isAdmin}
+              templates={contractTemplates}
+              campaign={campaign}
+              contractVars={contractVars}
+            />
+            {isAdmin && (
+              <DealInvoicePanel
+                campaignId={campaign.id}
+                existingInvoices={issuedInvoices}
+                issuers={issuerCompanies}
+              />
+            )}
+          </div>
         )}
       </div>
 

--- a/src/lib/contractVariables.ts
+++ b/src/lib/contractVariables.ts
@@ -1,4 +1,4 @@
-import type { CampaignWithRelations } from '@/types';
+import type { CampaignWithRelations } from '@/lib/queries/campaigns';
 
 /** Extrae las variables del trato para rellenar la plantilla */
 export function buildContractVars(c: CampaignWithRelations): Record<string, string> {
@@ -27,12 +27,12 @@ export function buildContractVars(c: CampaignWithRelations): Record<string, stri
     currency:          'EUR',
 
     // Marca
-    brand_name:        c.brandName    ?? '—',
-    brand_country:     '—',
+    brand_name:        c.brand.name,
+    brand_country:     c.brand.geo ?? '—',
 
     // Influencer
-    influencer_name:   c.talentName   ?? '—',
-    influencer_alias:  c.talentName   ?? '—',
+    influencer_name:   c.talent.name,
+    influencer_alias:  c.talent.name,
 
     // Agencia
     agency_name:       'SocialPro Agency',


### PR DESCRIPTION
Closes #12

## Summary
Wires the orphan `ContractTab`, `ContractGenerator`, and `DealInvoicePanel` components into the campaign detail page via a new "Contratos" tab inside the existing `CampaignDetailTabs`.

## Changes
- `src/app/admin/(dashboard)/campanas/[id]/page.tsx`: parallel-fetch contract, contract templates, issued invoices, issuer companies; build contract vars; thread `isAdmin` plus the new data into `CampaignDetailTabs`.
- `src/features/admin/campaigns/components/CampaignDetailTabs.tsx`: add `Contratos` tab, render `ContractTab` and (admin-only) `DealInvoicePanel`, extend Props with the contract/invoice/issuer data and `isAdmin`.
- `src/features/admin/_shared/components/campaigns/ContractTab.tsx` / `ContractGenerator.tsx`: switch `CampaignWithRelations` import from `@/types` (flat `brandName`/`talentName`) to `@/lib/queries/campaigns` (nested `brand.name`/`talent.name`) — matches what `getCampaignWithRelations` actually returns.
- `src/lib/contractVariables.ts`: same shape switch for `buildContractVars`; `brand_name`/`influencer_name` now read from nested objects, and `brand_country` uses the real `brand.geo` instead of the literal placeholder.

## Schema notes
- Master's `getCampaignWithRelations` returns nested `brand`/`talent` (no flat `brandName`/`talentName`); the orphan PR assumed the flat `@/types` shape. The fix is import-side only — orphans themselves only access `campaign.id` and `campaign.name`.
- `DealInvoicePanel` is gated by `isAdmin` because `createInvoiceFromDealAction` calls `requireRole('admin')` server-side. Showing the button to manager/staff would result in 401 redirects.
- No DB schema changes; no `package.json` changes; no `resend` singleton introduced (uses master's inline `new Resend(...)` already in `contract-actions.ts`).

## Validation
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint <changed files>` — exit 0 (2 pre-existing warnings on orphan components, no errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)