### PR TITLE
fix(admin-header): dark mode funcional + buscador global corregido

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -173,6 +173,16 @@
   --sidebar-ring: oklch(0.556 0 0);
 }
 
+/* ── Admin dark mode token overrides ─────────────────────────────── */
+html.dark {
+  --color-sp-admin-bg:     #111524;
+  --color-sp-admin-card:   #1a1e32;
+  --color-sp-admin-border: #272b42;
+  --color-sp-admin-text:   #ddddf0;
+  --color-sp-admin-muted:  #8888a0;
+  --color-sp-admin-hover:  #252940;
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/src/features/admin/_shared/components/AdminHeader.tsx
+++ b/src/features/admin/_shared/components/AdminHeader.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { BellIcon, SettingsIcon } from './SidebarIcons';
+import { BellIcon, SunIcon, MoonIcon } from './SidebarIcons';
 import { GlobalSearch } from './GlobalSearch';
 import { AlertResolveButton } from './dashboard/AlertResolveButton';
 import type { DashboardAlert, AlertSeverity } from '@/lib/queries/alerts';
@@ -107,9 +107,39 @@ function AlertDropdownItem({ alert, onClose }: { alert: DashboardAlert; onClose:
 
 // ── AdminHeader ───────────────────────────────────────────────────────
 
+// ── Theme toggle ──────────────────────────────────────────────────────
+
+function useThemeToggle(): { isDark: boolean; toggle: () => void } {
+  // Lazy init — lee localStorage en cliente, retorna false en SSR
+  const [isDark, setIsDark] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false;
+    const stored = localStorage.getItem('sp-theme');
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    return stored === 'dark' || (!stored && prefersDark);
+  });
+
+  // Aplica clase al DOM cada vez que cambia isDark (sin setState dentro)
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', isDark);
+  }, [isDark]);
+
+  const toggle = (): void => {
+    setIsDark((prev) => {
+      const next = !prev;
+      localStorage.setItem('sp-theme', next ? 'dark' : 'light');
+      return next;
+    });
+  };
+
+  return { isDark, toggle };
+}
+
+// ── AdminHeader ───────────────────────────────────────────────────────
+
 export function AdminHeader({ alertCount = 0, recentAlerts = [] }: Props): React.ReactElement {
   const [showActions, setShowActions] = useState(false);
   const [showAlerts,  setShowAlerts]  = useState(false);
+  const { isDark, toggle: toggleTheme } = useThemeToggle();
 
   const today = new Date().toLocaleDateString('es-ES', {
     weekday: 'long', day: 'numeric', month: 'long', year: 'numeric',
@@ -244,13 +274,17 @@ export function AdminHeader({ alertCount = 0, recentAlerts = [] }: Props): React
           )}
         </div>
 
-        {/* Settings */}
+        {/* Dark / Light mode toggle */}
         <button
           type="button"
+          onClick={toggleTheme}
           className="relative w-8 h-8 rounded-lg flex items-center justify-center text-sp-admin-muted hover:text-sp-admin-text hover:bg-sp-admin-hover transition-colors"
-          aria-label="Configuración"
+          aria-label={isDark ? 'Cambiar a modo claro' : 'Cambiar a modo oscuro'}
+          title={isDark ? 'Modo claro' : 'Modo oscuro'}
         >
-          <span className="w-4 h-4 block"><SettingsIcon /></span>
+          <span className="w-4 h-4 block">
+            {isDark ? <SunIcon /> : <MoonIcon />}
+          </span>
         </button>
       </div>
 

--- a/src/features/admin/_shared/components/GlobalSearch.tsx
+++ b/src/features/admin/_shared/components/GlobalSearch.tsx
@@ -153,10 +153,10 @@ export function GlobalSearch(): React.ReactElement {
           setActiveIndex(0);
           setOpen(true);
         }}
-        onFocus={() => setOpen(true)}
+        onFocus={() => { if (query.length > 0) setOpen(true); }}
         onKeyDown={onKeyDown}
-        placeholder="Buscar marcas, talentos, campañas… (⌘K)"
-        className="w-full h-10 pl-9 pr-12 rounded-lg bg-sp-admin-card border border-sp-admin-border text-[13px] text-sp-admin-text placeholder:text-sp-admin-muted focus:outline-none focus:border-sp-admin-accent/60 transition-colors"
+        placeholder="Buscar…"
+        className="w-full h-9 pl-9 pr-12 rounded-lg bg-sp-admin-card border border-sp-admin-border text-[13px] text-sp-admin-text placeholder:text-sp-admin-muted focus:outline-none focus:border-sp-admin-accent/60 transition-colors"
         aria-label="Buscar"
         role="combobox"
         aria-haspopup="listbox"

--- a/src/features/admin/_shared/components/SidebarIcons.tsx
+++ b/src/features/admin/_shared/components/SidebarIcons.tsx
@@ -213,6 +213,30 @@ export function MoreIcon() {
   );
 }
 
+export function SunIcon() {
+  return (
+    <svg {...s}>
+      <circle cx="10" cy="10" r="3.5" />
+      <line x1="10" y1="2" x2="10" y2="4.5" />
+      <line x1="10" y1="15.5" x2="10" y2="18" />
+      <line x1="2" y1="10" x2="4.5" y2="10" />
+      <line x1="15.5" y1="10" x2="18" y2="10" />
+      <line x1="4.2" y1="4.2" x2="5.9" y2="5.9" />
+      <line x1="14.1" y1="14.1" x2="15.8" y2="15.8" />
+      <line x1="4.2" y1="15.8" x2="5.9" y2="14.1" />
+      <line x1="14.1" y1="5.9" x2="15.8" y2="4.2" />
+    </svg>
+  );
+}
+
+export function MoonIcon() {
+  return (
+    <svg {...s}>
+      <path d="M15.5 10A6.5 6.5 0 1 1 10 4.5a5 5 0 0 0 5.5 5.5z" />
+    </svg>
+  );
+}
+
 export function LogoutIcon() {
   return (
     <svg {...s}>


### PR DESCRIPTION
## Qué cambia

Dos bugs visuales en la barra superior del admin.

---

### 1. Toggle dark mode / light mode — ahora funciona

**Problema**: el botón de engranaje (⚙️) en la esquina del header no tenía `onClick` y no hacía absolutamente nada.

**Solución**:
- Reemplazado por un toggle Luna / Sol funcional
- Persiste la preferencia en `localStorage` con clave `sp-theme`
- En primera visita respeta `prefers-color-scheme` del sistema operativo
- Implementación: `useState` con lazy initializer (lee localStorage en cliente, `false` en SSR) + `useEffect` que aplica/elimina la clase `.dark` en `<html>` — sin `setState` dentro del efecto (cumple la regla ESLint de Next.js)

**Tokens dark mode** añadidos en `globals.css`:
```css
html.dark {
  --color-sp-admin-bg:     #111524;
  --color-sp-admin-card:   #1a1e32;
  --color-sp-admin-border: #272b42;
  --color-sp-admin-text:   #ddddf0;
  --color-sp-admin-muted:  #8888a0;
  --color-sp-admin-hover:  #252940;
}
```
La paleta dark usa los mismos colores navy del sidebar, dando coherencia visual.

**Iconos nuevos** en `SidebarIcons.tsx`: `SunIcon` y `MoonIcon` (mismo sistema SVG 20×20 que el resto de iconos).

---

### 2. Buscador global — shortcut duplicado y apertura en vacío

**Problema 1**: el placeholder mostraba `"Buscar marcas, talentos, campañas… (⌘K)"` Y había un badge `<kbd>⌘K</kbd>` — doble indicación del mismo shortcut.

**Solución**: placeholder simplificado a `"Buscar…"`. El badge `⌘K` ya lo indica.

**Problema 2**: `onFocus={() => setOpen(true)}` abría el dropdown aunque el input estuviera vacío, mostrando "Escribe al menos 2 caracteres" — UX confuso.

**Solución**: `onFocus={() => { if (query.length > 0) setOpen(true); }}` — el dropdown solo abre si ya hay texto escrito.

---

## Archivos modificados
- `src/app/globals.css` — tokens dark mode para panel admin
- `src/features/admin/_shared/components/SidebarIcons.tsx` — `SunIcon`, `MoonIcon`
- `src/features/admin/_shared/components/AdminHeader.tsx` — hook `useThemeToggle`, botón Luna/Sol
- `src/features/admin/_shared/components/GlobalSearch.tsx` — placeholder + onFocus

## Test plan
- [ ] Clic en el icono Luna → panel se pone oscuro (fondo navy)
- [ ] Recargar página → sigue en modo oscuro (localStorage persistido)
- [ ] Clic en Sol → vuelve a modo claro
- [ ] Primera visita en incógnito con `prefers-color-scheme: dark` → abre en modo oscuro automáticamente
- [ ] Buscador: placeholder dice solo "Buscar…" (sin `⌘K` en el texto)
- [ ] Hacer click en el buscador sin escribir → dropdown NO aparece
- [ ] Escribir 2+ caracteres → dropdown aparece con resultados agrupados

🤖 Generated with [Claude Code](https://claude.com/claude-code)