### PR TITLE
feat(alerts): descartar alertas individuales + links directos a campañas

### DIFF
--- a/src/features/admin/_shared/components/dashboard/DashboardAlerts.tsx
+++ b/src/features/admin/_shared/components/dashboard/DashboardAlerts.tsx
@@ -1,6 +1,11 @@
+'use client';
+
+import { useState } from 'react';
 import Link from 'next/link';
 import type { DashboardAlert, AlertSeverity, AlertSummary } from '@/lib/queries/alerts';
 import { AlertResolveButton } from './AlertResolveButton';
+
+const STORAGE_KEY = 'sp-dismissed-alerts';
 
 type Props = {
   readonly alerts:  readonly DashboardAlert[];
@@ -45,7 +50,13 @@ function SeverityBadge({ severity }: { severity: AlertSeverity }): React.ReactEl
   );
 }
 
-function AlertItem({ alert }: { readonly alert: DashboardAlert }): React.ReactElement {
+function AlertItem({
+  alert,
+  onDismiss,
+}: {
+  readonly alert: DashboardAlert;
+  readonly onDismiss: (id: string) => void;
+}): React.ReactElement {
   const cfg  = SEVERITY_CFG[alert.severity];
   const icon = TYPE_ICON[alert.type] ?? '•';
 
@@ -101,6 +112,15 @@ function AlertItem({ alert }: { readonly alert: DashboardAlert }): React.ReactEl
         >
           Ver →
         </Link>
+        <button
+          type="button"
+          onClick={() => onDismiss(alert.id)}
+          className="text-sp-admin-muted/50 hover:text-sp-admin-muted transition-colors leading-none text-base"
+          aria-label="Descartar alerta"
+          title="Descartar"
+        >
+          ×
+        </button>
       </div>
     </div>
   );
@@ -180,16 +200,46 @@ function EmptyState(): React.ReactElement {
 // ── Componente principal ──────────────────────────────────────────────
 
 export function DashboardAlerts({ alerts, summary }: Props): React.ReactElement {
-  if (summary.total === 0) return <EmptyState />;
+  // Dismiss persistido en localStorage (por sesión de navegador)
+  const [dismissedIds, setDismissedIds] = useState<Set<string>>(() => {
+    if (typeof window === 'undefined') return new Set();
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      return new Set<string>(raw ? (JSON.parse(raw) as string[]) : []);
+    } catch { return new Set(); }
+  });
 
-  const critical = alerts.filter((a) => a.severity === 'critical').length;
-  const high     = alerts.filter((a) => a.severity === 'high').length;
+  function dismiss(id: string): void {
+    setDismissedIds((prev) => {
+      const next = new Set(prev);
+      next.add(id);
+      try { localStorage.setItem(STORAGE_KEY, JSON.stringify([...next])); } catch { /* ignore */ }
+      return next;
+    });
+  }
+
+  const visible = alerts.filter((a) => !dismissedIds.has(a.id));
+
+  // Recomputar summary excluyendo dismissed para mantener coherencia con la lista
+  const effectiveSummary: AlertSummary = {
+    overdueTasksCount:     visible.filter((a) => a.type === 'overdue_task').length,
+    overdueFollowupsCount: visible.filter((a) => a.type === 'overdue_followup').length,
+    unpaidBrandCount:      visible.filter((a) => a.type === 'unpaid_brand').length,
+    pendingTalentCount:    visible.filter((a) => a.type === 'pending_talent').length,
+    expiringDealsCount:    visible.filter((a) => a.type === 'expiring_deal' || a.type === 'expired_active').length,
+    total:                 visible.length,
+  };
+
+  if (effectiveSummary.total === 0) return <EmptyState />;
+
+  const critical = visible.filter((a) => a.severity === 'critical').length;
+  const high     = visible.filter((a) => a.severity === 'high').length;
 
   return (
     <div className="space-y-2">
 
       {/* Card "Hoy requiere atención" */}
-      <AttentionSummary summary={summary} />
+      <AttentionSummary summary={effectiveSummary} />
 
       {/* Lista de alertas */}
       <div className="rounded-xl bg-sp-admin-card shadow-[0_1px_3px_rgba(0,0,0,0.06)] overflow-hidden border border-sp-admin-border">
@@ -214,8 +264,20 @@ export function DashboardAlerts({ alerts, summary }: Props): React.ReactElement 
           </div>
           <div className="flex items-center gap-3">
             <span className="text-[9px] text-sp-admin-muted/60">
-              {summary.total} en total · mostrando {alerts.length}
+              {visible.length} alerta{visible.length !== 1 ? 's' : ''}{dismissedIds.size > 0 && ` · ${dismissedIds.size} descartada${dismissedIds.size !== 1 ? 's' : ''}`}
             </span>
+            {dismissedIds.size > 0 && (
+              <button
+                type="button"
+                onClick={() => {
+                  setDismissedIds(new Set());
+                  try { localStorage.removeItem(STORAGE_KEY); } catch { /* ignore */ }
+                }}
+                className="text-[9px] text-sp-admin-muted hover:text-sp-admin-accent transition-colors"
+              >
+                Restaurar
+              </button>
+            )}
             <Link href="/admin/analytics#analitica-alertas"
               className="text-[9px] font-bold text-sp-admin-accent hover:underline">
               Ver todas →
@@ -225,8 +287,8 @@ export function DashboardAlerts({ alerts, summary }: Props): React.ReactElement 
 
         {/* Items */}
         <div>
-          {alerts.map((alert) => (
-            <AlertItem key={alert.id} alert={alert} />
+          {visible.map((alert) => (
+            <AlertItem key={alert.id} alert={alert} onDismiss={dismiss} />
           ))}
         </div>
       </div>

--- a/src/lib/queries/alerts.ts
+++ b/src/lib/queries/alerts.ts
@@ -396,7 +396,7 @@ export async function getDashboardAlerts(opts?: {
       severity:    c.status === 'completada' ? 'high' : 'medium',
       title:       `Cobro pendiente${parts ? ` — ${parts}` : ''}`,
       description: `${fmt(amount)} sin cobrar`,
-      href:        '/admin/campanas',
+      href:        `/admin/campanas/${c.id}`,
       amount,
       daysInfo:    c.status === 'completada' ? 'Trato completado' : 'Trato activo',
     });
@@ -411,7 +411,7 @@ export async function getDashboardAlerts(opts?: {
       severity:    'medium',
       title:       `Pago pendiente — ${c.talentName ?? 'Talento'}`,
       description: `${fmt(amount)} sin pagar · ${c.brandName ?? ''}`,
-      href:        '/admin/campanas',
+      href:        `/admin/campanas/${c.id}`,
       amount,
       daysInfo:    'Sin pagar',
     });
@@ -429,7 +429,7 @@ export async function getDashboardAlerts(opts?: {
       severity:    daysLeft <= 2 ? 'high' : 'medium',
       title:       `Trato vence pronto — ${parts || c.name}`,
       description: c.name,
-      href:        '/admin/campanas',
+      href:        `/admin/campanas/${c.id}`,
       daysInfo:    label,
     });
   }
@@ -445,7 +445,7 @@ export async function getDashboardAlerts(opts?: {
       severity:    'high',
       title:       `Trato sin cerrar — ${parts || c.name}`,
       description: `Fecha de fin superada · ${c.name}`,
-      href:        '/admin/campanas',
+      href:        `/admin/campanas/${c.id}`,
       daysInfo:    label,
     });
   }


### PR DESCRIPTION
## Qué cambia

### 1. Botón Descartar (×) en cada alerta

Cada alerta del dashboard ahora tiene un botón `×` (Descartar) que la elimina visualmente de la lista.

**Implementación:**
- `DashboardAlerts` pasa a ser un Client Component (`'use client'`)  
- Estado `dismissedIds: Set<string>` con lazy initializer que lee `localStorage` en el cliente
- Al descartar: el ID se añade al Set y se persiste en `localStorage` bajo la clave `sp-dismissed-alerts`
- `try/catch` en lectura/escritura de localStorage para resilencia ante datos corruptos
- Las alertas descartadas reaparecerán si se recargan en otro navegador o se borra el localStorage — por diseño, reflejan condiciones reales que siguen existiendo

**El `AttentionSummary` (chips de "requiere atención") se recomputa a partir de las alertas visibles**, no del summary original del servidor. Así, si descartás "3 cobros pendientes", el chip también baja de 3.

**El header muestra** `N descartada(s)` + link "Restaurar" cuando hay alertas ocultas, para poder revertir si se descartó por error.

### 2. Links directos a la campaña específica

Antes, las alertas de tipo cobro/pago/vencimiento apuntaban genéricamente a `/admin/campanas`. Ahora apuntan a `/admin/campanas/{id}` para ir directamente a la campaña involucrada.

**Alertas corregidas:**
| Tipo | Antes | Después |
|------|-------|---------|
| `unpaid_brand` | `/admin/campanas` | `/admin/campanas/${c.id}` |
| `pending_talent` | `/admin/campanas` | `/admin/campanas/${c.id}` |
| `expiring_deal` | `/admin/campanas` | `/admin/campanas/${c.id}` |
| `expired_active` | `/admin/campanas` | `/admin/campanas/${c.id}` |

Los tipos `invoice_overdue` y `deal_brand_paid_talent_pending` ya tenían links específicos antes de este PR.

### 3. Alertas de tratos por vencer — ya existían

Las alertas `expiring_deal` y `expired_active` ya detectaban tratos a punto de terminar (≤7 días para vencer, ≤2 días = `high`). Con este PR, el link "Ver →" lleva directamente al trato específico para poder revisarlo.

## Archivos modificados
- `src/lib/queries/alerts.ts` — 4 hrefs específicos
- `src/features/admin/_shared/components/dashboard/DashboardAlerts.tsx` — dismiss con localStorage + recompute summary

## Nota para el programador

El dismiss es **por navegador** (localStorage), no por usuario ni sincronizado entre dispositivos. Las alertas vuelven a aparecer al cargar en otro browser. Es comportamiento intencionado: las alertas representan condiciones reales del CRM (tratos vencidos, cobros pendientes). Para dismiss persistente en DB se necesita una migración adicional.

## Test plan
- [ ] Cada alerta tiene botón `×` en el extremo derecho
- [ ] Pulsar `×` en una alerta la elimina de la lista sin recargar la página
- [ ] El chip de "Hoy requiere atención" actualiza su contador (ej: "3 cobros" → "2 cobros")
- [ ] Recargar la página: la alerta descartada sigue sin aparecer (localStorage persistido)
- [ ] Header muestra "1 descartada · Restaurar" cuando hay descartadas
- [ ] Pulsar "Restaurar" devuelve todas las alertas
- [ ] Alerta de trato venciendo: "Ver →" lleva directamente a esa campaña específica, no a la lista general
- [ ] Abrir consola del navegador → Application → localStorage → `sp-dismissed-alerts` contiene los IDs descartados

🤖 Generated with [Claude Code](https://claude.com/claude-code)