### PR TITLE
refactor(crm): visual hierarchy refactor — premium product feel

### DIFF
--- a/src/app/admin/(dashboard)/page.tsx
+++ b/src/app/admin/(dashboard)/page.tsx
@@ -78,9 +78,10 @@ export default async function AdminDashboardPage(): Promise<ReactElement> {
         </p>
       </div>
 
-      {/* ── KPIs — fila 1: negocio ──────────────────────────── */}
-      <div className="grid grid-cols-2 lg:grid-cols-4 gap-2">
+      {/* ── KPIs primarios — Revenue + Pipeline ─────────────── */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
         <StatCard
+          size="primary"
           label="Revenue este mes"
           value={formatEur(revenue.income)}
           description="Facturas cobradas y emitidas"
@@ -89,6 +90,7 @@ export default async function AdminDashboardPage(): Promise<ReactElement> {
           href="/admin/facturacion"
         />
         <StatCard
+          size="primary"
           label="Pipeline total"
           value={formatEur(MOCK_PIPELINE_TOTAL)}
           description="Valor estimado en negociación"
@@ -98,10 +100,14 @@ export default async function AdminDashboardPage(): Promise<ReactElement> {
           href="/admin/brands"
           isMock
         />
+      </div>
+
+      {/* ── KPIs secundarios — 6 métricas de cartera ─────────── */}
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-2">
         <StatCard
           label="Tratos cerrados"
           value={deals.yearlyDeals}
-          description={`Acuerdos cobrados en ${new Date().getFullYear()}`}
+          description={`Cobrados ${new Date().getFullYear()}`}
           icon={<GiveawayIcon />}
           accent="#16a34a"
           href="/admin/facturacion"
@@ -109,19 +115,15 @@ export default async function AdminDashboardPage(): Promise<ReactElement> {
         <StatCard
           label="Tratos activos"
           value={deals.activeDeals}
-          description="Facturas emitidas pendientes de cobro"
+          description="Pendientes de cobro"
           icon={<TasksIcon />}
           accent="#e8a800"
           href="/admin/facturacion"
         />
-      </div>
-
-      {/* ── KPIs — fila 2: cartera ───────────────────────────── */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
         <StatCard
           label="Influencers"
           value={stats.talentCount}
-          description={`${stats.publicCount} públicos · ${stats.internalCount} internos`}
+          description={`${stats.publicCount} pub · ${stats.internalCount} int`}
           icon={<TalentIcon />}
           accent="#f5632a"
           href="/admin/talents"
@@ -129,7 +131,7 @@ export default async function AdminDashboardPage(): Promise<ReactElement> {
         <StatCard
           label="Marcas activas"
           value={brandCounts.activa}
-          description="Clientes con campaña en curso"
+          description="Con campaña en curso"
           icon={<BrandIcon />}
           accent="#5b9bd5"
           href="/admin/brands"
@@ -137,15 +139,15 @@ export default async function AdminDashboardPage(): Promise<ReactElement> {
         <StatCard
           label="Leads CRM"
           value={brandCounts.lead}
-          description="Oportunidades en negociación"
+          description="En negociación"
           icon={<BrandIcon />}
           accent="#c42880"
           href="/admin/brands"
         />
         <StatCard
-          label="Sorteos activos"
+          label="Sorteos"
           value={stats.activeGiveawayCount}
-          description="Giveaways en curso"
+          description="Giveaways activos"
           icon={<GiveawayIcon />}
           accent="#5b9bd5"
           href="/admin/giveaways"

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -45,16 +45,16 @@
   --color-sp-admin-sidebar-active: #2e3350;
 
   /* Semantic state tokens */
-  --color-sp-success: #22c55e;
-  --color-sp-success-bg: rgba(34, 197, 94, 0.12);
-  --color-sp-warning: #eab308;
-  --color-sp-warning-bg: rgba(234, 179, 8, 0.12);
-  --color-sp-danger: #ef4444;
-  --color-sp-danger-bg: rgba(239, 68, 68, 0.12);
-  --color-sp-neutral: #71717a;
-  --color-sp-neutral-bg: rgba(113, 113, 122, 0.12);
-  --color-sp-info: #3b82f6;
-  --color-sp-info-bg: rgba(59, 130, 246, 0.12);
+  --color-sp-success: #16a34a;
+  --color-sp-success-bg: rgba(22, 163, 74, 0.14);
+  --color-sp-warning: #d97706;
+  --color-sp-warning-bg: rgba(217, 119, 6, 0.14);
+  --color-sp-danger: #dc2626;
+  --color-sp-danger-bg: rgba(220, 38, 38, 0.14);
+  --color-sp-neutral: #52525b;
+  --color-sp-neutral-bg: rgba(82, 82, 91, 0.10);
+  --color-sp-info: #2563eb;
+  --color-sp-info-bg: rgba(37, 99, 235, 0.12);
 
   /* Brand fonts */
   --font-display: "Barlow Condensed", sans-serif;

--- a/src/features/admin/_shared/components/AdminSidebar.tsx
+++ b/src/features/admin/_shared/components/AdminSidebar.tsx
@@ -166,12 +166,16 @@ export function AdminSidebar({
           ))}
 
           {groups && groups.length > 0 && (
-            <div className="mt-2 flex flex-col gap-2">
+            <div className="mt-1 flex flex-col gap-0">
               {groups.map((group) => (
-                <div key={group.key} className="flex flex-col gap-0.5">
-                  <h3 className="px-3 pt-2 pb-1 text-[10px] font-semibold uppercase tracking-[0.2em] text-sp-admin-muted/80">
-                    {group.label}
-                  </h3>
+                <div key={group.key} className="flex flex-col gap-0.5 mt-3">
+                  <div className="flex items-center gap-2 px-3 mb-0.5">
+                    <span className="flex-1 h-px bg-sp-admin-sidebar-border/50" />
+                    <h3 className="text-[9px] font-bold uppercase tracking-[0.25em] text-sp-admin-sidebar-muted/70 shrink-0">
+                      {group.label}
+                    </h3>
+                    <span className="flex-1 h-px bg-sp-admin-sidebar-border/50" />
+                  </div>
                   {group.items.map((item) => (
                     <NavLink
                       key={item.href}
@@ -272,16 +276,17 @@ function NavLink({ item, active, onClose, indent = false }: NavLinkProps): React
       href={item.href}
       prefetch={prefetch}
       onClick={onClose}
+      style={active ? { background: 'rgba(245, 99, 42, 0.13)' } : undefined}
       className={[
-        'relative flex items-center gap-3 py-2.5 rounded-lg transition-all duration-150 text-[13px] font-medium',
+        'relative flex items-center gap-3 py-2.5 rounded-lg transition-all duration-200 text-[13px] font-medium',
         indent ? 'pl-11 pr-3' : 'px-3',
         active
-          ? 'text-white bg-sp-admin-sidebar-active'
+          ? 'text-white'
           : 'text-sp-admin-sidebar-muted hover:text-sp-admin-sidebar-text hover:bg-sp-admin-sidebar-hover',
       ].join(' ')}
     >
       {active && (
-        <span className="absolute left-0 top-2 bottom-2 w-[3px] rounded-r-full bg-sp-admin-accent" />
+        <span className="absolute left-0 top-1.5 bottom-1.5 w-1 rounded-r-full bg-sp-admin-accent shadow-[0_0_6px_rgba(245,99,42,0.6)]" />
       )}
       <span className={`w-5 h-5 shrink-0 ${active ? 'text-sp-admin-accent' : ''}`}>
         {item.icon}

--- a/src/features/admin/_shared/components/dashboard/DashboardAlerts.tsx
+++ b/src/features/admin/_shared/components/dashboard/DashboardAlerts.tsx
@@ -109,38 +109,39 @@ function AlertItem({ alert }: { readonly alert: DashboardAlert }): React.ReactEl
 // ── Card "Hoy requiere atención" ──────────────────────────────────────
 
 function AttentionSummary({ summary }: { readonly summary: AlertSummary }): React.ReactElement {
-  const items: { count: number; label: string; href: string; accent: string }[] = [
-    { count: summary.overdueTasksCount,     label: 'tareas vencidas',       href: '/admin/tareas',   accent: '#dc2626' },
-    { count: summary.overdueFollowupsCount, label: 'follow-ups vencidos',   href: '/admin/brands',   accent: '#ea580c' },
-    { count: summary.unpaidBrandCount,      label: 'cobros pendientes',     href: '/admin/campanas', accent: '#d97706' },
-    { count: summary.pendingTalentCount,    label: 'pagos a talentos',      href: '/admin/campanas', accent: '#f59e0b' },
-    { count: summary.expiringDealsCount,    label: 'tratos vencen pronto',  href: '/admin/campanas', accent: '#2563eb' },
+  const items: { count: number; label: string; href: string; accent: string; bg: string }[] = [
+    { count: summary.overdueTasksCount,     label: 'tareas vencidas',      href: '/admin/tareas',   accent: '#dc2626', bg: 'rgba(220,38,38,0.08)'   },
+    { count: summary.overdueFollowupsCount, label: 'follow-ups vencidos',  href: '/admin/brands',   accent: '#ea580c', bg: 'rgba(234,88,12,0.08)'   },
+    { count: summary.unpaidBrandCount,      label: 'cobros pendientes',    href: '/admin/campanas', accent: '#d97706', bg: 'rgba(217,119,6,0.08)'   },
+    { count: summary.pendingTalentCount,    label: 'pagos a talentos',     href: '/admin/campanas', accent: '#ca8a04', bg: 'rgba(202,138,4,0.08)'   },
+    { count: summary.expiringDealsCount,    label: 'tratos por vencer',    href: '/admin/campanas', accent: '#2563eb', bg: 'rgba(37,99,235,0.08)'   },
   ].filter((i) => i.count > 0);
 
   if (items.length === 0) return <></>;
 
-  const totalUrgent = items.reduce((s, i) => s + i.count, 0);
+  const hasCritical = summary.overdueTasksCount > 0 || summary.overdueFollowupsCount > 0;
 
   return (
-    <div className="rounded-xl bg-sp-admin-card border border-amber-200 shadow-[0_1px_3px_rgba(0,0,0,0.06)] px-4 py-3">
-      <div className="flex items-center gap-2 mb-2.5">
-        <span className="text-amber-500 text-[14px]" aria-hidden>⚡</span>
-        <p className="text-[10px] font-black uppercase tracking-[0.18em] text-sp-admin-muted">
-          Hoy requiere atención
+    <div className={`rounded-xl bg-sp-admin-card shadow-[0_1px_3px_rgba(0,0,0,0.06)] px-4 py-3 border ${hasCritical ? 'border-red-200' : 'border-amber-200'}`}>
+      <div className="flex items-center gap-2 mb-3">
+        <span className={`w-2 h-2 rounded-full shrink-0 ${hasCritical ? 'bg-red-500' : 'bg-amber-400'}`} aria-hidden />
+        <p className="text-[10px] font-black uppercase tracking-[0.18em] text-sp-admin-text">
+          Requiere atención
         </p>
-        <span className="ml-auto text-[9px] font-bold text-amber-700 bg-amber-50 border border-amber-200 px-1.5 py-0.5 rounded-full">
-          {totalUrgent} {totalUrgent === 1 ? 'item' : 'items'}
+        <span className={`ml-auto text-[9px] font-bold px-1.5 py-0.5 rounded-full border ${hasCritical ? 'text-red-700 bg-red-50 border-red-200' : 'text-amber-700 bg-amber-50 border-amber-200'}`}>
+          {items.reduce((s, i) => s + i.count, 0)} pendientes
         </span>
       </div>
-      <div className="flex flex-wrap gap-2">
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-2">
         {items.map((item) => (
           <Link
             key={item.label}
             href={item.href}
-            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-sp-admin-border bg-sp-admin-hover/30 hover:bg-sp-admin-hover text-[11px] font-semibold text-sp-admin-text transition-colors"
+            style={{ background: item.bg, borderColor: `${item.accent}30` }}
+            className="flex flex-col items-start gap-0.5 px-3 py-2 rounded-lg border hover:opacity-80 transition-opacity"
           >
-            <span className="font-black tabular-nums" style={{ color: item.accent }}>{item.count}</span>
-            <span className="text-sp-admin-muted">{item.label}</span>
+            <span className="text-[22px] font-black tabular-nums leading-none" style={{ color: item.accent }}>{item.count}</span>
+            <span className="text-[10px] text-sp-admin-muted font-medium leading-tight">{item.label}</span>
           </Link>
         ))}
       </div>

--- a/src/features/admin/_shared/components/dashboard/StatCard.tsx
+++ b/src/features/admin/_shared/components/dashboard/StatCard.tsx
@@ -11,6 +11,7 @@ type StatCardProps = {
   readonly accent: string;
   readonly href?: string;
   readonly isMock?: boolean;
+  readonly size?: 'default' | 'primary';
 };
 
 export function StatCard({
@@ -23,10 +24,12 @@ export function StatCard({
   accent,
   href = '#',
   isMock = false,
+  size = 'default',
 }: StatCardProps): React.ReactElement {
   const trendPositive = trend !== undefined && trend > 0;
   const trendNegative = trend !== undefined && trend < 0;
   const trendNeutral  = trend !== undefined && trend === 0;
+  const isPrimary = size === 'primary';
 
   return (
     <Link
@@ -34,15 +37,15 @@ export function StatCard({
       prefetch={false}
       className="group flex flex-col rounded-lg bg-sp-admin-card overflow-hidden shadow-[0_1px_3px_rgba(0,0,0,0.06)] hover:shadow-[0_3px_12px_rgba(0,0,0,0.09)] transition-all duration-200"
     >
-      <div className="h-[2px] w-full shrink-0" style={{ background: accent }} />
+      <div className={isPrimary ? 'h-[3px] w-full shrink-0' : 'h-[2px] w-full shrink-0'} style={{ background: accent }} />
 
-      <div className="flex items-center gap-3 px-4 py-3">
+      <div className={`flex items-center gap-3 ${isPrimary ? 'px-5 py-4' : 'px-4 py-3'}`}>
         {/* Icon */}
         <div
-          className="w-8 h-8 rounded-lg flex items-center justify-center shrink-0"
-          style={{ background: `${accent}14`, color: accent }}
+          className={`rounded-xl flex items-center justify-center shrink-0 ${isPrimary ? 'w-11 h-11' : 'w-8 h-8 rounded-lg'}`}
+          style={{ background: `${accent}18`, color: accent }}
         >
-          <span className="w-3.5 h-3.5">{icon}</span>
+          <span className={isPrimary ? 'w-5 h-5' : 'w-3.5 h-3.5'}>{icon}</span>
         </div>
 
         {/* Text */}
@@ -50,7 +53,7 @@ export function StatCard({
           <p className="text-[9px] font-bold uppercase tracking-[0.16em] text-sp-admin-muted leading-none truncate">
             {label}{isMock && <span className="text-sp-admin-muted/40 ml-1 normal-case tracking-normal">·&nbsp;est.</span>}
           </p>
-          <p className="text-[20px] font-bold text-sp-admin-text tabular-nums leading-tight mt-0.5">
+          <p className={`font-bold text-sp-admin-text tabular-nums leading-tight mt-1 ${isPrimary ? 'text-[28px]' : 'text-[20px]'}`}>
             {value}
           </p>
           <p className="text-[9px] text-sp-admin-muted leading-none mt-0.5 truncate">{description}</p>
@@ -58,7 +61,7 @@ export function StatCard({
 
         {/* Trend */}
         {trend !== undefined && (
-          <div className={`text-[10px] font-semibold shrink-0 ${
+          <div className={`font-semibold shrink-0 ${isPrimary ? 'text-[12px]' : 'text-[10px]'} ${
             trendPositive ? 'text-emerald-600' :
             trendNegative ? 'text-red-500' :
             'text-sp-admin-muted'

--- a/src/features/admin/brands/components/BrandsCrmManager.tsx
+++ b/src/features/admin/brands/components/BrandsCrmManager.tsx
@@ -201,17 +201,33 @@ export function BrandsCrmManager({
       </FilterBar>
 
       {brands.length === 0 ? (
-        <div className="rounded-2xl border border-dashed border-sp-admin-border p-12 text-center">
-          <p className="text-sm text-sp-admin-muted">
-            No hay marcas registradas todavía. Crea la primera para empezar tu CRM.
-          </p>
+        <div className="rounded-2xl bg-sp-admin-card border border-sp-admin-border overflow-hidden">
+          <EmptyState
+            variant="no-data"
+            title="Sin marcas todavía"
+            description="Crea la primera marca para empezar tu CRM."
+            action={
+              <button
+                type="button"
+                onClick={openDrawerCreate}
+                className="inline-flex items-center gap-2 rounded-xl bg-sp-admin-accent px-4 py-2 text-sm font-semibold text-white hover:opacity-90 transition-opacity"
+              >
+                + Nueva marca
+              </button>
+            }
+          />
         </div>
       ) : filteredBrands.length === 0 ? (
         <div className="rounded-2xl bg-sp-admin-card border border-sp-admin-border overflow-hidden">
           <EmptyState
             variant="no-results"
             title="Sin resultados"
-            description="Prueba con otros filtros o limpia la búsqueda actual."
+            description="Prueba con otros filtros o limpia la búsqueda."
+            action={
+              <button type="button" onClick={resetFilters} className="text-xs font-semibold text-sp-admin-accent hover:underline">
+                Limpiar filtros
+              </button>
+            }
           />
         </div>
       ) : (

--- a/src/features/admin/invoices/components/InvoicesManager.tsx
+++ b/src/features/admin/invoices/components/InvoicesManager.tsx
@@ -163,11 +163,22 @@ export function InvoicesManager({
 
       {filtered.length === 0 ? (
         <EmptyState
-          title={invoices.length === 0 ? 'Aún no hay facturas registradas' : 'Sin resultados'}
+          title={invoices.length === 0 ? 'Aún no hay facturas' : 'Sin resultados'}
           description={
             invoices.length === 0
-              ? 'Crea la primera factura para empezar a controlar tu contabilidad.'
+              ? 'Registra la primera factura para empezar a controlar tu contabilidad.'
               : 'Ninguna factura coincide con los filtros activos.'
+          }
+          action={
+            invoices.length === 0 ? (
+              <button
+                type="button"
+                onClick={() => { setEditing(null); setDrawerOpen(true); }}
+                className="inline-flex items-center gap-2 rounded-xl bg-sp-admin-accent px-4 py-2 text-sm font-semibold text-white hover:opacity-90 transition-opacity"
+              >
+                + Nueva factura
+              </button>
+            ) : undefined
           }
         />
       ) : (

--- a/src/features/admin/talents/components/InfluencerCardsView.parts.tsx
+++ b/src/features/admin/talents/components/InfluencerCardsView.parts.tsx
@@ -103,17 +103,6 @@ export function TalentCard({ creator, verticals, selectMode, selected, onToggleS
     return list;
   }, [creator.socials]);
 
-  // Métrica principal: plataforma con más seguidores
-  const mainMetric = useMemo(() => {
-    if (creator.socials.length === 0) return null;
-    const best = creator.socials.reduce((a, b) =>
-      parseFollowers(a.followersDisplay) >= parseFollowers(b.followersDisplay) ? a : b,
-    );
-    const count = parseFollowers(best.followersDisplay);
-    if (count === 0) return null;
-    const label = PLATFORM_LABELS[best.platform.toLowerCase()] ?? best.platform;
-    return `${label} · ${formatCompact(count)}`;
-  }, [creator.socials]);
 
   // Sectores como badges (máx 2)
   const sectorBadges = useMemo(() =>
@@ -211,36 +200,14 @@ export function TalentCard({ creator, verticals, selectMode, selected, onToggleS
         )}
       </div>
 
-      {/* ── Cuerpo: nombre, categoría, plataformas, sectores ───── */}
-      <div className="px-3 pt-2.5 pb-2 flex-1">
+      {/* ── Cuerpo: nombre, sector, redes + números ────────────── */}
+      <div className="px-3 pt-2.5 pb-2 flex-1 flex flex-col">
         {/* Nombre */}
         <p className="font-bold text-[13px] text-sp-admin-text truncate leading-tight">{creator.name}</p>
 
-        {/* Categoría / juego */}
-        {creator.game && (
-          <p className="text-[10px] text-sp-admin-muted truncate mt-0.5">{creator.game}</p>
-        )}
-
-        {/* Plataformas — solo dots con nombre, sin números */}
-        {platforms.length > 0 && (
-          <div className="flex items-center gap-2 mt-2 flex-wrap">
-            {platforms.map((p) => (
-              <span key={p} className="inline-flex items-center gap-1">
-                <span
-                  className="w-1.5 h-1.5 rounded-full shrink-0"
-                  style={{ background: PLATFORM_DOT[p] ?? '#888' }}
-                />
-                <span className="text-[10px] text-sp-admin-muted font-medium">
-                  {PLATFORM_LABELS[p] ?? p}
-                </span>
-              </span>
-            ))}
-          </div>
-        )}
-
-        {/* Sectores como badges */}
+        {/* Sector como badge compacto */}
         {sectorBadges.length > 0 && (
-          <div className="flex flex-wrap gap-1 mt-2">
+          <div className="flex flex-wrap gap-1 mt-1.5">
             {sectorBadges.map((s) => (
               <span
                 key={s}
@@ -251,12 +218,38 @@ export function TalentCard({ creator, verticals, selectMode, selected, onToggleS
             ))}
           </div>
         )}
+
+        {/* Redes con seguidores — una fila por plataforma */}
+        {creator.socials.length > 0 && (
+          <div className="flex flex-col gap-0.5 mt-2">
+            {creator.socials.slice(0, 3).map((s) => {
+              const count = parseFollowers(s.followersDisplay);
+              const pKey  = s.platform.toLowerCase();
+              return (
+                <div key={s.platform} className="flex items-center justify-between gap-1">
+                  <span className="inline-flex items-center gap-1">
+                    <span
+                      className="w-1.5 h-1.5 rounded-full shrink-0"
+                      style={{ background: PLATFORM_DOT[pKey] ?? '#888' }}
+                    />
+                    <span className="text-[10px] text-sp-admin-muted font-medium">
+                      {PLATFORM_LABELS[pKey] ?? s.platform}
+                    </span>
+                  </span>
+                  {count > 0 && (
+                    <span className="text-[10px] font-bold text-sp-admin-text tabular-nums">
+                      {formatCompact(count)}
+                    </span>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
       </div>
 
-      {/* ── Footer: estado + métrica principal ─────────────────── */}
-      <div className="border-t border-sp-admin-border/50 px-3 py-2 flex items-center justify-between gap-2 mt-auto">
-
-        {/* Badge de estado — clickable */}
+      {/* ── Footer: solo estado ─────────────────────────────────── */}
+      <div className="border-t border-sp-admin-border/50 px-3 py-2 flex items-center mt-auto">
         {isPillClickable ? (
           <button
             type="button"
@@ -274,13 +267,6 @@ export function TalentCard({ creator, verticals, selectMode, selected, onToggleS
           <span className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[9px] font-bold ${statusCfg.bg} ${statusCfg.text}`}>
             <span className="w-1.5 h-1.5 rounded-full shrink-0" style={{ background: statusCfg.dot }} />
             {STATUS_LABELS[displayStatus] ?? displayStatus}
-          </span>
-        )}
-
-        {/* Métrica principal: una sola plataforma + seguidores */}
-        {mainMetric && (
-          <span className="text-[9px] text-sp-admin-muted tabular-nums truncate">
-            {mainMetric}
           </span>
         )}
       </div>

--- a/src/features/admin/talents/components/InfluencerCardsView.tsx
+++ b/src/features/admin/talents/components/InfluencerCardsView.tsx
@@ -28,6 +28,7 @@ export function InfluencerCardsView({ creators, verticalsByTalent }: Props): Rea
   const [verticalFilter, setVerticalFilter] = useState<TalentVertical | ''>('');
   const [platformFilter, setPlatformFilter] = useState<string>('');
   const [countryFilter, setCountryFilter] = useState<string>('');
+  const [showMoreFilters, setShowMoreFilters] = useState(false);
   const [showAdd, setShowAdd]             = useState(false);
   const [selectMode, setSelectMode]       = useState(false);
   const [selectedIds, setSelectedIds]     = useState<Set<number>>(new Set());
@@ -117,6 +118,7 @@ export function InfluencerCardsView({ creators, verticalsByTalent }: Props): Rea
 
       {/* Filtros + acciones */}
       <div className="flex flex-wrap items-center gap-2">
+        {/* Filtros principales — siempre visibles */}
         <input
           type="search"
           value={search}
@@ -128,16 +130,39 @@ export function InfluencerCardsView({ creators, verticalsByTalent }: Props): Rea
           <option value="">Todos los sectores</option>
           {TALENT_VERTICALS.map((v) => <option key={v} value={v}>{TALENT_VERTICAL_LABELS[v]}</option>)}
         </select>
-        <select value={platformFilter} onChange={(e) => setPlatformFilter(e.target.value)} className={INPUT_CLS}>
-          <option value="">Todas las plataformas</option>
-          {platforms.map((p) => <option key={p} value={p}>{PLATFORM_LABELS[p] ?? p}</option>)}
-        </select>
-        {countries.length > 0 && (
-          <select value={countryFilter} onChange={(e) => setCountryFilter(e.target.value)} className={INPUT_CLS}>
-            <option value="">Todos los países</option>
-            {countries.map((c) => <option key={c} value={c}>{c}</option>)}
-          </select>
+
+        {/* Filtros secundarios — se expanden con el botón */}
+        {showMoreFilters && (
+          <>
+            <select value={platformFilter} onChange={(e) => setPlatformFilter(e.target.value)} className={INPUT_CLS}>
+              <option value="">Todas las plataformas</option>
+              {platforms.map((p) => <option key={p} value={p}>{PLATFORM_LABELS[p] ?? p}</option>)}
+            </select>
+            {countries.length > 0 && (
+              <select value={countryFilter} onChange={(e) => setCountryFilter(e.target.value)} className={INPUT_CLS}>
+                <option value="">Todos los países</option>
+                {countries.map((c) => <option key={c} value={c}>{c}</option>)}
+              </select>
+            )}
+          </>
         )}
+
+        {/* Botón más filtros */}
+        <button
+          type="button"
+          onClick={() => setShowMoreFilters((v) => !v)}
+          className={`h-8 px-3 rounded-lg border text-[12px] transition-colors flex items-center gap-1 ${
+            showMoreFilters || platformFilter || countryFilter
+              ? 'border-sp-admin-accent/40 bg-sp-admin-accent/8 text-sp-admin-accent font-semibold'
+              : 'border-sp-admin-border text-sp-admin-muted hover:bg-sp-admin-hover'
+          }`}
+        >
+          {showMoreFilters ? '− Menos' : '+ Más filtros'}
+          {(platformFilter || countryFilter) && !showMoreFilters && (
+            <span className="ml-1 w-1.5 h-1.5 rounded-full bg-sp-admin-accent" />
+          )}
+        </button>
+
         <span className="text-[11px] text-sp-admin-muted tabular-nums">{filtered.length} de {creators.length}</span>
 
         {/* Acciones */}


### PR DESCRIPTION
## Qué cambia

Refactor visual completo del panel admin para mejorar jerarquía, claridad y percepción de producto premium.

### KPIs del dashboard
- **Revenue** y **Pipeline** pasan a tarjetas primarias (28px, icono mayor, barra 3px) en una fila de 2
- Las 6 métricas restantes (Tratos cerrados, Tratos activos, Influencers, Marcas, Leads, Sorteos) se reubican en una fila compacta de 6 columnas
- `StatCard` gana prop `size?: 'default' | 'primary'` — backward compatible

### Sidebar
- Estado activo: fondo con tint naranja (`rgba(245,99,42,0.13)`) en lugar del azul plano anterior
- Barra lateral izquierda: 3px → 4px con glow sutil
- Grupos (CRM / Operaciones / Finanzas): separadores centrados con línea + label uppercase

### Colores de estado (tokens CSS)
- `--color-sp-success`: `#22c55e` → `#16a34a` (verde oscuro, más legible)
- `--color-sp-warning`: `#eab308` → `#d97706` (ámbar más visible)
- `--color-sp-danger`: `#ef4444` → `#dc2626` (rojo más saturado)
- Opacidad de backgrounds: 12% → 14%

### Empty states accionables
- **Marcas** (`BrandsCrmManager`): el estado vacío ahora tiene botón `+ Nueva marca`
- **Facturas** (`InvoicesManager`): el estado vacío ahora tiene botón `+ Nueva factura`
- El estado "sin resultados" de marcas tiene botón `Limpiar filtros`

### TalentCard (influencers)
- Se elimina la línea de juego/categoría (ruido visual)
- Los dots de plataforma pasan a filas con nombre + seguidores: `YouTube  9.2K`
- El footer muestra solo el badge de estado

### Filtros de influencers
- Visible por defecto: Buscar + Sector
- Plataforma y País detrás de botón `+ Más filtros` (con dot naranja si hay filtros activos)

### Alertas del dashboard
- `AttentionSummary`: cambia de chips en línea a un **grid de tarjetas** por tipo de alerta
- Cada tarjeta tiene fondo cromático según severidad (rojo para tareas vencidas, ámbar para cobros, etc.)
- Borde del card: rojo cuando hay alertas críticas, ámbar en el resto

## Archivos modificados
- `src/app/globals.css` — tokens semánticos de estado
- `src/app/admin/(dashboard)/page.tsx` — layout KPIs
- `src/features/admin/_shared/components/AdminSidebar.tsx`
- `src/features/admin/_shared/components/dashboard/StatCard.tsx`
- `src/features/admin/_shared/components/dashboard/DashboardAlerts.tsx`
- `src/features/admin/brands/components/BrandsCrmManager.tsx`
- `src/features/admin/invoices/components/InvoicesManager.tsx`
- `src/features/admin/talents/components/InfluencerCardsView.tsx`
- `src/features/admin/talents/components/InfluencerCardsView.parts.tsx`

## Test plan
- [ ] Dashboard: Revenue y Pipeline visiblemente más grandes que el resto de KPIs
- [ ] Sidebar: item activo con fondo naranja translúcido + barra 4px
- [ ] Grupos del sidebar con separadores centrados
- [ ] Marcas → sin marcas → aparece botón "+ Nueva marca"
- [ ] Facturas → sin facturas → aparece botón "+ Nueva factura"
- [ ] Influencers: las cards muestran `YouTube  9.2K` en lugar de dots sin números
- [ ] Filtros influencers: Plataforma y País ocultos hasta pulsar "+ Más filtros"
- [ ] Alertas del dashboard: tarjetas coloreadas por tipo

🤖 Generated with [Claude Code](https://claude.com/claude-code)