### PR TITLE
seo(h1): keyword natural en H1 de 4 landing pages

### DIFF
--- a/src/app/agencia-influencers-valorant/page.tsx
+++ b/src/app/agencia-influencers-valorant/page.tsx
@@ -75,7 +75,7 @@ export default function AgenciaInfluencersValorantPage() {
         <div className="max-w-4xl mx-auto px-6 text-center">
           <p className="text-sp-orange text-xs font-bold uppercase tracking-[0.2em] mb-4">Agencia de Influencers Valorant</p>
           <h1 className="font-display text-4xl md:text-6xl font-black uppercase tracking-tight text-white leading-tight mb-6">
-            Influencers Valorant<br /><span style={g}>en España y LatAm</span>
+            Agencia de Influencers Valorant<br /><span style={g}>en España y LatAm</span>
           </h1>
           <p className="text-lg text-white/60 leading-relaxed max-w-2xl mx-auto mb-10">
             Streamers de Valorant verificados con audiencias reales en el mercado hispano.

--- a/src/app/influencers-cs2/page.tsx
+++ b/src/app/influencers-cs2/page.tsx
@@ -76,7 +76,7 @@ export default function InfluencersCs2Page() {
         <div className="max-w-4xl mx-auto px-6 text-center">
           <p className="text-sp-orange text-xs font-bold uppercase tracking-[0.2em] mb-4">Influencers CS2 · España y LatAm</p>
           <h1 className="font-display text-4xl md:text-6xl font-black uppercase tracking-tight text-white leading-tight mb-6">
-            Streamers de CS2<br /><span style={g}>que Convierten</span>
+            Influencers CS2 para tu Marca<br /><span style={g}>Audiencia que Convierte</span>
           </h1>
           <p className="text-lg text-white/60 leading-relaxed max-w-2xl mx-auto mb-10">
             Influencers CS2 verificados en España y LatAm. La audiencia con mayor propensión al gasto en gaming,

--- a/src/app/twitch-streamers-agency/page.tsx
+++ b/src/app/twitch-streamers-agency/page.tsx
@@ -76,7 +76,7 @@ export default function TwitchStreamersAgencyPage() {
         <div className="max-w-4xl mx-auto px-6 text-center">
           <p className="text-sp-orange text-xs font-bold uppercase tracking-[0.2em] mb-4">Twitch Streamers Agency</p>
           <h1 className="font-display text-4xl md:text-6xl font-black uppercase tracking-tight text-white leading-tight mb-6">
-            Twitch Streamers<br /><span style={g}>Live. Trusted. Measured.</span>
+            Twitch Streamers Agency<br /><span style={g}>Live. Trusted. Measured.</span>
           </h1>
           <p className="text-lg text-white/60 leading-relaxed max-w-2xl mx-auto mb-10">
             Live gaming influencer marketing with Twitch streamers across Spain and LatAm.

--- a/src/app/valorant-influencers-agency/page.tsx
+++ b/src/app/valorant-influencers-agency/page.tsx
@@ -75,7 +75,7 @@ export default function ValorantInfluencersAgencyPage() {
         <div className="max-w-4xl mx-auto px-6 text-center">
           <p className="text-sp-orange text-xs font-bold uppercase tracking-[0.2em] mb-4">Valorant Influencers Agency</p>
           <h1 className="font-display text-4xl md:text-6xl font-black uppercase tracking-tight text-white leading-tight mb-6">
-            Valorant Influencers<br /><span style={g}>That Move Brands</span>
+            Valorant Influencers Agency<br /><span style={g}>That Moves Your Brand</span>
           </h1>
           <p className="text-lg text-white/60 leading-relaxed max-w-2xl mx-auto mb-10">
             Brand-safe Valorant influencer campaigns with verified streamers across Spain and LatAm.


### PR DESCRIPTION
## Descripción

El H1 es la señal on-page más fuerte para Google. Las 4 landing pages afectadas tenían H1 orientados a conversión (copywriting) pero sin incluir la keyword objetivo, lo que debilitaba la señal de relevancia temática.

Este PR añade la keyword de forma natural — sin keyword stuffing — manteniendo el tono existente.

---

## Archivos modificados

| Archivo | Cambio |
|---------|--------|
| `src/app/valorant-influencers-agency/page.tsx` | H1: añade "Agency" para completar keyword |
| `src/app/twitch-streamers-agency/page.tsx` | H1: añade "Agency" para completar keyword |
| `src/app/influencers-cs2/page.tsx` | H1: reestructurado para incluir "Influencers CS2" |
| `src/app/agencia-influencers-valorant/page.tsx` | H1: añade "Agencia de" para completar keyword |

**No se toca ningún otro archivo.**

---

## Qué cambia exactamente

```
/valorant-influencers-agency
  ANTES: "Valorant Influencers · That Move Brands"
  DESPUÉS: "Valorant Influencers Agency · That Moves Your Brand"

/twitch-streamers-agency
  ANTES: "Twitch Streamers · Live. Trusted. Measured."
  DESPUÉS: "Twitch Streamers Agency · Live. Trusted. Measured."

/influencers-cs2
  ANTES: "Streamers de CS2 · que Convierten"
  DESPUÉS: "Influencers CS2 para tu Marca · Audiencia que Convierte"

/agencia-influencers-valorant
  ANTES: "Influencers Valorant · en España y LatAm"
  DESPUÉS: "Agencia de Influencers Valorant · en España y LatAm"
```

---

## Riesgo

**Bajo.** Solo afecta al texto visible del H1. Sin cambios en rutas, lógica, componentes compartidos, base de datos ni server actions.

---

## Cómo probarlo

1. Levantar servidor local (`npm run dev`)
2. Cargar cada URL:
   - `localhost:3000/valorant-influencers-agency`
   - `localhost:3000/twitch-streamers-agency`
   - `localhost:3000/influencers-cs2`
   - `localhost:3000/agencia-influencers-valorant`
3. Verificar en el inspector de elementos que el `<h1>` incluye la keyword objetivo
4. Confirmar que el tono se mantiene natural (no robótico)

```bash
npm run build   # debe pasar sin errores
npx tsc --noEmit  # 0 errores TypeScript
npm run lint    # 0 errores ESLint
```

---

## Checklist de revisión

- [ ] H1 de `/valorant-influencers-agency` incluye "Valorant Influencers Agency"
- [ ] H1 de `/twitch-streamers-agency` incluye "Twitch Streamers Agency"
- [ ] H1 de `/influencers-cs2` incluye "Influencers CS2"
- [ ] H1 de `/agencia-influencers-valorant` incluye "Agencia de Influencers Valorant"
- [ ] El tono de cada H1 es natural (no parece SEO forzado)
- [ ] Build pasa sin errores
- [ ] TypeScript: 0 errores
- [ ] Lint: 0 errores (solo warnings pre-existentes)
- [ ] Sin cambios en ningún otro archivo

---

## Notas adicionales

Las otras 3 landings con H1 mixtos (CS2, Esports EN, Esports ES) tienen también cambios de keyword en el H1 **pero mezclados con ajustes de schema Turkey** — esos van en el PR `feat/seo-geographic-turkey` para mantener la separación de responsabilidades.

🤖 Generated with [Claude Code](https://claude.com/claude-code)