### PR TITLE
feat(crm-brands): manager column + sectores/geos refactor + manager contacts

### DIFF
--- a/drizzle/0046_brand_crm_redaction.sql
+++ b/drizzle/0046_brand_crm_redaction.sql
@@ -1,0 +1,19 @@
+-- Renombra "razón social" (legal_name) a "manager": el campo se usa como
+-- contacto principal de la marca. La razón social legal real vive en fiscal_name.
+ALTER TABLE "crm_brands" RENAME COLUMN "legal_name" TO "manager";--> statement-breakpoint
+
+-- Añade canales de contacto rápido del manager (anteriormente sólo en
+-- crm_brand_contacts, ahora también accesibles desde la propia marca).
+ALTER TABLE "crm_brands" ADD COLUMN "discord" varchar(80);--> statement-breakpoint
+ALTER TABLE "crm_brands" ADD COLUMN "telegram" varchar(80);--> statement-breakpoint
+ALTER TABLE "crm_brands" ADD COLUMN "whatsapp" varchar(40);--> statement-breakpoint
+
+-- Mapeo de sectores: sector ahora es {gambling, trading, casino, sports_betting, perifericos, otros}.
+UPDATE "crm_brands" SET "sector" = 'trading'        WHERE "sector" IN ('cs2_cases','cs2_marketplace','crypto');--> statement-breakpoint
+UPDATE "crm_brands" SET "sector" = 'sports_betting' WHERE "sector" = 'apuestas';--> statement-breakpoint
+UPDATE "crm_brands" SET "sector" = 'otros'          WHERE "sector" IN ('fmcg','tech','gaming_brands');--> statement-breakpoint
+
+-- Mapeo de geos a tiers: geo ahora es {tier_1, tier_2, tier_3}.
+UPDATE "crm_brands" SET "geo" = 'tier_1' WHERE "geo" IN ('spain','europa','japon');--> statement-breakpoint
+UPDATE "crm_brands" SET "geo" = 'tier_2' WHERE "geo" IN ('latam','turquia','global');--> statement-breakpoint
+UPDATE "crm_brands" SET "geo" = 'tier_3' WHERE "geo" IN ('india','otros');

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -323,6 +323,13 @@
       "when": 1777748734128,
       "tag": "0045_press_targets_init",
       "breakpoints": true
+    },
+    {
+      "idx": 46,
+      "version": "7",
+      "when": 1777800000000,
+      "tag": "0046_brand_crm_redaction",
+      "breakpoints": true
     }
   ]
 }

--- a/src/__tests__/server/crmBrands.test.ts
+++ b/src/__tests__/server/crmBrands.test.ts
@@ -105,7 +105,7 @@ describe('listCrmBrands', () => {
     const matchingBrand = {
       id: 1,
       name: 'Brand A',
-      legalName: null,
+      manager: null,
       website: null,
       sector: null,
       tipo: null,
@@ -149,14 +149,14 @@ describe('listCrmBrands', () => {
   it('admin: returns all brands (no visibility filter)', async () => {
     const brands = [
       {
-        id: 1, name: 'Brand A', legalName: null, website: null, sector: null, tipo: null,
+        id: 1, name: 'Brand A', manager: null, website: null, sector: null, tipo: null,
         geo: null, country: null, status: 'lead' as const, ownerUserId: null, portalUserId: null,
         createdByUserId: 'user-1', assignedToUserId: null, lastContactAt: null,
         nextFollowupAt: null, notes: null, createdAt: new Date(), updatedAt: new Date(),
         contactCount: 0, ownerName: null,
       },
       {
-        id: 2, name: 'Brand B', legalName: null, website: null, sector: null, tipo: null,
+        id: 2, name: 'Brand B', manager: null, website: null, sector: null, tipo: null,
         geo: null, country: null, status: 'activa' as const, ownerUserId: null, portalUserId: null,
         createdByUserId: 'user-2', assignedToUserId: 'user-3', lastContactAt: null,
         nextFollowupAt: null, notes: null, createdAt: new Date(), updatedAt: new Date(),
@@ -178,7 +178,7 @@ describe('listCrmBrands', () => {
   it('manager: returns all brands (no visibility filter)', async () => {
     const brands = [
       {
-        id: 10, name: 'Brand X', legalName: null, website: null, sector: null, tipo: null,
+        id: 10, name: 'Brand X', manager: null, website: null, sector: null, tipo: null,
         geo: null, country: null, status: 'lead' as const, ownerUserId: null, portalUserId: null,
         createdByUserId: 'someone', assignedToUserId: 'other', lastContactAt: null,
         nextFollowupAt: null, notes: null, createdAt: new Date(), updatedAt: new Date(),
@@ -202,7 +202,7 @@ describe('listCrmBrands', () => {
     yesterday.setDate(yesterday.getDate() - 1);
 
     const brand = {
-      id: 5, name: 'Overdue Brand', legalName: null, website: null, sector: null, tipo: null,
+      id: 5, name: 'Overdue Brand', manager: null, website: null, sector: null, tipo: null,
       geo: null, country: null, status: 'lead' as const, ownerUserId: null, portalUserId: null,
       createdByUserId: 'user-1', assignedToUserId: null, lastContactAt: null,
       nextFollowupAt: yesterday, notes: null, createdAt: new Date(), updatedAt: new Date(),

--- a/src/app/admin/(dashboard)/brands/[id]/page.tsx
+++ b/src/app/admin/(dashboard)/brands/[id]/page.tsx
@@ -171,7 +171,7 @@ export default async function BrandDetailPage({
           </div>
           <div className="p-4 space-y-2.5">
             {[
-              { label: 'Razón social', value: brand.legalName },
+              { label: 'Manager', value: brand.manager },
               { label: 'Tipo', value: brand.tipo },
               { label: 'Sector', value: brand.sector },
               { label: 'GEO', value: brand.geo },

--- a/src/db/schema/crmBrands.ts
+++ b/src/db/schema/crmBrands.ts
@@ -51,7 +51,7 @@ export const crmBrands = pgTable(
     id: serial('id').primaryKey(),
 
     name: varchar('name', { length: 200 }).notNull(),
-    legalName: varchar('legal_name', { length: 250 }),
+    manager: varchar('manager', { length: 250 }),
     website: text('website'),
     tipo: varchar('tipo', { length: 20 }),
     sector: varchar('sector', { length: 80 }),
@@ -75,6 +75,11 @@ export const crmBrands = pgTable(
     // Info legal
     taxId:   varchar('tax_id',  { length: 30 }),
     address: text('address'),
+
+    // Canales de contacto rápido del manager
+    discord:  varchar('discord',  { length: 80 }),
+    telegram: varchar('telegram', { length: 80 }),
+    whatsapp: varchar('whatsapp', { length: 40 }),
 
     // Seguimiento
     lastContactAt:  timestamp('last_contact_at',   { withTimezone: true }),

--- a/src/features/admin/brands/components/BrandFormDrawer.tsx
+++ b/src/features/admin/brands/components/BrandFormDrawer.tsx
@@ -114,10 +114,10 @@ export function BrandFormDrawer({
       <form id="brand-form-drawer" action={formAction} className="space-y-5">
         {isEdit && <input type="hidden" name="id" value={brand.id} />}
 
-        {/* Nombre + Razón social */}
+        {/* Marca + Manager */}
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
           <div>
-            <label className={LABEL} htmlFor="bfd-name">Nombre *</label>
+            <label className={LABEL} htmlFor="bfd-name">Marca *</label>
             <input
               id="bfd-name"
               name="name"
@@ -125,18 +125,18 @@ export function BrandFormDrawer({
               maxLength={200}
               defaultValue={brand?.name ?? ''}
               className={INPUT}
-              placeholder="Nombre de la marca"
+              placeholder="Nombre comercial de la marca"
             />
           </div>
           <div>
-            <label className={LABEL} htmlFor="bfd-legalName">Razón social</label>
+            <label className={LABEL} htmlFor="bfd-manager">Manager</label>
             <input
-              id="bfd-legalName"
-              name="legalName"
+              id="bfd-manager"
+              name="manager"
               maxLength={250}
-              defaultValue={brand?.legalName ?? ''}
+              defaultValue={brand?.manager ?? ''}
               className={INPUT}
-              placeholder="Nombre legal"
+              placeholder="Nombre del contacto principal"
             />
           </div>
         </div>
@@ -271,6 +271,48 @@ export function BrandFormDrawer({
             </select>
           </div>
         )}
+
+        {/* Contactos rápidos del manager */}
+        <div className="border-t border-sp-admin-border/50 pt-4">
+          <p className="text-[11px] uppercase tracking-wider font-semibold text-sp-admin-muted mb-3">
+            Contacto del manager
+          </p>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+            <div>
+              <label className={LABEL} htmlFor="bfd-discord">Discord</label>
+              <input
+                id="bfd-discord"
+                name="discord"
+                maxLength={80}
+                defaultValue={brand?.discord ?? ''}
+                className={INPUT}
+                placeholder="usuario#0000"
+              />
+            </div>
+            <div>
+              <label className={LABEL} htmlFor="bfd-telegram">Telegram</label>
+              <input
+                id="bfd-telegram"
+                name="telegram"
+                maxLength={80}
+                defaultValue={brand?.telegram ?? ''}
+                className={INPUT}
+                placeholder="@usuario"
+              />
+            </div>
+            <div>
+              <label className={LABEL} htmlFor="bfd-whatsapp">WhatsApp</label>
+              <input
+                id="bfd-whatsapp"
+                name="whatsapp"
+                maxLength={40}
+                defaultValue={brand?.whatsapp ?? ''}
+                className={INPUT}
+                placeholder="+34 …"
+              />
+            </div>
+          </div>
+        </div>
 
         {/* Notas */}
         <div>

--- a/src/features/admin/brands/components/BrandFormModal.tsx
+++ b/src/features/admin/brands/components/BrandFormModal.tsx
@@ -118,7 +118,7 @@ function BrandForm(props: FormProps): React.ReactElement {
   const [lookingFor, setLookingFor] = useState<string[]>(parseList(brand?.lookingFor));
   const [dealTypes,  setDealTypes]  = useState<string[]>(parseList(brand?.dealTypes));
   const [legalOpen,  setLegalOpen]  = useState(
-    !!(brand?.legalName || brand?.taxId || brand?.address || brand?.country),
+    !!(brand?.taxId || brand?.address || brand?.country),
   );
 
   if (state.success && !isPending) setTimeout(onDone, 0);
@@ -136,9 +136,13 @@ function BrandForm(props: FormProps): React.ReactElement {
       <div>
         <p className={SECTION}>1 · Información principal</p>
         <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
-          <div className="md:col-span-3">
-            <label className={LABEL}>Nombre *</label>
+          <div className="md:col-span-2">
+            <label className={LABEL}>Marca *</label>
             <input name="name" required defaultValue={brand?.name} placeholder="Nombre comercial de la marca" className={INPUT} />
+          </div>
+          <div>
+            <label className={LABEL}>Manager</label>
+            <input name="manager" defaultValue={brand?.manager ?? ''} placeholder="Contacto principal" className={INPUT} />
           </div>
           <div>
             <label className={LABEL}>Tipo</label>
@@ -252,23 +256,38 @@ function BrandForm(props: FormProps): React.ReactElement {
         {legalOpen && (
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
             <div>
-              <label className={LABEL}>Razón social</label>
-              <input name="legalName" defaultValue={brand?.legalName ?? ''} className={INPUT} />
-            </div>
-            <div>
               <label className={LABEL}>CIF / VAT</label>
               <input name="taxId" placeholder="B12345678 / ES-…" defaultValue={brand?.taxId ?? ''} className={INPUT} />
-            </div>
-            <div className="md:col-span-2">
-              <label className={LABEL}>Dirección</label>
-              <input name="address" defaultValue={brand?.address ?? ''} className={INPUT} />
             </div>
             <div>
               <label className={LABEL}>País (ISO 2)</label>
               <input name="country" maxLength={2} placeholder="ES" defaultValue={brand?.country ?? ''} className={INPUT} />
             </div>
+            <div className="md:col-span-2">
+              <label className={LABEL}>Dirección</label>
+              <input name="address" defaultValue={brand?.address ?? ''} className={INPUT} />
+            </div>
           </div>
         )}
+      </div>
+
+      {/* ── Contactos rápidos del manager ── */}
+      <div>
+        <p className={SECTION}>{mode === 'create' ? '5' : '4'} · Contacto del manager</p>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div>
+            <label className={LABEL}>Discord</label>
+            <input name="discord" defaultValue={brand?.discord ?? ''} placeholder="usuario#0000" className={INPUT} />
+          </div>
+          <div>
+            <label className={LABEL}>Telegram</label>
+            <input name="telegram" defaultValue={brand?.telegram ?? ''} placeholder="@usuario" className={INPUT} />
+          </div>
+          <div>
+            <label className={LABEL}>WhatsApp</label>
+            <input name="whatsapp" defaultValue={brand?.whatsapp ?? ''} placeholder="+34 …" className={INPUT} />
+          </div>
+        </div>
       </div>
 
       {state.error && <p className="text-xs text-red-400 font-medium">{state.error}</p>}

--- a/src/features/admin/brands/components/BrandsCrmManager.brand-row.tsx
+++ b/src/features/admin/brands/components/BrandsCrmManager.brand-row.tsx
@@ -219,7 +219,7 @@ function ExpandedBrandRow({
 function BrandDetails({ brand }: { readonly brand: CrmBrandWithDerived }): React.ReactElement {
   return (
     <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
-      <Field label="Razón social" value={brand.legalName} />
+      <Field label="Manager" value={brand.manager} />
       <Field label="Web" value={brand.website} link />
       <Field label="Geo" value={brand.geo ? (GEO_LABELS[brand.geo as CrmBrandGeo] ?? brand.geo) : null} />
       <Field label="País" value={brand.country} />

--- a/src/lib/queries/crmBrands.ts
+++ b/src/lib/queries/crmBrands.ts
@@ -80,7 +80,7 @@ export async function listCrmBrands(opts?: {
     .select({
       id: crmBrands.id,
       name: crmBrands.name,
-      legalName: crmBrands.legalName,
+      manager: crmBrands.manager,
       website: crmBrands.website,
       sector: crmBrands.sector,
       tipo: crmBrands.tipo,
@@ -96,6 +96,9 @@ export async function listCrmBrands(opts?: {
       dealTypes: crmBrands.dealTypes,
       taxId: crmBrands.taxId,
       address: crmBrands.address,
+      discord: crmBrands.discord,
+      telegram: crmBrands.telegram,
+      whatsapp: crmBrands.whatsapp,
       lastContactAt: crmBrands.lastContactAt,
       nextFollowupAt: crmBrands.nextFollowupAt,
       nextFollowUpAt: crmBrands.nextFollowUpAt,

--- a/src/lib/schemas/crmBrand.ts
+++ b/src/lib/schemas/crmBrand.ts
@@ -31,27 +31,18 @@ export type CrmBrandStatus = (typeof CRM_BRAND_STATUSES)[number];
 export const CRM_BRAND_TIPOS = ['agencia', 'marca'] as const;
 
 export const CRM_BRAND_SECTORES = [
-  'cs2_cases',
-  'cs2_marketplace',
+  'gambling',
+  'trading',
   'casino',
-  'apuestas',
+  'sports_betting',
   'perifericos',
-  'crypto',
-  'fmcg',
-  'tech',
-  'gaming_brands',
   'otros',
 ] as const;
 
 export const CRM_BRAND_GEOS = [
-  'spain',
-  'latam',
-  'europa',
-  'turquia',
-  'india',
-  'japon',
-  'global',
-  'otros',
+  'tier_1',
+  'tier_2',
+  'tier_3',
 ] as const;
 
 export type CrmBrandTipo = (typeof CRM_BRAND_TIPOS)[number];
@@ -59,27 +50,18 @@ export type CrmBrandSector = (typeof CRM_BRAND_SECTORES)[number];
 export type CrmBrandGeo = (typeof CRM_BRAND_GEOS)[number];
 
 export const SECTOR_LABELS: Record<CrmBrandSector, string> = {
-  cs2_cases: 'CS2 Cases',
-  cs2_marketplace: 'Marketplace CS2',
+  gambling: 'Gambling',
+  trading: 'Trading',
   casino: 'Casino',
-  apuestas: 'Casas de apuesta',
+  sports_betting: 'Sports Betting',
   perifericos: 'Periféricos',
-  crypto: 'Crypto',
-  fmcg: 'FMCG',
-  tech: 'Tech',
-  gaming_brands: 'Gaming brands',
   otros: 'Otros',
 };
 
 export const GEO_LABELS: Record<CrmBrandGeo, string> = {
-  spain: 'Spain',
-  latam: 'LATAM',
-  europa: 'Europa',
-  turquia: 'Turquía',
-  india: 'India',
-  japon: 'Japón',
-  global: 'Global',
-  otros: 'Otros',
+  tier_1: 'Tier 1',
+  tier_2: 'Tier 2',
+  tier_3: 'Tier 3',
 };
 
 export const CRM_FOLLOWUP_CHANNELS = [
@@ -129,7 +111,7 @@ export type BrandTalentTier = (typeof BRAND_TALENT_TIERS)[number];
 
 const brandFields = z.object({
   name:         z.string().min(1).max(200),
-  legalName:    optStr(250),
+  manager:      optStr(250),
   website:      optUrl,
   tipo:         optEnum(CRM_BRAND_TIPOS),
   sector:       optEnum(CRM_BRAND_SECTORES),
@@ -149,6 +131,11 @@ const brandFields = z.object({
   dealTypes:   optStr(200),
   taxId:       optStr(30),
   address:     z.string().optional(),
+
+  // Contactos rápidos del manager
+  discord:  optStr(80),
+  telegram: optStr(80),
+  whatsapp: optStr(40),
 
   notes: z.string().optional(),
   // Rate cards & workspace defaults


### PR DESCRIPTION
## Summary
Refactor del formulario de Marca del CRM (`/admin/brands`) según feedback operativo. **No toca SEO ni la web pública** — completamente independiente de los PRs de SEO.

### Cambios funcionales del form
- **"Nombre" → "Marca"**: relabel del campo principal.
- **"Razón social" → "Manager"**: la columna `legal_name` ahora se llama `manager` (RENAME en BD, datos preservados). La razón social legal real sigue viviendo en `fiscal_name` (sección Datos fiscales).
- **Sector** reducido de 10 a 6 opciones: `gambling, trading, casino, sports_betting, perifericos, otros`.
- **Geo** sustituido por `tier_1, tier_2, tier_3`.
- **Nueva sección "Contacto del manager"** con 3 campos directos en la marca: Discord, Telegram, WhatsApp. Complementa `crm_brand_contacts` (que sigue para múltiples contactos por marca) con acceso rápido desde el drawer.

### Migración aplicada (`drizzle/0046_brand_crm_redaction.sql`)
```sql
ALTER TABLE crm_brands RENAME COLUMN legal_name TO manager;
ALTER TABLE crm_brands ADD COLUMN discord  varchar(80);
ALTER TABLE crm_brands ADD COLUMN telegram varchar(80);
ALTER TABLE crm_brands ADD COLUMN whatsapp varchar(40);
-- Mapeo de datos viejos → nuevos:
-- sector: cs2_cases|cs2_marketplace|crypto → trading
-- sector: apuestas → sports_betting
-- sector: fmcg|tech|gaming_brands → otros
-- geo: spain|europa|japon → tier_1
-- geo: latam|turquia|global → tier_2
-- geo: india|otros → tier_3
```
Migración ya aplicada en Neon en mi entorno local — verifica en `__drizzle_migrations` antes de mergear si hay otras envs.

### Archivos tocados (10)
- `src/db/schema/crmBrands.ts` (rename + 3 cols)
- `src/lib/schemas/crmBrand.ts` (Zod enums + brandFields)
- `src/lib/queries/crmBrands.ts` (select fields)
- `src/features/admin/brands/components/BrandFormDrawer.tsx` (form)
- `src/features/admin/brands/components/BrandFormModal.tsx` (form alt)
- `src/features/admin/brands/components/BrandsCrmManager.brand-row.tsx` (row display)
- `src/app/admin/(dashboard)/brands/[id]/page.tsx` (detalle)
- `src/__tests__/server/crmBrands.test.ts` (mocks)
- `drizzle/0046_brand_crm_redaction.sql` (nueva)
- `drizzle/meta/_journal.json` (entry 46)

### Out of scope (no tocados)
- `src/lib/schemas/crmBrand.ts` — `CRM_FOLLOWUP_CHANNELS` no cambia (es para follow-ups, no para contactos de marca).
- `src/features/admin/talents/components/AddTalentModal.tsx` — selector país TR.
- `src/lib/campaignHelpers.tsx` — lista de regiones para campañas.

## Test plan
- [ ] `npx tsc --noEmit` ✅ verde local
- [ ] `npm test` ✅ 924 tests pasan local
- [ ] `npm run lint` ✅ 0 errors local
- [ ] Aplicar `npm run migrate` en staging antes de mergear a master
- [ ] Verificar en `/admin/brands` que el drawer muestra "Marca", "Manager", sector con 6 opciones, geo con tiers, sección Contacto del manager
- [ ] Verificar que marcas existentes con sector=`cs2_cases` etc. ahora muestren `trading` correctamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)