### PR TITLE
feat(i18n): EN/ES toggle in Nav + Turkey deprioritised in chrome

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -93,7 +93,7 @@ const SOCIALS = [
 const STATS = [
   { value: '13+', label: 'Años de experiencia' },
   { value: '15M', label: 'Views al mes' },
-  { value: '3', label: 'Mercados activos' },
+  { value: 'ES + LatAm', label: 'Mercados activos' },
 ];
 
 /**
@@ -222,7 +222,7 @@ export function Footer() {
             <Link href="/legal" className="hover:text-white/60 transition-colors">Aviso Legal</Link>
           </div>
           <p className="text-xs text-white/20">
-            Gaming &amp; Esports · España · LatAm · Turquía
+            Gaming &amp; Esports · España · LatAm · Europa
           </p>
         </div>
       </div>

--- a/src/components/layout/LangSwitch.tsx
+++ b/src/components/layout/LangSwitch.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+type Pair = { alt: string; targetLang: 'EN' | 'ES' };
+
+// Pares ES↔EN — sincronizar con sitemap.ts si se añade una landing nueva.
+// Para betting el ES único es /servicios/igaming (decisión PR #51 del dev),
+// /influencers-betting redirige 301 y queda fuera del map.
+const PAIRS: Record<string, Pair> = {
+  '/influencers-cs2':              { alt: '/cs2-influencer-marketing',     targetLang: 'EN' },
+  '/agencia-influencers-valorant': { alt: '/valorant-influencers-agency',  targetLang: 'EN' },
+  '/servicios/igaming':            { alt: '/betting-influencers',          targetLang: 'EN' },
+  '/agencia-marketing-esports':    { alt: '/esports-marketing-agency',     targetLang: 'EN' },
+  '/cs2-influencer-marketing':     { alt: '/influencers-cs2',              targetLang: 'ES' },
+  '/valorant-influencers-agency':  { alt: '/agencia-influencers-valorant', targetLang: 'ES' },
+  '/betting-influencers':          { alt: '/servicios/igaming',            targetLang: 'ES' },
+  '/esports-marketing-agency':     { alt: '/agencia-marketing-esports',    targetLang: 'ES' },
+};
+
+/** Útil para que el Nav decida si renderiza el wrapper del toggle. */
+export function hasLangAlternate(pathname: string): boolean {
+  return pathname in PAIRS;
+}
+
+type Props = {
+  className?: string;
+  onNavigate?: () => void;
+};
+
+/**
+ * Toggle EN/ES. Solo se renderiza si la ruta actual tiene un equivalente
+ * declarado en PAIRS. Si no hay equivalente, retorna null (no mostramos
+ * un fallback genérico que mande al visitante a una landing aleatoria).
+ */
+export function LangSwitch({ className, onNavigate }: Props): React.JSX.Element | null {
+  const pathname = usePathname() ?? '/';
+  const pair = PAIRS[pathname];
+
+  if (!pair) return null;
+
+  const ariaLabel = pair.targetLang === 'EN' ? 'Switch to English' : 'Cambiar a español';
+
+  return (
+    <Link
+      href={pair.alt}
+      hrefLang={pair.targetLang.toLowerCase()}
+      aria-label={ariaLabel}
+      {...(onNavigate ? { onClick: onNavigate } : {})}
+      className={
+        className ??
+        'inline-flex items-center gap-1 px-3 py-1.5 text-[11px] font-bold uppercase tracking-widest text-white/60 hover:text-white border border-white/15 hover:border-white/40 rounded-full transition-colors'
+      }
+    >
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+        <circle cx="12" cy="12" r="10" />
+        <path d="M2 12h20" />
+        <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
+      </svg>
+      {pair.targetLang}
+    </Link>
+  );
+}

--- a/src/components/layout/Nav.tsx
+++ b/src/components/layout/Nav.tsx
@@ -3,8 +3,11 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
+import { usePathname } from 'next/navigation';
 import * as m from 'motion/react-client';
 import { AnimatePresence, useMotionValue } from 'motion/react';
+
+import { LangSwitch, hasLangAlternate } from '@/components/layout/LangSwitch';
 
 const NAV_LINKS = [
   { href: '/talentos', label: 'Talentos' },
@@ -24,6 +27,9 @@ const NAV_LINKS = [
  * @feature layout
  */
 export function Nav() {
+  const pathname = usePathname() ?? '/';
+  const showLangToggle = hasLangAlternate(pathname);
+
   const [open, setOpen] = useState(false);
   const [scrolled, setScrolled] = useState(false);
   // Scroll progress driven by a native listener (more reliable than motion's
@@ -128,15 +134,18 @@ export function Nav() {
           ))}
         </ul>
 
-        {/* CTA */}
-        <m.a
-          href="/contacto"
-          whileHover={{ scale: 1.02 }}
-          whileTap={{ scale: 0.98 }}
-          className="hidden md:inline-flex items-center gap-2 px-5 py-2 text-xs font-bold uppercase tracking-widest text-white bg-sp-grad"
-        >
-          Trabajemos juntos
-        </m.a>
+        {/* Right cluster: language toggle (only when alternate exists) + CTA */}
+        <div className="hidden md:flex items-center gap-3">
+          {showLangToggle && <LangSwitch />}
+          <m.a
+            href="/contacto"
+            whileHover={{ scale: 1.02 }}
+            whileTap={{ scale: 0.98 }}
+            className="inline-flex items-center gap-2 px-5 py-2 text-xs font-bold uppercase tracking-widest text-white bg-sp-grad"
+          >
+            Trabajemos juntos
+          </m.a>
+        </div>
 
         {/* Mobile burger */}
         <button
@@ -194,11 +203,21 @@ export function Nav() {
                 </m.a>
               )
             )}
+            {showLangToggle && (
+              <m.div
+                initial={{ opacity: 0, x: -8 }}
+                animate={{ opacity: 1, x: 0 }}
+                transition={{ duration: 0.15, ease: 'easeOut', delay: NAV_LINKS.length * 0.04 }}
+                className="self-start"
+              >
+                <LangSwitch onNavigate={() => setOpen(false)} />
+              </m.div>
+            )}
             <m.a
               href="/contacto"
               initial={{ opacity: 0, x: -8 }}
               animate={{ opacity: 1, x: 0 }}
-              transition={{ duration: 0.15, ease: 'easeOut', delay: NAV_LINKS.length * 0.04 }}
+              transition={{ duration: 0.15, ease: 'easeOut', delay: (NAV_LINKS.length + (showLangToggle ? 1 : 0)) * 0.04 }}
               className="text-xs font-bold uppercase tracking-widest text-white text-center py-3 bg-sp-grad"
               onClick={() => setOpen(false)}
             >

--- a/src/features/marketing-site/components/CtaSection.tsx
+++ b/src/features/marketing-site/components/CtaSection.tsx
@@ -41,7 +41,7 @@ export function CtaSection(): React.JSX.Element {
           className="text-sp-muted2 text-lg mb-4"
         >
           +340 FTDs en una activación · 15M views/mes · 13 años ejecutando en
-          España, LatAm y Turquía.
+          España, LatAm y Europa.
         </m.p>
         <m.p
           variants={fadeUp}

--- a/src/features/marketing-site/components/Hero.tsx
+++ b/src/features/marketing-site/components/Hero.tsx
@@ -95,7 +95,7 @@ export function Hero() {
           transition={{ duration: 1, delay: 0.2 }}
           className="inline-block text-[10px] font-bold uppercase tracking-[0.4em] text-sp-muted2 mb-6"
         >
-          Gaming &amp; Esports · Europa · LatAm · Turquía
+          Gaming &amp; Esports · España · LatAm · Europa
         </m.span>
 
         <h1 className="font-display text-[2.75rem] xs:text-[3.5rem] sm:text-[5rem] md:text-[7rem] lg:text-[10rem] font-black uppercase leading-[0.85] tracking-tight mb-10">
@@ -134,7 +134,7 @@ export function Hero() {
           >
             Campañas gaming y iGaming con talentos verificados, compliance
             integrado y FTDs rastreados. 13+ años ejecutando en España, LatAm
-            y Turquía.
+            y Europa.
           </m.p>
 
           <m.div

--- a/src/features/marketing-site/components/ServicesSection.tsx
+++ b/src/features/marketing-site/components/ServicesSection.tsx
@@ -72,15 +72,15 @@ const ADVANTAGES = [
   },
   {
     title: 'Normativa iGaming',
-    desc: 'Conocimiento regulatorio en España, LatAm y Turquía. Campañas que cumplen desde el día uno.',
+    desc: 'Conocimiento regulatorio en España, LatAm y Europa. Campañas que cumplen desde el día uno.',
   },
   {
     title: 'Red exclusiva',
     desc: '+15 talentos cualificados con audiencias verificadas y engagement real.',
   },
   {
-    title: '3 mercados',
-    desc: 'Presencia activa en España, Latinoamérica y Turquía con equipos locales.',
+    title: 'España, LatAm y Europa',
+    desc: 'Presencia activa en España, Latinoamérica y mercados europeos con equipos locales.',
   },
 ];
 


### PR DESCRIPTION
## Summary
Reduced version of the i18n toggle. **Chrome-only** — no landings, no `layout.tsx`, no `/servicios/igaming`, no sitemap, no redirects. Respects PR #50 (Turkey deprioritised) and PR #51 (`/servicios/igaming` as iGaming hub).

## Archivos tocados (6)

**Nuevo (1):**
- `src/components/layout/LangSwitch.tsx` (56 líneas) — toggle EN/ES + helper `hasLangAlternate()`.

**Modificados (5):**
- `src/components/layout/Nav.tsx` — `usePathname()` + render condicional del toggle. Sin tocar contenido del nav.
- `src/components/layout/Footer.tsx` — solo `STATS[2]` (`'3 Mercados activos'` → `'ES + LatAm Mercados activos'`) y bottom-bar tag-line. **No toca la columna Especialidades del PR #51.**
- `src/features/marketing-site/components/Hero.tsx` — tag-line top y párrafo: `… y Turquía` → `… y Europa`.
- `src/features/marketing-site/components/CtaSection.tsx` — subtítulo: `… y Turquía` → `… y Europa`.
- `src/features/marketing-site/components/ServicesSection.tsx` — 2 advantages: `'Conocimiento regulatorio en España, LatAm y Turquía'` → `… y Europa` y `'3 mercados / España, Latinoamérica y Turquía'` → `'España, LatAm y Europa / España, Latinoamérica y mercados europeos'`.

**No tocados (estricto):**
- ❌ `src/app/layout.tsx`
- ❌ Las 9 landings ES/EN
- ❌ `src/app/servicios/page.tsx`, `servicios/igaming/page.tsx`, `metodologia/page.tsx`
- ❌ `src/app/gaming/cs2/page.tsx`, `gaming/betting/page.tsx`
- ❌ `src/app/sitemap.ts`
- ❌ `next.config.ts`
- ❌ Footer column 'Especialidades' (preservada del PR #51)

## Qué hace el LangSwitch

Toggle pequeño con icono globo y label `EN` o `ES`, montado a la izquierda del CTA `Trabajemos juntos` en desktop, y dentro del menú mobile. Detecta el `pathname` actual con `usePathname()`.

Comportamiento:

| Caso | Acción |
|------|--------|
| La ruta está en `PAIRS` | Renderiza el toggle apuntando al equivalente directo |
| La ruta NO está en `PAIRS` | **Retorna `null`** — el toggle no se muestra |

Sin fallback genérico. El `Nav` también usa `hasLangAlternate(pathname)` para no renderizar el wrapper del toggle (evita huecos visuales en desktop cluster y `<m.div>` vacío en mobile menu).

## URLs alternas (`PAIRS`)

| Origen | Destino | Lang destino |
|--------|---------|--------------|
| `/cs2-influencer-marketing` | `/influencers-cs2` | ES |
| `/influencers-cs2` | `/cs2-influencer-marketing` | EN |
| `/valorant-influencers-agency` | `/agencia-influencers-valorant` | ES |
| `/agencia-influencers-valorant` | `/valorant-influencers-agency` | EN |
| `/esports-marketing-agency` | `/agencia-marketing-esports` | ES |
| `/agencia-marketing-esports` | `/esports-marketing-agency` | EN |
| `/servicios/igaming` | `/betting-influencers` | EN |
| `/betting-influencers` | `/servicios/igaming` | ES |

**Notas importantes**:
- `/influencers-betting` (que ahora redirige 301 a `/servicios/igaming` por PR #51) **queda fuera del map**. El toggle nunca apunta a esta URL.
- `/twitch-streamers-agency` no tiene par ES y queda fuera del map → toggle oculto en esa página.
- `/` (home), `/talentos`, `/casos`, `/contacto`, `/blog`, `/nosotros`, `/metodologia`, `/para-creadores`, `/giveaways`, `/sorteos` y slugs dinámicos no tienen versión inglesa → toggle oculto.

## Sin hrefs a URLs redirigidas

Verificado con curl que cada `href` del toggle responde **200 directo**, sin pasar por ningún 301:

- `curl /influencers-cs2` → 200
- `curl /betting-influencers` → 200
- `curl /servicios/igaming` → 200

Ningún `href` apunta a `/influencers-betting` (que sí redirige). El destino correcto desde `/betting-influencers` es `/servicios/igaming`, alineado con la decisión Opción A del PR #51.

## tsc / lint

- `npx tsc --noEmit` → ✅ verde
- `npm run lint` → ✅ 0 errors (61 warnings preexistentes, sin cambio respecto a `master`)

## Cómo probarlo manualmente

```bash
git fetch origin
git checkout seo/lang-toggle-chrome
npm run dev
```

1. Visita `http://localhost:3000/` → Nav muestra solo el CTA (toggle oculto, `/` no tiene par).
2. Visita `http://localhost:3000/cs2-influencer-marketing` → toggle muestra **ES**, pulsar lleva a `/influencers-cs2` (200, sin redirect).
3. Visita `http://localhost:3000/influencers-cs2` → toggle muestra **EN**, pulsar lleva a `/cs2-influencer-marketing`.
4. Visita `http://localhost:3000/servicios/igaming` → toggle muestra **EN**, pulsar lleva a `/betting-influencers` (respeta hub iGaming).
5. Visita `http://localhost:3000/betting-influencers` → toggle muestra **ES**, pulsar lleva a `/servicios/igaming` (no a `/influencers-betting` que es 301).
6. Visita `http://localhost:3000/talentos`, `/blog`, `/casos`, `/twitch-streamers-agency` → Nav sin toggle (no hay par EN/ES definido).
7. En el Footer: stats finales muestran `ES + LatAm Mercados activos`, tag-line bottom bar `Gaming & Esports · España · LatAm · Europa`. Columna Especialidades intacta (incluye `iGaming & Betting` del PR #51).
8. Mobile menu: abrir burger en una página con par → ve el toggle al final (animación coherente). En página sin par no aparece.

## Test plan

- [ ] CI: tsc + lint pasan en GitHub Actions
- [ ] Probar manualmente las 12 rutas listadas arriba en local
- [ ] Verificar que mobile menu no deja hueco al ocultar el toggle
- [ ] Confirmar que el cambio de copy `'Turquía' → 'Europa'` en Hero/CtaSection/ServicesSection es coherente con el posicionamiento decidido (España + LatAm + Europa primario; Turquía/Brasil secundarios solo en /servicios/igaming, /betting-influencers, /influencers-betting)

## Próximo paso

PR-C (EN pages: `/en`, `/services`, `/talents`, `/cases`, `/contact`) queda en stand-by hasta que este PR-B esté mergeado. PR-C se rebaseará sobre `master` post-merge y se reconciliará con el sitemap del PR #51.

🤖 Generated with [Claude Code](https://claude.com/claude-code)