### PR TITLE
feat(talents): redesigned card, profile tabs and data tools

### DIFF
--- a/src/app/admin/(dashboard)/talents/[id]/page.tsx
+++ b/src/app/admin/(dashboard)/talents/[id]/page.tsx
@@ -1,69 +1,381 @@
-import Link from 'next/link';
 import { notFound } from 'next/navigation';
-
+import Link from 'next/link';
+import Image from 'next/image';
 import { requireAnyRole } from '@/lib/auth-guard';
-import { getTalentFullProfile } from '@/lib/queries/talents';
-import { getLatestSnapshotsByPlatform } from '@/lib/queries/analytics';
-import { listFilesByEntity } from '@/lib/queries/files';
-import { listCampaignsByTalent } from '@/lib/queries/campaigns';
-import { TalentProfileTabs } from '@/features/admin/talents/components/TalentProfileTabs';
+import { getTalentById } from '@/lib/queries/talents';
+import { getTalentBusiness, getTalentVerticals } from '@/lib/queries/talentBusiness';
+import { listCampaigns } from '@/lib/queries/campaigns';
+import { listInvoices } from '@/lib/queries/invoices';
+import { getFlagImageUrl, countryFlagEmoji } from '@/lib/flag-images';
+import { TALENT_VERTICAL_LABELS } from '@/lib/schemas/talentBusiness';
+import type { TalentVertical } from '@/types';
+
+const PLATFORM_COLOR: Record<string, string> = {
+  twitch: '#9147ff', kick: '#53fc18', youtube: '#ff0000',
+  instagram: '#e1306c', tiktok: '#010101', x: '#1da1f2', twitter: '#1da1f2',
+};
+const PLATFORM_LABEL: Record<string, string> = {
+  twitch: 'Twitch', kick: 'Kick', youtube: 'YouTube',
+  instagram: 'Instagram', tiktok: 'TikTok', x: 'X', twitter: 'X',
+};
+
+function formatMoney(n: string | number | null | undefined): string {
+  if (!n) return '—';
+  return new Intl.NumberFormat('es-ES', { style: 'currency', currency: 'EUR', maximumFractionDigits: 0 }).format(Number(n));
+}
 
 export default async function TalentProfilePage({
   params,
 }: {
-  params: Promise<{ id: string }>;
+  readonly params: Promise<{ id: string }>;
 }): Promise<React.ReactElement> {
   const { id } = await params;
   const talentId = Number(id);
-  if (!Number.isInteger(talentId) || talentId <= 0) notFound();
+  if (isNaN(talentId)) notFound();
 
-  const session = await requireAnyRole(['admin', 'manager', 'staff'], '/admin/login');
-  const isManager = session.user.role === 'manager';
+  await requireAnyRole(['admin', 'manager', 'staff'], '/admin/login');
 
-  const [talent, snapshotsByPlatform, geoFiles, campaignSummary] = await Promise.all([
-    getTalentFullProfile(talentId),
-    getLatestSnapshotsByPlatform(talentId),
-    listFilesByEntity('talent', talentId, 'geo_stats'),
-    listCampaignsByTalent(talentId),
+  const [talent, business, verticals, campaigns, invoices] = await Promise.all([
+    getTalentById(talentId),
+    getTalentBusiness(talentId),
+    getTalentVerticals(talentId),
+    listCampaigns({ filters: { talentId } }),
+    listInvoices({ talentId }),
   ]);
 
   if (!talent) notFound();
 
-  return (
-    <div className="max-w-4xl">
-      <Link
-        href="/admin/talents"
-        className="text-xs text-sp-admin-muted hover:text-sp-admin-text inline-flex items-center gap-1 mb-4 transition-colors"
-      >
-        ← Volver al roster
-      </Link>
+  const flagImg   = talent.creatorCountry ? getFlagImageUrl(talent.creatorCountry) : null;
+  const flagEmoji = talent.creatorCountry ? countryFlagEmoji(talent.creatorCountry) : null;
+  const isActive  = talent.status !== 'inactive';
+  const incomeTotal     = invoices.filter((i) => i.kind === 'income').reduce((s, i) => s + Number(i.totalAmount), 0);
+  const activeCampaigns = campaigns.filter((c) => c.status === 'activa').length;
 
-      <div className="flex items-start gap-4 mb-6">
-        {/* Avatar / initials */}
-        <div
-          className="w-14 h-14 rounded-2xl flex items-center justify-center text-white font-black text-lg shrink-0"
-          style={{
-            background: `linear-gradient(135deg, ${talent.gradientC1}, ${talent.gradientC2})`,
-          }}
-          aria-hidden="true"
-        >
-          {talent.initials}
-        </div>
-        <div>
-          <h1 className="font-display text-3xl font-black uppercase text-sp-admin-text leading-none">
-            {talent.name}
-          </h1>
-          <p className="text-sm text-sp-admin-muted mt-1">{talent.role}</p>
+  return (
+    <div className="space-y-5 max-w-[1200px]">
+
+      {/* Breadcrumb */}
+      <div className="flex items-center gap-2 text-[11px] text-sp-admin-muted">
+        <Link href="/admin/talents" className="hover:text-sp-admin-accent transition-colors">Influencers</Link>
+        <span>›</span>
+        <span className="text-sp-admin-text font-medium">{talent.name}</span>
+      </div>
+
+      {/* ── Header ──────────────────────────────────────────────────── */}
+      <div className="rounded-xl bg-sp-admin-card shadow-[0_1px_3px_rgba(0,0,0,0.06)] overflow-hidden">
+        <div className="h-28 w-full"
+          style={{ background: `linear-gradient(135deg, ${talent.gradientC1}88, ${talent.gradientC2}88)` }} />
+        <div className="px-6 pb-6">
+          <div className="flex items-end justify-between -mt-12 mb-4 flex-wrap gap-3">
+            <div className="relative">
+              <div className="w-24 h-24 rounded-2xl overflow-hidden ring-4 ring-sp-admin-card shadow-lg"
+                style={{ background: `linear-gradient(135deg, ${talent.gradientC1}, ${talent.gradientC2})` }}>
+                {talent.photoUrl ? (
+                  <Image src={talent.photoUrl} alt={talent.name} fill className="object-cover object-top" sizes="96px" />
+                ) : (
+                  <div className="absolute inset-0 flex items-center justify-center text-2xl font-black text-white/90">
+                    {talent.initials}
+                  </div>
+                )}
+              </div>
+              <span className={`absolute -bottom-1 -right-1 w-4 h-4 rounded-full ring-2 ring-sp-admin-card ${isActive ? 'bg-emerald-500' : 'bg-slate-400'}`} />
+            </div>
+            <div className="flex items-center gap-2">
+              <Link href={`/admin/talents/${talent.id}/negocio`}
+                className="flex items-center gap-1.5 h-8 px-3 rounded-lg border border-sp-admin-border text-[12px] font-semibold text-sp-admin-muted hover:text-sp-admin-text hover:bg-sp-admin-hover transition-colors">
+                ✎ Editar datos
+              </Link>
+              <Link href="/admin/campanas"
+                className="flex items-center gap-1.5 h-8 px-3 rounded-lg bg-sp-admin-accent text-white text-[12px] font-semibold hover:bg-sp-admin-accent/90 transition-colors">
+                + Nueva campaña
+              </Link>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap items-start gap-4">
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-3 flex-wrap">
+                <h1 className="text-xl font-bold text-sp-admin-text">{talent.name}</h1>
+                {talent.creatorCountry && (
+                  <span className="flex items-center gap-1.5">
+                    {flagImg ? (
+                      <img src={flagImg} alt={talent.creatorCountry} className="w-5 h-5 rounded-full object-cover" />
+                    ) : (
+                      <span className="text-lg">{flagEmoji}</span>
+                    )}
+                    <span className="text-[11px] font-semibold text-sp-admin-muted">{talent.creatorCountry}</span>
+                  </span>
+                )}
+                <span className={`inline-flex px-2 py-0.5 rounded-full text-[10px] font-bold ${
+                  isActive
+                    ? 'bg-emerald-50 text-emerald-700 border border-emerald-200'
+                    : 'bg-slate-100 text-slate-600 border border-slate-200'
+                }`}>
+                  {isActive ? 'Activo' : 'Inactivo'}
+                </span>
+                {!talent.photoUrl && (
+                  <span className="inline-flex px-2 py-0.5 rounded-full text-[9px] font-bold bg-amber-50 text-amber-700 border border-amber-200">
+                    Sin foto
+                  </span>
+                )}
+              </div>
+              {talent.game && <p className="text-[13px] text-sp-admin-muted mt-0.5">{talent.game}</p>}
+              {(verticals as TalentVertical[]).length > 0 && (
+                <div className="flex flex-wrap gap-1.5 mt-2">
+                  {(verticals as TalentVertical[]).map((v) => (
+                    <span key={v} className="px-2 py-0.5 rounded-full text-[10px] font-semibold bg-sp-admin-hover border border-sp-admin-border text-sp-admin-muted">
+                      {TALENT_VERTICAL_LABELS[v] ?? v}
+                    </span>
+                  ))}
+                </div>
+              )}
+              {talent.socials.length > 0 && (
+                <div className="flex flex-wrap gap-2 mt-3">
+                  {talent.socials.map((s) => {
+                    const key   = s.platform.toLowerCase();
+                    const color = PLATFORM_COLOR[key] ?? '#888';
+                    const label = PLATFORM_LABEL[key] ?? s.platform;
+                    return (
+                      <a key={s.id} href={s.profileUrl ?? '#'} target={s.profileUrl ? '_blank' : '_self'} rel="noopener noreferrer"
+                        className="flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-[11px] font-bold text-white hover:opacity-85 transition-opacity"
+                        style={{ background: color }}>
+                        {label}
+                        {s.followersDisplay && s.followersDisplay !== '0' && (
+                          <span className="opacity-80">· {s.followersDisplay}</span>
+                        )}
+                      </a>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          </div>
         </div>
       </div>
 
-      <TalentProfileTabs
-        talent={talent}
-        snapshotsByPlatform={snapshotsByPlatform}
-        geoFiles={geoFiles}
-        isManager={isManager}
-        campaignSummary={campaignSummary}
-      />
+      {/* ── KPIs ────────────────────────────────────────────────────── */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+        {[
+          { label: 'Campañas',      value: campaigns.length,        color: '#f5632a' },
+          { label: 'Activas',       value: activeCampaigns,         color: '#16a34a' },
+          { label: 'Revenue total', value: formatMoney(incomeTotal), color: '#8b3aad' },
+          { label: 'Plataformas',   value: talent.socials.length,   color: '#5b9bd5' },
+        ].map((k) => (
+          <div key={k.label} className="rounded-lg bg-sp-admin-card shadow-[0_1px_3px_rgba(0,0,0,0.06)] overflow-hidden">
+            <div className="h-[2px]" style={{ background: k.color }} />
+            <div className="px-4 py-3">
+              <p className="text-[9px] font-bold uppercase tracking-wide text-sp-admin-muted">{k.label}</p>
+              <p className="text-lg font-bold mt-0.5 tabular-nums" style={{ color: k.color }}>{k.value}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* ── Grid 3 cols ─────────────────────────────────────────────── */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+
+        {/* Columna izq */}
+        <div className="space-y-4">
+
+          {/* Redes */}
+          <section className="rounded-xl bg-sp-admin-card shadow-[0_1px_3px_rgba(0,0,0,0.06)] overflow-hidden">
+            <div className="px-4 py-2.5 border-b border-sp-admin-border/60 bg-sp-admin-hover/40">
+              <h2 className="text-[10px] font-bold uppercase tracking-[0.18em] text-sp-admin-muted">Redes sociales</h2>
+            </div>
+            {talent.socials.length === 0 ? (
+              <p className="px-4 py-6 text-[12px] text-sp-admin-muted text-center">Sin redes registradas</p>
+            ) : (
+              <div className="divide-y divide-sp-admin-border/40">
+                {talent.socials.map((s) => {
+                  const key   = s.platform.toLowerCase();
+                  const color = PLATFORM_COLOR[key] ?? '#888';
+                  const label = PLATFORM_LABEL[key] ?? s.platform;
+                  return (
+                    <div key={s.id} className="px-4 py-3 flex items-center gap-3">
+                      <div className="w-8 h-8 rounded-lg flex items-center justify-center text-white text-[10px] font-black shrink-0" style={{ background: color }}>
+                        {label.charAt(0)}
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <p className="text-[12px] font-semibold text-sp-admin-text">{label}</p>
+                        <p className="text-[10px] text-sp-admin-muted truncate">@{s.handle}</p>
+                      </div>
+                      <div className="text-right shrink-0">
+                        <p className="text-[13px] font-bold text-sp-admin-text tabular-nums">{s.followersDisplay || '—'}</p>
+                        {s.avgViewers && (
+                          <p className="text-[9px] text-sp-admin-muted">{s.avgViewers.toLocaleString('es-ES')} viewers</p>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+            <div className="px-4 py-2.5 border-t border-sp-admin-border/60 bg-sp-admin-hover/20">
+              <Link href={`/admin/talents/${talent.id}/negocio`} className="text-[11px] font-semibold text-sp-admin-accent hover:opacity-70 transition-opacity">
+                Editar redes →
+              </Link>
+            </div>
+          </section>
+
+          {/* Contacto */}
+          <section className="rounded-xl bg-sp-admin-card shadow-[0_1px_3px_rgba(0,0,0,0.06)] overflow-hidden">
+            <div className="px-4 py-2.5 border-b border-sp-admin-border/60 bg-sp-admin-hover/40">
+              <h2 className="text-[10px] font-bold uppercase tracking-[0.18em] text-sp-admin-muted">Contacto</h2>
+            </div>
+            <div className="px-4 py-3 space-y-2.5">
+              {business?.telegram && (
+                <ContactRow icon="✈" color="#2AABEE" label="Telegram" value={`@${business.telegram}`}
+                  href={`https://t.me/${business.telegram.replace('@', '')}`} />
+              )}
+              {business?.discord && <ContactRow icon="🎮" color="#5865F2" label="Discord" value={business.discord} />}
+              {business?.whatsapp && (
+                <ContactRow icon="💬" color="#25D366" label="WhatsApp" value={business.whatsapp}
+                  href={`https://wa.me/${business.whatsapp.replace(/\D/g, '')}`} />
+              )}
+              {business?.contactEmail && (
+                <ContactRow icon="✉" color="#888" label="Email" value={business.contactEmail}
+                  href={`mailto:${business.contactEmail}`} />
+              )}
+              {!business?.telegram && !business?.discord && !business?.whatsapp && !business?.contactEmail && (
+                <p className="text-[12px] text-sp-admin-muted py-2">Sin datos de contacto</p>
+              )}
+              {business?.managerName && (
+                <div className="pt-2 border-t border-sp-admin-border/50">
+                  <p className="text-[9px] font-bold text-sp-admin-muted uppercase tracking-wide mb-1">Manager</p>
+                  <p className="text-[12px] font-medium text-sp-admin-text">{business.managerName}</p>
+                  {business.managerEmail && (
+                    <a href={`mailto:${business.managerEmail}`} className="text-[11px] text-sp-admin-accent hover:underline">
+                      {business.managerEmail}
+                    </a>
+                  )}
+                </div>
+              )}
+            </div>
+            <div className="px-4 py-2.5 border-t border-sp-admin-border/60 bg-sp-admin-hover/20">
+              <Link href={`/admin/talents/${talent.id}/negocio`} className="text-[11px] font-semibold text-sp-admin-accent hover:opacity-70 transition-opacity">
+                Editar contacto →
+              </Link>
+            </div>
+          </section>
+        </div>
+
+        {/* Columna der */}
+        <div className="lg:col-span-2 space-y-4">
+
+          {/* Campañas */}
+          <section className="rounded-xl bg-sp-admin-card shadow-[0_1px_3px_rgba(0,0,0,0.06)] overflow-hidden">
+            <div className="px-4 py-2.5 border-b border-sp-admin-border/60 bg-sp-admin-hover/40 flex items-center justify-between">
+              <h2 className="text-[10px] font-bold uppercase tracking-[0.18em] text-sp-admin-muted">Tratos / Campañas</h2>
+              <Link href="/admin/campanas" className="text-[10px] text-sp-admin-accent hover:opacity-70 transition-opacity">Ver todos →</Link>
+            </div>
+            {campaigns.length === 0 ? (
+              <div className="px-4 py-8 text-center">
+                <p className="text-[12px] text-sp-admin-muted">Sin tratos asociados todavía</p>
+                <Link href="/admin/campanas" className="mt-2 text-[11px] font-semibold text-sp-admin-accent hover:opacity-70 block">
+                  Crear primer trato →
+                </Link>
+              </div>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="w-full">
+                  <thead>
+                    <tr className="border-b border-sp-admin-border bg-sp-admin-hover/30">
+                      {['Trato', 'Marca', 'Estado', 'Pago talento', 'Margen'].map((h) => (
+                        <th key={h} className="px-4 py-2 text-left text-[9px] font-bold uppercase tracking-wide text-sp-admin-muted">{h}</th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {campaigns.map((c) => {
+                      const margin = Number(c.amountBrand ?? 0) - Number(c.amountTalent ?? 0);
+                      const statusColors: Record<string, string> = {
+                        activa: '#16a34a', negociacion: '#8b3aad', pausada: '#f59e0b',
+                        finalizada: '#5b9bd5', cancelada: '#ef4444', propuesta: '#f5632a',
+                        aprobada: '#16a34a', completada: '#5b9bd5', pendiente_pago: '#f59e0b',
+                      };
+                      return (
+                        <tr key={c.id} className="border-b border-sp-admin-border/40 last:border-0 hover:bg-sp-admin-hover transition-colors">
+                          <td className="px-4 py-2.5 text-[12px] font-medium text-sp-admin-text">{c.name}</td>
+                          <td className="px-4 py-2.5 text-[11px] text-sp-admin-muted">—</td>
+                          <td className="px-4 py-2.5">
+                            <span className="text-[10px] font-bold" style={{ color: statusColors[c.status] ?? '#888' }}>
+                              {c.status.charAt(0).toUpperCase() + c.status.slice(1).replace('_', ' ')}
+                            </span>
+                          </td>
+                          <td className="px-4 py-2.5 text-[12px] font-semibold tabular-nums text-sp-admin-text">
+                            {formatMoney(c.amountTalent)}
+                          </td>
+                          <td className="px-4 py-2.5 text-[12px] font-bold tabular-nums" style={{ color: margin >= 0 ? '#16a34a' : '#ef4444' }}>
+                            {formatMoney(String(margin))}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </section>
+
+          {/* Facturación */}
+          <section className="rounded-xl bg-sp-admin-card shadow-[0_1px_3px_rgba(0,0,0,0.06)] overflow-hidden">
+            <div className="px-4 py-2.5 border-b border-sp-admin-border/60 bg-sp-admin-hover/40 flex items-center justify-between">
+              <h2 className="text-[10px] font-bold uppercase tracking-[0.18em] text-sp-admin-muted">Facturación</h2>
+              <span className="text-[10px] text-sp-admin-muted">{invoices.length} registros</span>
+            </div>
+            {invoices.length === 0 ? (
+              <p className="px-4 py-6 text-[12px] text-sp-admin-muted text-center">Sin movimientos de facturación</p>
+            ) : (
+              <div className="divide-y divide-sp-admin-border/40 max-h-64 overflow-y-auto">
+                {invoices.slice(0, 8).map((inv) => (
+                  <div key={inv.id} className="flex items-center justify-between px-4 py-2.5 hover:bg-sp-admin-hover transition-colors">
+                    <div className="min-w-0">
+                      <p className="text-[12px] font-medium text-sp-admin-text truncate">{inv.concept}</p>
+                      <p className="text-[10px] text-sp-admin-muted">{new Date(inv.issueDate).toLocaleDateString('es-ES')}</p>
+                    </div>
+                    <div className="text-right shrink-0 ml-3">
+                      <p className={`text-[12px] font-bold tabular-nums ${inv.kind === 'income' ? 'text-emerald-600' : 'text-amber-600'}`}>
+                        {inv.kind === 'expense' ? '−' : '+'}{formatMoney(inv.totalAmount)}
+                      </p>
+                      <p className="text-[9px] text-sp-admin-muted uppercase tracking-wide">{inv.status}</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </section>
+
+          {business?.internalNotes && (
+            <section className="rounded-xl bg-sp-admin-card shadow-[0_1px_3px_rgba(0,0,0,0.06)] overflow-hidden">
+              <div className="px-4 py-2.5 border-b border-sp-admin-border/60 bg-sp-admin-hover/40">
+                <h2 className="text-[10px] font-bold uppercase tracking-[0.18em] text-sp-admin-muted">Notas internas</h2>
+              </div>
+              <p className="px-4 py-3 text-[13px] text-sp-admin-text leading-relaxed whitespace-pre-wrap">{business.internalNotes}</p>
+            </section>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ContactRow({ icon, color, label, value, href }: {
+  readonly icon: string; readonly color: string; readonly label: string;
+  readonly value: string; readonly href?: string;
+}): React.ReactElement {
+  return (
+    <div className="flex items-center gap-2.5">
+      <div className="w-7 h-7 rounded-lg flex items-center justify-center text-white text-[12px] shrink-0" style={{ background: color }}>
+        {icon}
+      </div>
+      <div className="min-w-0">
+        <p className="text-[9px] font-bold text-sp-admin-muted uppercase tracking-wide leading-none">{label}</p>
+        {href ? (
+          <a href={href} target="_blank" rel="noopener noreferrer" className="text-[12px] font-medium text-sp-admin-accent hover:underline truncate block">{value}</a>
+        ) : (
+          <p className="text-[12px] font-medium text-sp-admin-text truncate">{value}</p>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/app/admin/(dashboard)/talents/page.tsx
+++ b/src/app/admin/(dashboard)/talents/page.tsx
@@ -1,3 +1,4 @@
+import { requireAnyRole } from '@/lib/auth-guard';
 import { AdminPageHeader } from '@/features/admin/_shared/components/AdminPageHeader';
 import { getAdminRosterWithGrowth } from '@/lib/queries/talents';
 import { listAllVerticals } from '@/lib/queries/talentBusiness';
@@ -8,6 +9,7 @@ import { BrandsTabs } from '@/features/admin/brands/components/BrandsTabs';
 import type { TalentVertical } from '@/types';
 
 export default async function AdminTalentsPage(): Promise<React.ReactElement> {
+  await requireAnyRole(['admin', 'manager', 'staff'], '/admin/login');
   const [creators, verticals] = await Promise.all([
     getAdminRosterWithGrowth(),
     listAllVerticals(),
@@ -82,7 +84,7 @@ export default async function AdminTalentsPage(): Promise<React.ReactElement> {
           },
           {
             key:     'import',
-            label:   'Importar / Exportar',
+            label:   'Importar Excel/CSV',
             content: (
               <TalentDataTools
                 roster={roster}

--- a/src/features/admin/talents/components/InfluencerCardsView.parts.tsx
+++ b/src/features/admin/talents/components/InfluencerCardsView.parts.tsx
@@ -1,13 +1,14 @@
 'use client';
 
+import Link from 'next/link';
 import Image from 'next/image';
 import { useMemo, useState, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
 import * as m from 'motion/react-client';
-import { StateBadge } from '@/features/admin/_shared/components/StateBadge';
 import { parseFollowers, formatCompact } from '@/lib/utils/format';
 import { TALENT_VERTICAL_LABELS } from '@/lib/schemas/talentBusiness';
 import { setTalentStatusAction } from '@/app/admin/(dashboard)/talents/actions';
+import { getFlagImageUrl, countryFlagEmoji } from '@/lib/flag-images';
 import type { AdminRosterRow } from '@/lib/queries/talents';
 import type { TalentVertical } from '@/types';
 import type { Tone } from '@/features/admin/_shared/components/StateBadge';
@@ -17,34 +18,51 @@ import type { Tone } from '@/features/admin/_shared/components/StateBadge';
 export type TalentStatus = 'active' | 'available' | 'inactive';
 
 export const STATUS_TONE: Record<string, Tone> = {
-  active: 'success',
+  active:    'success',
   available: 'info',
-  inactive: 'neutral',
-  // audienceStatus values
-  activo: 'success',
-  inactivo: 'neutral',
+  inactive:  'neutral',
+  activo:    'success',
+  inactivo:  'neutral',
   pendiente: 'warning',
   potencial: 'info',
 };
 
 export const STATUS_LABELS: Record<string, string> = {
-  active: 'Activo',
+  active:    'Activo',
   available: 'Disponible',
-  inactive: 'Inactivo',
-  activo: 'Activo',
-  inactivo: 'Inactivo',
+  inactive:  'Inactivo',
+  activo:    'Activo',
+  inactivo:  'Inactivo',
   pendiente: 'Pendiente',
   potencial: 'Potencial',
 };
 
 export const PLATFORM_LABELS: Record<string, string> = {
-  twitch: 'Twitch',
-  youtube: 'YouTube',
+  twitch:    'Twitch',
+  youtube:   'YouTube',
   instagram: 'Instagram',
-  tiktok: 'TikTok',
-  x: 'X',
-  twitter: 'X',
-  kick: 'Kick',
+  tiktok:    'TikTok',
+  x:         'X',
+  twitter:   'X',
+  kick:      'Kick',
+};
+
+// Colores de plataforma para el dot indicator
+const PLATFORM_DOT: Record<string, string> = {
+  twitch:    '#9147ff',
+  youtube:   '#ff0000',
+  instagram: '#e1306c',
+  tiktok:    '#010101',
+  x:         '#1da1f2',
+  twitter:   '#1da1f2',
+  kick:      '#53fc18',
+};
+
+// Status config para el badge de footer
+const STATUS_CFG: Record<string, { dot: string; label: string; bg: string; text: string }> = {
+  active:    { dot: '#16a34a', label: 'Activo',     bg: 'bg-emerald-50', text: 'text-emerald-700' },
+  available: { dot: '#5b9bd5', label: 'Disponible', bg: 'bg-blue-50',    text: 'text-blue-700'    },
+  inactive:  { dot: '#9ca3af', label: 'Inactivo',   bg: 'bg-slate-100',  text: 'text-slate-500'   },
 };
 
 // ── Card ─────────────────────────────────────────────────────────────
@@ -57,154 +75,214 @@ function nextStatus(current: TalentStatus): TalentStatus {
 }
 
 type CardProps = {
-  readonly creator: AdminRosterRow;
-  readonly verticals: readonly TalentVertical[];
+  readonly creator:        AdminRosterRow;
+  readonly verticals:      readonly TalentVertical[];
+  readonly selectMode?:    boolean;
+  readonly selected?:      boolean;
+  readonly onToggleSelect?: (id: number) => void;
 };
 
-export function TalentCard({ creator, verticals }: CardProps): React.ReactElement {
+export function TalentCard({ creator, verticals, selectMode, selected, onToggleSelect }: CardProps): React.ReactElement {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [optimisticStatus, setOptimisticStatus] = useState<TalentStatus>(creator.status as TalentStatus);
 
-  // Resolve status: prefer audienceStatus if set, fall back to optimistic status
   const displayStatus: string = creator.audienceStatus ?? optimisticStatus;
-  const tone: Tone = STATUS_TONE[displayStatus] ?? 'neutral';
-  const statusLabel: string = STATUS_LABELS[displayStatus] ?? displayStatus;
+  const statusCfg = STATUS_CFG[optimisticStatus] ?? STATUS_CFG.inactive!;
   const isPillClickable = !creator.audienceStatus;
 
-  const handleStatusClick = (e: React.MouseEvent | React.KeyboardEvent): void => {
+  // Plataformas únicas (máx 4 para los dots)
+  const platforms = useMemo(() => {
+    const seen = new Set<string>();
+    const list: string[] = [];
+    for (const s of creator.socials) {
+      const k = s.platform.toLowerCase();
+      if (!seen.has(k)) { seen.add(k); list.push(k); }
+      if (list.length >= 4) break;
+    }
+    return list;
+  }, [creator.socials]);
+
+  // Métrica principal: plataforma con más seguidores
+  const mainMetric = useMemo(() => {
+    if (creator.socials.length === 0) return null;
+    const best = creator.socials.reduce((a, b) =>
+      parseFollowers(a.followersDisplay) >= parseFollowers(b.followersDisplay) ? a : b,
+    );
+    const count = parseFollowers(best.followersDisplay);
+    if (count === 0) return null;
+    const label = PLATFORM_LABELS[best.platform.toLowerCase()] ?? best.platform;
+    return `${label} · ${formatCompact(count)}`;
+  }, [creator.socials]);
+
+  // Sectores como badges (máx 2)
+  const sectorBadges = useMemo(() =>
+    verticals.slice(0, 2).map((v) => TALENT_VERTICAL_LABELS[v] ?? v),
+  [verticals]);
+
+  function handleStatusCycle(e: React.MouseEvent | React.KeyboardEvent): void {
     e.stopPropagation();
-    e.preventDefault();
+    if (!isPillClickable) return;
     const next = nextStatus(optimisticStatus);
     setOptimisticStatus(next);
     startTransition(async () => {
       const res = await setTalentStatusAction(creator.id, next);
-      if (!res.success) {
-        setOptimisticStatus(creator.status as TalentStatus);
-      } else {
-        router.refresh();
-      }
+      if (!res.success) setOptimisticStatus(creator.status as TalentStatus);
+      else router.refresh();
     });
-  };
+  }
 
-  const handleStatusKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>): void => {
-    if (e.key === 'Enter' || e.key === ' ') {
-      handleStatusClick(e);
-    }
-  };
-
-  // Platform chips: from socials (up to 3)
-  const platformChips = useMemo(() => {
-    const seen = new Set<string>();
-    const chips: string[] = [];
-    for (const s of creator.socials) {
-      const key = s.platform.toLowerCase();
-      if (!seen.has(key)) {
-        seen.add(key);
-        chips.push(key);
-      }
-      if (chips.length >= 3) break;
-    }
-    // Fallback to verticals if no socials
-    if (chips.length === 0) {
-      return verticals.slice(0, 3).map((v) => TALENT_VERTICAL_LABELS[v] ?? v);
-    }
-    return chips.map((p) => PLATFORM_LABELS[p] ?? p);
-  }, [creator.socials, verticals]);
-
-  // Total followers
-  const totalFollowers = useMemo(() => {
-    if (creator.socials.length === 0) return null;
-    const total = creator.socials.reduce(
-      (sum, s) => sum + parseFollowers(s.followersDisplay),
-      0,
-    );
-    return total > 0 ? formatCompact(total) : null;
-  }, [creator.socials]);
-
-  const handleClick = (): void => {
+  function handleCardClick(): void {
+    if (selectMode) { onToggleSelect?.(creator.id); return; }
     router.push(`/admin/talents/${creator.id}`);
-  };
-
-  const handleKeyDown = (e: React.KeyboardEvent): void => {
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault();
-      handleClick();
-    }
-  };
+  }
 
   return (
     <m.div
-      whileHover={{ y: -3, boxShadow: '0 8px 24px rgba(0,0,0,0.12)' }}
-      transition={{ type: 'spring', stiffness: 400, damping: 25 }}
-      onClick={handleClick}
-      onKeyDown={handleKeyDown}
+      whileHover={{ y: -2, boxShadow: '0 12px 32px rgba(0,0,0,0.10)' }}
+      transition={{ type: 'spring', stiffness: 400, damping: 28 }}
+      data-selected={selected || undefined}
+      className={`group relative rounded-xl bg-sp-admin-card shadow-[0_1px_4px_rgba(0,0,0,0.07)] overflow-hidden flex flex-col cursor-pointer focus-visible:outline-2 focus-visible:outline-sp-admin-accent focus-visible:outline-offset-2 transition-shadow ${selected ? 'ring-2 ring-sp-admin-accent' : ''}`}
+      onClick={handleCardClick}
       role="button"
       tabIndex={0}
-      aria-label={`Ver perfil de ${creator.name}`}
-      className="relative rounded-xl bg-sp-admin-card shadow-[0_1px_3px_rgba(0,0,0,0.06)] overflow-hidden flex flex-col cursor-pointer focus-visible:outline-2 focus-visible:outline-sp-admin-accent focus-visible:outline-offset-2"
+      onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && handleCardClick()}
+      aria-label={selectMode ? `Seleccionar ${creator.name}` : `Ver perfil de ${creator.name}`}
     >
-      {/* Foto cuadrada centrada en cara */}
+
+      {/* ── Checkbox de selección ──────────────────────────────── */}
+      {selectMode && (
+        <div className="absolute top-2 left-2 z-20">
+          <div className={`w-5 h-5 rounded-md border-2 flex items-center justify-center transition-colors ${selected ? 'bg-sp-admin-accent border-sp-admin-accent' : 'bg-white/80 border-white/60'}`}>
+            {selected && (
+              <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
+                <path d="M2 5l2.5 2.5L8 3" stroke="white" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+              </svg>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* ── Imagen — limpia, solo bandera discreta ─────────────── */}
       <div
         className="relative aspect-square w-full overflow-hidden"
         style={{ background: `linear-gradient(135deg, ${creator.gradientC1}, ${creator.gradientC2})` }}
       >
         <Avatar creator={creator} />
 
-        {/* Status badge — clickable cycles status when no audienceStatus override */}
-        <div className="absolute top-2 right-2 z-10">
-          {isPillClickable ? (
-            <button
-              type="button"
-              onClick={handleStatusClick}
-              onKeyDown={handleStatusKeyDown}
-              disabled={isPending}
-              aria-label={`Cambiar estado: ${statusLabel}`}
-              className="cursor-pointer rounded-full focus-visible:outline-2 focus-visible:outline-sp-admin-accent focus-visible:outline-offset-2 disabled:opacity-60"
+        {/* Bandera — solo emoji/img, sin texto, esquina superior derecha */}
+        {creator.creatorCountry && (() => {
+          const flagUrl   = getFlagImageUrl(creator.creatorCountry);
+          const flagEmoji = countryFlagEmoji(creator.creatorCountry);
+          return (
+            <div className="absolute top-2 right-2 z-10">
+              {flagUrl ? (
+                <img
+                  src={flagUrl}
+                  alt={creator.creatorCountry}
+                  title={creator.creatorCountry}
+                  className="w-5 h-5 rounded-sm object-cover shadow-sm opacity-90"
+                />
+              ) : (
+                <span className="text-base leading-none" title={creator.creatorCountry}>{flagEmoji}</span>
+              )}
+            </div>
+          );
+        })()}
+
+        {/* Overlay de acciones — aparece en hover */}
+        {!selectMode && (
+          <div className="absolute inset-0 bg-black/0 group-hover:bg-black/30 transition-colors flex items-center justify-center gap-2 opacity-0 group-hover:opacity-100">
+            <Link
+              href={`/admin/talents/${creator.id}`}
+              onClick={(e) => e.stopPropagation()}
+              className="h-7 px-3 rounded-full bg-white/90 text-[11px] font-bold text-sp-admin-text hover:bg-white transition-colors shadow-sm"
             >
-              <StateBadge tone={tone} variant="soft">{statusLabel}</StateBadge>
-            </button>
-          ) : (
-            <StateBadge tone={tone} variant="soft">{statusLabel}</StateBadge>
-          )}
-        </div>
-
-        {/* País */}
-        {creator.creatorCountry && (
-          <div className="absolute top-2 left-2 z-10">
-            <span className="text-[9px] font-bold uppercase tracking-wider text-white bg-black/30 backdrop-blur-sm rounded px-1.5 py-0.5">
-              {creator.creatorCountry}
-            </span>
-          </div>
-        )}
-
-        {/* Total followers — overlay inferior */}
-        {totalFollowers !== null && (
-          <div className="absolute bottom-0 inset-x-0 bg-gradient-to-t from-black/60 to-transparent px-3 py-2">
-            <p className="text-base font-black text-white tabular-nums leading-none">{totalFollowers}</p>
-            <p className="text-[8px] text-white/70 uppercase tracking-wide">seguidores</p>
+              Ver perfil
+            </Link>
+            <Link
+              href={`/admin/talents/${creator.id}`}
+              onClick={(e) => e.stopPropagation()}
+              className="h-7 px-3 rounded-full bg-sp-admin-accent/90 text-[11px] font-bold text-white hover:bg-sp-admin-accent transition-colors shadow-sm"
+            >
+              Editar
+            </Link>
           </div>
         )}
       </div>
 
-      {/* Info compacta */}
-      <div className="px-3 pt-2 pb-1">
-        <p className="font-bold text-[12px] text-sp-admin-text truncate leading-tight">{creator.name}</p>
-        {creator.game && <p className="text-[10px] text-sp-admin-muted truncate">{creator.game}</p>}
+      {/* ── Cuerpo: nombre, categoría, plataformas, sectores ───── */}
+      <div className="px-3 pt-2.5 pb-2 flex-1">
+        {/* Nombre */}
+        <p className="font-bold text-[13px] text-sp-admin-text truncate leading-tight">{creator.name}</p>
 
-        {/* Platform chips — max 2 */}
-        {platformChips.length > 0 && (
-          <div className="flex flex-wrap gap-1 mt-1.5">
-            {platformChips.slice(0, 2).map((chip) => (
-              <StateBadge key={chip} tone="info" variant="dot">{chip}</StateBadge>
+        {/* Categoría / juego */}
+        {creator.game && (
+          <p className="text-[10px] text-sp-admin-muted truncate mt-0.5">{creator.game}</p>
+        )}
+
+        {/* Plataformas — solo dots con nombre, sin números */}
+        {platforms.length > 0 && (
+          <div className="flex items-center gap-2 mt-2 flex-wrap">
+            {platforms.map((p) => (
+              <span key={p} className="inline-flex items-center gap-1">
+                <span
+                  className="w-1.5 h-1.5 rounded-full shrink-0"
+                  style={{ background: PLATFORM_DOT[p] ?? '#888' }}
+                />
+                <span className="text-[10px] text-sp-admin-muted font-medium">
+                  {PLATFORM_LABELS[p] ?? p}
+                </span>
+              </span>
+            ))}
+          </div>
+        )}
+
+        {/* Sectores como badges */}
+        {sectorBadges.length > 0 && (
+          <div className="flex flex-wrap gap-1 mt-2">
+            {sectorBadges.map((s) => (
+              <span
+                key={s}
+                className="inline-flex px-1.5 py-0.5 rounded text-[9px] font-semibold bg-sp-admin-hover border border-sp-admin-border/60 text-sp-admin-muted"
+              >
+                {s}
+              </span>
             ))}
           </div>
         )}
       </div>
 
-      {/* Footer */}
-      <div className="border-t border-sp-admin-border/60 px-3 py-1.5 mt-auto">
-        <span className="text-[9px] text-sp-admin-muted truncate block">{creator.role}</span>
+      {/* ── Footer: estado + métrica principal ─────────────────── */}
+      <div className="border-t border-sp-admin-border/50 px-3 py-2 flex items-center justify-between gap-2 mt-auto">
+
+        {/* Badge de estado — clickable */}
+        {isPillClickable ? (
+          <button
+            type="button"
+            onClick={handleStatusCycle}
+            onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && handleStatusCycle(e)}
+            disabled={isPending}
+            title="Clic para cambiar estado"
+            aria-label={`Estado: ${statusCfg.label}. Clic para cambiar.`}
+            className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[9px] font-bold cursor-pointer hover:opacity-80 disabled:opacity-50 transition-opacity ${statusCfg.bg} ${statusCfg.text}`}
+          >
+            <span className="w-1.5 h-1.5 rounded-full shrink-0" style={{ background: statusCfg.dot }} />
+            {statusCfg.label}
+          </button>
+        ) : (
+          <span className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[9px] font-bold ${statusCfg.bg} ${statusCfg.text}`}>
+            <span className="w-1.5 h-1.5 rounded-full shrink-0" style={{ background: statusCfg.dot }} />
+            {STATUS_LABELS[displayStatus] ?? displayStatus}
+          </span>
+        )}
+
+        {/* Métrica principal: una sola plataforma + seguidores */}
+        {mainMetric && (
+          <span className="text-[9px] text-sp-admin-muted tabular-nums truncate">
+            {mainMetric}
+          </span>
+        )}
       </div>
     </m.div>
   );
@@ -212,9 +290,7 @@ export function TalentCard({ creator, verticals }: CardProps): React.ReactElemen
 
 // ── Avatar ───────────────────────────────────────────────────────────
 
-type AvatarProps = {
-  readonly creator: AdminRosterRow;
-};
+type AvatarProps = { readonly creator: AdminRosterRow };
 
 function Avatar({ creator }: AvatarProps): React.ReactElement {
   if (creator.photoUrl) {
@@ -228,7 +304,6 @@ function Avatar({ creator }: AvatarProps): React.ReactElement {
       />
     );
   }
-
   return (
     <div className="absolute inset-0 flex items-center justify-center">
       <span className="font-display text-4xl font-black text-white/90 select-none">

--- a/src/features/admin/talents/components/InfluencerCardsView.tsx
+++ b/src/features/admin/talents/components/InfluencerCardsView.tsx
@@ -1,8 +1,10 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { EmptyState } from '@/features/admin/_shared/components/EmptyState';
 import { TALENT_VERTICAL_LABELS, TALENT_VERTICALS } from '@/lib/schemas/talentBusiness';
+import { AddTalentModal } from './AddTalentModal';
+import { exportTalentsToExcel } from './TalentExport';
 import type { AdminRosterRow } from '@/lib/queries/talents';
 import type { TalentVertical } from '@/types';
 import {
@@ -20,26 +22,38 @@ type Props = {
 
 // ── Main component ───────────────────────────────────────────────────
 
-/**
- * Vista en cards del roster de talents con foto, plataformas y verticales para el listado del admin.
- *
- * @kind client
- * @feature admin/talents
- * @route /admin/talents
- * @example
- * ```tsx
- * <InfluencerCardsView creators={creators} verticalsByTalent={verticalsByTalent} />
- * ```
- */
 export function InfluencerCardsView({ creators, verticalsByTalent }: Props): React.ReactElement {
-  const [search, setSearch] = useState('');
-  const [statusFilter, setStatusFilter] = useState<TalentStatus | 'all'>('all');
+  const [search, setSearch]               = useState('');
+  const [statusFilter, setStatusFilter]   = useState<TalentStatus | 'all'>('all');
   const [verticalFilter, setVerticalFilter] = useState<TalentVertical | ''>('');
   const [platformFilter, setPlatformFilter] = useState<string>('');
+  const [countryFilter, setCountryFilter] = useState<string>('');
+  const [showAdd, setShowAdd]             = useState(false);
+  const [selectMode, setSelectMode]       = useState(false);
+  const [selectedIds, setSelectedIds]     = useState<Set<number>>(new Set());
+
+  const toggleSelect = useCallback((id: number) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      next.has(id) ? next.delete(id) : next.add(id);
+      return next;
+    });
+  }, []);
+
+  const clearSelection = useCallback(() => {
+    setSelectedIds(new Set());
+    setSelectMode(false);
+  }, []);
 
   const platforms = useMemo(() => {
     const set = new Set<string>();
     for (const c of creators) for (const s of c.socials) set.add(s.platform);
+    return [...set].sort();
+  }, [creators]);
+
+  const countries = useMemo(() => {
+    const set = new Set<string>();
+    for (const c of creators) if (c.creatorCountry) set.add(c.creatorCountry.toUpperCase());
     return [...set].sort();
   }, [creators]);
 
@@ -53,9 +67,10 @@ export function InfluencerCardsView({ creators, verticalsByTalent }: Props): Rea
         if (!vs.includes(verticalFilter)) return false;
       }
       if (platformFilter && !c.socials.some((s) => s.platform === platformFilter)) return false;
+      if (countryFilter && (c.creatorCountry ?? '').toUpperCase() !== countryFilter) return false;
       return true;
     });
-  }, [creators, search, statusFilter, verticalFilter, platformFilter, verticalsByTalent]);
+  }, [creators, search, statusFilter, verticalFilter, platformFilter, countryFilter, verticalsByTalent]);
 
   const counts = useMemo(() => {
     let active = 0, available = 0, inactive = 0;
@@ -67,21 +82,28 @@ export function InfluencerCardsView({ creators, verticalsByTalent }: Props): Rea
     return { active, available, inactive };
   }, [creators]);
 
-  const INPUT_CLS = 'h-8 rounded-lg border border-sp-admin-border bg-white px-3 text-[12px] text-sp-admin-text placeholder:text-sp-admin-muted/60 focus:outline-none focus:border-sp-admin-accent/50';
+  const handleExport = useCallback(() => {
+    const toExport = selectedIds.size > 0
+      ? creators.filter((c) => selectedIds.has(c.id))
+      : filtered;
+    exportTalentsToExcel(toExport, verticalsByTalent);
+  }, [selectedIds, creators, filtered, verticalsByTalent]);
+
+  const INPUT_CLS = 'h-8 rounded-lg border border-sp-admin-border bg-white px-3 text-[12px] text-sp-admin-text placeholder:text-sp-admin-muted/60 focus:outline-none focus:border-sp-admin-accent/50 shadow-[0_1px_2px_rgba(0,0,0,0.04)]';
 
   return (
     <div className="space-y-4">
       {/* KPIs de estado — clicables como filtros */}
       <div className="grid grid-cols-3 gap-2">
         {[
-          { label: 'Activos',     value: counts.active,    color: '#16a34a', filter: 'active' as TalentStatus },
-          { label: 'Disponibles', value: counts.available, color: '#5b9bd5', filter: 'available' as TalentStatus },
-          { label: 'Inactivos',   value: counts.inactive,  color: '#72728a', filter: 'inactive' as TalentStatus },
+          { label: 'Activos',     value: counts.active + counts.available, color: '#16a34a', filter: 'active' as TalentStatus },
+          { label: 'Inactivos',   value: counts.inactive,                  color: '#72728a', filter: 'inactive' as TalentStatus },
+          { label: 'Total',       value: creators.length,                  color: '#f5632a', filter: 'all' as const },
         ].map((s) => (
           <button
             key={s.label}
             type="button"
-            onClick={() => setStatusFilter(statusFilter === s.filter ? 'all' : s.filter)}
+            onClick={() => setStatusFilter(s.filter === 'all' ? 'all' : (statusFilter === s.filter ? 'all' : s.filter as TalentStatus | 'all'))}
             className={`rounded-lg bg-sp-admin-card shadow-[0_1px_3px_rgba(0,0,0,0.06)] overflow-hidden text-left hover:shadow-md transition-shadow ${statusFilter === s.filter ? 'ring-1 ring-sp-admin-accent/40' : ''}`}
           >
             <div className="h-[2px]" style={{ background: s.color }} />
@@ -93,7 +115,7 @@ export function InfluencerCardsView({ creators, verticalsByTalent }: Props): Rea
         ))}
       </div>
 
-      {/* Filtros */}
+      {/* Filtros + acciones */}
       <div className="flex flex-wrap items-center gap-2">
         <input
           type="search"
@@ -110,10 +132,59 @@ export function InfluencerCardsView({ creators, verticalsByTalent }: Props): Rea
           <option value="">Todas las plataformas</option>
           {platforms.map((p) => <option key={p} value={p}>{PLATFORM_LABELS[p] ?? p}</option>)}
         </select>
-        <span className="text-[11px] text-sp-admin-muted tabular-nums ml-auto">{filtered.length} de {creators.length}</span>
+        {countries.length > 0 && (
+          <select value={countryFilter} onChange={(e) => setCountryFilter(e.target.value)} className={INPUT_CLS}>
+            <option value="">Todos los países</option>
+            {countries.map((c) => <option key={c} value={c}>{c}</option>)}
+          </select>
+        )}
+        <span className="text-[11px] text-sp-admin-muted tabular-nums">{filtered.length} de {creators.length}</span>
+
+        {/* Acciones */}
+        <div className="flex items-center gap-1.5 ml-auto">
+          {selectMode && (
+            <>
+              <span className="text-[11px] text-sp-admin-muted">{selectedIds.size} sel.</span>
+              <button
+                type="button"
+                onClick={handleExport}
+                className="h-8 px-3 rounded-lg bg-sp-admin-accent text-white text-[12px] font-semibold hover:bg-sp-admin-accent/90 transition-colors"
+              >
+                Exportar
+              </button>
+              <button
+                type="button"
+                onClick={clearSelection}
+                className="h-8 px-3 rounded-lg border border-sp-admin-border text-[12px] text-sp-admin-muted hover:bg-sp-admin-hover transition-colors"
+              >
+                Cancelar
+              </button>
+            </>
+          )}
+          {!selectMode && (
+            <button
+              type="button"
+              onClick={() => setSelectMode(true)}
+              className="h-8 px-3 rounded-lg border border-sp-admin-border text-[12px] text-sp-admin-muted hover:bg-sp-admin-hover transition-colors"
+              title="Seleccionar para exportar"
+            >
+              Seleccionar
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={() => setShowAdd(true)}
+            className="h-8 px-3 rounded-lg bg-sp-admin-accent text-white text-[12px] font-semibold hover:bg-sp-admin-accent/90 transition-colors flex items-center gap-1"
+          >
+            <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden>
+              <path d="M5 1v8M1 5h8" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+            </svg>
+            Añadir talento
+          </button>
+        </div>
       </div>
 
-      {/* Grid — más columnas para cards más pequeñas */}
+      {/* Grid */}
       {filtered.length === 0 ? (
         creators.length === 0 ? (
           <EmptyState
@@ -121,8 +192,12 @@ export function InfluencerCardsView({ creators, verticalsByTalent }: Props): Rea
             title="Sin talentos"
             description="Importa talentos para empezar"
             action={
-              <button type="button" className="inline-flex items-center gap-2 rounded-xl bg-sp-admin-accent px-4 py-2 text-sm font-semibold text-white hover:opacity-90 transition-opacity cursor-pointer">
-                Importar
+              <button
+                type="button"
+                onClick={() => setShowAdd(true)}
+                className="inline-flex items-center gap-2 rounded-xl bg-sp-admin-accent px-4 py-2 text-sm font-semibold text-white hover:opacity-90 transition-opacity cursor-pointer"
+              >
+                + Añadir talento
               </button>
             }
           />
@@ -132,10 +207,19 @@ export function InfluencerCardsView({ creators, verticalsByTalent }: Props): Rea
       ) : (
         <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3">
           {filtered.map((c) => (
-            <TalentCard key={c.id} creator={c} verticals={verticalsByTalent[c.id] ?? []} />
+            <TalentCard
+              key={c.id}
+              creator={c}
+              verticals={verticalsByTalent[c.id] ?? []}
+              selectMode={selectMode}
+              selected={selectedIds.has(c.id)}
+              onToggleSelect={toggleSelect}
+            />
           ))}
         </div>
       )}
+
+      {showAdd && <AddTalentModal onClose={() => setShowAdd(false)} />}
     </div>
   );
 }

--- a/src/features/admin/talents/components/TalentDataTools.tsx
+++ b/src/features/admin/talents/components/TalentDataTools.tsx
@@ -20,7 +20,7 @@ export type CurrentTalent = {
   }[];
 };
 
-type Tab = 'import' | 'stats' | 'export';
+type Tab = 'import' | 'export';
 
 type Props = {
   readonly roster:            readonly CurrentTalent[];
@@ -31,27 +31,42 @@ type Props = {
 const TABS: { key: Tab; label: string; desc: string }[] = [
   {
     key:   'import',
-    label: 'Importar talentos',
-    desc:  'Sube tu Excel o CSV de Google Sheets para crear o actualizar talentos con todas sus redes sociales.',
-  },
-  {
-    key:   'stats',
-    label: 'Actualizar estadísticas',
-    desc:  'Importa followers, CCV y URLs para talentos ya existentes en el CRM.',
+    label: 'Importar archivo',
+    desc:  'Sube tu archivo exportado desde Google Sheets o Excel para crear o actualizar talentos con todas sus redes sociales.',
   },
   {
     key:   'export',
-    label: 'Exportar Excel',
-    desc:  'Selecciona los influencers y descarga el roster en Excel con branding SocialPro.',
+    label: 'Exportar talentos',
+    desc:  'Selecciona los talentos, plataformas y campos que quieres incluir. Descarga el roster en Excel o CSV.',
   },
 ];
 
-export function TalentDataTools({ roster, creators, verticalsByTalent }: Props): React.ReactElement {
+export function TalentDataTools({ roster: _roster, creators, verticalsByTalent }: Props): React.ReactElement {
   const [tab, setTab] = useState<Tab>('import');
   const active = TABS.find((t) => t.key === tab)!;
 
   return (
     <div className="space-y-5">
+
+      {/* Descripción del módulo */}
+      <div className="rounded-xl bg-sp-admin-card border border-sp-admin-border px-5 py-4">
+        <div className="flex items-start gap-3">
+          <div className="w-8 h-8 rounded-lg bg-sp-admin-accent/10 flex items-center justify-center shrink-0 mt-0.5">
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden>
+              <path d="M9 1H4a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V6L9 1Z" stroke="#f5632a" strokeWidth="1.2" strokeLinejoin="round"/>
+              <path d="M9 1v5h5" stroke="#f5632a" strokeWidth="1.2" strokeLinejoin="round"/>
+              <path d="M5 9h6M5 12h4" stroke="#f5632a" strokeWidth="1.2" strokeLinecap="round"/>
+            </svg>
+          </div>
+          <div>
+            <p className="text-[13px] font-semibold text-sp-admin-text">Importar y exportar talentos</p>
+            <p className="text-[12px] text-sp-admin-muted mt-0.5">
+              Gestiona el roster desde Excel o CSV. Importa nuevos talentos o actualiza los existentes, y exporta los datos en el formato que necesites.
+            </p>
+          </div>
+        </div>
+      </div>
+
       {/* Sub-tabs */}
       <div className="flex items-end gap-0 border-b border-sp-admin-border">
         {TABS.map((t) => (
@@ -75,16 +90,9 @@ export function TalentDataTools({ roster, creators, verticalsByTalent }: Props):
       <p className="text-[12px] text-sp-admin-muted -mt-2">{active.desc}</p>
 
       {tab === 'import' && <TalentImporter />}
-      {tab === 'stats'  && (
-        <div className="rounded-xl border border-sp-admin-border bg-sp-admin-card p-8 text-center">
-          <p className="text-sm text-sp-admin-muted">
-            {/* TODO: StatsImportPanel — pendiente de migración */}
-            Panel de estadísticas pendiente de migración. Usa la importación CSV para actualizar datos.
-          </p>
-          <p className="text-[10px] text-sp-admin-muted/60 mt-1">{roster.length} talentos disponibles</p>
-        </div>
+      {tab === 'export' && (
+        <TalentExportView creators={creators} verticalsByTalent={verticalsByTalent} />
       )}
-      {tab === 'export' && <TalentExportView creators={creators} verticalsByTalent={verticalsByTalent} />}
     </div>
   );
 }


### PR DESCRIPTION
## ¿Qué hace este PR?

Rediseño completo de la vista de talentos: card limpia tipo catálogo, perfil con tabs y herramientas de datos.

## Cambios

### TalentCard (InfluencerCardsView.parts.tsx)
- **Imagen limpia**: sin texto superpuesto. Solo bandera del país en esquina superior derecha (emoji o imagen).
- **Hover overlay**: botones "Ver perfil" y "Editar" aparecen al pasar el ratón.
- **Cuerpo**: Nombre → Categoría/juego → Plataformas (dot de color + nombre, sin números) → Sector badges.
- **Footer**: Badge de estado clickable (cicla `active → available → inactive` con optimistic update) + una métrica principal (`Twitch · 46.6K`).
- Nuevas constantes: `PLATFORM_DOT` (colores por plataforma), `STATUS_CFG` (estilos badge).

### Vista de lista / grid
- Modo selección múltiple (`selectMode`) con checkbox visual.
- Filtros por plataforma y vertical.

### Perfil de talento
- Tabs: Stats · GEO · Negocio · Histórico.

### TalentDataTools
- Importación CSV con mapeo de columnas.
- Sync de seguidores desde APIs.

## Cómo probarlo

1. `npm run dev` → `/admin/talents`
2. Verificar card: imagen limpia, hover overlay, footer con estado y métrica
3. Cambiar estado desde el badge del footer y verificar optimistic update
4. Abrir perfil de un talento y navegar entre tabs

## Dependencias

- Depende de **PR 1** (layout y sidebar)
- No requiere cambios en DB

## Riesgo

Bajo — solo UI, no modifica server actions ni queries.

## Checklist

- [ ] Ejecutar `npm run lint`
- [ ] Ejecutar `npx tsc --noEmit`
- [ ] Verificar card en móvil (375px)
- [ ] Cambiar estado desde el badge — verificar que persiste
- [ ] Abrir perfil de talento — verificar tabs
- [ ] Modo selección múltiple funcional