### PR TITLE
seo(geo): Turquía como mercado secundario — España+LatAm+Europa como prioridad

### DIFF
--- a/src/app/agencia-marketing-esports/page.tsx
+++ b/src/app/agencia-marketing-esports/page.tsx
@@ -39,7 +39,7 @@ const jsonLd = {
   inLanguage: 'es',
   provider: { '@type': 'Organization', name: 'SocialPro', url: SITE_URL },
   foundingDate: '2012',
-  areaServed: ['España', 'México', 'Argentina', 'Colombia', 'Chile', 'Turquía'],
+  areaServed: ['España', 'México', 'Argentina', 'Colombia', 'Chile'],
   description: 'Agencia de marketing esports en España y LatAm desde 2012. Campañas con influencers, gestión de talentos y activaciones en torneos con métricas verificadas.',
 };
 
@@ -84,7 +84,7 @@ export default function AgenciaMarketingEsportsPage() {
         <div className="max-w-4xl mx-auto px-6 text-center">
           <p className="text-sp-orange text-xs font-bold uppercase tracking-[0.2em] mb-4">Agencia de Marketing Esports</p>
           <h1 className="font-display text-4xl md:text-6xl font-black uppercase tracking-tight text-white leading-tight mb-6">
-            Marketing Esports<br /><span style={g}>con 13 Años de Resultados</span>
+            Agencia de Marketing Esports<br /><span style={g}>con 13 Años de Resultados</span>
           </h1>
           <p className="text-lg text-white/60 leading-relaxed max-w-2xl mx-auto mb-10">
             Agencia de marketing esports en España y LatAm desde 2012. Campañas con influencers,

--- a/src/app/cs2-influencer-marketing/page.tsx
+++ b/src/app/cs2-influencer-marketing/page.tsx
@@ -17,7 +17,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: 'CS2 Influencer Marketing Agency — Spain & LatAm | SocialPro',
     description:
-      'Counter-Strike 2 influencer marketing with verified streamers. FTD tracking and ROI-focused campaigns in Spain, LatAm and Turkey.',
+      'Counter-Strike 2 influencer marketing with verified streamers. FTD tracking and ROI-focused campaigns in Spain and LatAm.',
     url: absoluteUrl('/cs2-influencer-marketing'),
     type: 'website',
     images: [{ url: absoluteUrl('/og-default.jpg'), width: 1200, height: 630 }],
@@ -39,7 +39,7 @@ const jsonLd = {
   serviceType: 'Esports Influencer Marketing',
   inLanguage: 'en',
   provider: { '@type': 'Organization', name: 'SocialPro', url: SITE_URL },
-  areaServed: ['España', 'México', 'Argentina', 'Colombia', 'Chile', 'Turquía'],
+  areaServed: ['España', 'México', 'Argentina', 'Colombia', 'Chile'],
   description: 'CS2 influencer marketing campaigns with verified streamers across Spain and LatAm. FTD tracking, compliance and activation in under 72 hours.',
 };
 
@@ -78,10 +78,10 @@ export default function Cs2InfluencerMarketingPage() {
         <div className="max-w-4xl mx-auto px-6 text-center">
           <p className="text-sp-orange text-xs font-bold uppercase tracking-[0.2em] mb-4">CS2 Influencer Marketing Agency</p>
           <h1 className="font-display text-4xl md:text-6xl font-black uppercase tracking-tight text-white leading-tight mb-6">
-            The <span style={g}>CS2 Audience</span> Converts.<br />We Prove It.
+            CS2 Influencer Marketing —<br /><span style={g}>The Audience That Converts</span>
           </h1>
           <p className="text-lg text-white/60 leading-relaxed max-w-2xl mx-auto mb-10">
-            CS2 influencer marketing with verified streamers across Spain, LatAm and Turkey.
+            CS2 influencer marketing with verified streamers across Spain and LatAm.
             FTD tracking, compliance and activation in under 72 hours.
           </p>
           <div className="flex flex-wrap justify-center gap-8 mb-10">

--- a/src/app/esports-marketing-agency/page.tsx
+++ b/src/app/esports-marketing-agency/page.tsx
@@ -39,7 +39,7 @@ const jsonLd = {
   inLanguage: 'en',
   provider: { '@type': 'Organization', name: 'SocialPro', url: SITE_URL },
   foundingDate: '2012',
-  areaServed: ['España', 'México', 'Argentina', 'Colombia', 'Chile', 'Turquía'],
+  areaServed: ['España', 'México', 'Argentina', 'Colombia', 'Chile'],
   description: 'Esports marketing agency operating in Spain and LatAm since 2012. Influencer campaigns, tournament activations and creator management with performance tracking.',
 };
 
@@ -78,7 +78,7 @@ export default function EsportsMarketingAgencyPage() {
         <div className="max-w-4xl mx-auto px-6 text-center">
           <p className="text-sp-orange text-xs font-bold uppercase tracking-[0.2em] mb-4">Esports Marketing Agency</p>
           <h1 className="font-display text-4xl md:text-6xl font-black uppercase tracking-tight text-white leading-tight mb-6">
-            Esports Marketing<br /><span style={g}>Built on 13 Years of Results</span>
+            Esports Marketing Agency<br /><span style={g}>Built on 13 Years of Results</span>
           </h1>
           <p className="text-lg text-white/60 leading-relaxed max-w-2xl mx-auto mb-10">
             Esports marketing agency in Spain and LatAm since 2012.

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -125,8 +125,8 @@ const jsonLd = {
         { '@type': 'Country', name: 'Argentina' },
         { '@type': 'Country', name: 'Colombia' },
         { '@type': 'Country', name: 'Chile' },
-        { '@type': 'Country', name: 'Turquía' },
         { '@type': 'Continent', name: 'Europa' },
+        { '@type': 'Country', name: 'Turquía' },
       ],
       makesOffer: [
         { '@type': 'Offer', itemOffered: { '@type': 'Service', name: 'Gestión de Talentos Gaming' } },

--- a/src/app/servicios/page.tsx
+++ b/src/app/servicios/page.tsx
@@ -127,7 +127,7 @@ const professionalServiceJsonLd = {
   '@id': `${SITE_URL}/servicios`,
   name: 'SocialPro — Agencia de Performance Marketing Gaming',
   description:
-    'Agencia especializada en performance influencer marketing gaming, esports e iGaming. Streamers de CS2, Valorant, Twitch y YouTube en España, LatAm y Turquía.',
+    'Agencia especializada en performance influencer marketing gaming, esports e iGaming. Streamers de CS2, Valorant, Twitch y YouTube en España y LatAm.',
   url: `${SITE_URL}/servicios`,
   telephone: '+34-604-868-426',
   email: 'marketing@socialpro.es',
@@ -136,7 +136,9 @@ const professionalServiceJsonLd = {
     { '@type': 'Country', name: 'España' },
     { '@type': 'Country', name: 'México' },
     { '@type': 'Country', name: 'Argentina' },
-    { '@type': 'Country', name: 'Turquía' },
+    { '@type': 'Country', name: 'Colombia' },
+    { '@type': 'Country', name: 'Chile' },
+    { '@type': 'Continent', name: 'Europa' },
   ],
   knowsAbout: [
     'Influencer Marketing Gaming',


### PR DESCRIPTION
## Descripción

Ajuste de posicionamiento geográfico en los schemas JSON-LD y textos de metadata.

**Estrategia:** Turquía es un mercado activo para iGaming/betting, pero **no** para CS2 generalista ni esports en sentido amplio. Los schemas de páginas genéricas de servicios y esports la incluían al mismo nivel que España y LatAm, generando una señal geográfica confusa para Google.

Este PR ajusta el peso de Turquía sin eliminarla donde tiene sentido de negocio real.

---

## Archivos modificados

| Archivo | Cambio | Tipo |
|---------|--------|------|
| `src/app/layout.tsx` | Turkey al final del array `areaServed`, después de Europa | Schema JSON-LD |
| `src/app/servicios/page.tsx` | Turkey eliminada de `ProfessionalService` description y `areaServed` | Schema JSON-LD |
| `src/app/cs2-influencer-marketing/page.tsx` | H1 + Turkey removida de `areaServed` + OG description | H1 + Schema + Meta |
| `src/app/esports-marketing-agency/page.tsx` | H1 + Turkey removida de `areaServed` | H1 + Schema |
| `src/app/agencia-marketing-esports/page.tsx` | H1 + Turkey removida de `areaServed` | H1 + Schema |

**Turkey se mantiene sin cambios en:** `servicios/igaming`, `betting-influencers`, `influencers-betting` — son los verticales donde Turquía es un mercado iGaming genuino.

---

## Qué cambia exactamente

### `layout.tsx` — Organization.areaServed
```
ANTES: [España, México, Argentina, Colombia, Chile, Turquía, Europa]
DESPUÉS: [España, México, Argentina, Colombia, Chile, Europa, Turquía]
```
Turquía pasa del puesto 6 al 7 (detrás del continente Europa).

### `servicios/page.tsx` — ProfessionalService schema
```
ANTES description: "...en España, LatAm y Turquía"
DESPUÉS description: "...en España y LatAm"

ANTES areaServed: [España, México, Argentina, Turquía]
DESPUÉS areaServed: [España, México, Argentina, Colombia, Chile, Europa]
```

### `cs2-influencer-marketing/page.tsx`
```
H1 ANTES: "The CS2 Audience Converts. We Prove It."
H1 DESPUÉS: "CS2 Influencer Marketing — The Audience That Converts"

areaServed ANTES: [España, México, Argentina, Colombia, Chile, Turquía]
areaServed DESPUÉS: [España, México, Argentina, Colombia, Chile]

OG description ANTES: "...campaigns in Spain, LatAm and Turkey"
OG description DESPUÉS: "...campaigns in Spain and LatAm"
```

### `esports-marketing-agency/page.tsx`
```
H1 ANTES: "Esports Marketing · Built on 13 Years of Results"
H1 DESPUÉS: "Esports Marketing Agency · Built on 13 Years of Results"

areaServed: Turkey removida
```

### `agencia-marketing-esports/page.tsx`
```
H1 ANTES: "Marketing Esports · con 13 Años de Resultados"
H1 DESPUÉS: "Agencia de Marketing Esports · con 13 Años de Resultados"

areaServed: Turkey removida
```

---

## Riesgo

**Bajo.** Los cambios afectan exclusivamente a:
- JSON-LD schemas (no visibles para el usuario)
- 3 H1s (texto visible, sin cambio de diseño)
- 1 OG description (solo para compartir en redes)

Sin cambios en rutas, lógica de negocio, componentes compartidos ni base de datos.

---

## Cómo probarlo

### Visual
1. `npm run dev`
2. Verificar H1 en:
   - `localhost:3000/cs2-influencer-marketing`
   - `localhost:3000/esports-marketing-agency`
   - `localhost:3000/agencia-marketing-esports`

### Schema
3. Copiar el JSON-LD de cada página (inspector → `<script type="application/ld+json">`)
4. Pegar en [Google Rich Results Test](https://search.google.com/test/rich-results) o [Schema.org Validator](https://validator.schema.org/)
5. Verificar que `areaServed` no incluye Turquía en CS2 y Esports

### Verificar que Turkey se mantiene en iGaming
6. Cargar `localhost:3000/servicios/igaming` — Turkey debe seguir en `areaServed`
7. Cargar `localhost:3000/betting-influencers` — Turkey debe seguir en `areaServed`

```bash
npm run build   # debe pasar sin errores
npx tsc --noEmit  # 0 errores TypeScript
npm run lint    # 0 errores ESLint
```

---

## Checklist de revisión

### H1s
- [ ] `/cs2-influencer-marketing` H1 incluye "CS2 Influencer Marketing"
- [ ] `/esports-marketing-agency` H1 incluye "Esports Marketing Agency"
- [ ] `/agencia-marketing-esports` H1 incluye "Agencia de Marketing Esports"

### Schema — Turkey ajustado
- [ ] `layout.tsx`: Turkey al final (posición 7, después de Europa)
- [ ] `servicios/page.tsx` ProfessionalService: sin Turkey en areaServed ni description
- [ ] `cs2-influencer-marketing`: sin Turkey en areaServed
- [ ] `esports-marketing-agency`: sin Turkey en areaServed
- [ ] `agencia-marketing-esports`: sin Turkey en areaServed

### Schema — Turkey se mantiene donde debe
- [ ] `servicios/igaming`: Turkey presente en areaServed ✓
- [ ] `betting-influencers`: Turkey presente en areaServed ✓

### Técnico
- [ ] Build pasa sin errores
- [ ] TypeScript: 0 errores
- [ ] Lint: 0 errores nuevos

---

## Decisión de negocio que respalda este cambio

Turquía es un mercado activo de SocialPro **exclusivamente en el vertical iGaming/betting**, donde opera bajo normativa local específica. Incluirla al mismo nivel que España y LatAm en páginas de CS2, Esports generalistas y el schema global de la organización daba una señal geográfica inexacta a Google y a clientes potenciales que buscan servicios en el mercado hispano.

🤖 Generated with [Claude Code](https://claude.com/claude-code)