### PR TITLE
feat(talents): sort por tratos activos + badge en card

### DIFF
--- a/src/features/admin/talents/components/InfluencerCardsView.parts.tsx
+++ b/src/features/admin/talents/components/InfluencerCardsView.parts.tsx
@@ -248,8 +248,8 @@ export function TalentCard({ creator, verticals, selectMode, selected, onToggleS
         )}
       </div>
 
-      {/* ── Footer: solo estado ─────────────────────────────────── */}
-      <div className="border-t border-sp-admin-border/50 px-3 py-2 flex items-center mt-auto">
+      {/* ── Footer: estado + tratos activos ────────────────────── */}
+      <div className="border-t border-sp-admin-border/50 px-3 py-2 flex items-center justify-between gap-2 mt-auto">
         {isPillClickable ? (
           <button
             type="button"
@@ -267,6 +267,13 @@ export function TalentCard({ creator, verticals, selectMode, selected, onToggleS
           <span className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[9px] font-bold ${statusCfg.bg} ${statusCfg.text}`}>
             <span className="w-1.5 h-1.5 rounded-full shrink-0" style={{ background: statusCfg.dot }} />
             {STATUS_LABELS[displayStatus] ?? displayStatus}
+          </span>
+        )}
+
+        {/* Badge de tratos activos */}
+        {(creator.activeDealsCount ?? 0) > 0 && (
+          <span className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[9px] font-bold bg-sp-admin-accent/10 text-sp-admin-accent">
+            {creator.activeDealsCount} {creator.activeDealsCount === 1 ? 'trato' : 'tratos'}
           </span>
         )}
       </div>

--- a/src/features/admin/talents/components/InfluencerCardsView.tsx
+++ b/src/features/admin/talents/components/InfluencerCardsView.tsx
@@ -29,6 +29,7 @@ export function InfluencerCardsView({ creators, verticalsByTalent }: Props): Rea
   const [platformFilter, setPlatformFilter] = useState<string>('');
   const [countryFilter, setCountryFilter] = useState<string>('');
   const [showMoreFilters, setShowMoreFilters] = useState(false);
+  const [sortBy, setSortBy]               = useState<'default' | 'deals'>('default');
   const [showAdd, setShowAdd]             = useState(false);
   const [selectMode, setSelectMode]       = useState(false);
   const [selectedIds, setSelectedIds]     = useState<Set<number>>(new Set());
@@ -60,7 +61,7 @@ export function InfluencerCardsView({ creators, verticalsByTalent }: Props): Rea
 
   const filtered = useMemo(() => {
     const q = search.trim().toLowerCase();
-    return creators.filter((c) => {
+    const list = creators.filter((c) => {
       if (q && !c.name.toLowerCase().includes(q) && !c.slug.toLowerCase().includes(q)) return false;
       if (statusFilter !== 'all' && c.status !== statusFilter) return false;
       if (verticalFilter) {
@@ -71,7 +72,11 @@ export function InfluencerCardsView({ creators, verticalsByTalent }: Props): Rea
       if (countryFilter && (c.creatorCountry ?? '').toUpperCase() !== countryFilter) return false;
       return true;
     });
-  }, [creators, search, statusFilter, verticalFilter, platformFilter, countryFilter, verticalsByTalent]);
+    if (sortBy === 'deals') {
+      return [...list].sort((a, b) => (b.activeDealsCount ?? 0) - (a.activeDealsCount ?? 0));
+    }
+    return list;
+  }, [creators, search, statusFilter, verticalFilter, platformFilter, countryFilter, verticalsByTalent, sortBy]);
 
   const counts = useMemo(() => {
     let active = 0, available = 0, inactive = 0;
@@ -164,6 +169,23 @@ export function InfluencerCardsView({ creators, verticalsByTalent }: Props): Rea
         </button>
 
         <span className="text-[11px] text-sp-admin-muted tabular-nums">{filtered.length} de {creators.length}</span>
+
+        {/* Sort por tratos */}
+        <button
+          type="button"
+          onClick={() => setSortBy((v) => v === 'deals' ? 'default' : 'deals')}
+          className={`h-8 px-3 rounded-lg border text-[12px] font-medium transition-colors flex items-center gap-1.5 ${
+            sortBy === 'deals'
+              ? 'border-sp-admin-accent/50 bg-sp-admin-accent/8 text-sp-admin-accent font-semibold'
+              : 'border-sp-admin-border text-sp-admin-muted hover:bg-sp-admin-hover'
+          }`}
+          title={sortBy === 'deals' ? 'Quitar orden por tratos' : 'Ordenar por más tratos activos'}
+        >
+          <svg width="11" height="11" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" aria-hidden>
+            <path d="M2 10V6M5 10V2M8 10V5M11 10V8"/>
+          </svg>
+          Más tratos
+        </button>
 
         {/* Acciones */}
         <div className="flex items-center gap-1.5 ml-auto">

--- a/src/lib/queries/talents.ts
+++ b/src/lib/queries/talents.ts
@@ -1,7 +1,7 @@
 import { cache } from 'react';
-import { eq, and, inArray, sql, type SQL } from 'drizzle-orm';
+import { eq, and, inArray, sql, count, type SQL } from 'drizzle-orm';
 import { db } from '@/lib/db';
-import { talents, talentTags, talentStats, talentSocials, talentBusiness, talentVerticals } from '@/db/schema';
+import { talents, talentTags, talentStats, talentSocials, talentBusiness, talentVerticals, campaigns } from '@/db/schema';
 import { parseFollowers, formatFollowers, slugify, initialsOf } from '@/lib/utils/import-utils';
 import type { TalentWithRelations, TalentBusiness, TalentVertical, TalentSocial, TalentTag } from '@/types';
 import type { Talent } from '@/types';
@@ -178,6 +178,7 @@ export type GrowthData = {
 
 export type AdminRosterRow = TalentWithRelations & {
   growth: GrowthData[];
+  activeDealsCount: number;
 };
 
 /**
@@ -194,11 +195,21 @@ export async function getAdminRosterWithGrowth(): Promise<AdminRosterRow[]> {
   thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
   const fromDate = thirtyDaysAgo.toISOString().split('T')[0]!;
 
-  const [allTalents, latestSnaps, earliestSnaps] = await Promise.all([
+  const [allTalents, latestSnaps, earliestSnaps, activeDealRows] = await Promise.all([
     getAllTalents(),
     getLatestSnapshots(),
     getEarliestSnapshots(fromDate),
+    db
+      .select({ talentId: campaigns.talentId, cnt: count(campaigns.id) })
+      .from(campaigns)
+      .where(inArray(campaigns.status, ['propuesta', 'negociacion', 'aprobada', 'activa']))
+      .groupBy(campaigns.talentId),
   ]);
+
+  const dealsMap = new Map<number, number>();
+  for (const row of activeDealRows) {
+    if (row.talentId !== null) dealsMap.set(row.talentId, Number(row.cnt));
+  }
 
   const latestMap = new Map<string, number>();
   for (const s of latestSnaps) {
@@ -229,7 +240,7 @@ export async function getAdminRosterWithGrowth(): Promise<AdminRosterRow[]> {
       }
     }
 
-    return { ...t, growth };
+    return { ...t, growth, activeDealsCount: dealsMap.get(t.id) ?? 0 };
   });
 }
 


### PR DESCRIPTION
## Dependencia

**Requiere que PR #40 (`feat/crm-visual-hierarchy`) esté mergeado primero.**
Este PR está basado en esa rama porque comparte `InfluencerCardsView`.

## Qué cambia

### Query — `getAdminRosterWithGrowth()`

Se añade una consulta paralela que cuenta campañas activas por talento (`propuesta | negociacion | aprobada | activa`), agrupando por `talentId`. El resultado se mergea al map existente sin coste adicional de round-trips (es una query extra en el mismo `Promise.all`).

`AdminRosterRow` gana el campo:
```ts
activeDealsCount: number  // 0 si sin tratos activos
```

### UI — InfluencerCardsView

Botón toggle **"Más tratos"** en la barra de filtros:
- Inactivo (por defecto): orden natural del roster
- Activo: ordena las tarjetas de más a menos tratos activos (`b.activeDealsCount - a.activeDealsCount`)
- Visualmente resaltado en naranja cuando está activo (mismo patrón que "Más filtros")

### TalentCard (footer)

Badge **`N tratos`** en color accent naranja que aparece cuando `activeDealsCount > 0`. Permite ver de un vistazo qué streamers tienen campañas abiertas sin entrar en su perfil.

## Archivos modificados
- `src/lib/queries/talents.ts` — query de conteo + tipo `AdminRosterRow`
- `src/features/admin/talents/components/InfluencerCardsView.tsx` — estado sortBy + botón toggle
- `src/features/admin/talents/components/InfluencerCardsView.parts.tsx` — badge en footer de TalentCard

## Test plan
- [ ] `/admin/talents` carga sin errores
- [ ] Botón "Más tratos" aparece en la barra de filtros
- [ ] Al pulsarlo, los talentos con más campañas activas aparecen primero
- [ ] Las tarjetas de talentos con ≥1 trato activo muestran el badge naranja `N tratos`
- [ ] Talentos sin tratos no muestran el badge
- [ ] Volver a pulsar "Más tratos" restaura el orden por defecto

🤖 Generated with [Claude Code](https://claude.com/claude-code)