### PR TITLE
chore(labels): expandir abreviaciones de plataforma a nombres completos

### DIFF
--- a/src/features/admin/stats/components/RankingTable.tsx
+++ b/src/features/admin/stats/components/RankingTable.tsx
@@ -10,12 +10,12 @@ type Props = {
 };
 
 const PLATFORM_LABELS: Record<string, string> = {
-  youtube: 'YT',
-  twitch: 'TW',
-  instagram: 'IG',
-  tiktok: 'TK',
-  twitter: 'X',
-  x: 'X',
+  youtube:   'YouTube',
+  twitch:    'Twitch',
+  instagram: 'Instagram',
+  tiktok:    'TikTok',
+  twitter:   'X',
+  x:         'X',
 };
 
 const PLATFORM_COLORS: Record<string, string> = {

--- a/src/features/admin/targets/components/targets-constants.ts
+++ b/src/features/admin/targets/components/targets-constants.ts
@@ -22,10 +22,10 @@ export const PLATFORM_COLORS: Record<string, string> = {
 };
 
 export const PLATFORM_LABELS: Record<string, string> = {
-  instagram: 'IG',
-  youtube: 'YT',
-  twitch: 'TW',
-  kick: 'KK',
+  instagram: 'Instagram',
+  youtube:   'YouTube',
+  twitch:    'Twitch',
+  kick:      'Kick',
 };
 
 export const STATUS_COLORS: Record<StatusValue, string> = {

--- a/src/features/brand-portal/components/BrandTargetsSpreadsheet.tsx
+++ b/src/features/brand-portal/components/BrandTargetsSpreadsheet.tsx
@@ -147,7 +147,7 @@ export function BrandTargetsSpreadsheet({
                           />
                         ) : (
                           <div className="w-9 h-9 rounded-full bg-sp-dark text-white text-[10px] font-bold flex items-center justify-center shrink-0">
-                            {target.platform === 'instagram' ? 'IG' : 'YT'}
+                            {target.platform === 'instagram' ? 'In' : 'Yt'}
                           </div>
                         )}
                         <div className="min-w-0">

--- a/src/lib/utils/platform.ts
+++ b/src/lib/utils/platform.ts
@@ -1,10 +1,10 @@
 export const SOCIAL_PLATFORMS = [
-  { key: 'yt', label: 'YT', color: '#FF0000', canonical: 'youtube' },
-  { key: 'twitch', label: 'TW', color: '#9146FF', canonical: 'twitch' },
-  { key: 'x', label: 'X', color: '#1DA1F2', canonical: 'x' },
-  { key: 'ig', label: 'IG', color: '#E1306C', canonical: 'instagram' },
-  { key: 'tt', label: 'TT', color: '#e8e8f0', canonical: 'tiktok' },
-  { key: 'kick', label: 'Kick', color: '#53FC18', canonical: 'kick' },
+  { key: 'yt',     label: 'YouTube',   color: '#FF0000', canonical: 'youtube'   },
+  { key: 'twitch', label: 'Twitch',    color: '#9146FF', canonical: 'twitch'    },
+  { key: 'x',      label: 'X',         color: '#1DA1F2', canonical: 'x'         },
+  { key: 'ig',     label: 'Instagram', color: '#E1306C', canonical: 'instagram' },
+  { key: 'tt',     label: 'TikTok',    color: '#e8e8f0', canonical: 'tiktok'    },
+  { key: 'kick',   label: 'Kick',      color: '#53FC18', canonical: 'kick'      },
 ] as const;
 
 export const TRACKABLE_SOCIAL_PLATFORM_KEYS = ['yt', 'youtube', 'twitch'] as const;


### PR DESCRIPTION
## Qué cambia

Elimina las abreviaciones de plataforma en todos los labels de display del panel admin y el portal de marcas.

| Antes | Después |
|-------|---------|
| `IG`  | `Instagram` |
| `YT`  | `YouTube` |
| `TW`  | `Twitch` |
| `TT`  | `TikTok` |
| `KK`  | `Kick` |

**Los keys internos no cambian** (`yt`, `ig`, `tw`, `tt`, `kick`) — solo los `label` de display. El `normalizePlatform()` y los alias de resolución funcionan igual. Los tests de `platform.test.ts` siguen en verde.

## Archivos modificados

| Archivo | Qué había | Qué hay |
|---------|-----------|---------|
| `src/lib/utils/platform.ts` | `label: 'YT'` | `label: 'YouTube'` (fuente de verdad) |
| `src/features/admin/targets/components/targets-constants.ts` | `PLATFORM_LABELS: { instagram: 'IG', ... }` | Nombres completos |
| `src/features/admin/stats/components/RankingTable.tsx` | Map local con abreviaciones | Nombres completos |
| `src/features/brand-portal/components/BrandTargetsSpreadsheet.tsx` | Avatar fallback `'IG'`/`'YT'` | `'In'`/`'Yt'` (iniciales en círculo 36px) |

## Nota sobre el avatar de marca

En `BrandTargetsSpreadsheet`, el circle de 36px se usa como fallback cuando no hay foto de perfil. Se cambia a iniciales de 2 letras (`'In'` para Instagram, `'Yt'` para YouTube) en lugar del nombre completo que no cabe visualmente.

## Test plan
- [ ] `/admin/targets` → columna Plataforma muestra "Instagram", "YouTube", "Twitch"
- [ ] `/admin/analytics` → tabla de ranking muestra nombres completos de plataforma
- [ ] Portal de marcas `/marcas/targets` → avatar fallback muestra "In" o "Yt"
- [ ] `npx tsx scripts/sync-followers.ts` sigue funcionando (normalización interna sin cambios)

🤖 Generated with [Claude Code](https://claude.com/claude-code)