### PR TITLE
feat(tasks): modal simplificado + bulk delete + PDF contratos profesional

### DIFF
--- a/src/features/admin/_shared/components/campaigns/ContractGenerator.tsx
+++ b/src/features/admin/_shared/components/campaigns/ContractGenerator.tsx
@@ -42,47 +42,137 @@ export function ContractGenerator({ campaign, templates, vars, onDone }: Props):
     setGenError(null);
     try {
       const { jsPDF } = await import('jspdf');
+
+      // ── Constantes de diseño (mismas que generateInvoicePdf) ──────────
+      const PAGE_W  = 210;
+      const PAGE_H  = 297;
+      const MARGIN  = 20;
+      const COL_R   = PAGE_W - MARGIN;
+      const CONTENT_BOTTOM = PAGE_H - 16; // espacio para footer
+      const ACCENT  = '#f5632a';
+      const GRAY    = '#72728a';
+      const BLACK   = '#16161f';
+      const LIGHT   = '#f5f5fa';
+      const BORDER  = '#e2e2ec';
+
       const doc = new jsPDF({ orientation: 'portrait', unit: 'mm', format: 'a4' });
+      let y = 0;
+      let pageNum = 1;
 
-      const margin   = 20;
-      const pageW    = 210;
-      const pageH    = 297;
-      const maxWidth = pageW - margin * 2;
-      let y = margin;
+      // ── Helpers ──────────────────────────────────────────────────────
+      function sf(size: number, style: 'normal' | 'bold' = 'normal', color = BLACK): void {
+        doc.setFontSize(size); doc.setFont('helvetica', style); doc.setTextColor(color);
+      }
+      function fillRect(x: number, yy: number, w: number, h: number, fill: string): void {
+        doc.setFillColor(fill); doc.setDrawColor(fill); doc.rect(x, yy, w, h, 'F');
+      }
+      function hLine(yy: number, color = BORDER): void {
+        doc.setDrawColor(color); doc.setLineWidth(0.25); doc.line(MARGIN, yy, COL_R, yy);
+      }
 
-      doc.setFont('helvetica', 'normal');
-      doc.setFontSize(10);
+      function addHeader(): void {
+        // Banda naranja superior
+        fillRect(0, 0, PAGE_W, 2.5, ACCENT);
 
-      const lines = previewContent.split('\n');
-      for (const rawLine of lines) {
-        const isSeparator = /^[=\-]{3,}/.test(rawLine);
-        const isTitle     = /^[A-ZÁÉÍÓÚ ]{4,}$/.test(rawLine.trim()) && rawLine.trim().length < 60;
+        // Logo de texto "SocialPro"
+        sf(15, 'bold', ACCENT);
+        doc.text('SocialPro', MARGIN, 11);
 
-        if (isSeparator) {
-          // Draw a thin line
-          if (y > pageH - margin) { doc.addPage(); y = margin; }
-          doc.setDrawColor(180);
-          doc.line(margin, y, pageW - margin, y);
-          y += 4;
-          continue;
-        }
+        // Etiqueta "CONTRATO" a la derecha
+        sf(11, 'bold', BLACK);
+        doc.text('CONTRATO', COL_R, 9, { align: 'right' });
+        sf(8, 'normal', GRAY);
+        doc.text(selectedTemplate?.name ?? 'Contrato de servicios', COL_R, 14, { align: 'right' });
 
-        if (isTitle) {
-          doc.setFont('helvetica', 'bold');
-          doc.setFontSize(11);
-        } else {
-          doc.setFont('helvetica', 'normal');
-          doc.setFontSize(10);
-        }
+        y = 20;
+        hLine(y, BORDER);
+        y += 6;
+      }
 
-        const wrapped = doc.splitTextToSize(rawLine || ' ', maxWidth);
-        for (const wline of wrapped) {
-          if (y > pageH - margin) { doc.addPage(); y = margin; }
-          doc.text(wline, margin, y);
-          y += isTitle ? 7 : 5.5;
+      function addFooter(): void {
+        hLine(PAGE_H - 13, BORDER);
+        sf(7, 'normal', GRAY);
+        doc.text('SocialPro · Contrato de servicios', MARGIN, PAGE_H - 9);
+        doc.text(`Pág. ${pageNum}`, COL_R, PAGE_H - 9, { align: 'right' });
+        const today = new Date().toLocaleDateString('es-ES', { day: '2-digit', month: '2-digit', year: 'numeric' });
+        doc.text(today, PAGE_W / 2, PAGE_H - 9, { align: 'center' });
+      }
+
+      function checkPage(needed = 6): void {
+        if (y + needed > CONTENT_BOTTOM) {
+          addFooter();
+          doc.addPage();
+          pageNum++;
+          addHeader();
         }
       }
 
+      // ── Página 1: cabecera ────────────────────────────────────────────
+      addHeader();
+
+      // Bloque de datos del trato (mini tabla 2 columnas)
+      const metaRows: [string, string][] = [
+        ['Trato', campaign.name],
+        ['Marca',  vars['brand_name']    ?? '—'],
+        ['Talento', vars['influencer_name'] ?? '—'],
+        ['Importe',  vars['total_amount']   ?? '—'],
+        ['Fecha inicio', vars['start_date'] ?? '—'],
+        ['Fecha fin',    vars['end_date']   ?? '—'],
+      ].filter(([, v]) => v !== '—') as [string, string][];
+
+      const colMid = PAGE_W / 2 + 2;
+      const half   = metaRows.slice(0, Math.ceil(metaRows.length / 2));
+      const second = metaRows.slice(Math.ceil(metaRows.length / 2));
+      const startY = y;
+
+      for (let i = 0; i < Math.max(half.length, second.length); i++) {
+        const l = half[i];
+        const r = second[i];
+        if (l) {
+          sf(7, 'bold', GRAY); doc.text(l[0].toUpperCase(), MARGIN, y);
+          sf(9, 'normal', BLACK); doc.text(l[1], MARGIN + 28, y);
+        }
+        if (r) {
+          sf(7, 'bold', GRAY); doc.text(r[0].toUpperCase(), colMid, y);
+          sf(9, 'normal', BLACK); doc.text(r[1], colMid + 28, y);
+        }
+        y += 5;
+      }
+
+      if (y > startY) { y += 3; hLine(y, '#ebebf5'); y += 7; }
+
+      // ── Contenido del contrato ────────────────────────────────────────
+      const lines = previewContent.split('\n');
+      for (const rawLine of lines) {
+        const trimmed    = rawLine.trim();
+        const isSep      = /^[=\-]{3,}/.test(trimmed);
+        const isTitle    = /^[A-ZÁÉÍÓÚ\d\s\.]{3,}$/.test(trimmed) && trimmed.length > 2 && trimmed.length < 70;
+        const isEmpty    = trimmed === '';
+
+        if (isEmpty)   { y += 2.5; continue; }
+        if (isSep)     { checkPage(5); hLine(y, '#d8d8e8'); y += 5; continue; }
+
+        if (isTitle) {
+          checkPage(12);
+          fillRect(MARGIN, y - 3.5, COL_R - MARGIN, 7, LIGHT);
+          sf(10, 'bold', ACCENT);
+          doc.text(trimmed, MARGIN + 3, y);
+          y += 9;
+        } else {
+          const wrapped = doc.splitTextToSize(rawLine, COL_R - MARGIN - 2);
+          for (const wline of wrapped) {
+            checkPage(6);
+            sf(9.5, 'normal', BLACK);
+            doc.text(wline, MARGIN, y);
+            y += 5.5;
+          }
+        }
+      }
+
+      // Footer de última página
+      addFooter();
+
+      // ── Guardar ───────────────────────────────────────────────────────
       const pdfBytes = doc.output('arraybuffer');
       const pdfBlob  = new Blob([pdfBytes], { type: 'application/pdf' });
       const fileName = `contrato-${campaign.name.replace(/[^\w]/g, '-').toLowerCase()}-${new Date().toISOString().slice(0, 10)}.pdf`;
@@ -93,7 +183,6 @@ export function ContractGenerator({ campaign, templates, vars, onDone }: Props):
       fd.append('templateId', String(selectedTemplateId));
       fd.append('fileName',   fileName);
 
-      // Trigger the server action via formAction
       formAction(fd);
     } catch (err) {
       setGenError(err instanceof Error ? err.message : 'Error al generar el PDF');

--- a/src/features/admin/tasks/components/TaskList.parts.tsx
+++ b/src/features/admin/tasks/components/TaskList.parts.tsx
@@ -199,6 +199,8 @@ type RowProps = {
   readonly onEdit: (task: CrmTask) => void;
   readonly onRemove: (task: CrmTask) => void;
   readonly onFieldChange: (taskId: number, patch: FieldPatch) => void;
+  readonly selected?: boolean;
+  readonly onToggleSelect?: (id: number) => void;
 };
 
 export function TaskRow({
@@ -212,20 +214,33 @@ export function TaskRow({
   onEdit,
   onRemove,
   onFieldChange,
+  selected = false,
+  onToggleSelect,
 }: RowProps): React.ReactElement {
   const owner = usersById.get(t.ownerId);
   const mine = t.ownerId === currentUserId;
   const isDone = t.status === 'completada';
   return (
-    <tr className={`${mine ? 'bg-sp-admin-accent/5' : ''} hover:bg-sp-admin-hover`}>
-      <td className="px-3 py-2.5">
-        <input
-          type="checkbox"
-          checked={isDone}
-          onChange={() => onToggleComplete(t)}
-          disabled={isDone}
-          aria-label={`Completar ${t.title}`}
-        />
+    <tr className={`${mine ? 'bg-sp-admin-accent/5' : ''} ${selected ? 'bg-red-50/40' : ''} hover:bg-sp-admin-hover`}>
+      {/* Selección bulk */}
+      <td className="pl-3 pr-1 py-2.5 w-8">
+        {onToggleSelect ? (
+          <input
+            type="checkbox"
+            checked={selected}
+            onChange={() => onToggleSelect(t.id)}
+            aria-label={`Seleccionar ${t.title}`}
+            className="rounded border-sp-admin-border cursor-pointer accent-red-500"
+          />
+        ) : (
+          <input
+            type="checkbox"
+            checked={isDone}
+            onChange={() => onToggleComplete(t)}
+            disabled={isDone}
+            aria-label={`Completar ${t.title}`}
+          />
+        )}
       </td>
       <td className="px-3 py-2.5 max-w-[260px]">
         <button type="button" onClick={() => onEdit(t)} className="text-left w-full">

--- a/src/features/admin/tasks/components/TaskList.tsx
+++ b/src/features/admin/tasks/components/TaskList.tsx
@@ -6,6 +6,7 @@ import type { CrmTask, CrmTaskPriority } from '@/types';
 import type { RelatedLabel } from '@/lib/queries/crmTasks';
 import { TaskModal } from './TaskModal';
 import {
+  bulkDeleteTasksAction,
   completeTaskAction,
   deleteTaskAction,
   updateTaskPartialAction,
@@ -61,6 +62,8 @@ export function TaskList({
   const [creating, setCreating] = useState(false);
   const [feedback, setFeedback] = useState<Feedback | null>(null);
   const [isPending, startTransition] = useTransition();
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+  const [deleteMode, setDeleteMode] = useState(false);
 
   const activeId = searchParams.get('t');
   const editingTask = useMemo<CrmTask | null>(() => {
@@ -122,6 +125,43 @@ export function TaskList({
     return c;
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tasks, todayStr]);
+
+  const toggleSelect = (id: number): void => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      next.has(id) ? next.delete(id) : next.add(id);
+      return next;
+    });
+  };
+
+  const selectAll = (): void => {
+    if (selectedIds.size === filtered.length) {
+      setSelectedIds(new Set());
+    } else {
+      setSelectedIds(new Set(filtered.map((t) => t.id)));
+    }
+  };
+
+  const cancelDeleteMode = (): void => {
+    setDeleteMode(false);
+    setSelectedIds(new Set());
+  };
+
+  const handleBulkDelete = (): void => {
+    if (selectedIds.size === 0) return;
+    const ids = [...selectedIds];
+    const msg = `¿Eliminar ${ids.length} tarea${ids.length !== 1 ? 's' : ''}? Esta acción no se puede deshacer.`;
+    if (!confirm(msg)) return;
+    startTransition(async () => {
+      const result = await bulkDeleteTasksAction(ids);
+      if (result?.error) {
+        setFeedback({ kind: 'error', message: result.error });
+      } else {
+        setFeedback({ kind: 'ok', message: `${ids.length} tarea${ids.length !== 1 ? 's' : ''} eliminada${ids.length !== 1 ? 's' : ''}` });
+        cancelDeleteMode();
+      }
+    });
+  };
 
   const openCreate = (): void => {
     setCreating(true);
@@ -196,11 +236,61 @@ export function TaskList({
         onCreate={openCreate}
       />
 
+      {/* Toolbar modo borrar */}
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-[11px] text-sp-admin-muted tabular-nums">
+          {filtered.length} tarea{filtered.length !== 1 ? 's' : ''} · semana <span className="font-semibold text-sp-admin-text">{weekLabel}</span>
+        </p>
+        {!deleteMode ? (
+          <button
+            type="button"
+            onClick={() => setDeleteMode(true)}
+            className="flex items-center gap-1.5 h-7 px-3 rounded-lg border border-sp-admin-border text-[11px] text-sp-admin-muted hover:text-red-500 hover:border-red-300 transition-colors"
+          >
+            <svg width="11" height="11" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" aria-hidden>
+              <path d="M2 3h8M5 3V2h2v1M4.5 3v6M7.5 3v6M3 3l.5 7h5l.5-7" />
+            </svg>
+            Borrar tareas
+          </button>
+        ) : (
+          <div className="flex items-center gap-2">
+            <span className="text-[11px] text-sp-admin-muted">
+              {selectedIds.size > 0 ? `${selectedIds.size} seleccionada${selectedIds.size !== 1 ? 's' : ''}` : 'Selecciona tareas'}
+            </span>
+            <button
+              type="button"
+              onClick={handleBulkDelete}
+              disabled={selectedIds.size === 0 || isPending}
+              className="h-7 px-3 rounded-lg bg-red-500 text-white text-[11px] font-bold hover:bg-red-600 disabled:opacity-40 transition-colors"
+            >
+              Eliminar {selectedIds.size > 0 ? selectedIds.size : ''}
+            </button>
+            <button
+              type="button"
+              onClick={cancelDeleteMode}
+              className="h-7 px-3 rounded-lg border border-sp-admin-border text-[11px] text-sp-admin-muted hover:bg-sp-admin-hover transition-colors"
+            >
+              Cancelar
+            </button>
+          </div>
+        )}
+      </div>
+
       <div className="overflow-hidden rounded-xl border border-sp-admin-border bg-sp-admin-card">
         <table className="w-full text-left text-sm">
           <thead>
             <tr className="border-b border-sp-admin-border/60 text-[10px] font-semibold uppercase tracking-[0.2em] text-sp-admin-muted">
-              <th className="px-3 py-3 w-10"></th>
+              <th className="pl-3 pr-1 py-3 w-8">
+                {deleteMode && filtered.length > 0 ? (
+                  <input
+                    type="checkbox"
+                    checked={selectedIds.size === filtered.length}
+                    onChange={selectAll}
+                    aria-label="Seleccionar todas"
+                    className="rounded border-sp-admin-border cursor-pointer accent-red-500"
+                  />
+                ) : null}
+              </th>
               <th className="px-3 py-3">Título</th>
               <th className="px-3 py-3">Prioridad</th>
               <th className="px-3 py-3">Estado</th>
@@ -213,7 +303,7 @@ export function TaskList({
           <tbody className="divide-y divide-sp-admin-border/60">
             {filtered.length === 0 ? (
               <tr>
-                <td colSpan={8} className="px-4 py-10 text-center text-sp-admin-muted">
+                <td colSpan={9} className="px-4 py-10 text-center text-sp-admin-muted">
                   No hay tareas que cumplan los filtros.
                 </td>
               </tr>
@@ -235,16 +325,14 @@ export function TaskList({
                   onEdit={openEdit}
                   onRemove={remove}
                   onFieldChange={handleFieldChange}
+                  selected={selectedIds.has(t.id)}
+                  {...(deleteMode ? { onToggleSelect: toggleSelect } : {})}
                 />
               ))
             )}
           </tbody>
         </table>
       </div>
-
-      <p className="mt-3 text-[11px] text-sp-admin-muted">
-        Semana actual: <span className="font-semibold text-sp-admin-text">{weekLabel}</span>
-      </p>
 
       <FeedbackToast feedback={feedback} />
 

--- a/src/features/admin/tasks/components/TaskModal.tsx
+++ b/src/features/admin/tasks/components/TaskModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useId, useRef, useState, useTransition } from 'react';
+import { useEffect, useId, useMemo, useRef, useState, useTransition } from 'react';
 import type { CrmTask, CrmTaskPriority, CrmTaskStatus } from '@/types';
 import { createTaskAction, updateTaskAction, type TaskFormInput } from '@/app/admin/(dashboard)/tareas/actions';
 import type { RelatedOptions } from './RelatedSelector';
@@ -20,17 +20,33 @@ type Props = {
   readonly suggestedCategories?: readonly string[];
   readonly defaultOwnerId: string;
   readonly relatedOptions?: RelatedOptions;
+  readonly defaultCategory?: string;
+};
+
+const RELATED_SEARCH_TYPES = ['brand', 'talent', 'campaign'] as const;
+const RELATED_SEARCH_LABELS: Record<typeof RELATED_SEARCH_TYPES[number], string> = {
+  brand: 'Marcas', talent: 'Talentos', campaign: 'Campañas',
 };
 
 /**
- * Modal CRUD de una tarea. Crea (task=null) o edita una tarea existente vía createTaskAction/updateTaskAction.
- * Incluye selección de owner, dueDate, prioridad, estado, categoría y entidad relacionada.
+ * Modal CRUD de una tarea. Muestra campos primarios (título, asignado, fecha, prioridad)
+ * y sección secundaria colapsable (descripción, categoría, estado, relacionado con).
+ * La categoría es opcional y por defecto "General".
+ * El campo "relacionado con" usa un buscador unificado sobre marcas, talentos y campañas.
  *
  * @kind client
  * @feature admin/tasks
  */
-export function TaskModal({ onCloseAction, task, users, suggestedCategories = [], defaultOwnerId, relatedOptions }: Props): React.ReactElement {
-  const titleId = useId();
+export function TaskModal({
+  onCloseAction,
+  task,
+  users,
+  suggestedCategories = [],
+  defaultOwnerId,
+  relatedOptions,
+  defaultCategory,
+}: Props): React.ReactElement {
+  const titleId   = useId();
   const dialogRef = useRef<HTMLDivElement>(null);
 
   const [title,       setTitle]       = useState(task?.title ?? '');
@@ -39,12 +55,20 @@ export function TaskModal({ onCloseAction, task, users, suggestedCategories = []
   const [dueDate,     setDueDate]     = useState(task?.dueDate ?? '');
   const [priority,    setPriority]    = useState<CrmTaskPriority>(task?.priority ?? 'media');
   const [status,      setStatus]      = useState<CrmTaskStatus>(task?.status ?? 'pendiente');
-  const [category,    setCategory]    = useState(task?.category ?? '');
+  const [category,    setCategory]    = useState(task?.category ?? defaultCategory ?? 'General');
   const [relatedType, setRelatedType] = useState<string>((task?.relatedType ?? '') as string);
-  const [relatedId,   setRelatedId]   = useState<string>(task?.relatedId !== null && task?.relatedId !== undefined ? String(task.relatedId) : '');
+  const [relatedId,   setRelatedId]   = useState<string>(
+    task?.relatedId !== null && task?.relatedId !== undefined ? String(task.relatedId) : '',
+  );
   const [relatedSearch, setRelatedSearch] = useState('');
   const [error,       setError]       = useState<string | null>(null);
   const [isPending,   startTransition] = useTransition();
+
+  // Auto-abrir sección avanzada si la tarea tiene campos secundarios
+  const [showAdvanced, setShowAdvanced] = useState(() => {
+    if (!task) return false;
+    return !!(task.description?.trim() || (task.category && task.category !== 'General') || task.relatedType);
+  });
 
   // Restaurar foco al desmontar
   useEffect(() => {
@@ -63,27 +87,47 @@ export function TaskModal({ onCloseAction, task, users, suggestedCategories = []
       );
       if (focusables.length === 0) return;
       const first = focusables[0]!;
-      const last = focusables[focusables.length - 1]!;
+      const last  = focusables[focusables.length - 1]!;
       const active = document.activeElement;
-      if (e.shiftKey && active === first) { e.preventDefault(); last.focus(); }
+      if (e.shiftKey && active === first)  { e.preventDefault(); last.focus();  }
       else if (!e.shiftKey && active === last) { e.preventDefault(); first.focus(); }
     };
     document.addEventListener('keydown', onKeyDown);
     return () => document.removeEventListener('keydown', onKeyDown);
   }, [onCloseAction]);
 
-  // Lista filtrada por búsqueda
-  const relatedList = (() => {
-    if (!relatedType || relatedType === 'general' || !relatedOptions) return [];
-    const opts = relatedOptions[relatedType as keyof typeof relatedOptions] ?? [];
-    if (!relatedSearch) return opts;
-    const q = relatedSearch.toLowerCase();
-    return opts.filter((o: { id: number | string; label: string }) => o.label.toLowerCase().includes(q));
-  })();
+  // Buscador unificado: filtra marca, talento y campaña a la vez
+  const relatedSearchResults = useMemo(() => {
+    const q = relatedSearch.trim().toLowerCase();
+    if (q.length < 1 || !relatedOptions) return [];
+    const results: Array<{ rtype: typeof RELATED_SEARCH_TYPES[number]; id: number; label: string }> = [];
+    for (const rtype of RELATED_SEARCH_TYPES) {
+      for (const o of relatedOptions[rtype]) {
+        if (o.label.toLowerCase().includes(q)) results.push({ rtype, id: Number(o.id), label: o.label });
+      }
+    }
+    return results.slice(0, 12);
+  }, [relatedOptions, relatedSearch]);
+
+  // Label de la entidad relacionada seleccionada
+  const selectedRelatedLabel = useMemo(() => {
+    if (!relatedType || !relatedId) return null;
+    if (relatedType === 'general') return 'General';
+    if (!relatedOptions) return null;
+    const opts = relatedOptions[relatedType as keyof RelatedOptions] ?? [];
+    const opt  = opts.find((o) => String(o.id) === relatedId);
+    if (!opt) return null;
+    const typeLabel = RELATED_TYPE_LABELS[relatedType as keyof typeof RELATED_TYPE_LABELS] ?? relatedType;
+    return `${typeLabel} · ${opt.label}`;
+  }, [relatedType, relatedId, relatedOptions]);
+
+  // ¿Hay algún campo secundario relleno?
+  const hasSecondaryData = !!(description || category !== 'General' || relatedType);
+
+  const clearRelated = (): void => { setRelatedType(''); setRelatedId(''); setRelatedSearch(''); };
 
   const submit = (): void => {
     if (!title.trim()) { setError('El título es obligatorio'); return; }
-    if (!category.trim()) { setError('La categoría es obligatoria'); return; }
 
     const input: TaskFormInput = {
       title:       title.trim(),
@@ -92,7 +136,7 @@ export function TaskModal({ onCloseAction, task, users, suggestedCategories = []
       dueDate:     dueDate || null,
       priority,
       status,
-      category:    category.trim(),
+      category:    category.trim() || 'General',
       relatedType: (relatedType || undefined) as TaskFormInput['relatedType'],
       relatedId:   relatedId ? Number(relatedId) : undefined,
     };
@@ -114,19 +158,26 @@ export function TaskModal({ onCloseAction, task, users, suggestedCategories = []
       aria-labelledby={titleId}
     >
       <div ref={dialogRef} className="w-full max-w-lg rounded-xl border border-sp-admin-border bg-sp-admin-card shadow-2xl overflow-hidden">
+
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-sp-admin-border">
           <h2 id={titleId} className="text-base font-bold text-sp-admin-text">
             {task ? 'Editar tarea' : 'Nueva tarea'}
           </h2>
-          <button type="button" onClick={onCloseAction} className="text-sp-admin-muted hover:text-sp-admin-text text-xl leading-none transition-colors" aria-label="Cerrar">
+          <button
+            type="button"
+            onClick={onCloseAction}
+            className="text-sp-admin-muted hover:text-sp-admin-text text-xl leading-none transition-colors"
+            aria-label="Cerrar"
+          >
             ×
           </button>
         </div>
 
         <form onSubmit={(e) => { e.preventDefault(); submit(); }} className="p-6 space-y-4">
 
-          {/* Título */}
+          {/* ── Campos primarios ──────────────────────────────── */}
+
           <Field label="Título *">
             <input
               value={title}
@@ -139,25 +190,12 @@ export function TaskModal({ onCloseAction, task, users, suggestedCategories = []
             />
           </Field>
 
-          {/* Descripción */}
-          <Field label="Descripción (opcional)">
-            <textarea
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              rows={2}
-              className={`${inputCls} resize-none`}
-              placeholder="Notas adicionales…"
-            />
-          </Field>
-
-          {/* Asignado + Fecha */}
-          <div className="grid grid-cols-2 gap-3">
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
             <Field label="Asignado">
               <select value={ownerId} onChange={(e) => setOwnerId(e.target.value)} className={inputCls}>
                 {users.map((u) => <option key={u.id} value={u.id}>{u.name}</option>)}
               </select>
             </Field>
-
             <Field label="Fecha límite">
               <input
                 type="date"
@@ -166,91 +204,147 @@ export function TaskModal({ onCloseAction, task, users, suggestedCategories = []
                 className={inputCls}
               />
             </Field>
-
             <Field label="Prioridad">
-              <select value={priority} onChange={(e) => setPriority(e.target.value as CrmTaskPriority)} className={inputCls}>
-                {PRIORITIES.map((p) => <option key={p} value={p}>{p}</option>)}
+              <select
+                value={priority}
+                onChange={(e) => setPriority(e.target.value as CrmTaskPriority)}
+                className={inputCls}
+              >
+                {PRIORITIES.map((p) => (
+                  <option key={p} value={p}>{p.charAt(0).toUpperCase() + p.slice(1)}</option>
+                ))}
               </select>
             </Field>
+          </div>
 
-            <Field label="Estado">
-              <select value={status} onChange={(e) => setStatus(e.target.value as CrmTaskStatus)} className={inputCls}>
-                {STATUSES.map((s) => <option key={s} value={s}>{s.replace('_', ' ')}</option>)}
-              </select>
-            </Field>
+          {/* ── Toggle sección avanzada ───────────────────────── */}
+          <button
+            type="button"
+            onClick={() => setShowAdvanced((v) => !v)}
+            className="flex items-center gap-1.5 text-[11px] font-semibold text-sp-admin-muted hover:text-sp-admin-text transition-colors"
+          >
+            <svg
+              width="10" height="10" viewBox="0 0 10 10"
+              className={`transition-transform duration-150 ${showAdvanced ? 'rotate-180' : ''}`}
+              fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"
+              aria-hidden
+            >
+              <path d="M2 3.5L5 6.5L8 3.5" />
+            </svg>
+            {showAdvanced ? 'Menos opciones' : 'Más opciones'}
+            {hasSecondaryData && !showAdvanced && (
+              <span className="w-1.5 h-1.5 rounded-full bg-sp-admin-accent" aria-hidden />
+            )}
+          </button>
 
-            <div className="col-span-2">
-              <Field label="Categoría">
-                <select
-                  value={category}
-                  onChange={(e) => setCategory(e.target.value)}
-                  className={inputCls}
-                  required
-                >
-                  <option value="">— Seleccionar categoría —</option>
-                  {suggestedCategories.map((c) => (
-                    <option key={c} value={c}>{c}</option>
-                  ))}
-                </select>
+          {/* ── Sección avanzada (colapsable) ────────────────── */}
+          {showAdvanced && (
+            <div className="space-y-4 pt-1 border-t border-sp-admin-border/60">
+
+              <Field label="Descripción">
+                <textarea
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  rows={2}
+                  className={`${inputCls} resize-none`}
+                  placeholder="Notas adicionales…"
+                />
               </Field>
-            </div>
 
-            <div className="col-span-2">
-              <Field label="Relacionado con">
-                <div className="space-y-2">
-                  <div className="grid grid-cols-4 gap-1">
-                    <button
-                      type="button"
-                      onClick={() => { setRelatedType(''); setRelatedId(''); setRelatedSearch(''); }}
-                      className={`px-2 py-1.5 rounded-lg border text-[11px] font-semibold transition-colors cursor-pointer ${relatedType === '' ? 'bg-sp-admin-accent/10 border-sp-admin-accent text-sp-admin-accent' : 'border-sp-admin-border text-sp-admin-muted hover:text-sp-admin-text'}`}
-                    >
-                      Ninguna
-                    </button>
-                    {(['brand', 'talent', 'campaign', 'invoice', 'general'] as const).map((k) => (
-                      <button
-                        key={k}
-                        type="button"
-                        onClick={() => { setRelatedType(k); setRelatedId(''); setRelatedSearch(''); }}
-                        className={`px-2 py-1.5 rounded-lg border text-[11px] font-semibold transition-colors cursor-pointer ${relatedType === k ? 'bg-sp-admin-accent/10 border-sp-admin-accent text-sp-admin-accent' : 'border-sp-admin-border text-sp-admin-muted hover:text-sp-admin-text'}`}
-                      >
-                        {RELATED_TYPE_LABELS[k]}
-                      </button>
+              <div className="grid grid-cols-2 gap-3">
+                <Field label="Categoría">
+                  <input
+                    list="task-category-suggestions"
+                    value={category}
+                    onChange={(e) => setCategory(e.target.value)}
+                    className={inputCls}
+                    placeholder="General"
+                    maxLength={40}
+                  />
+                  <datalist id="task-category-suggestions">
+                    <option value="General" />
+                    {suggestedCategories
+                      .filter((c) => c !== 'General')
+                      .map((c) => <option key={c} value={c} />)}
+                  </datalist>
+                </Field>
+
+                <Field label="Estado">
+                  <select
+                    value={status}
+                    onChange={(e) => setStatus(e.target.value as CrmTaskStatus)}
+                    className={inputCls}
+                  >
+                    {STATUSES.map((s) => (
+                      <option key={s} value={s}>{s.replace('_', ' ')}</option>
                     ))}
-                  </div>
-                  {relatedType && relatedType !== 'general' && (
-                    <>
+                  </select>
+                </Field>
+              </div>
+
+              {/* Relacionado con — buscador unificado */}
+              {relatedOptions && (
+                <Field label="Relacionado con">
+                  {selectedRelatedLabel ? (
+                    <div className="flex items-center gap-2">
+                      <span className="inline-flex items-center gap-1.5 rounded-full bg-sp-admin-hover border border-sp-admin-border px-3 py-1 text-xs font-semibold text-sp-admin-text">
+                        {selectedRelatedLabel}
+                        <button
+                          type="button"
+                          onClick={clearRelated}
+                          className="text-sp-admin-muted hover:text-red-500 transition-colors leading-none"
+                          aria-label="Quitar relación"
+                        >
+                          ×
+                        </button>
+                      </span>
+                    </div>
+                  ) : (
+                    <div className="relative">
                       <input
                         type="search"
                         value={relatedSearch}
                         onChange={(e) => setRelatedSearch(e.target.value)}
-                        placeholder={`Buscar ${RELATED_TYPE_LABELS[relatedType as keyof typeof RELATED_TYPE_LABELS] ?? relatedType}...`}
+                        placeholder="Buscar marca, talento o campaña…"
                         className={inputCls}
+                        autoComplete="off"
                       />
-                      <div className="max-h-32 overflow-y-auto rounded-lg border border-sp-admin-border bg-sp-admin-bg">
-                        {relatedList.length === 0 ? (
-                          <p className="px-3 py-2 text-xs italic text-sp-admin-muted">Sin resultados.</p>
-                        ) : (
-                          relatedList.map((o: { id: number | string; label: string }) => {
-                            const isSel = relatedId === String(o.id);
+                      {relatedSearchResults.length > 0 && (
+                        <div className="absolute top-full left-0 right-0 z-10 mt-1 max-h-48 overflow-y-auto rounded-lg border border-sp-admin-border bg-sp-admin-card shadow-lg">
+                          {RELATED_SEARCH_TYPES.map((rtype) => {
+                            const items = relatedSearchResults.filter((r) => r.rtype === rtype);
+                            if (items.length === 0) return null;
                             return (
-                              <button
-                                key={o.id}
-                                type="button"
-                                onClick={() => setRelatedId(String(o.id))}
-                                className={`w-full text-left px-3 py-1.5 text-xs cursor-pointer ${isSel ? 'bg-sp-admin-accent/15 text-sp-admin-accent font-semibold' : 'text-sp-admin-text hover:bg-sp-admin-hover'}`}
-                              >
-                                {o.label}
-                              </button>
+                              <div key={rtype}>
+                                <div className="sticky top-0 px-3 py-1 text-[9px] font-bold uppercase tracking-wider text-sp-admin-muted bg-sp-admin-bg/90 border-b border-sp-admin-border/40">
+                                  {RELATED_SEARCH_LABELS[rtype]}
+                                </div>
+                                {items.map((r) => (
+                                  <button
+                                    key={`${r.rtype}:${r.id}`}
+                                    type="button"
+                                    onClick={() => {
+                                      setRelatedType(r.rtype);
+                                      setRelatedId(String(r.id));
+                                      setRelatedSearch('');
+                                    }}
+                                    className="w-full text-left px-3 py-1.5 text-xs text-sp-admin-text hover:bg-sp-admin-hover transition-colors"
+                                  >
+                                    {r.label}
+                                  </button>
+                                ))}
+                              </div>
                             );
-                          })
-                        )}
-                      </div>
-                    </>
+                          })}
+                        </div>
+                      )}
+                    </div>
                   )}
-                </div>
-              </Field>
+                </Field>
+              )}
+
             </div>
-          </div>
+          )}
 
           {error && (
             <p className="text-[12px] text-red-600 bg-red-50 border border-red-200 rounded-lg px-3 py-2">
@@ -275,6 +369,7 @@ export function TaskModal({ onCloseAction, task, users, suggestedCategories = []
               {isPending ? 'Guardando…' : task ? 'Guardar cambios' : 'Crear tarea'}
             </button>
           </div>
+
         </form>
       </div>
     </div>

--- a/src/lib/schemas/task.ts
+++ b/src/lib/schemas/task.ts
@@ -30,7 +30,7 @@ export const taskFormSchema = z
       .transform((v) => (v === '' ? null : v)),
     priority: z.enum(CRM_TASK_PRIORITIES),
     status: z.enum(CRM_TASK_STATUSES),
-    category: z.string().trim().min(1).max(40),
+    category: z.string().trim().max(40).transform((v) => v || 'General'),
     relatedType: relatedTypeSchema,
     relatedId: relatedIdSchema,
   })


### PR DESCRIPTION
## Qué cambia

Dos mejoras independientes en el módulo de tareas y una mejora visual en contratos.

---

### 1. Modal de tareas — UX simplificado

**Problema**: el modal mostraba todos los campos a la vez (descripción, categoría, estado, relacionado con) bloqueando la creación rápida.

**Solución**:
- **Campos primarios** (siempre visibles): Título + grid 3-col (Asignado · Fecha límite · Prioridad)
- **Campos secundarios** (colapsables con `▼ Más opciones`): Descripción · Categoría · Estado · Relacionado con
- El toggle se **auto-abre** al editar una tarea que ya tiene campos secundarios rellenos
- Dot naranja en el toggle cuando hay datos ocultos (señal visual sin abrir)
- **Categoría ahora es opcional** — valor por defecto "General", no bloquea el guardado
- **Buscador unificado** en "Relacionado con": un solo input busca simultáneamente en Marcas, Talentos y Campañas; resultado seleccionado aparece como chip con × para quitar
- Nueva prop `defaultCategory?: string` preparada para cuando se creen tareas desde campañas o marcas con categoría pre-asignada

**Schema** (`task.ts`): `category` pasa de `z.string().trim().min(1)` a `z.string().trim().max(40).transform(v => v || 'General')`.

---

### 2. Bulk delete de tareas

**Problema**: no había forma de borrar varias tareas a la vez (la server action `bulkDeleteTasksAction` existía pero sin UI).

**Solución**:
- Botón `Borrar tareas` en la barra superior de la lista — activa modo selección
- En modo selección: cada fila muestra un checkbox rojo
- Checkbox en la cabecera: selecciona/deselecciona todas las visibles
- Barra de acciones muestra: `X seleccionadas — [Eliminar N] [Cancelar]`
- Confirmación nativa antes de borrar para evitar accidentes
- Toast verde al completarse; modo selección se cierra automáticamente
- El borrado individual (✕) y el completar tarea (✓) siguen funcionando igual fuera del modo selección

---

### 3. PDF de contratos — diseño profesional

**Problema**: el PDF generado era texto plano (helvetica negro sobre blanco sin branding).

**Solución** (mismos estándares visuales que las facturas emitidas):
- **Banda naranja** en la parte superior (color accent #f5632a)
- **"SocialPro"** en naranja a la izquierda + nombre del contrato a la derecha
- **Bloque de datos del trato** en rejilla de 2 columnas: marca, talento, importe, fechas
- **Títulos de sección** con fondo gris claro (`#f5f5fa`) y texto en naranja accent
- **Footer** en cada página: "SocialPro · Contrato de servicios" + número de página + fecha
- Gestión automática de saltos de página con cabecera y pie en cada hoja

---

## Archivos modificados
- `src/lib/schemas/task.ts` — category opcional con default
- `src/features/admin/tasks/components/TaskModal.tsx` — modal rediseñado
- `src/features/admin/tasks/components/TaskList.tsx` — estado de selección + bulk delete
- `src/features/admin/tasks/components/TaskList.parts.tsx` — props `selected` / `onToggleSelect` en TaskRow
- `src/features/admin/_shared/components/campaigns/ContractGenerator.tsx` — PDF profesional

## Test plan
- [ ] Crear tarea: modal muestra solo Título + Asignado + Fecha + Prioridad
- [ ] Pulsar "Más opciones": aparecen Descripción, Categoría (default "General"), Estado, Relacionado con
- [ ] Crear tarea sin rellenar Categoría → se guarda con categoría "General"
- [ ] Buscador de "Relacionado con": escribir "Nike" filtra Marcas + Talentos + Campañas simultáneamente
- [ ] Editar tarea con descripción → modal se abre con sección avanzada ya visible
- [ ] `Borrar tareas` → modo selección → checkboxes rojos por fila
- [ ] Seleccionar 3 tareas → "Eliminar 3" → confirmación → borradas → toast
- [ ] Checkbox de cabecera selecciona todas las visibles (respeta filtros activos)
- [ ] Campañas → trato → tab Contrato → Generar PDF → verificar diseño con banda naranja y footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)