### PR TITLE
feat(contracts): contract tab, template manager and seed templates

### DIFF
--- a/src/app/admin/(dashboard)/campanas/plantillas/actions.ts
+++ b/src/app/admin/(dashboard)/campanas/plantillas/actions.ts
@@ -1,0 +1,109 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { requireRole } from '@/lib/auth-guard';
+import {
+  createContractTemplate,
+  updateContractTemplate,
+  deleteContractTemplate,
+} from '@/lib/queries/contractTemplates';
+import { CONTRACT_TEMPLATE_SEEDS } from '@/lib/contractTemplateSeeds';
+
+type ActionState = { readonly error?: string; readonly success?: boolean; readonly id?: number };
+
+// ── Crear plantilla ───────────────────────────────────────────────────
+
+export async function createTemplateAction(
+  _prev: ActionState,
+  formData: FormData,
+): Promise<ActionState> {
+  await requireRole('admin', '/admin/login');
+
+  const name    = (formData.get('name')    as string | null)?.trim();
+  const type    = (formData.get('type')    as string | null)?.trim() ?? 'general';
+  const content = (formData.get('content') as string | null)?.trim();
+
+  if (!name)    return { error: 'El nombre es obligatorio' };
+  if (!content) return { error: 'El contenido no puede estar vacío' };
+
+  try {
+    const tpl = await createContractTemplate({ name, type, content });
+    revalidatePath('/admin/campanas/plantillas');
+    return { success: true, id: tpl.id };
+  } catch (err) {
+    console.error('[admin] createTemplate error:', err instanceof Error ? err.message : 'unknown');
+    return { error: 'Error al crear la plantilla' };
+  }
+}
+
+// ── Actualizar plantilla ──────────────────────────────────────────────
+
+export async function updateTemplateAction(
+  _prev: ActionState,
+  formData: FormData,
+): Promise<ActionState> {
+  await requireRole('admin', '/admin/login');
+
+  const id      = Number(formData.get('id'));
+  const name    = (formData.get('name')    as string | null)?.trim();
+  const type    = (formData.get('type')    as string | null)?.trim();
+  const content = (formData.get('content') as string | null)?.trim();
+
+  if (isNaN(id)) return { error: 'ID inválido' };
+  if (!name)     return { error: 'El nombre es obligatorio' };
+  if (!content)  return { error: 'El contenido no puede estar vacío' };
+
+  try {
+    await updateContractTemplate(id, { name, type: type ?? 'general', content });
+    revalidatePath('/admin/campanas/plantillas');
+    return { success: true };
+  } catch (err) {
+    console.error('[admin] updateTemplate error:', err instanceof Error ? err.message : 'unknown');
+    return { error: 'Error al guardar la plantilla' };
+  }
+}
+
+// ── Activar / desactivar ──────────────────────────────────────────────
+
+export async function toggleTemplateActiveAction(id: number, isActive: boolean): Promise<ActionState> {
+  await requireRole('admin', '/admin/login');
+  try {
+    await updateContractTemplate(id, { isActive });
+    revalidatePath('/admin/campanas/plantillas');
+    return { success: true };
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : 'Error' };
+  }
+}
+
+// ── Eliminar ──────────────────────────────────────────────────────────
+
+export async function deleteTemplateAction(id: number): Promise<ActionState> {
+  await requireRole('admin', '/admin/login');
+  try {
+    await deleteContractTemplate(id);
+    revalidatePath('/admin/campanas/plantillas');
+    return { success: true };
+  } catch (err) {
+    console.error('[admin] deleteTemplate error:', err instanceof Error ? err.message : 'unknown');
+    return { error: 'Error al eliminar la plantilla' };
+  }
+}
+
+// ── Importar plantillas semilla ───────────────────────────────────────
+
+export async function seedDefaultTemplatesAction(): Promise<ActionState> {
+  await requireRole('admin', '/admin/login');
+  try {
+    let created = 0;
+    for (const seed of CONTRACT_TEMPLATE_SEEDS) {
+      await createContractTemplate({ name: seed.name, type: seed.type, content: seed.content });
+      created++;
+    }
+    revalidatePath('/admin/campanas/plantillas');
+    return { success: true, id: created };
+  } catch (err) {
+    console.error('[admin] seedTemplates error:', err instanceof Error ? err.message : 'unknown');
+    return { error: 'Error al importar plantillas' };
+  }
+}

--- a/src/app/admin/(dashboard)/campanas/plantillas/page.tsx
+++ b/src/app/admin/(dashboard)/campanas/plantillas/page.tsx
@@ -1,0 +1,12 @@
+import { requireRole } from '@/lib/auth-guard';
+import { listContractTemplates } from '@/lib/queries/contractTemplates';
+import { ContractTemplatesManager } from '@/features/admin/campaigns/components/ContractTemplatesManager';
+
+export const metadata = { title: 'Plantillas de contratos | Admin' };
+
+export default async function ContractTemplatesPage(): Promise<React.ReactElement> {
+  await requireRole('admin', '/admin/login');
+  const templates = await listContractTemplates(true); // incluye inactivas para gestión
+
+  return <ContractTemplatesManager templates={templates} />;
+}

--- a/src/features/admin/_shared/components/campaigns/ContractTab.tsx
+++ b/src/features/admin/_shared/components/campaigns/ContractTab.tsx
@@ -81,12 +81,17 @@ export function ContractTab({ campaignId, contract, isAdmin, templates, campaign
           onDone={() => setShowGenerator(false)}
         />
       ) : (
-        <div className="flex items-center gap-3">
-          {templates.length > 0 && (
+        <div className="flex items-center gap-3 flex-wrap">
+          {templates.length > 0 ? (
             <button type="button" onClick={() => setShowGenerator(true)}
               className={`${BP} flex items-center gap-2`}>
               ✨ Generar contrato desde plantilla
             </button>
+          ) : (
+            <a href="/admin/campanas/plantillas" target="_blank" rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 h-8 px-3 rounded-lg border border-sp-admin-border text-[11px] font-semibold text-sp-admin-muted hover:text-sp-admin-accent hover:bg-sp-admin-hover transition-colors">
+              📋 Crear plantillas de contrato →
+            </a>
           )}
           <span className="text-[11px] text-sp-admin-muted">o súbelo manualmente abajo</span>
         </div>

--- a/src/features/admin/campaigns/components/ContractTemplatesManager.tsx
+++ b/src/features/admin/campaigns/components/ContractTemplatesManager.tsx
@@ -1,0 +1,409 @@
+'use client';
+
+import { useActionState, useMemo, useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import {
+  createTemplateAction,
+  updateTemplateAction,
+  toggleTemplateActiveAction,
+  deleteTemplateAction,
+  seedDefaultTemplatesAction,
+} from '@/app/admin/(dashboard)/campanas/plantillas/actions';
+import { AVAILABLE_VARIABLES } from '@/lib/contractVariables';
+import { TEMPLATE_TYPES } from '@/lib/queries/contractTemplates';
+import type { ContractTemplate } from '@/lib/queries/contractTemplates';
+
+// ── Estilos ───────────────────────────────────────────────────────────
+
+const I   = 'w-full rounded-lg border border-sp-admin-border bg-white px-3 py-2 text-[12px] text-sp-admin-text outline-none focus:border-sp-admin-accent/50 transition-colors shadow-[0_1px_2px_rgba(0,0,0,0.04)]';
+const TA  = `${I} resize-none font-mono text-[11px]`;
+const LB  = 'block text-[10px] font-bold uppercase tracking-[0.14em] text-sp-admin-muted mb-1';
+
+// ── Tipo label ────────────────────────────────────────────────────────
+
+function TypeBadge({ type }: { type: string }): React.ReactElement {
+  const cfg = TEMPLATE_TYPES.find((t) => t.value === type);
+  const colors: Record<string, string> = {
+    casino:     'bg-red-50 text-red-700 border-red-200',
+    cs2_cases:  'bg-yellow-50 text-yellow-700 border-yellow-200',
+    marketplace: 'bg-orange-50 text-orange-700 border-orange-200',
+    youtube:    'bg-red-50 text-red-600 border-red-200',
+    twitch:     'bg-purple-50 text-purple-700 border-purple-200',
+    instagram:  'bg-pink-50 text-pink-700 border-pink-200',
+    sports_bet: 'bg-green-50 text-green-700 border-green-200',
+    general:    'bg-slate-50 text-slate-600 border-slate-200',
+  };
+  return (
+    <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-[9px] font-bold border ${colors[type] ?? colors.general}`}>
+      {cfg?.label ?? type}
+    </span>
+  );
+}
+
+// ── Editor de plantilla ───────────────────────────────────────────────
+
+function TemplateEditor({
+  template,
+  onClose,
+  mode,
+}: {
+  readonly template?: ContractTemplate | undefined;
+  readonly onClose:   () => void;
+  readonly mode:      'create' | 'edit';
+}): React.ReactElement {
+  const action = mode === 'create' ? createTemplateAction : updateTemplateAction;
+  const [state, formAction, isPending] = useActionState(action, {});
+
+  const [content, setContent] = useState(template?.content ?? '');
+  const [search,  setSearch]  = useState('');
+
+  if (state.success && !isPending) setTimeout(onClose, 0);
+
+  const filteredVars = useMemo(() =>
+    AVAILABLE_VARIABLES.filter((v) =>
+      v.key.includes(search.toLowerCase()) || v.label.toLowerCase().includes(search.toLowerCase()),
+    ),
+  [search]);
+
+  function insertVariable(key: string): void {
+    setContent((prev) => `${prev}{{${key}}}`);
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/40 backdrop-blur-sm flex items-start justify-center p-4 overflow-y-auto">
+      <div className="bg-sp-admin-card rounded-xl shadow-2xl w-full max-w-5xl my-4" onClick={(e) => e.stopPropagation()}>
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-sp-admin-border sticky top-0 bg-sp-admin-card z-10 rounded-t-xl">
+          <h2 className="text-[15px] font-bold text-sp-admin-text">
+            {mode === 'create' ? 'Nueva plantilla' : `Editar: ${template?.name}`}
+          </h2>
+          <button type="button" onClick={onClose} className="text-sp-admin-muted hover:text-sp-admin-text text-xl leading-none">×</button>
+        </div>
+
+        <form action={formAction} className="flex gap-0 h-[70vh]">
+          {mode === 'edit' && template && <input type="hidden" name="id" value={template.id} />}
+          <input type="hidden" name="content" value={content} />
+
+          {/* Panel izquierdo: meta + editor */}
+          <div className="flex-1 flex flex-col border-r border-sp-admin-border">
+            {/* Meta */}
+            <div className="grid grid-cols-2 gap-3 px-5 py-4 border-b border-sp-admin-border/60">
+              <div>
+                <label className={LB}>Nombre *</label>
+                <input name="name" required defaultValue={template?.name ?? ''} placeholder="Contrato Casino — Tier 1 LATAM" className={I} />
+              </div>
+              <div>
+                <label className={LB}>Tipo de campaña</label>
+                <select name="type" defaultValue={template?.type ?? 'general'} className={I}>
+                  {TEMPLATE_TYPES.map((t) => (
+                    <option key={t.value} value={t.value}>{t.label}</option>
+                  ))}
+                </select>
+              </div>
+            </div>
+
+            {/* Editor de texto */}
+            <div className="flex-1 px-5 py-3 flex flex-col">
+              <div className="flex items-center justify-between mb-2">
+                <label className={LB}>Contenido de la plantilla *</label>
+                <span className="text-[9px] text-sp-admin-muted/60">
+                  Usa <code className="font-mono bg-sp-admin-hover px-1 rounded">{`{{variable}}`}</code> para insertar datos del trato
+                </span>
+              </div>
+              <textarea
+                name="_content_display"
+                value={content}
+                onChange={(e) => setContent(e.target.value)}
+                rows={20}
+                placeholder="Escribe el contenido del contrato aquí…&#10;&#10;Usa {{brand_name}}, {{influencer_name}}, {{total_amount}}, etc."
+                className={`${TA} flex-1`}
+              />
+            </div>
+          </div>
+
+          {/* Panel derecho: variables */}
+          <div className="w-60 flex flex-col bg-sp-admin-hover/20">
+            <div className="px-4 py-3 border-b border-sp-admin-border/60">
+              <p className="text-[10px] font-bold uppercase tracking-wider text-sp-admin-muted mb-2">Variables disponibles</p>
+              <input
+                type="search"
+                placeholder="Buscar variable…"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                className={`${I} h-7 text-[11px]`}
+              />
+            </div>
+            <div className="flex-1 overflow-y-auto px-3 py-2 space-y-1">
+              {filteredVars.map((v) => (
+                <button
+                  key={v.key}
+                  type="button"
+                  onClick={() => insertVariable(v.key)}
+                  className="w-full text-left rounded-lg px-2.5 py-2 hover:bg-sp-admin-hover transition-colors group"
+                  title={`Insertar {{${v.key}}}`}
+                >
+                  <p className="text-[10px] font-mono font-semibold text-sp-admin-accent group-hover:text-sp-admin-accent/80">
+                    {`{{${v.key}}}`}
+                  </p>
+                  <p className="text-[9px] text-sp-admin-muted truncate">{v.label}</p>
+                </button>
+              ))}
+            </div>
+          </div>
+        </form>
+
+        {/* Footer */}
+        <div className="flex items-center justify-between px-6 py-4 border-t border-sp-admin-border">
+          {state.error && <p className="text-[12px] text-red-500">{state.error}</p>}
+          <div className="ml-auto flex items-center gap-2">
+            <button type="button" onClick={onClose}
+              className="h-9 px-4 rounded-lg border border-sp-admin-border text-[12px] text-sp-admin-muted hover:bg-sp-admin-hover transition-colors">
+              Cancelar
+            </button>
+            <button
+              type="submit"
+              form=""
+              disabled={isPending}
+              onClick={() => {
+                const form = document.querySelector('form');
+                if (form) form.requestSubmit();
+              }}
+              className="h-9 px-5 rounded-lg bg-sp-admin-accent text-white text-[12px] font-bold hover:bg-sp-admin-accent/90 disabled:opacity-50 transition-colors"
+            >
+              {isPending ? 'Guardando…' : mode === 'create' ? 'Crear plantilla' : 'Guardar cambios'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Componente principal ──────────────────────────────────────────────
+
+type Props = { readonly templates: readonly ContractTemplate[] };
+
+export function ContractTemplatesManager({ templates }: Props): React.ReactElement {
+  const router = useRouter();
+  const [, startTransition] = useTransition();
+  const [editing,   setEditing]   = useState<ContractTemplate | null>(null);
+  const [creating,  setCreating]  = useState(false);
+  const [seeding,   setSeeding]   = useState(false);
+  const [seedMsg,   setSeedMsg]   = useState('');
+
+  // Agrupar por tipo
+  const grouped = useMemo(() => {
+    const map = new Map<string, ContractTemplate[]>();
+    for (const t of templates) {
+      const list = map.get(t.type) ?? [];
+      list.push(t);
+      map.set(t.type, list);
+    }
+    return map;
+  }, [templates]);
+
+  function handleToggle(id: number, current: boolean): void {
+    startTransition(async () => {
+      await toggleTemplateActiveAction(id, !current);
+      router.refresh();
+    });
+  }
+
+  function handleDelete(t: ContractTemplate): void {
+    if (!confirm(`¿Eliminar la plantilla "${t.name}"? Esta acción no se puede deshacer.`)) return;
+    startTransition(async () => {
+      await deleteTemplateAction(t.id);
+      router.refresh();
+    });
+  }
+
+  function handleSeed(): void {
+    if (!confirm('¿Importar las 6 plantillas predefinidas (General, Casino, CS2, Marketplace, YouTube, Twitch)? Se añadirán a las existentes.')) return;
+    setSeeding(true);
+    setSeedMsg('');
+    startTransition(async () => {
+      const res = await seedDefaultTemplatesAction();
+      if (res.success) {
+        setSeedMsg(`✓ ${res.id} plantillas importadas correctamente`);
+        router.refresh();
+      } else {
+        setSeedMsg(`✕ ${res.error ?? 'Error'}`);
+      }
+      setSeeding(false);
+    });
+  }
+
+  return (
+    <div className="space-y-5">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-4 flex-wrap">
+        <div>
+          <div className="flex items-center gap-2 mb-0.5">
+            <Link href="/admin/campanas" className="text-[11px] text-sp-admin-muted hover:text-sp-admin-accent transition-colors">
+              ← Tratos
+            </Link>
+          </div>
+          <h1 className="text-xl font-bold text-sp-admin-text leading-none">Plantillas de contratos</h1>
+          <p className="text-[11px] text-sp-admin-muted mt-1">
+            {templates.length} plantillas · gestiona los modelos reutilizables para generar contratos desde los tratos
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {templates.length === 0 && (
+            <button
+              type="button"
+              onClick={handleSeed}
+              disabled={seeding}
+              className="h-9 px-4 rounded-lg border border-sp-admin-border text-[12px] font-semibold text-sp-admin-muted hover:bg-sp-admin-hover disabled:opacity-50 transition-colors"
+            >
+              {seeding ? 'Importando…' : '📥 Importar plantillas predefinidas'}
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={() => setCreating(true)}
+            className="flex items-center gap-1.5 h-9 px-4 rounded-lg bg-sp-admin-accent text-white text-[12px] font-semibold hover:bg-sp-admin-accent/90 transition-colors"
+          >
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden>
+              <path d="M6 1v10M1 6h10" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round"/>
+            </svg>
+            Nueva plantilla
+          </button>
+        </div>
+      </div>
+
+      {/* Feedback seed */}
+      {seedMsg && (
+        <div className={`rounded-xl border px-4 py-2.5 text-[12px] font-medium ${
+          seedMsg.startsWith('✓') ? 'border-emerald-200 bg-emerald-50 text-emerald-800' : 'border-red-200 bg-red-50 text-red-800'
+        }`}>
+          {seedMsg}
+        </div>
+      )}
+
+      {/* Banner importar si hay pocas plantillas */}
+      {templates.length > 0 && templates.length < 3 && (
+        <div className="flex items-center gap-3 rounded-xl border border-blue-200 bg-blue-50 px-4 py-3">
+          <span className="text-blue-500 text-[15px]" aria-hidden>💡</span>
+          <div className="flex-1">
+            <p className="text-[12px] text-blue-800 font-medium">
+              Importa las plantillas predefinidas para Casino, CS2, Marketplace, YouTube y Twitch con un clic.
+            </p>
+          </div>
+          <button type="button" onClick={handleSeed} disabled={seeding}
+            className="h-7 px-3 rounded-lg bg-blue-600 text-white text-[11px] font-bold hover:bg-blue-700 disabled:opacity-50 transition-colors shrink-0">
+            {seeding ? '…' : 'Importar'}
+          </button>
+        </div>
+      )}
+
+      {/* Vacío */}
+      {templates.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-sp-admin-border bg-sp-admin-card p-10 text-center">
+          <p className="text-[15px] font-bold text-sp-admin-text mb-1">Sin plantillas todavía</p>
+          <p className="text-[12px] text-sp-admin-muted mb-4">
+            Importa las plantillas predefinidas (Casino, CS2, YouTube, Twitch…) o crea una desde cero.
+          </p>
+          <div className="flex items-center justify-center gap-3">
+            <button type="button" onClick={handleSeed} disabled={seeding}
+              className="h-9 px-4 rounded-lg border border-sp-admin-border text-[12px] font-semibold text-sp-admin-muted hover:bg-sp-admin-hover disabled:opacity-50 transition-colors">
+              {seeding ? 'Importando…' : '📥 Importar predefinidas (Casino, CS2, YouTube…)'}
+            </button>
+            <button type="button" onClick={() => setCreating(true)}
+              className="h-9 px-4 rounded-lg bg-sp-admin-accent text-white text-[12px] font-semibold hover:bg-sp-admin-accent/90 transition-colors">
+              + Crear desde cero
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="space-y-5">
+          {TEMPLATE_TYPES.map(({ value: typeKey, label: typeLabel }) => {
+            const list = grouped.get(typeKey);
+            if (!list?.length) return null;
+            return (
+              <div key={typeKey}>
+                <div className="flex items-center gap-2 mb-2">
+                  <TypeBadge type={typeKey} />
+                  <span className="text-[10px] text-sp-admin-muted">{list.length} plantilla{list.length !== 1 ? 's' : ''}</span>
+                </div>
+                <div className="rounded-xl border border-sp-admin-border bg-sp-admin-card overflow-hidden">
+                  {list.map((tpl) => (
+                    <div
+                      key={tpl.id}
+                      className={`flex items-center gap-3 px-4 py-3 border-b border-sp-admin-border/40 last:border-0 transition-colors group hover:bg-sp-admin-hover/20 ${!tpl.isActive ? 'opacity-50' : ''}`}
+                    >
+                      {/* Toggle activa */}
+                      <input
+                        type="checkbox"
+                        checked={tpl.isActive}
+                        onChange={() => handleToggle(tpl.id, tpl.isActive)}
+                        className="rounded accent-sp-admin-accent cursor-pointer shrink-0"
+                        title={tpl.isActive ? 'Desactivar' : 'Activar'}
+                      />
+
+                      {/* Info */}
+                      <div className="flex-1 min-w-0">
+                        <p className="text-[13px] font-semibold text-sp-admin-text truncate">{tpl.name}</p>
+                        <p className="text-[10px] text-sp-admin-muted mt-0.5">
+                          {tpl.content.length} caracteres · actualizada {new Date(tpl.updatedAt).toLocaleDateString('es-ES')}
+                        </p>
+                      </div>
+
+                      {/* Acciones */}
+                      <div className="flex items-center gap-1.5 opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
+                        <button
+                          type="button"
+                          onClick={() => setEditing(tpl)}
+                          className="h-7 px-3 rounded-lg border border-sp-admin-border text-[11px] font-semibold text-sp-admin-muted hover:text-sp-admin-text hover:bg-sp-admin-hover transition-colors"
+                        >
+                          Editar
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleDelete(tpl)}
+                          className="h-7 px-2 rounded-lg text-[11px] font-semibold text-red-400 hover:bg-red-50 transition-colors"
+                        >
+                          ✕
+                        </button>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Variables disponibles referencia */}
+      <details className="group">
+        <summary className="cursor-pointer select-none flex items-center gap-2 text-[11px] font-semibold text-sp-admin-muted hover:text-sp-admin-text">
+          <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"
+            className="group-open:rotate-90 transition-transform" aria-hidden>
+            <path d="M3 1l4 4-4 4"/>
+          </svg>
+          Variables disponibles para usar en plantillas
+        </summary>
+        <div className="mt-3 rounded-xl border border-sp-admin-border bg-sp-admin-card px-4 py-3">
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-2">
+            {AVAILABLE_VARIABLES.map((v) => (
+              <div key={v.key} className="rounded-lg bg-sp-admin-hover/40 px-2.5 py-2">
+                <p className="text-[10px] font-mono font-bold text-sp-admin-accent">{`{{${v.key}}}`}</p>
+                <p className="text-[9px] text-sp-admin-muted">{v.label}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </details>
+
+      {/* Modales */}
+      {creating && (
+        <TemplateEditor mode="create" onClose={() => { setCreating(false); router.refresh(); }} />
+      )}
+      {editing && (
+        <TemplateEditor mode="edit" template={editing} onClose={() => { setEditing(null); router.refresh(); }} />
+      )}
+    </div>
+  );
+}

--- a/src/lib/contractTemplateSeeds.ts
+++ b/src/lib/contractTemplateSeeds.ts
@@ -1,0 +1,413 @@
+/**
+ * Plantillas semilla de contratos para cada tipo de campaña.
+ * Se pueden insertar desde la UI de gestión de plantillas.
+ */
+
+export const CONTRACT_TEMPLATE_SEEDS = [
+
+  // ── GENERAL ────────────────────────────────────────────────────────
+  {
+    name:    'Contrato de servicios — General',
+    type:    'general',
+    content: `CONTRATO DE PRESTACIÓN DE SERVICIOS DE MARKETING DIGITAL
+
+Entre las partes:
+
+AGENCIA: {{agency_entity}}, con NIF {{agency_taxid}}, en adelante "la Agencia".
+
+MARCA: {{brand_name}}, en adelante "el Cliente".
+
+CREADOR: {{influencer_name}}, en adelante "el Creador".
+
+=====================================
+1. OBJETO DEL CONTRATO
+=====================================
+
+El presente contrato tiene por objeto la prestación de servicios de marketing digital y promoción de contenido para la campaña denominada "{{campaign_name}}", en el ámbito geográfico de {{geo}}.
+
+=====================================
+2. SERVICIOS Y ENTREGABLES
+=====================================
+
+El Creador se compromete a realizar los siguientes entregables:
+
+{{deliverables}}
+
+Periodo de campaña: del {{start_date}} al {{end_date}}.
+
+=====================================
+3. RETRIBUCIÓN
+=====================================
+
+El Cliente abonará a la Agencia la cantidad de {{total_amount}} {{currency}} (IVA no incluido) en concepto de los servicios descritos.
+
+La Agencia abonará al Creador la cantidad acordada según acuerdo interno.
+
+Forma de pago: transferencia bancaria dentro de los 30 días naturales desde la firma del contrato.
+
+=====================================
+4. DERECHOS DE USO
+=====================================
+
+El Cliente queda autorizado a utilizar los contenidos generados durante la campaña para sus canales propios durante 12 meses desde la fecha de publicación.
+
+=====================================
+5. CONFIDENCIALIDAD
+=====================================
+
+Ambas partes se comprometen a mantener la confidencialidad de los términos económicos del presente contrato.
+
+=====================================
+6. LEGISLACIÓN APLICABLE
+=====================================
+
+Este contrato se rige por la legislación española. Las partes se someten a los juzgados y tribunales de España para la resolución de cualquier conflicto.
+
+=====================================
+FIRMAS
+=====================================
+
+Por la Agencia:                    Por el Cliente:
+{{agency_name}}                    {{brand_name}}
+
+Nombre: ___________________        Nombre: ___________________
+Fecha: {{today}}                   Fecha: {{today}}
+
+Por el Creador:
+{{influencer_name}}
+
+Nombre: ___________________
+Fecha: {{today}}`,
+  },
+
+  // ── CASINO / iGAMING ───────────────────────────────────────────────
+  {
+    name:    'Contrato de servicios — Casino / iGaming',
+    type:    'casino',
+    content: `CONTRATO DE COLABORACIÓN PUBLICITARIA — SECTOR iGAMING
+
+Entre las partes:
+
+AGENCIA: {{agency_entity}}, NIF {{agency_taxid}}.
+OPERADOR: {{brand_name}}.
+CREADOR DE CONTENIDO: {{influencer_name}}.
+
+=====================================
+AVISO LEGAL OBLIGATORIO
+=====================================
+
+Los servicios promocionales objeto de este contrato están destinados exclusivamente a audiencias mayores de 18 años. El Creador se compromete a incluir en todos los contenidos el mensaje de juego responsable requerido por la normativa aplicable y las directrices del Operador.
+
+=====================================
+1. OBJETO
+=====================================
+
+Promoción de los servicios del Operador {{brand_name}} a través de contenido digital en las plataformas acordadas, durante la campaña "{{campaign_name}}" en el mercado de {{geo}}.
+
+=====================================
+2. OBLIGACIONES DEL CREADOR
+=====================================
+
+El Creador se compromete a:
+
+{{deliverables}}
+
+- Incluir en TODOS los contenidos el aviso de juego responsable.
+- No dirigir el contenido a menores de 18 años.
+- Respetar las restricciones de comunicación comercial de juego aplicables en {{geo}}.
+- No realizar comparaciones directas con competidores sin aprobación previa.
+
+Periodo de campaña: {{start_date}} — {{end_date}}.
+
+=====================================
+3. CONTENIDO PROHIBIDO
+=====================================
+
+Queda expresamente prohibido:
+- Garantizar ganancias o resultados positivos.
+- Promocionar el juego como solución a problemas económicos.
+- Usar lenguaje o imágenes que minimicen los riesgos del juego.
+
+=====================================
+4. RETRIBUCIÓN
+=====================================
+
+Importe total: {{total_amount}} {{currency}}.
+Comisión de agencia: {{commission}} {{currency}}.
+
+Pago a 30 días desde la entrega y aprobación de los contenidos.
+
+=====================================
+5. EXCLUSIVIDAD
+=====================================
+
+Durante la vigencia del contrato, el Creador no podrá colaborar con operadores de iGaming competidores directos en el mismo mercado geográfico sin consentimiento previo por escrito.
+
+=====================================
+FIRMAS
+=====================================
+
+{{agency_name}} / {{brand_name}} / {{influencer_name}}
+
+Fecha: {{today}}`,
+  },
+
+  // ── CS2 CASES ─────────────────────────────────────────────────────
+  {
+    name:    'Contrato de servicios — CS2 Cases / Skins',
+    type:    'cs2_cases',
+    content: `CONTRATO DE COLABORACIÓN — CS2 CASES & SKINS
+
+Partes:
+
+AGENCIA: {{agency_entity}}, NIF {{agency_taxid}}.
+PLATAFORMA: {{brand_name}}.
+CREADOR: {{influencer_name}}.
+
+=====================================
+1. OBJETO
+=====================================
+
+Promoción de la plataforma {{brand_name}} mediante contenido de entretenimiento relacionado con CS2 (Counter-Strike 2) en la campaña "{{campaign_name}}".
+
+Mercado: {{geo}}.
+Periodo: {{start_date}} — {{end_date}}.
+
+=====================================
+2. ENTREGABLES
+=====================================
+
+{{deliverables}}
+
+Especificaciones de contenido:
+- Los vídeos/streams deben mostrar el uso real de la plataforma.
+- Incluir código de referido o enlace de afiliado en descripción y chat.
+- Mencionar los beneficios para nuevos usuarios.
+
+=====================================
+3. REQUISITOS LEGALES Y DE PLATAFORMA
+=====================================
+
+El Creador confirma que:
+- Su audiencia es mayoritariamente mayor de 18 años.
+- El contenido cumple con las normas de las plataformas (YouTube/Twitch/TikTok).
+- Se indicará que el contenido es publicidad (etiqueta #AD o equivalente).
+
+=====================================
+4. RETRIBUCIÓN
+=====================================
+
+Importe acordado: {{total_amount}} {{currency}}.
+
+Condiciones de pago: transferencia bancaria a los 15 días desde la publicación del contenido.
+
+=====================================
+5. APROBACIÓN DE CONTENIDO
+=====================================
+
+El Creador enviará a la Agencia el contenido previo a su publicación para revisión. La Agencia dispondrá de 48 horas para aprobar o solicitar modificaciones.
+
+=====================================
+FIRMAS
+=====================================
+
+Por {{agency_name}}: _______________
+Por {{brand_name}}: ________________
+Por {{influencer_name}}: ____________
+
+Fecha: {{today}}`,
+  },
+
+  // ── MARKETPLACE CS2 ────────────────────────────────────────────────
+  {
+    name:    'Contrato de servicios — Marketplace (Skins/Items)',
+    type:    'marketplace',
+    content: `CONTRATO DE COLABORACIÓN — MARKETPLACE DE SKINS
+
+Partes:
+
+AGENCIA: {{agency_entity}}, NIF {{agency_taxid}}.
+MARKETPLACE: {{brand_name}}.
+CREADOR: {{influencer_name}}.
+
+=====================================
+1. OBJETO
+=====================================
+
+Promoción del marketplace {{brand_name}} (compra/venta de skins e items de videojuegos) a través de la campaña "{{campaign_name}}" en {{geo}}.
+
+Periodo: {{start_date}} — {{end_date}}.
+
+=====================================
+2. ENTREGABLES Y ACCIONES
+=====================================
+
+{{deliverables}}
+
+El Creador deberá:
+- Mostrar el proceso de compra/venta en la plataforma.
+- Destacar las ventajas competitivas (precio, seguridad, variedad).
+- Incluir el enlace de referido en la descripción del vídeo/stream.
+
+=====================================
+3. COMISIÓN DE REFERIDOS (si aplica)
+=====================================
+
+Adicionalmente al fee fijo, el Creador podrá recibir comisión por referidos activos generados a través de su enlace único, según las condiciones acordadas por separado.
+
+=====================================
+4. RETRIBUCIÓN FIJA
+=====================================
+
+Fee fijo de campaña: {{total_amount}} {{currency}}.
+Comisión de agencia: {{commission}} {{currency}}.
+
+Pago en los 30 días siguientes a la publicación del contenido y presentación de métricas.
+
+=====================================
+5. MÉTRICAS Y REPORTING
+=====================================
+
+El Creador se compromete a facilitar a la Agencia las métricas de alcance (impresiones, clics en enlace, conversiones) en los 7 días siguientes a la finalización de la campaña.
+
+=====================================
+FIRMAS
+=====================================
+
+{{agency_name}} | {{brand_name}} | {{influencer_name}} — {{today}}`,
+  },
+
+  // ── YOUTUBE ────────────────────────────────────────────────────────
+  {
+    name:    'Contrato de servicios — YouTube',
+    type:    'youtube',
+    content: `CONTRATO DE INTEGRACIÓN PUBLICITARIA — YOUTUBE
+
+Partes:
+
+AGENCIA: {{agency_entity}}, NIF {{agency_taxid}}.
+ANUNCIANTE: {{brand_name}}.
+YOUTUBER: {{influencer_name}}.
+
+=====================================
+1. OBJETO
+=====================================
+
+Integración publicitaria de {{brand_name}} en el canal de YouTube de {{influencer_name}}, en el marco de la campaña "{{campaign_name}}".
+
+Periodo: {{start_date}} — {{end_date}}.
+Mercado objetivo: {{geo}}.
+
+=====================================
+2. ENTREGABLES
+=====================================
+
+{{deliverables}}
+
+Especificaciones técnicas:
+- La mención patrocinada debe durar un mínimo de 60 segundos.
+- Situar preferiblemente entre el minuto 3 y 8 del vídeo.
+- Incluir los elementos visuales y textos de marca proporcionados por {{brand_name}}.
+- El vídeo debe incluir el enlace en la descripción y el CTA oral.
+
+=====================================
+3. CUMPLIMIENTO DE NORMAS YOUTUBE
+=====================================
+
+El Creador se compromete a:
+- Marcar el contenido como "publicidad" en YouTube Studio.
+- Incluir la declaración de contenido de pago en la descripción.
+- No eliminar el vídeo durante al menos 12 meses desde su publicación.
+
+=====================================
+4. DERECHOS DE USO
+=====================================
+
+{{brand_name}} podrá reutilizar el segmento de integración en sus propios canales de redes sociales por un período de 6 meses, siempre citando al Creador.
+
+=====================================
+5. RETRIBUCIÓN
+=====================================
+
+Fee por vídeo: {{total_amount}} {{currency}}.
+
+Pago: 50% al firmar el contrato, 50% tras la publicación y envío de métricas.
+
+=====================================
+FIRMAS
+=====================================
+
+{{agency_name}}: _________________
+{{brand_name}}: __________________
+{{influencer_name}}: _____________
+
+Fecha: {{today}}`,
+  },
+
+  // ── TWITCH / STREAMING ─────────────────────────────────────────────
+  {
+    name:    'Contrato de servicios — Twitch / Streaming',
+    type:    'twitch',
+    content: `CONTRATO DE COLABORACIÓN — STREAMING EN DIRECTO
+
+Partes:
+
+AGENCIA: {{agency_entity}}, NIF {{agency_taxid}}.
+PATROCINADOR: {{brand_name}}.
+STREAMER: {{influencer_name}}.
+
+=====================================
+1. OBJETO
+=====================================
+
+Patrocinio de directos en Twitch (u otras plataformas de streaming) de {{influencer_name}} para la promoción de {{brand_name}}, en la campaña "{{campaign_name}}".
+
+Periodo: {{start_date}} — {{end_date}}.
+Mercado: {{geo}}.
+
+=====================================
+2. ENTREGABLES EN DIRECTO
+=====================================
+
+{{deliverables}}
+
+Requisitos por stream patrocinado:
+- Mencionar a {{brand_name}} al inicio y al menos cada 45 minutos.
+- Mostrar el panel/banner de {{brand_name}} durante toda la emisión.
+- Realizar la integración en el momento de mayor audiencia del stream.
+- Compartir en redes sociales el anuncio del directo con mención al patrocinador.
+
+=====================================
+3. PANEL Y OVERLAYS
+=====================================
+
+{{brand_name}} proporcionará los assets visuales (overlays, paneles, alertas). El Streamer se compromete a implementarlos correctamente antes del primer directo patrocinado.
+
+=====================================
+4. EXCLUSIVIDAD DE CATEGORÍA
+=====================================
+
+Durante la vigencia del contrato, el Streamer no aceptará patrocinios de competidores directos de {{brand_name}} en la misma categoría de producto.
+
+=====================================
+5. CANCELACIÓN DE STREAMS
+=====================================
+
+En caso de cancelación de un directo patrocinado por causa del Streamer con menos de 48 horas de antelación, deberá recuperarse en los 7 días siguientes.
+
+=====================================
+6. RETRIBUCIÓN
+=====================================
+
+Fee total por campaña: {{total_amount}} {{currency}}.
+Pago mensual / según calendario acordado.
+
+=====================================
+FIRMAS
+=====================================
+
+{{agency_name}} | {{brand_name}} | {{influencer_name}}
+Fecha: {{today}}`,
+  },
+
+] as const;

--- a/src/lib/queries/contractTemplates.ts
+++ b/src/lib/queries/contractTemplates.ts
@@ -1,18 +1,61 @@
 import { asc, eq } from 'drizzle-orm';
 import { db } from '@/lib/db';
 import { contractTemplates } from '@/db/schema';
-import type { InferSelectModel } from 'drizzle-orm';
+import type { InferSelectModel, InferInsertModel } from 'drizzle-orm';
 
-export type ContractTemplate = InferSelectModel<typeof contractTemplates>;
+export type ContractTemplate    = InferSelectModel<typeof contractTemplates>;
+export type NewContractTemplate = InferInsertModel<typeof contractTemplates>;
 
-export async function listContractTemplates(): Promise<readonly ContractTemplate[]> {
-  return db.select().from(contractTemplates)
-    .where(eq(contractTemplates.isActive, true))
-    .orderBy(asc(contractTemplates.id));
+export const TEMPLATE_TYPES = [
+  { value: 'general',      label: 'General'             },
+  { value: 'casino',       label: 'Casino / iGaming'    },
+  { value: 'cs2_cases',    label: 'CS2 Cases / Skins'   },
+  { value: 'marketplace',  label: 'Marketplace / CS2'   },
+  { value: 'youtube',      label: 'YouTube'              },
+  { value: 'twitch',       label: 'Twitch / Streaming'  },
+  { value: 'instagram',    label: 'Instagram / Reels'   },
+  { value: 'sports_bet',   label: 'Apuestas deportivas' },
+] as const;
+
+export type TemplateType = (typeof TEMPLATE_TYPES)[number]['value'];
+
+// ── Queries ───────────────────────────────────────────────────────────
+
+export async function listContractTemplates(includeInactive = false): Promise<readonly ContractTemplate[]> {
+  const query = db.select().from(contractTemplates).orderBy(asc(contractTemplates.type), asc(contractTemplates.name));
+  if (!includeInactive) {
+    return query.where(eq(contractTemplates.isActive, true));
+  }
+  return query;
 }
 
 export async function getContractTemplate(id: number): Promise<ContractTemplate | null> {
   const [row] = await db.select().from(contractTemplates)
     .where(eq(contractTemplates.id, id)).limit(1);
   return row ?? null;
+}
+
+export async function createContractTemplate(
+  values: Pick<NewContractTemplate, 'name' | 'type' | 'content'>,
+): Promise<ContractTemplate> {
+  const [row] = await db.insert(contractTemplates)
+    .values({ ...values, isActive: true })
+    .returning();
+  if (!row) throw new Error('Failed to insert contract template');
+  return row;
+}
+
+export async function updateContractTemplate(
+  id: number,
+  patch: Partial<Pick<ContractTemplate, 'name' | 'type' | 'content' | 'isActive'>>,
+): Promise<ContractTemplate | null> {
+  const [row] = await db.update(contractTemplates)
+    .set({ ...patch, updatedAt: new Date() })
+    .where(eq(contractTemplates.id, id))
+    .returning();
+  return row ?? null;
+}
+
+export async function deleteContractTemplate(id: number): Promise<void> {
+  await db.delete(contractTemplates).where(eq(contractTemplates.id, id));
 }


### PR DESCRIPTION
## ¿Qué hace este PR?

Sistema de contratos: tab en el detalle de campaña, gestión de plantillas y 6 plantillas predefinidas.

## Cambios

- **`ContractTab`** — Tab "Contrato" dentro del detalle de campaña. Permite seleccionar plantilla, rellenar variables (`{{brand_name}}`, `{{influencer_name}}`, `{{total_amount}}`, etc.) y generar el contrato.
- **`ContractTemplatesManager`** — CRUD completo de plantillas con editor de texto y panel lateral de variables disponibles. Agrupadas por tipo.
- **`/campanas/plantillas`** — Ruta y server actions para importar plantillas predefinidas.
- **`contractTemplateSeeds.ts`** — 6 plantillas predefinidas: General, Casino/iGaming, CS2 Cases, Marketplace, YouTube, Twitch/Streaming.
- **`contractTemplates.ts`** — Queries: `listTemplates`, `createTemplate`, `updateTemplate`, `deleteTemplate`.

## Cómo probarlo

1. `npm run dev` → `/admin/campanas/plantillas`
2. Importar plantillas predefinidas con el botón "Importar plantillas"
3. Editar una plantilla — verificar panel de variables
4. Abrir un trato → tab Contrato → seleccionar plantilla → generar

## Dependencias

- Depende de **PR 6** (usa el tab de detalle de campaña)
- No requiere cambios en DB (usa tabla `contract_templates` ya existente)

## Riesgo

Bajo — módulo autónomo.

## Checklist

- [ ] Ejecutar `npm run lint`
- [ ] Ejecutar `npx tsc --noEmit`
- [ ] Importar plantillas predefinidas — verificar que se crean
- [ ] Editar plantilla — verificar editor y variables
- [ ] Generar contrato desde un trato — verificar sustitución de variables