### PR TITLE
feat(admin): dashboard alerts system with staff filtering

### DIFF
--- a/src/app/admin/(dashboard)/page.tsx
+++ b/src/app/admin/(dashboard)/page.tsx
@@ -7,6 +7,7 @@ import {
   getDealStats,
 } from '@/lib/queries/dashboard';
 import { getDashboardAlerts } from '@/lib/queries/alerts';
+import { requireAnyRole } from '@/lib/auth-guard';
 import { DashboardAlerts } from '@/features/admin/_shared/components/dashboard/DashboardAlerts';
 import { getIsoWeekLabel, getWeekStart } from '@/lib/utils/week';
 import {
@@ -45,6 +46,8 @@ function getGreeting(): string {
 }
 
 export default async function AdminDashboardPage(): Promise<ReactElement> {
+  const session  = await requireAnyRole(['admin', 'manager', 'staff'], '/admin/login');
+  const isStaff  = session.user.role === 'staff';
   const weekLabel = getIsoWeekLabel(new Date());
   const weekStart = getWeekStart(weekLabel);
   const weekStr = weekStart.toLocaleDateString('es-ES', { day: 'numeric', month: 'long' });
@@ -56,7 +59,7 @@ export default async function AdminDashboardPage(): Promise<ReactElement> {
     getDashboardUpcomingFollowups(8),
     getMonthlyRevenue(),
     getDealStats(),
-    getDashboardAlerts(),
+    getDashboardAlerts(isStaff ? { staffUserId: session.user.id, skipFinancial: true } : undefined),
   ]);
 
   return (

--- a/src/features/admin/_shared/components/dashboard/AlertResolveButton.tsx
+++ b/src/features/admin/_shared/components/dashboard/AlertResolveButton.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { completeTaskAction } from '@/app/admin/(dashboard)/tareas/actions';
+import type { AlertResolveHint } from '@/lib/queries/alerts';
+
+type Props = {
+  readonly hint:     AlertResolveHint;
+  readonly compact?: boolean;
+};
+
+/**
+ * Botón "Resolver" para alertas de tareas.
+ * Llama completeTaskAction y refresca la página al completarse.
+ *
+ * @kind client
+ * @feature admin/dashboard
+ */
+export function AlertResolveButton({ hint, compact = false }: Props): React.ReactElement {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  function handleResolve(): void {
+    if (hint.type !== 'complete_task') return;
+    startTransition(async () => {
+      const result = await completeTaskAction(hint.taskId);
+      if (!result?.error) {
+        router.refresh();
+      }
+    });
+  }
+
+  if (hint.type !== 'complete_task') return <></>;
+
+  if (compact) {
+    return (
+      <button
+        type="button"
+        onClick={handleResolve}
+        disabled={isPending}
+        className="shrink-0 text-[9px] font-bold text-emerald-600 hover:text-emerald-700 hover:underline disabled:opacity-50 whitespace-nowrap"
+        aria-label="Marcar tarea como completada"
+      >
+        {isPending ? '...' : '✓ Hecha'}
+      </button>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleResolve}
+      disabled={isPending}
+      className="inline-flex items-center gap-1 h-6 px-2.5 rounded-full border border-emerald-200 bg-emerald-50 text-[9px] font-bold text-emerald-700 hover:bg-emerald-100 disabled:opacity-50 transition-colors shrink-0"
+      aria-label="Marcar tarea como completada"
+    >
+      {isPending ? (
+        <span className="inline-block w-2.5 h-2.5 border border-emerald-500 border-t-transparent rounded-full animate-spin" aria-hidden />
+      ) : (
+        <svg width="8" height="8" viewBox="0 0 8 8" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" aria-hidden>
+          <path d="M1.5 4l1.5 1.5 3-3"/>
+        </svg>
+      )}
+      {isPending ? 'Resolviendo…' : 'Resolver'}
+    </button>
+  );
+}

--- a/src/features/admin/_shared/components/dashboard/DashboardAlerts.tsx
+++ b/src/features/admin/_shared/components/dashboard/DashboardAlerts.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import type { DashboardAlert, AlertSeverity, AlertSummary } from '@/lib/queries/alerts';
+import { AlertResolveButton } from './AlertResolveButton';
 
 type Props = {
   readonly alerts:  readonly DashboardAlert[];
@@ -8,28 +9,37 @@ type Props = {
 
 // ── Configuración visual ──────────────────────────────────────────────
 
-const SEVERITY_CFG: Record<AlertSeverity, { bar: string; badge: string; label: string }> = {
-  critical: { bar: 'bg-red-500',    badge: 'bg-red-50 text-red-700 border-red-200',     label: 'Crítica' },
-  high:     { bar: 'bg-orange-500', badge: 'bg-orange-50 text-orange-700 border-orange-200', label: 'Alta' },
-  medium:   { bar: 'bg-amber-400',  badge: 'bg-amber-50 text-amber-700 border-amber-200',   label: 'Media' },
-  low:      { bar: 'bg-blue-400',   badge: 'bg-blue-50 text-blue-700 border-blue-200',       label: 'Baja' },
+const SEVERITY_CFG: Record<AlertSeverity, { bar: string; badge: string; label: string; dot: string }> = {
+  critical: { bar: 'bg-red-500',    badge: 'bg-red-50 text-red-700 border-red-200',         dot: 'bg-red-500',    label: 'Crítica' },
+  high:     { bar: 'bg-orange-500', badge: 'bg-orange-50 text-orange-700 border-orange-200', dot: 'bg-orange-500', label: 'Alta'    },
+  medium:   { bar: 'bg-amber-400',  badge: 'bg-amber-50 text-amber-700 border-amber-200',    dot: 'bg-amber-400',  label: 'Media'   },
+  low:      { bar: 'bg-blue-400',   badge: 'bg-blue-50 text-blue-700 border-blue-200',       dot: 'bg-blue-400',   label: 'Baja'    },
 };
 
 const TYPE_ICON: Record<string, string> = {
-  overdue_task:     '✓',
-  overdue_followup: '📅',
-  unpaid_brand:     '€',
-  pending_talent:   '💸',
-  expiring_deal:    '⏳',
-  expired_active:   '⚠',
+  overdue_task:                 '✓',
+  overdue_followup:             '📅',
+  unpaid_brand:                 '💰',
+  pending_talent:               '💸',
+  expiring_deal:                '⏳',
+  expired_active:               '⚠️',
+  task_due_today_high:          '🔥',
+  task_rolled_over:             '↻',
+  invoice_overdue:                '📄',
+  deal_brand_paid_talent_pending: '⚡',
+  issued_invoice_overdue:         '🧾',
+  issued_invoice_due_soon:        '⏰',
 };
+
+const EUR = new Intl.NumberFormat('es-ES', { style: 'currency', currency: 'EUR', maximumFractionDigits: 0 });
 
 // ── Subcomponentes ────────────────────────────────────────────────────
 
 function SeverityBadge({ severity }: { severity: AlertSeverity }): React.ReactElement {
   const cfg = SEVERITY_CFG[severity];
   return (
-    <span className={`inline-flex items-center px-1.5 py-0.5 rounded-full text-[8px] font-bold border ${cfg.badge}`}>
+    <span className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[8px] font-bold border ${cfg.badge}`}>
+      <span className={`w-1 h-1 rounded-full ${cfg.dot}`} />
       {cfg.label}
     </span>
   );
@@ -40,25 +50,39 @@ function AlertItem({ alert }: { readonly alert: DashboardAlert }): React.ReactEl
   const icon = TYPE_ICON[alert.type] ?? '•';
 
   return (
-    <div className="flex items-start gap-3 px-4 py-3 hover:bg-sp-admin-hover/40 transition-colors group/alert border-b border-sp-admin-border/40 last:border-0">
+    <div className="flex items-start gap-3 px-4 py-3 hover:bg-sp-admin-hover/40 transition-colors border-b border-sp-admin-border/40 last:border-0">
       {/* Barra lateral de severidad */}
       <div className={`w-0.5 self-stretch rounded-full shrink-0 ${cfg.bar}`} />
 
       {/* Icono */}
-      <span className="text-[13px] leading-none mt-0.5 shrink-0 select-none">{icon}</span>
+      <span className="text-[14px] leading-none mt-0.5 shrink-0 select-none" aria-hidden>{icon}</span>
 
       {/* Contenido */}
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2 flex-wrap">
-          <p className="text-[12px] font-semibold text-sp-admin-text leading-snug truncate">{alert.title}</p>
+          <p className="text-[12px] font-semibold text-sp-admin-text leading-snug truncate max-w-[280px]">
+            {alert.title}
+          </p>
           <SeverityBadge severity={alert.severity} />
         </div>
         <div className="flex items-center gap-2 mt-0.5 flex-wrap">
-          <span className="text-[10px] text-sp-admin-muted truncate">{alert.description}</span>
+          <span className="text-[10px] text-sp-admin-muted">{alert.description}</span>
+          {alert.amount !== undefined && alert.amount > 0 && (
+            <>
+              <span className="text-sp-admin-muted/40 text-[10px]">·</span>
+              <span className="text-[10px] font-bold tabular-nums text-sp-admin-text">
+                {EUR.format(alert.amount)}
+              </span>
+            </>
+          )}
           {alert.daysInfo && (
             <>
               <span className="text-sp-admin-muted/40 text-[10px]">·</span>
-              <span className={`text-[10px] font-semibold ${alert.severity === 'critical' || alert.severity === 'high' ? 'text-red-500' : 'text-amber-600'}`}>
+              <span className={`text-[10px] font-semibold ${
+                alert.severity === 'critical' || alert.severity === 'high'
+                  ? 'text-red-500'
+                  : 'text-amber-600'
+              }`}>
                 {alert.daysInfo}
               </span>
             </>
@@ -66,11 +90,18 @@ function AlertItem({ alert }: { readonly alert: DashboardAlert }): React.ReactEl
         </div>
       </div>
 
-      {/* Acción */}
-      <Link href={alert.href}
-        className="shrink-0 opacity-0 group-hover/alert:opacity-100 transition-opacity text-[10px] font-bold text-sp-admin-accent hover:underline">
-        Ver →
-      </Link>
+      {/* Acciones */}
+      <div className="flex items-center gap-2 shrink-0">
+        {alert.resolveHint && (
+          <AlertResolveButton hint={alert.resolveHint} />
+        )}
+        <Link
+          href={alert.href}
+          className="text-[10px] font-bold text-sp-admin-accent hover:underline whitespace-nowrap"
+        >
+          Ver →
+        </Link>
+      </div>
     </div>
   );
 }
@@ -79,22 +110,35 @@ function AlertItem({ alert }: { readonly alert: DashboardAlert }): React.ReactEl
 
 function AttentionSummary({ summary }: { readonly summary: AlertSummary }): React.ReactElement {
   const items: { count: number; label: string; href: string; accent: string }[] = [
-    { count: summary.overdueTasksCount,     label: 'tareas vencidas',        href: '/admin/tareas',    accent: '#dc2626' },
-    { count: summary.overdueFollowupsCount, label: 'follow-ups vencidos',    href: '/admin/brands',    accent: '#ea580c' },
-    { count: summary.unpaidBrandCount,      label: 'cobros pendientes',      href: '/admin/campanas',  accent: '#d97706' },
-    { count: summary.pendingTalentCount,    label: 'pagos a talentos',       href: '/admin/campanas',  accent: '#f59e0b' },
-    { count: summary.expiringDealsCount,    label: 'tratos vencen pronto',   href: '/admin/campanas',  accent: '#2563eb' },
+    { count: summary.overdueTasksCount,     label: 'tareas vencidas',       href: '/admin/tareas',   accent: '#dc2626' },
+    { count: summary.overdueFollowupsCount, label: 'follow-ups vencidos',   href: '/admin/brands',   accent: '#ea580c' },
+    { count: summary.unpaidBrandCount,      label: 'cobros pendientes',     href: '/admin/campanas', accent: '#d97706' },
+    { count: summary.pendingTalentCount,    label: 'pagos a talentos',      href: '/admin/campanas', accent: '#f59e0b' },
+    { count: summary.expiringDealsCount,    label: 'tratos vencen pronto',  href: '/admin/campanas', accent: '#2563eb' },
   ].filter((i) => i.count > 0);
 
   if (items.length === 0) return <></>;
 
+  const totalUrgent = items.reduce((s, i) => s + i.count, 0);
+
   return (
-    <div className="rounded-xl bg-sp-admin-card border border-sp-admin-border shadow-[0_1px_3px_rgba(0,0,0,0.06)] px-4 py-3">
-      <p className="text-[9px] font-black uppercase tracking-[0.18em] text-sp-admin-muted mb-2">Hoy requiere atención</p>
+    <div className="rounded-xl bg-sp-admin-card border border-amber-200 shadow-[0_1px_3px_rgba(0,0,0,0.06)] px-4 py-3">
+      <div className="flex items-center gap-2 mb-2.5">
+        <span className="text-amber-500 text-[14px]" aria-hidden>⚡</span>
+        <p className="text-[10px] font-black uppercase tracking-[0.18em] text-sp-admin-muted">
+          Hoy requiere atención
+        </p>
+        <span className="ml-auto text-[9px] font-bold text-amber-700 bg-amber-50 border border-amber-200 px-1.5 py-0.5 rounded-full">
+          {totalUrgent} {totalUrgent === 1 ? 'item' : 'items'}
+        </span>
+      </div>
       <div className="flex flex-wrap gap-2">
         {items.map((item) => (
-          <Link key={item.label} href={item.href}
-            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-sp-admin-border bg-sp-admin-hover/30 hover:bg-sp-admin-hover text-[11px] font-semibold text-sp-admin-text transition-colors">
+          <Link
+            key={item.label}
+            href={item.href}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-sp-admin-border bg-sp-admin-hover/30 hover:bg-sp-admin-hover text-[11px] font-semibold text-sp-admin-text transition-colors"
+          >
             <span className="font-black tabular-nums" style={{ color: item.accent }}>{item.count}</span>
             <span className="text-sp-admin-muted">{item.label}</span>
           </Link>
@@ -108,18 +152,23 @@ function AttentionSummary({ summary }: { readonly summary: AlertSummary }): Reac
 
 function EmptyState(): React.ReactElement {
   return (
-    <div className="rounded-xl bg-sp-admin-card border border-sp-admin-border shadow-[0_1px_3px_rgba(0,0,0,0.06)] px-5 py-6 text-center">
-      <p className="text-2xl mb-2">✓</p>
+    <div className="rounded-xl bg-sp-admin-card border border-emerald-200 shadow-[0_1px_3px_rgba(0,0,0,0.06)] px-5 py-5 text-center">
+      <div className="w-8 h-8 rounded-full bg-emerald-100 flex items-center justify-center mx-auto mb-2">
+        <span className="text-emerald-600 text-[16px]" aria-hidden>✓</span>
+      </div>
       <p className="text-[13px] font-bold text-sp-admin-text">Todo bajo control</p>
-      <p className="text-[11px] text-sp-admin-muted mt-1 mb-4">No hay alertas críticas pendientes</p>
-      <div className="flex items-center justify-center gap-3 flex-wrap">
+      <p className="text-[11px] text-sp-admin-muted mt-0.5 mb-3">No hay alertas críticas pendientes</p>
+      <div className="flex items-center justify-center gap-4 flex-wrap">
         {[
-          { label: 'Revisar leads', href: '/admin/brands' },
+          { label: 'Revisar leads',      href: '/admin/brands'  },
           { label: 'Actualizar talentos', href: '/admin/talents' },
-          { label: 'Crear follow-ups', href: '/admin/brands' },
+          { label: 'Crear follow-ups',   href: '/admin/brands'  },
         ].map((s) => (
-          <Link key={s.label} href={s.href}
-            className="text-[11px] font-semibold text-sp-admin-accent hover:underline">
+          <Link
+            key={s.label}
+            href={s.href}
+            className="text-[11px] font-semibold text-sp-admin-accent hover:underline"
+          >
             {s.label} →
           </Link>
         ))}
@@ -138,27 +187,40 @@ export function DashboardAlerts({ alerts, summary }: Props): React.ReactElement 
 
   return (
     <div className="space-y-2">
-      {/* Resumen de atención */}
+
+      {/* Card "Hoy requiere atención" */}
       <AttentionSummary summary={summary} />
 
       {/* Lista de alertas */}
-      <div className="rounded-xl bg-sp-admin-card shadow-[0_1px_3px_rgba(0,0,0,0.06)] overflow-hidden">
+      <div className="rounded-xl bg-sp-admin-card shadow-[0_1px_3px_rgba(0,0,0,0.06)] overflow-hidden border border-sp-admin-border">
         {/* Cabecera */}
         <div className="flex items-center justify-between px-4 py-2.5 border-b border-sp-admin-border bg-sp-admin-hover/30">
           <div className="flex items-center gap-2">
-            <p className="text-[9px] font-black uppercase tracking-[0.18em] text-sp-admin-muted">Alertas críticas</p>
+            <p className="text-[9px] font-black uppercase tracking-[0.18em] text-sp-admin-muted">
+              Alertas críticas
+            </p>
             {critical > 0 && (
-              <span className="inline-flex items-center px-1.5 py-0.5 rounded-full text-[8px] font-bold bg-red-50 text-red-700 border border-red-200">
+              <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[8px] font-bold bg-red-50 text-red-700 border border-red-200">
+                <span className="w-1 h-1 rounded-full bg-red-500" />
                 {critical} crítica{critical !== 1 ? 's' : ''}
               </span>
             )}
             {high > 0 && (
-              <span className="inline-flex items-center px-1.5 py-0.5 rounded-full text-[8px] font-bold bg-orange-50 text-orange-700 border border-orange-200">
+              <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[8px] font-bold bg-orange-50 text-orange-700 border border-orange-200">
+                <span className="w-1 h-1 rounded-full bg-orange-500" />
                 {high} alta{high !== 1 ? 's' : ''}
               </span>
             )}
           </div>
-          <span className="text-[9px] text-sp-admin-muted/60">{summary.total} en total · mostrando {alerts.length}</span>
+          <div className="flex items-center gap-3">
+            <span className="text-[9px] text-sp-admin-muted/60">
+              {summary.total} en total · mostrando {alerts.length}
+            </span>
+            <Link href="/admin/analytics#analitica-alertas"
+              className="text-[9px] font-bold text-sp-admin-accent hover:underline">
+              Ver todas →
+            </Link>
+          </div>
         </div>
 
         {/* Items */}
@@ -168,6 +230,7 @@ export function DashboardAlerts({ alerts, summary }: Props): React.ReactElement 
           ))}
         </div>
       </div>
+
     </div>
   );
 }

--- a/src/lib/queries/alerts.ts
+++ b/src/lib/queries/alerts.ts
@@ -1,6 +1,6 @@
-import { and, asc, eq, isNull, isNotNull, lt, not, sql } from 'drizzle-orm';
+import { and, asc, eq, inArray, isNull, isNotNull, lt, not, or, sql } from 'drizzle-orm';
 import { db } from '@/lib/db';
-import { crmTasks, crmBrandFollowups, crmBrands, campaigns, talents } from '@/db/schema';
+import { crmTasks, crmBrandFollowups, crmBrands, campaigns, talents, invoices, issuedInvoices, billingClients } from '@/db/schema';
 
 export type AlertSeverity = 'critical' | 'high' | 'medium' | 'low';
 export type AlertType =
@@ -9,17 +9,30 @@ export type AlertType =
   | 'unpaid_brand'
   | 'pending_talent'
   | 'expiring_deal'
-  | 'expired_active';
+  | 'expired_active'
+  | 'task_due_today_high'
+  | 'task_rolled_over'
+  | 'invoice_overdue'
+  | 'deal_brand_paid_talent_pending'
+  | 'issued_invoice_overdue'
+  | 'issued_invoice_due_soon';
+
+export type AlertResolveHint = {
+  readonly type:   'complete_task';
+  readonly taskId: number;
+};
 
 export type DashboardAlert = {
-  readonly id:          string;
-  readonly type:        AlertType;
-  readonly severity:    AlertSeverity;
-  readonly title:       string;
-  readonly description: string;
-  readonly href:        string;
-  readonly amount?:     number | undefined;
-  readonly daysInfo?:   string | undefined;
+  readonly id:           string;
+  readonly type:         AlertType;
+  readonly severity:     AlertSeverity;
+  readonly title:        string;
+  readonly description:  string;
+  readonly href:         string;
+  readonly amount?:      number | undefined;
+  readonly daysInfo?:    string | undefined;
+  /** Datos para resolver la alerta en un clic (solo tareas). */
+  readonly resolveHint?: AlertResolveHint | undefined;
 };
 
 export type AlertSummary = {
@@ -59,13 +72,41 @@ const SEVERITY_ORDER: Record<AlertSeverity, number> = { critical: 0, high: 1, me
 
 // ── Main query ────────────────────────────────────────────────────────
 
-export async function getDashboardAlerts(): Promise<{
+export async function getDashboardAlerts(opts?: {
+  /** Si se pasa, filtra alertas de tareas y followups para este usuario (staff) */
+  readonly staffUserId?: string;
+  /** Si true, omite alertas financieras globales (para staff sin acceso financiero) */
+  readonly skipFinancial?: boolean;
+}): Promise<{
   alerts:  readonly DashboardAlert[];
   summary: AlertSummary;
 }> {
+  const staffUserId    = opts?.staffUserId;
+  const skipFinancial  = opts?.skipFinancial ?? false;
   const today    = todayMadrid();
   const in7days  = new Date(Date.now() + 7  * 86_400_000).toISOString().slice(0, 10);
   const in3days  = new Date(Date.now() + 3  * 86_400_000).toISOString().slice(0, 10);
+
+  const twoWeeksAgoLabel = (() => {
+    const d = new Date();
+    d.setDate(d.getDate() - 14);
+    return new Intl.DateTimeFormat('en-CA', {
+      timeZone: 'Europe/Madrid', year: 'numeric', month: '2-digit', day: '2-digit',
+    }).format(d).replace(/-/g, '') as string;
+  })();
+  const prevWeekLabel = (() => {
+    const d = new Date();
+    d.setDate(d.getDate() - 7);
+    const civil = new Intl.DateTimeFormat('en-CA', {
+      timeZone: 'Europe/Madrid', year: 'numeric', month: '2-digit', day: '2-digit',
+    }).format(d);
+    const [y, m, dd] = civil.split('-').map(Number);
+    const dayOfWeek = (new Date(y!, m! - 1, dd!).getDay() + 6) % 7;
+    const jan4 = new Date(y!, 0, 4);
+    const jan4DayOfWeek = (jan4.getDay() + 6) % 7;
+    const weekNum = Math.floor((new Date(y!, m! - 1, dd!).getTime() - jan4.getTime() + jan4DayOfWeek * 86_400_000) / (7 * 86_400_000)) + 1;
+    return `${y}-W${String(weekNum).padStart(2, '0')}`;
+  })();
 
   const [
     overdueTasks,
@@ -74,8 +115,14 @@ export async function getDashboardAlerts(): Promise<{
     pendingTalent,
     expiringDeals,
     expiredActive,
+    tasksDueToday,
+    rolledOverOld,
+    overdueInvoices,
+    brandPaidTalentPending,
+    overdueIssuedInvoices,
+    dueSoonIssuedInvoices,
   ] = await Promise.all([
-    // 1. Tareas vencidas (max 3)
+    // 1. Tareas vencidas (max 3) — filtradas por staffUserId si aplica
     db.select({
       id: crmTasks.id, title: crmTasks.title,
       priority: crmTasks.priority, category: crmTasks.category, dueDate: crmTasks.dueDate,
@@ -84,11 +131,14 @@ export async function getDashboardAlerts(): Promise<{
         not(eq(crmTasks.status, 'completada')),
         isNotNull(crmTasks.dueDate),
         sql`${crmTasks.dueDate}::date < ${today}::date`,
+        staffUserId
+          ? or(eq(crmTasks.assignedToUserId, staffUserId), eq(crmTasks.ownerId, staffUserId))
+          : undefined,
       ))
       .orderBy(asc(crmTasks.dueDate))
       .limit(3),
 
-    // 2. Follow-ups vencidos (max 3)
+    // 2. Follow-ups vencidos (max 3) — staff ve solo los suyos
     db.select({
       id: crmBrandFollowups.id, note: crmBrandFollowups.note,
       scheduledAt: crmBrandFollowups.scheduledAt,
@@ -98,6 +148,12 @@ export async function getDashboardAlerts(): Promise<{
       .where(and(
         isNull(crmBrandFollowups.completedAt),
         lt(crmBrandFollowups.scheduledAt, new Date()),
+        staffUserId
+          ? or(
+              eq(crmBrandFollowups.assignedToUserId, staffUserId),
+              eq(crmBrandFollowups.responsibleUserId, staffUserId),
+            )
+          : undefined,
       ))
       .orderBy(asc(crmBrandFollowups.scheduledAt))
       .limit(3),
@@ -134,7 +190,7 @@ export async function getDashboardAlerts(): Promise<{
       ))
       .limit(3),
 
-    // 5. Tratos que vencen en ≤7 días (max 3)
+    // 5. Tratos que vencen en ≤7 días (max 3) — staff ve solo los suyos
     db.select({
       id: campaigns.id, name: campaigns.name, endDate: campaigns.endDate,
       brandName: crmBrands.name, talentName: talents.name,
@@ -146,11 +202,14 @@ export async function getDashboardAlerts(): Promise<{
         isNotNull(campaigns.endDate),
         sql`${campaigns.endDate}::date >= ${today}::date`,
         sql`${campaigns.endDate}::date <= ${in7days}::date`,
+        staffUserId
+          ? or(eq(campaigns.assignedToUserId, staffUserId), eq(campaigns.createdByUserId, staffUserId))
+          : undefined,
       ))
       .orderBy(asc(campaigns.endDate))
       .limit(3),
 
-    // 6. Tratos activos con fecha ya vencida (max 3)
+    // 6. Tratos activos con fecha ya vencida (max 3) — staff ve solo los suyos
     db.select({
       id: campaigns.id, name: campaigns.name, endDate: campaigns.endDate,
       brandName: crmBrands.name, talentName: talents.name,
@@ -161,25 +220,155 @@ export async function getDashboardAlerts(): Promise<{
         eq(campaigns.status, 'activa'),
         isNotNull(campaigns.endDate),
         sql`${campaigns.endDate}::date < ${today}::date`,
+        staffUserId
+          ? or(eq(campaigns.assignedToUserId, staffUserId), eq(campaigns.createdByUserId, staffUserId))
+          : undefined,
       ))
       .orderBy(asc(campaigns.endDate))
       .limit(3),
+
+    // 7. Tareas de alta prioridad que vencen hoy (max 3)
+    // 7. Tareas de alta prioridad que vencen hoy — staff ve solo las suyas
+    db.select({
+      id: crmTasks.id, title: crmTasks.title, category: crmTasks.category,
+    }).from(crmTasks)
+      .where(and(
+        not(eq(crmTasks.status, 'completada')),
+        eq(crmTasks.priority, 'alta'),
+        isNotNull(crmTasks.dueDate),
+        sql`${crmTasks.dueDate}::date = ${today}::date`,
+        staffUserId
+          ? or(eq(crmTasks.assignedToUserId, staffUserId), eq(crmTasks.ownerId, staffUserId))
+          : undefined,
+      ))
+      .limit(3),
+
+    // 8. Tareas arrastradas desde hace más de 1 semana — staff ve solo las suyas
+    db.select({
+      id: crmTasks.id, title: crmTasks.title,
+      category: crmTasks.category, rolledFromWeek: crmTasks.rolledFromWeek,
+    }).from(crmTasks)
+      .where(and(
+        not(eq(crmTasks.status, 'completada')),
+        eq(crmTasks.rolledOver, true),
+        isNotNull(crmTasks.rolledFromWeek),
+        sql`${crmTasks.rolledFromWeek} < ${prevWeekLabel}`,
+        staffUserId
+          ? or(eq(crmTasks.assignedToUserId, staffUserId), eq(crmTasks.ownerId, staffUserId))
+          : undefined,
+      ))
+      .orderBy(asc(crmTasks.rolledFromWeek))
+      .limit(3),
+
+    // 9. Facturas vencidas — pendiente/emitida con dueDate pasado (max 4)
+    db.select({
+      id:        invoices.id,
+      concept:   invoices.concept,
+      kind:      invoices.kind,
+      dueDate:   invoices.dueDate,
+      totalAmount: invoices.totalAmount,
+      campaignId: invoices.campaignId,
+    }).from(invoices)
+      .where(and(
+        inArray(invoices.status, ['pendiente', 'emitida', 'no_cobrada', 'no_cobrado', 'no_pagada', 'no_pagado']),
+        isNotNull(invoices.dueDate),
+        sql`${invoices.dueDate}::date < ${today}::date`,
+        not(eq(invoices.status, 'anulada')),
+      ))
+      .orderBy(asc(invoices.dueDate))
+      .limit(4),
+
+    // 10. Tratos donde marca pagó (income cobrada) pero talento sigue sin pagar (max 3)
+    db.select({
+      id:          campaigns.id,
+      name:        campaigns.name,
+      talentName:  talents.name,
+      brandName:   crmBrands.name,
+      amountTalent: campaigns.amountTalent,
+    }).from(campaigns)
+      .leftJoin(crmBrands, eq(crmBrands.id, campaigns.brandId))
+      .leftJoin(talents,   eq(talents.id,   campaigns.talentId))
+      .where(and(
+        not(eq(campaigns.status, 'cancelada')),
+        not(eq(campaigns.status, 'pagada')),
+        isNull(campaigns.archivedAt),
+        sql`${campaigns.amountTalent} > 0`,
+        // Has at least one cobrada income invoice
+        sql`EXISTS (
+          SELECT 1 FROM invoices i
+          WHERE i.campaign_id = ${campaigns.id}
+            AND i.kind = 'income'
+            AND i.status = 'cobrada'
+        )`,
+        // But NO pagada expense invoice
+        sql`NOT EXISTS (
+          SELECT 1 FROM invoices i
+          WHERE i.campaign_id = ${campaigns.id}
+            AND i.kind = 'expense'
+            AND i.status IN ('pagada', 'cobrada')
+        )`,
+      ))
+      .limit(3),
+
+    // 11. Facturas emitidas vencidas (dueDate pasado, status emitida/enviada)
+    skipFinancial ? Promise.resolve([]) :
+    db.select({
+      id:            issuedInvoices.id,
+      invoiceNumber: issuedInvoices.invoiceNumber,
+      totalAmount:   issuedInvoices.totalAmount,
+      currency:      issuedInvoices.currency,
+      dueDate:       issuedInvoices.dueDate,
+      relatedDealId: issuedInvoices.relatedDealId,
+      clientName:    billingClients.name,
+    })
+    .from(issuedInvoices)
+    .leftJoin(billingClients, eq(billingClients.id, issuedInvoices.billingClientId))
+    .where(and(
+      inArray(issuedInvoices.status, ['emitida', 'enviada']),
+      isNotNull(issuedInvoices.dueDate),
+      sql`${issuedInvoices.dueDate}::date < ${today}::date`,
+    ))
+    .orderBy(asc(issuedInvoices.dueDate))
+    .limit(3),
+
+    // 12. Facturas emitidas que vencen en ≤7 días (dueDate próximo)
+    skipFinancial ? Promise.resolve([]) :
+    db.select({
+      id:            issuedInvoices.id,
+      invoiceNumber: issuedInvoices.invoiceNumber,
+      totalAmount:   issuedInvoices.totalAmount,
+      currency:      issuedInvoices.currency,
+      dueDate:       issuedInvoices.dueDate,
+      relatedDealId: issuedInvoices.relatedDealId,
+      clientName:    billingClients.name,
+    })
+    .from(issuedInvoices)
+    .leftJoin(billingClients, eq(billingClients.id, issuedInvoices.billingClientId))
+    .where(and(
+      inArray(issuedInvoices.status, ['emitida', 'enviada']),
+      isNotNull(issuedInvoices.dueDate),
+      sql`${issuedInvoices.dueDate}::date >= ${today}::date`,
+      sql`${issuedInvoices.dueDate}::date <= ${in7days}::date`,
+    ))
+    .orderBy(asc(issuedInvoices.dueDate))
+    .limit(3),
   ]);
 
   const items: DashboardAlert[] = [];
 
-  // 1 → alertas de tareas
+  // 1 → alertas de tareas vencidas
   for (const t of overdueTasks) {
     if (!t.dueDate) continue;
     const { days, label } = daysOverdueStr(t.dueDate);
     items.push({
-      id:          `overdue_task_${t.id}`,
-      type:        'overdue_task',
-      severity:    t.priority === 'alta' ? 'critical' : t.priority === 'media' ? 'high' : 'medium',
-      title:       `Tarea vencida — ${t.title}`,
-      description: `${t.category}`,
-      href:        '/admin/tareas',
-      daysInfo:    label,
+      id:           `overdue_task_${t.id}`,
+      type:         'overdue_task',
+      severity:     t.priority === 'alta' ? 'critical' : t.priority === 'media' ? 'high' : 'medium',
+      title:        `Tarea vencida — ${t.title}`,
+      description:  `${t.category}`,
+      href:         '/admin/tareas',
+      daysInfo:     label,
+      resolveHint:  { type: 'complete_task', taskId: t.id },
     });
   }
 
@@ -197,8 +386,8 @@ export async function getDashboardAlerts(): Promise<{
     });
   }
 
-  // 3 → cobros pendientes
-  for (const c of unpaidBrand) {
+  // 3 → cobros pendientes (solo admin/manager)
+  for (const c of (!skipFinancial ? unpaidBrand : [])) {
     const amount = Number(c.amountBrand ?? 0);
     const parts  = [c.brandName, c.talentName].filter(Boolean).join(' × ');
     items.push({
@@ -213,8 +402,8 @@ export async function getDashboardAlerts(): Promise<{
     });
   }
 
-  // 4 → pagos a talento
-  for (const c of pendingTalent) {
+  // 4 → pagos a talento (solo admin/manager)
+  for (const c of (!skipFinancial ? pendingTalent : [])) {
     const amount = Number(c.amountTalent ?? 0);
     items.push({
       id:          `pending_talent_${c.id}`,
@@ -257,6 +446,99 @@ export async function getDashboardAlerts(): Promise<{
       title:       `Trato sin cerrar — ${parts || c.name}`,
       description: `Fecha de fin superada · ${c.name}`,
       href:        '/admin/campanas',
+      daysInfo:    label,
+    });
+  }
+
+  // 7 → tareas de alta prioridad que vencen hoy
+  for (const t of tasksDueToday) {
+    items.push({
+      id:          `task_due_today_${t.id}`,
+      type:        'task_due_today_high',
+      severity:    'critical',
+      title:       `Vence hoy — ${t.title}`,
+      description: `Prioridad alta · ${t.category}`,
+      href:        '/admin/tareas',
+      daysInfo:    'Hoy',
+      resolveHint: { type: 'complete_task', taskId: t.id },
+    });
+  }
+
+  // 8 → tareas arrastradas más de 1 semana
+  for (const t of rolledOverOld) {
+    items.push({
+      id:          `task_rolled_${t.id}`,
+      type:        'task_rolled_over',
+      severity:    'medium',
+      title:       `Tarea arrastrada — ${t.title}`,
+      description: `${t.category} · desde ${t.rolledFromWeek ?? 'semana anterior'}`,
+      href:        '/admin/tareas',
+      daysInfo:    'Más de 1 semana',
+      resolveHint: { type: 'complete_task', taskId: t.id },
+    });
+  }
+
+  // 9 → facturas vencidas
+  for (const inv of (!skipFinancial ? overdueInvoices : [])) {
+    if (!inv.dueDate) continue;
+    const { days, label } = daysOverdueStr(inv.dueDate);
+    const kindLabel = inv.kind === 'income' ? 'Ingreso' : 'Gasto';
+    items.push({
+      id:          `invoice_overdue_${inv.id}`,
+      type:        'invoice_overdue',
+      severity:    days >= 14 ? 'critical' : days >= 7 ? 'high' : 'medium',
+      title:       `${kindLabel} vencido — ${inv.concept}`,
+      description: `${fmt(Number(inv.totalAmount))} sin ${inv.kind === 'income' ? 'cobrar' : 'pagar'}`,
+      href:        inv.campaignId ? `/admin/campanas/${inv.campaignId}` : '/admin/facturacion',
+      amount:      Number(inv.totalAmount),
+      daysInfo:    label,
+    });
+  }
+
+  // 10 → marca pagó pero talento pendiente
+  for (const c of (!skipFinancial ? brandPaidTalentPending : [])) {
+    const amount = Number(c.amountTalent ?? 0);
+    const parts  = [c.brandName, c.talentName].filter(Boolean).join(' × ');
+    items.push({
+      id:          `brand_paid_talent_pending_${c.id}`,
+      type:        'deal_brand_paid_talent_pending',
+      severity:    'high',
+      title:       `Marca pagó — talento pendiente: ${parts || c.name}`,
+      description: `${fmt(amount)} aún sin pagar al creador`,
+      href:        `/admin/campanas/${c.id}`,
+      amount,
+      daysInfo:    'Sin pagar',
+    });
+  }
+
+  // 11 → facturas emitidas vencidas
+  for (const inv of overdueIssuedInvoices) {
+    if (!inv.dueDate) continue;
+    const { days, label } = daysOverdueStr(inv.dueDate);
+    items.push({
+      id:          `issued_inv_overdue_${inv.id}`,
+      type:        'issued_invoice_overdue',
+      severity:    days >= 14 ? 'critical' : 'high',
+      title:       `Factura vencida — ${inv.invoiceNumber}`,
+      description: inv.clientName ? `Cliente: ${inv.clientName}` : 'Factura emitida sin cobrar',
+      href:        '/admin/facturacion?tab=facturas',
+      amount:      Number(inv.totalAmount),
+      daysInfo:    label,
+    });
+  }
+
+  // 12 → facturas emitidas próximas a vencer
+  for (const inv of dueSoonIssuedInvoices) {
+    if (!inv.dueDate) continue;
+    const { label } = daysOverdueStr(inv.dueDate);
+    items.push({
+      id:          `issued_inv_due_soon_${inv.id}`,
+      type:        'issued_invoice_due_soon',
+      severity:    'medium',
+      title:       `Factura vence pronto — ${inv.invoiceNumber}`,
+      description: inv.clientName ? `Cliente: ${inv.clientName}` : 'Revisar fecha de vencimiento',
+      href:        '/admin/facturacion?tab=facturas',
+      amount:      Number(inv.totalAmount),
       daysInfo:    label,
     });
   }


### PR DESCRIPTION
## ¿Qué hace este PR?

Sistema de alertas críticas en el dashboard del panel admin con soporte para filtrado por rol.

## Cambios

- **`DashboardAlerts`** — Widget de alertas con niveles de severidad: `critical` (rojo), `high` (naranja), `medium` (amarillo), `low` (azul). Botón de resolución inline por alerta.
- **`AlertResolveButton`** — Componente server action para marcar alertas como resueltas.
- **`alerts.ts`** — `getDashboardAlerts()` acepta `{ staffUserId, skipFinancial }` para filtrar visibilidad: staff solo ve sus tareas urgentes, no datos financieros.
- **`page.tsx`** — Añade `requireAnyRole` + detección `isStaff`; pasa filtro al widget de alertas.

## Cómo probarlo

1. `npm run dev` → abrir `/admin`
2. Con rol admin: ver todas las alertas incluyendo financieras
3. Con rol staff: solo alertas de tareas asignadas (sin facturas ni pagos)
4. Resolver una alerta y verificar que desaparece del widget

## Dependencias

- Depende de **PR 1** (layout.tsx carga alertas en el servidor)
- Depende de **PR 2** (schema DB — sin cambios en este PR pero el query asume el schema actual)

## Checklist

- [ ] Ejecutar `npm run lint`
- [ ] Ejecutar `npx tsc --noEmit`
- [ ] Probar con rol admin — ver alertas financieras
- [ ] Probar con rol staff — no ver alertas financieras
- [ ] Resolver alerta y confirmar que se elimina