### PR TITLE
feat(i18n): EN versions of home, services, talents, cases, contact

### DIFF
--- a/src/app/betting-influencers/page.tsx
+++ b/src/app/betting-influencers/page.tsx
@@ -90,7 +90,7 @@ export default function BettingInfluencersPage() {
               </div>
             ))}
           </div>
-          <Link href="/contacto" className="inline-block bg-sp-grad text-white font-display font-bold uppercase tracking-wider text-sm px-8 py-3 rounded-full hover:opacity-90 transition-opacity">
+          <Link href="/contact" className="inline-block bg-sp-grad text-white font-display font-bold uppercase tracking-wider text-sm px-8 py-3 rounded-full hover:opacity-90 transition-opacity">
             Activate betting campaign
           </Link>
         </div>
@@ -136,7 +136,7 @@ export default function BettingInfluencersPage() {
           <h2 className="font-display text-3xl font-black uppercase text-white mb-4">Ready to launch your <span style={g}>betting campaign?</span></h2>
           <p className="text-white/50 mb-8">Tell us your operator, target market and conversion goal. We deliver a proposal with compliance included in 48 hours.</p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <Link href="/contacto" className="inline-block bg-sp-grad text-white font-display font-bold uppercase tracking-wider text-sm px-8 py-3 rounded-full hover:opacity-90 transition-opacity">Request proposal</Link>
+            <Link href="/contact" className="inline-block bg-sp-grad text-white font-display font-bold uppercase tracking-wider text-sm px-8 py-3 rounded-full hover:opacity-90 transition-opacity">Request proposal</Link>
             <Link href="/servicios/igaming" className="inline-block border border-white/20 text-white/60 font-display font-bold uppercase tracking-wider text-sm px-8 py-3 rounded-full hover:border-white/40 hover:text-white transition-colors">Ver en español →</Link>
           </div>
         </div>

--- a/src/app/cases/page.tsx
+++ b/src/app/cases/page.tsx
@@ -1,0 +1,111 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import Image from 'next/image';
+
+import { getCaseStudies } from '@/lib/queries/cases';
+import { absoluteUrl } from '@/lib/site-url';
+
+export const revalidate = 3600;
+
+export const metadata: Metadata = {
+  title: 'Gaming Campaign Case Studies — Verified Results',
+  description:
+    'Real campaigns with top brands: 1WIN (8M+ reach), SkinsMonkey (€200K conversions), RAZER (2.5M reach). See SocialPro’s gaming marketing results and methodology.',
+  alternates: {
+    canonical: '/cases',
+    languages: {
+      en: absoluteUrl('/cases'),
+      es: absoluteUrl('/casos'),
+      'x-default': absoluteUrl('/cases'),
+    },
+  },
+  openGraph: {
+    title: 'Gaming Campaign Case Studies | SocialPro',
+    description: '1WIN (8M+ reach), SkinsMonkey (€200K conversions), RAZER (2.5M reach). Verified gaming marketing results.',
+    url: absoluteUrl('/cases'),
+    images: [{ url: absoluteUrl('/og-default.jpg'), width: 1200, height: 630 }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Gaming Campaign Case Studies | SocialPro',
+    description: '1WIN (8M+ reach), SkinsMonkey (€200K), RAZER (2.5M). Verified gaming marketing results.',
+    images: [absoluteUrl('/og-default.jpg')],
+  },
+};
+
+const g = {
+  background: 'linear-gradient(135deg,#f5632a 0%,#e03070 35%,#c42880 62%,#8b3aad 100%)',
+  WebkitBackgroundClip: 'text' as const,
+  WebkitTextFillColor: 'transparent' as const,
+  backgroundClip: 'text' as const,
+};
+
+export default async function CasesEnPage() {
+  const cases = await getCaseStudies();
+
+  return (
+    <>
+      {/* Hero */}
+      <section className="bg-sp-black pt-32 pb-16 text-center">
+        <div className="max-w-4xl mx-auto px-6">
+          <p className="text-sp-orange text-xs font-bold uppercase tracking-[0.2em] mb-4">Case studies</p>
+          <h1 className="font-display text-4xl md:text-6xl font-black uppercase tracking-tight text-white leading-tight mb-6">
+            Gaming campaigns with<br /><span style={g}>verified results</span>
+          </h1>
+          <p className="text-lg text-white/60 leading-relaxed max-w-2xl mx-auto">
+            Real numbers, real attribution. Reach, conversions and ROI tracked with raw data — not estimates.
+          </p>
+        </div>
+      </section>
+
+      {/* Grid */}
+      <section className="bg-white py-16 md:py-20">
+        <div className="max-w-6xl mx-auto px-6">
+          {cases.length === 0 ? (
+            <p className="text-center text-sp-muted">No case studies published yet.</p>
+          ) : (
+            <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+              {cases.map((c) => (
+                <Link
+                  key={c.id}
+                  href={`/casos/${c.slug}`}
+                  className="group block rounded-2xl border border-sp-border bg-sp-off overflow-hidden hover:border-sp-orange transition-colors"
+                >
+                  {c.heroImageUrl && (
+                    <div className="relative aspect-video bg-sp-dark/5 overflow-hidden">
+                      <Image src={c.heroImageUrl} alt={c.title} fill sizes="(max-width:768px) 100vw, (max-width:1024px) 50vw, 33vw" className="object-cover group-hover:scale-105 transition-transform duration-500" />
+                    </div>
+                  )}
+                  <div className="p-6">
+                    <p className="text-[11px] font-bold uppercase tracking-wider text-sp-orange mb-2">{c.brandName}</p>
+                    <h2 className="font-display text-lg font-black uppercase text-sp-dark mb-3 group-hover:text-sp-orange transition-colors">{c.title}</h2>
+                    {c.reach && <p className="font-display text-3xl font-black mb-2" style={g}>{c.reach}</p>}
+                    {c.excerpt && <p className="text-sm text-sp-muted leading-relaxed mb-4">{c.excerpt}</p>}
+                    <div className="flex flex-wrap gap-2 text-[11px] text-sp-muted/80">
+                      {c.engagementRate && <span className="px-2 py-0.5 rounded-full bg-white border border-sp-border">{c.engagementRate} eng.</span>}
+                      {c.conversions    && <span className="px-2 py-0.5 rounded-full bg-white border border-sp-border">{c.conversions}</span>}
+                      {c.roiMultiplier  && <span className="px-2 py-0.5 rounded-full bg-white border border-sp-border">{c.roiMultiplier} ROI</span>}
+                    </div>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          )}
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="bg-sp-black py-16 text-center">
+        <div className="max-w-2xl mx-auto px-6">
+          <h2 className="font-display text-3xl md:text-4xl font-black uppercase text-white mb-4">
+            Want results like <span style={g}>these?</span>
+          </h2>
+          <p className="text-white/60 mb-8">Tell us your brand, target market and conversion goal. We deliver a custom proposal in 48 hours.</p>
+          <Link href="/contact" className="inline-block bg-sp-grad text-white font-display font-bold uppercase tracking-wider text-sm px-8 py-3 rounded-full hover:opacity-90 transition-opacity">
+            Request a proposal
+          </Link>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,59 @@
+import type { Metadata } from 'next';
+
+import { absoluteUrl } from '@/lib/site-url';
+import { ContactFormEn } from '@/features/contact/components/ContactFormEn';
+
+export const metadata: Metadata = {
+  title: 'Contact Our Gaming Marketing Agency',
+  description:
+    'Looking for streamers for your gaming or iGaming campaign? Tell us about your project. We reply within 24 hours. No commitment.',
+  alternates: {
+    canonical: '/contact',
+    languages: {
+      en: absoluteUrl('/contact'),
+      es: absoluteUrl('/contacto'),
+      'x-default': absoluteUrl('/contact'),
+    },
+  },
+  openGraph: {
+    title: 'Contact Our Gaming Marketing Agency | SocialPro',
+    description: 'Looking for streamers for your gaming or iGaming campaign? We reply within 24 hours.',
+    url: absoluteUrl('/contact'),
+    images: [{ url: absoluteUrl('/og-default.jpg'), width: 1200, height: 630 }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Contact Our Gaming Marketing Agency | SocialPro',
+    description: 'Looking for streamers for your gaming or iGaming campaign? Reply within 24h.',
+    images: [absoluteUrl('/og-default.jpg')],
+  },
+};
+
+const g = {
+  background: 'linear-gradient(135deg,#f5632a 0%,#e03070 35%,#c42880 62%,#8b3aad 100%)',
+  WebkitBackgroundClip: 'text' as const,
+  WebkitTextFillColor: 'transparent' as const,
+  backgroundClip: 'text' as const,
+};
+
+export default function ContactEnPage() {
+  return (
+    <>
+      {/* Hero */}
+      <section className="bg-sp-black pt-32 pb-12 text-center">
+        <div className="max-w-3xl mx-auto px-6">
+          <p className="text-sp-orange text-xs font-bold uppercase tracking-[0.2em] mb-4">Contact</p>
+          <h1 className="font-display text-4xl md:text-6xl font-black uppercase tracking-tight text-white leading-tight mb-6">
+            Let’s talk <span style={g}>today</span>
+          </h1>
+          <p className="text-lg text-white/60 leading-relaxed max-w-2xl mx-auto">
+            Tell us about your campaign. We reply within 24 hours with a tailored proposal.
+            No commitment — just a clear conversation.
+          </p>
+        </div>
+      </section>
+
+      <ContactFormEn />
+    </>
+  );
+}

--- a/src/app/cs2-influencer-marketing/page.tsx
+++ b/src/app/cs2-influencer-marketing/page.tsx
@@ -92,7 +92,7 @@ export default function Cs2InfluencerMarketingPage() {
               </div>
             ))}
           </div>
-          <Link href="/contacto" className="inline-block bg-sp-grad text-white font-display font-bold uppercase tracking-wider text-sm px-8 py-3 rounded-full hover:opacity-90 transition-opacity">
+          <Link href="/contact" className="inline-block bg-sp-grad text-white font-display font-bold uppercase tracking-wider text-sm px-8 py-3 rounded-full hover:opacity-90 transition-opacity">
             Launch your CS2 campaign
           </Link>
         </div>
@@ -144,7 +144,7 @@ export default function Cs2InfluencerMarketingPage() {
           </h2>
           <p className="text-white/50 mb-8">Tell us your product, conversion goal and target market. We deliver a proposal with selected CS2 streamers in 48 hours.</p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <Link href="/contacto" className="inline-block bg-sp-grad text-white font-display font-bold uppercase tracking-wider text-sm px-8 py-3 rounded-full hover:opacity-90 transition-opacity">Request proposal</Link>
+            <Link href="/contact" className="inline-block bg-sp-grad text-white font-display font-bold uppercase tracking-wider text-sm px-8 py-3 rounded-full hover:opacity-90 transition-opacity">Request proposal</Link>
             <Link href="/influencers-cs2" className="inline-block border border-white/20 text-white/60 font-display font-bold uppercase tracking-wider text-sm px-8 py-3 rounded-full hover:border-white/40 hover:text-white transition-colors">Ver en español →</Link>
           </div>
         </div>

--- a/src/app/en/page.tsx
+++ b/src/app/en/page.tsx
@@ -1,0 +1,259 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import Image from 'next/image';
+
+import { getTalents } from '@/lib/queries/talents';
+import { getCaseStudies } from '@/lib/queries/cases';
+import { absoluteUrl, SITE_URL } from '@/lib/site-url';
+
+export const revalidate = 3600;
+
+export const metadata: Metadata = {
+  title: 'Gaming & Esports Influencer Marketing Agency — Spain & LatAm',
+  description:
+    'SocialPro connects creators with brands. 13+ years in gaming, esports and iGaming influencer marketing. Verified streamers in Spain and LatAm. Performance-tracked campaigns.',
+  alternates: {
+    canonical: '/en',
+    languages: {
+      en: absoluteUrl('/en'),
+      es: SITE_URL,
+      'x-default': absoluteUrl('/en'),
+    },
+  },
+  openGraph: {
+    title: 'Gaming & Esports Influencer Marketing Agency | SocialPro',
+    description:
+      'Verified gaming creators in Spain and LatAm. Performance-tracked campaigns for iGaming, esports and consumer brands.',
+    url: absoluteUrl('/en'),
+    type: 'website',
+    images: [{ url: absoluteUrl('/og-default.jpg'), width: 1200, height: 630 }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Gaming & Esports Influencer Marketing Agency | SocialPro',
+    description: 'Verified gaming creators in Spain and LatAm. Performance-tracked influencer campaigns.',
+    images: [absoluteUrl('/og-default.jpg')],
+  },
+};
+
+const g = {
+  background: 'linear-gradient(135deg,#f5632a 0%,#e03070 35%,#c42880 62%,#8b3aad 100%)',
+  WebkitBackgroundClip: 'text' as const,
+  WebkitTextFillColor: 'transparent' as const,
+  backgroundClip: 'text' as const,
+};
+
+const STATS = [
+  { stat: '13+',  label: 'Years in gaming marketing' },
+  { stat: '15M+', label: 'Monthly views across roster' },
+  { stat: '+340', label: 'FTDs in a single activation' },
+  { stat: '8M+',  label: 'Reach on flagship CS2 campaign' },
+];
+
+const SERVICES = [
+  { title: 'Influencer campaigns', desc: 'Streamer activations for awareness, product launches and conversion-focused campaigns. Every creator verified, every metric tracked.' },
+  { title: 'iGaming campaigns', desc: 'Specialised campaigns for betting, casino and skins operators. DGOJ compliance built in. FTD tracking from day one.' },
+  { title: 'Talent management', desc: 'Full representation for gaming creators: deal negotiation, content strategy, sponsorship management and channel growth.' },
+  { title: 'Esports activations', desc: 'Brand integrations in tournaments, custom overlays, in-stream mentions and live audience activations.' },
+];
+
+const FAQ = [
+  { q: 'What does SocialPro do?', a: 'SocialPro is a gaming and esports influencer marketing agency. We connect brands with verified streamers and creators in Spain and LatAm, and we manage end-to-end campaigns with performance tracking and compliance built in.' },
+  { q: 'Which markets do you cover?', a: 'Spain, Mexico, Argentina, Colombia and Chile — the largest Spanish-speaking gaming markets. Our roster reaches over 15 million monthly viewers across Twitch and YouTube.' },
+  { q: 'How fast can a campaign launch?', a: 'From brief to live in under 72 hours for our verified roster. This includes creator selection, contract signing, compliance briefing and publishing coordination.' },
+  { q: 'How do you measure results?', a: 'Every streamer gets a unique tracking code. We monitor clicks, registrations and FTDs (First Time Deposits) attributed per creator. Reports use raw data, not estimates.' },
+  { q: 'What makes SocialPro different?', a: 'We have been exclusively in gaming, esports and iGaming since 2012. We are not a generic agency that added "gaming" to its portfolio — we know the culture, platforms, audiences and compliance.' },
+];
+
+const faqJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: FAQ.map(({ q, a }) => ({
+    '@type': 'Question',
+    name: q,
+    acceptedAnswer: { '@type': 'Answer', text: a },
+  })),
+};
+
+export default async function HomeEnPage() {
+  const [talents, cases] = await Promise.all([getTalents(), getCaseStudies()]);
+  const topTalents = talents.slice(0, 8);
+  const topCases   = cases.slice(0, 3);
+
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }} />
+
+      {/* Hero */}
+      <section className="relative bg-sp-black text-white pt-32 pb-24 overflow-hidden">
+        <div className="max-w-5xl mx-auto px-6 text-center relative z-10">
+          <p className="text-[10px] font-bold uppercase tracking-[0.4em] text-sp-muted2 mb-6">
+            Gaming &amp; Esports · Spain · Europe · LatAm
+          </p>
+          <h1 className="font-display text-4xl sm:text-6xl md:text-7xl font-black uppercase tracking-tight leading-[0.9] mb-8">
+            We connect <span style={g}>creators</span><br />with brands
+          </h1>
+          <p className="text-base sm:text-lg text-white/60 max-w-2xl mx-auto mb-10 leading-relaxed">
+            Gaming and iGaming campaigns with verified talent, integrated compliance and tracked FTDs.
+            13+ years executing in Spain and LatAm.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
+            <Link href="/contact" className="px-10 py-4 rounded-full font-bold text-white text-sm tracking-widest uppercase bg-sp-grad hover:opacity-90 transition-opacity">
+              Start a proposal
+            </Link>
+            <Link href="/cases" className="px-10 py-4 rounded-full font-bold text-white text-sm tracking-widest uppercase border border-white/15 hover:bg-white/5 transition-colors">
+              View case studies
+            </Link>
+          </div>
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-6 max-w-3xl mx-auto">
+            {STATS.map(({ stat, label }) => (
+              <div key={label} className="text-center">
+                <div className="font-display text-3xl font-black" style={g}>{stat}</div>
+                <div className="text-[11px] text-white/40 mt-1 uppercase tracking-wide">{label}</div>
+              </div>
+            ))}
+          </div>
+          <p className="mt-8 text-[11px] font-semibold uppercase tracking-[0.25em] text-sp-muted2/80">
+            Reply within 24h · No commitment
+          </p>
+        </div>
+      </section>
+
+      {/* Talent preview */}
+      <section className="bg-white py-16 md:py-20">
+        <div className="max-w-7xl mx-auto px-6">
+          <div className="text-center mb-10">
+            <p className="text-sp-orange text-xs font-bold uppercase tracking-[0.2em] mb-2">Our roster</p>
+            <h2 className="font-display text-3xl md:text-4xl font-black uppercase text-sp-dark mb-4">
+              <span style={g}>Streamers and creators</span> with verified audiences
+            </h2>
+            <p className="text-sp-muted max-w-xl mx-auto text-sm leading-relaxed">
+              Real audiences with high engagement. Filter and explore the full roster.
+            </p>
+          </div>
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4 mb-8">
+            {topTalents.map((t) => (
+              <Link
+                key={t.id}
+                href={`/talentos/${t.slug}`}
+                className="group block rounded-2xl bg-sp-off border border-sp-border overflow-hidden hover:border-sp-orange transition-colors"
+              >
+                <div className="relative aspect-[4/5] bg-sp-dark/5 overflow-hidden">
+                  {t.photoUrl ? (
+                    <Image src={t.photoUrl} alt={t.name} fill sizes="(max-width:640px) 50vw, (max-width:1024px) 33vw, 25vw" className="object-cover group-hover:scale-105 transition-transform duration-500" />
+                  ) : (
+                    <div className="w-full h-full flex items-center justify-center font-display text-3xl font-black text-sp-muted">
+                      {t.name.charAt(0)}
+                    </div>
+                  )}
+                </div>
+                <div className="p-4">
+                  <p className="font-display text-base font-black uppercase text-sp-dark truncate">{t.name}</p>
+                  <p className="text-xs text-sp-muted truncate">{t.role}</p>
+                </div>
+              </Link>
+            ))}
+          </div>
+          <div className="text-center">
+            <Link href="/talents" className="inline-block text-sm font-semibold text-sp-orange hover:underline">
+              View full roster →
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      {/* Services */}
+      <section className="bg-sp-off py-16 md:py-20">
+        <div className="max-w-5xl mx-auto px-6">
+          <p className="text-sp-orange text-xs font-bold uppercase tracking-[0.2em] mb-2">What we do</p>
+          <h2 className="font-display text-3xl md:text-4xl font-black uppercase text-sp-dark mb-10">
+            Performance-driven gaming marketing
+          </h2>
+          <div className="grid sm:grid-cols-2 gap-6">
+            {SERVICES.map((s) => (
+              <div key={s.title} className="rounded-2xl border border-sp-border bg-white p-6">
+                <h3 className="font-display text-base font-black uppercase text-sp-dark mb-3">{s.title}</h3>
+                <p className="text-sm text-sp-muted leading-relaxed">{s.desc}</p>
+              </div>
+            ))}
+          </div>
+          <div className="mt-8 text-center">
+            <Link href="/services" className="inline-block text-sm font-semibold text-sp-orange hover:underline">
+              All services →
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      {/* Case studies */}
+      {topCases.length > 0 && (
+        <section className="bg-white py-16 md:py-20">
+          <div className="max-w-5xl mx-auto px-6">
+            <p className="text-sp-orange text-xs font-bold uppercase tracking-[0.2em] mb-2">Recent campaigns</p>
+            <h2 className="font-display text-3xl md:text-4xl font-black uppercase text-sp-dark mb-10">
+              Verified results, not estimates
+            </h2>
+            <div className="grid md:grid-cols-3 gap-6">
+              {topCases.map((c) => (
+                <Link
+                  key={c.id}
+                  href={`/casos/${c.slug}`}
+                  className="group block rounded-2xl border border-sp-border bg-sp-off p-6 hover:border-sp-orange transition-colors"
+                >
+                  <p className="text-[11px] font-bold uppercase tracking-wider text-sp-orange mb-2">{c.brandName}</p>
+                  <h3 className="font-display text-lg font-black uppercase text-sp-dark mb-2 group-hover:text-sp-orange transition-colors">{c.title}</h3>
+                  {c.reach && <p className="font-display text-3xl font-black mb-2" style={g}>{c.reach}</p>}
+                  {c.excerpt && <p className="text-sm text-sp-muted leading-relaxed">{c.excerpt}</p>}
+                </Link>
+              ))}
+            </div>
+            <div className="mt-8 text-center">
+              <Link href="/cases" className="inline-block text-sm font-semibold text-sp-orange hover:underline">
+                View all cases →
+              </Link>
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* FAQ */}
+      <section className="bg-sp-off py-16 md:py-20">
+        <div className="max-w-3xl mx-auto px-6">
+          <p className="text-sp-orange text-xs font-bold uppercase tracking-[0.2em] mb-2">FAQ</p>
+          <h2 className="font-display text-3xl md:text-4xl font-black uppercase text-sp-dark mb-10">
+            Common questions
+          </h2>
+          <div className="space-y-4">
+            {FAQ.map(({ q, a }) => (
+              <details key={q} className="group rounded-2xl border border-sp-border bg-white p-5">
+                <summary className="cursor-pointer font-display font-black uppercase text-sm text-sp-dark list-none flex justify-between items-center">
+                  {q}
+                  <span className="text-sp-orange ml-4 transition-transform group-open:rotate-180">▾</span>
+                </summary>
+                <p className="mt-3 text-sm text-sp-muted leading-relaxed">{a}</p>
+              </details>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="bg-sp-black py-20 text-center">
+        <div className="max-w-2xl mx-auto px-6">
+          <h2 className="font-display text-3xl md:text-5xl font-black uppercase text-white mb-4">
+            Let’s build your <span style={g}>next campaign</span>
+          </h2>
+          <p className="text-white/60 mb-8 leading-relaxed">
+            +340 FTDs in one activation · 15M views/month · 13 years executing in Spain and LatAm.
+          </p>
+          <Link href="/contact" className="inline-block px-10 py-4 rounded-full font-bold text-white text-sm tracking-widest uppercase bg-sp-grad hover:opacity-90 transition-opacity">
+            Start a proposal →
+          </Link>
+          <p className="mt-5 text-[11px] font-semibold uppercase tracking-[0.25em] text-white/40">
+            Reply within 24h · No commitment
+          </p>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/src/app/esports-marketing-agency/page.tsx
+++ b/src/app/esports-marketing-agency/page.tsx
@@ -92,7 +92,7 @@ export default function EsportsMarketingAgencyPage() {
               </div>
             ))}
           </div>
-          <Link href="/contacto" className="inline-block bg-sp-grad text-white font-display font-bold uppercase tracking-wider text-sm px-8 py-3 rounded-full hover:opacity-90 transition-opacity">
+          <Link href="/contact" className="inline-block bg-sp-grad text-white font-display font-bold uppercase tracking-wider text-sm px-8 py-3 rounded-full hover:opacity-90 transition-opacity">
             Work with us
           </Link>
         </div>
@@ -137,7 +137,7 @@ export default function EsportsMarketingAgencyPage() {
           <h2 className="font-display text-3xl font-black uppercase text-sp-dark mb-4">Ready to enter <span style={g}>esports?</span></h2>
           <p className="text-sp-muted mb-8">Whether you are an endemic brand or entering esports for the first time, we build the right activation for your goals and audience.</p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <Link href="/contacto" className="inline-block bg-sp-grad text-white font-display font-bold uppercase tracking-wider text-sm px-8 py-3 rounded-full hover:opacity-90 transition-opacity">Get a proposal</Link>
+            <Link href="/contact" className="inline-block bg-sp-grad text-white font-display font-bold uppercase tracking-wider text-sm px-8 py-3 rounded-full hover:opacity-90 transition-opacity">Get a proposal</Link>
             <Link href="/agencia-marketing-esports" className="inline-block border border-sp-border text-sp-dark font-display font-bold uppercase tracking-wider text-sm px-8 py-3 rounded-full hover:border-sp-orange hover:text-sp-orange transition-colors">Ver en español →</Link>
           </div>
         </div>

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -1,0 +1,225 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+import { absoluteUrl, SITE_URL } from '@/lib/site-url';
+
+export const metadata: Metadata = {
+  title: 'Gaming, Esports & iGaming Marketing Services',
+  description:
+    'Influencer campaigns, iGaming activations, talent management and esports sponsorships. Performance-tracked services for brands targeting gaming audiences in Spain and LatAm.',
+  alternates: {
+    canonical: '/services',
+    languages: {
+      en: absoluteUrl('/services'),
+      es: absoluteUrl('/servicios'),
+      'x-default': absoluteUrl('/services'),
+    },
+  },
+  openGraph: {
+    title: 'Gaming, Esports & iGaming Marketing Services | SocialPro',
+    description: 'Hire CS2, Valorant and iGaming streamers in Spain and LatAm. 15+ verified creators, <72h activation, FTD tracking included.',
+    url: absoluteUrl('/services'),
+    images: [{ url: absoluteUrl('/og-default.jpg'), width: 1200, height: 630 }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Gaming, Esports & iGaming Services | SocialPro',
+    description: 'CS2, Valorant and iGaming streamers in Spain and LatAm. <72h activation, FTD tracking included.',
+    images: [absoluteUrl('/og-default.jpg')],
+  },
+};
+
+const g = {
+  background: 'linear-gradient(135deg,#f5632a 0%,#e03070 35%,#c42880 62%,#8b3aad 100%)',
+  WebkitBackgroundClip: 'text' as const,
+  WebkitTextFillColor: 'transparent' as const,
+  backgroundClip: 'text' as const,
+};
+
+const SERVICES = [
+  {
+    title: 'Influencer campaigns',
+    desc: 'Streamer activations on Twitch and YouTube for awareness, product launches and conversion-focused campaigns. Each creator vetted for audience authenticity. Every metric tracked end-to-end.',
+    bullets: ['Audience verification', 'Creator briefing & content review', 'Live tracking & FTD attribution'],
+  },
+  {
+    title: 'iGaming campaigns',
+    desc: 'Specialised campaigns for betting, casino and skins operators. DGOJ compliance built into every step. FTD tracking and attribution per creator.',
+    bullets: ['DGOJ compliance integration', 'Age-gating & responsible-gambling disclaimers', 'Verified FTD reporting'],
+  },
+  {
+    title: 'Talent management',
+    desc: 'Full representation for gaming creators: deal negotiation, content strategy, sponsorship management and channel growth. We manage the relationship so brands and creators focus on results.',
+    bullets: ['Deal negotiation', 'Content & growth strategy', 'Sponsorship & schedule management'],
+  },
+  {
+    title: 'Esports activations',
+    desc: 'Brand integrations in tournaments and esports events: custom overlays, in-stream mentions, pre-roll spots and live audience activations. From grassroots to major tournaments.',
+    bullets: ['Tournament sponsorship', 'Custom overlays & broadcast assets', 'Live audience activations'],
+  },
+];
+
+const PROCESS = [
+  { num: '01', t: 'Discovery', d: 'We analyse your brand, target audience, competition and business goals. Clear KPIs before we start.' },
+  { num: '02', t: 'Matching',  d: 'We select creators whose audience and style match your brand. No spam — only verified profiles.' },
+  { num: '03', t: 'Execution', d: 'Full campaign coordination: briefings, content review, scheduling, compliance and publishing.' },
+  { num: '04', t: 'Reporting', d: 'Reports with real metrics: reach, engagement, conversions and ROI. Verified data, not screenshots.' },
+];
+
+const FAQ = [
+  { q: 'Which platforms do you cover?', a: 'Twitch and YouTube as primary platforms for streamers (CS2, Valorant, iGaming and esports). We also coordinate Instagram, TikTok and X for amplification across the Spanish-speaking market.' },
+  { q: 'How fast can a campaign launch?', a: 'From brief to live in under 72 hours for our verified roster. For larger multi-creator campaigns, allow 5–7 working days for production.' },
+  { q: 'Do you handle iGaming compliance?', a: 'Yes. SocialPro integrates DGOJ compliance for Spanish operators and adapts to LatAm regulatory frameworks for international campaigns. Disclaimers, age verification and pre-publication review are standard.' },
+  { q: 'How do you measure ROI?', a: 'Each creator gets a unique tracking code or affiliate link. We attribute clicks, registrations and FTDs (First Time Deposits) per creator. Reports use raw data verified with the operator.' },
+  { q: 'What size of campaigns do you run?', a: 'From single-creator product seeding to multi-territory activations with 100+ streamers. Our 1WIN CS2 campaign reached 8M+ across Spain, Mexico, Argentina and Colombia in a single tournament.' },
+];
+
+const serviceJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'ProfessionalService',
+  '@id': absoluteUrl('/services'),
+  name: 'SocialPro — Gaming Marketing Agency',
+  description: 'Performance influencer marketing for gaming, esports and iGaming brands in Spain and LatAm.',
+  url: absoluteUrl('/services'),
+  inLanguage: 'en',
+  telephone: '+34-604-868-426',
+  email: 'marketing@socialpro.es',
+  priceRange: '$$',
+  provider: { '@type': 'Organization', name: 'SocialPro', url: SITE_URL },
+  areaServed: ['España', 'México', 'Argentina', 'Colombia', 'Chile'],
+  hasOfferCatalog: {
+    '@type': 'OfferCatalog',
+    name: 'Gaming marketing services',
+    itemListElement: SERVICES.map((s, i) => ({
+      '@type': 'Offer',
+      position: i + 1,
+      itemOffered: { '@type': 'Service', name: s.title, description: s.desc },
+    })),
+  },
+};
+
+const faqJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: FAQ.map(({ q, a }) => ({
+    '@type': 'Question',
+    name: q,
+    acceptedAnswer: { '@type': 'Answer', text: a },
+  })),
+};
+
+export default function ServicesEnPage() {
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(serviceJsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }} />
+
+      {/* Hero */}
+      <section className="bg-sp-black pt-32 pb-16 text-center">
+        <div className="max-w-4xl mx-auto px-6">
+          <p className="text-sp-orange text-xs font-bold uppercase tracking-[0.2em] mb-4">Services</p>
+          <h1 className="font-display text-4xl md:text-6xl font-black uppercase tracking-tight text-white leading-tight mb-6">
+            Gaming marketing<br /><span style={g}>that delivers</span>
+          </h1>
+          <p className="text-lg text-white/60 leading-relaxed max-w-2xl mx-auto">
+            Performance-driven services for gaming, esports and iGaming brands across Spain and LatAm.
+            Every campaign tracked. Every metric verified.
+          </p>
+        </div>
+      </section>
+
+      {/* Services grid */}
+      <section className="bg-white py-16 md:py-20">
+        <div className="max-w-5xl mx-auto px-6">
+          <p className="text-sp-orange text-xs font-bold uppercase tracking-[0.2em] mb-2">What we do</p>
+          <h2 className="font-display text-3xl font-black uppercase text-sp-dark mb-10">Full-spectrum gaming marketing</h2>
+          <div className="grid sm:grid-cols-2 gap-6">
+            {SERVICES.map((s) => (
+              <div key={s.title} className="rounded-2xl border border-sp-border bg-sp-off p-6">
+                <h3 className="font-display text-base font-black uppercase text-sp-dark mb-3">{s.title}</h3>
+                <p className="text-sm text-sp-muted leading-relaxed mb-4">{s.desc}</p>
+                <ul className="space-y-1.5">
+                  {s.bullets.map((b) => (
+                    <li key={b} className="flex items-start gap-2 text-xs text-sp-muted">
+                      <span className="mt-1 h-1.5 w-1.5 rounded-full bg-sp-orange shrink-0" />
+                      {b}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Process */}
+      <section className="bg-sp-off py-16 md:py-20">
+        <div className="max-w-5xl mx-auto px-6">
+          <p className="text-sp-orange text-xs font-bold uppercase tracking-[0.2em] mb-2">How we work</p>
+          <h2 className="font-display text-3xl font-black uppercase text-sp-dark mb-10">From brief to results in 4 phases</h2>
+          <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-4">
+            {PROCESS.map((p) => (
+              <div key={p.num} className="rounded-2xl border border-sp-border bg-white p-6">
+                <div className="font-display text-3xl font-black mb-3" style={g}>{p.num}</div>
+                <h3 className="font-display text-base font-black uppercase text-sp-dark mb-2">{p.t}</h3>
+                <p className="text-sm text-sp-muted leading-relaxed">{p.d}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Specialties */}
+      <nav aria-label="Specialties" className="bg-white border-t border-sp-border py-8">
+        <div className="max-w-5xl mx-auto px-6">
+          <p className="text-[9px] font-bold uppercase tracking-[0.22em] text-sp-muted mb-4">Specialties</p>
+          <div className="flex flex-wrap gap-2">
+            {[
+              { href: '/cs2-influencer-marketing',    label: 'CS2 Influencer Marketing' },
+              { href: '/valorant-influencers-agency', label: 'Valorant Influencers Agency' },
+              { href: '/esports-marketing-agency',    label: 'Esports Marketing Agency' },
+              { href: '/twitch-streamers-agency',     label: 'Twitch Streamers Agency' },
+              { href: '/betting-influencers',         label: 'Betting Influencers' },
+            ].map(({ href, label }) => (
+              <Link key={href} href={href} className="text-xs font-semibold text-sp-muted hover:text-sp-orange border border-sp-border hover:border-sp-orange rounded-full px-3 py-1.5 transition-colors">
+                {label}
+              </Link>
+            ))}
+          </div>
+        </div>
+      </nav>
+
+      {/* FAQ */}
+      <section className="bg-sp-off py-16 md:py-20">
+        <div className="max-w-3xl mx-auto px-6">
+          <p className="text-sp-orange text-xs font-bold uppercase tracking-[0.2em] mb-2">FAQ</p>
+          <h2 className="font-display text-3xl font-black uppercase text-sp-dark mb-10">Common questions</h2>
+          <div className="space-y-4">
+            {FAQ.map(({ q, a }) => (
+              <details key={q} className="group rounded-2xl border border-sp-border bg-white p-5">
+                <summary className="cursor-pointer font-display font-black uppercase text-sm text-sp-dark list-none flex justify-between items-center">
+                  {q}
+                  <span className="text-sp-orange ml-4 transition-transform group-open:rotate-180">▾</span>
+                </summary>
+                <p className="mt-3 text-sm text-sp-muted leading-relaxed">{a}</p>
+              </details>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="bg-sp-black py-16 text-center">
+        <div className="max-w-2xl mx-auto px-6">
+          <h2 className="font-display text-3xl md:text-4xl font-black uppercase text-white mb-4">
+            Tell us about your <span style={g}>next campaign</span>
+          </h2>
+          <p className="text-white/60 mb-8">Send us your product, target market and goal. We deliver a tailored proposal in 48 hours.</p>
+          <Link href="/contact" className="inline-block bg-sp-grad text-white font-display font-bold uppercase tracking-wider text-sm px-8 py-3 rounded-full hover:opacity-90 transition-opacity">
+            Request a proposal
+          </Link>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -65,6 +65,66 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     priority: 0.6,
   }));
 
+  // ── Marketing core bilingual pairs ────────────────────────────────────────
+  // ES + EN core marketing pages with mutual hreflang and x-default → EN.
+  const corePairs: MetadataRoute.Sitemap = [
+    // Home
+    {
+      url: SITE_URL,
+      lastModified: D.home, changeFrequency: 'weekly', priority: 1,
+      alternates: { languages: { es: SITE_URL, en: absoluteUrl('/en'), 'x-default': absoluteUrl('/en') } },
+    },
+    {
+      url: absoluteUrl('/en'),
+      lastModified: D.home, changeFrequency: 'weekly', priority: 0.95,
+      alternates: { languages: { en: absoluteUrl('/en'), es: SITE_URL, 'x-default': absoluteUrl('/en') } },
+    },
+    // Talents
+    {
+      url: absoluteUrl('/talentos'),
+      lastModified: D.talentos, changeFrequency: 'weekly', priority: 0.9,
+      alternates: { languages: { es: absoluteUrl('/talentos'), en: absoluteUrl('/talents'), 'x-default': absoluteUrl('/talents') } },
+    },
+    {
+      url: absoluteUrl('/talents'),
+      lastModified: D.talentos, changeFrequency: 'weekly', priority: 0.85,
+      alternates: { languages: { en: absoluteUrl('/talents'), es: absoluteUrl('/talentos'), 'x-default': absoluteUrl('/talents') } },
+    },
+    // Services
+    {
+      url: absoluteUrl('/servicios'),
+      lastModified: D.servicios, changeFrequency: 'monthly', priority: 0.8,
+      alternates: { languages: { es: absoluteUrl('/servicios'), en: absoluteUrl('/services'), 'x-default': absoluteUrl('/services') } },
+    },
+    {
+      url: absoluteUrl('/services'),
+      lastModified: D.servicios, changeFrequency: 'monthly', priority: 0.85,
+      alternates: { languages: { en: absoluteUrl('/services'), es: absoluteUrl('/servicios'), 'x-default': absoluteUrl('/services') } },
+    },
+    // Cases
+    {
+      url: absoluteUrl('/casos'),
+      lastModified: D.casos, changeFrequency: 'weekly', priority: 0.8,
+      alternates: { languages: { es: absoluteUrl('/casos'), en: absoluteUrl('/cases'), 'x-default': absoluteUrl('/cases') } },
+    },
+    {
+      url: absoluteUrl('/cases'),
+      lastModified: D.casos, changeFrequency: 'weekly', priority: 0.85,
+      alternates: { languages: { en: absoluteUrl('/cases'), es: absoluteUrl('/casos'), 'x-default': absoluteUrl('/cases') } },
+    },
+    // Contact
+    {
+      url: absoluteUrl('/contacto'),
+      lastModified: D.contacto, changeFrequency: 'monthly', priority: 0.8,
+      alternates: { languages: { es: absoluteUrl('/contacto'), en: absoluteUrl('/contact'), 'x-default': absoluteUrl('/contact') } },
+    },
+    {
+      url: absoluteUrl('/contact'),
+      lastModified: D.contacto, changeFrequency: 'monthly', priority: 0.85,
+      alternates: { languages: { en: absoluteUrl('/contact'), es: absoluteUrl('/contacto'), 'x-default': absoluteUrl('/contact') } },
+    },
+  ];
+
   // ── Multilingual landing pairs ────────────────────────────────────────────
   // EN (primary, priority 0.85) + ES (support, priority 0.80).
   // alternates.languages → Google outputs hreflang in sitemap.xml.
@@ -122,14 +182,11 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   ];
 
   return [
-    // ── Core pages ────────────────────────────────────────────────────────
-    { url: SITE_URL,                         lastModified: D.home,          changeFrequency: 'weekly',  priority: 1    },
-    { url: absoluteUrl('/talentos'),          lastModified: D.talentos,      changeFrequency: 'weekly',  priority: 0.9  },
-    { url: absoluteUrl('/servicios'),         lastModified: D.servicios,     changeFrequency: 'monthly', priority: 0.8  },
+    // ── Marketing core (bilingual pairs: home, talents, services, cases, contact) ──
+    ...corePairs,
+    // ── Other ES-only core pages ──────────────────────────────────────────
     { url: absoluteUrl('/servicios/igaming'), lastModified: D.igaming,       changeFrequency: 'monthly', priority: 0.85 },
-    { url: absoluteUrl('/casos'),             lastModified: D.casos,         changeFrequency: 'weekly',  priority: 0.8  },
     { url: absoluteUrl('/nosotros'),          lastModified: D.nosotros,      changeFrequency: 'monthly', priority: 0.7  },
-    { url: absoluteUrl('/contacto'),          lastModified: D.contacto,      changeFrequency: 'monthly', priority: 0.8  },
     { url: absoluteUrl('/metodologia'),       lastModified: D.metodologia,   changeFrequency: 'monthly', priority: 0.7  },
     { url: absoluteUrl('/para-creadores'),    lastModified: D.paraCreadores, changeFrequency: 'monthly', priority: 0.8  },
     { url: absoluteUrl('/blog'),              lastModified: D.blog,          changeFrequency: 'weekly',  priority: 0.7  },

--- a/src/app/talents/page.tsx
+++ b/src/app/talents/page.tsx
@@ -1,0 +1,154 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import Image from 'next/image';
+
+import { getTalents } from '@/lib/queries/talents';
+import { absoluteUrl, SITE_URL } from '@/lib/site-url';
+
+export const revalidate = 3600;
+
+export const metadata: Metadata = {
+  title: 'Gaming Talent Roster — Verified Streamers in Spain & LatAm',
+  description:
+    'Browse SocialPro’s gaming talent roster. CS2, Valorant, Twitch and YouTube creators with verified audiences across Spain and LatAm. 15M+ monthly views.',
+  alternates: {
+    canonical: '/talents',
+    languages: {
+      en: absoluteUrl('/talents'),
+      es: absoluteUrl('/talentos'),
+      'x-default': absoluteUrl('/talents'),
+    },
+  },
+  openGraph: {
+    title: 'Gaming Talent Roster — Verified Streamers in Spain & LatAm | SocialPro',
+    description: 'CS2, Valorant, Twitch and YouTube creators with verified audiences. 15M+ monthly views across Spain and LatAm.',
+    url: absoluteUrl('/talents'),
+    images: [{ url: absoluteUrl('/og-default.jpg'), width: 1200, height: 630 }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Gaming Talent Roster | SocialPro',
+    description: 'Verified gaming streamers in Spain and LatAm. 15M+ monthly views.',
+    images: [absoluteUrl('/og-default.jpg')],
+  },
+};
+
+const g = {
+  background: 'linear-gradient(135deg,#f5632a 0%,#e03070 35%,#c42880 62%,#8b3aad 100%)',
+  WebkitBackgroundClip: 'text' as const,
+  WebkitTextFillColor: 'transparent' as const,
+  backgroundClip: 'text' as const,
+};
+
+export default async function TalentsEnPage() {
+  const talents = await getTalents();
+
+  const itemListJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    name: 'SocialPro Gaming Talent Roster',
+    description: 'Streamers and gaming content creators managed by SocialPro across Spain and LatAm.',
+    url: absoluteUrl('/talents'),
+    inLanguage: 'en',
+    numberOfItems: talents.length,
+    itemListElement: talents.map((t, i) => ({
+      '@type': 'ListItem',
+      position: i + 1,
+      item: {
+        '@type': 'Person',
+        name: t.name,
+        jobTitle: t.role,
+        url: absoluteUrl(`/talentos/${t.slug}`),
+        ...(t.photoUrl ? { image: t.photoUrl } : {}),
+        worksFor: { '@type': 'Organization', name: 'SocialPro', url: SITE_URL },
+      },
+    })),
+  };
+
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(itemListJsonLd) }} />
+
+      {/* Hero */}
+      <section className="bg-sp-black pt-32 pb-16 text-center">
+        <div className="max-w-4xl mx-auto px-6">
+          <p className="text-sp-orange text-xs font-bold uppercase tracking-[0.2em] mb-4">Our roster</p>
+          <h1 className="font-display text-4xl md:text-6xl font-black uppercase tracking-tight text-white leading-tight mb-6">
+            Gaming creators<br /><span style={g}>that move audiences</span>
+          </h1>
+          <p className="text-lg text-white/60 leading-relaxed max-w-2xl mx-auto">
+            Verified streamers and content creators across Spain and LatAm. 15M+ monthly views,
+            real engagement and audiences that convert.
+          </p>
+        </div>
+      </section>
+
+      {/* Grid */}
+      <section className="bg-white py-16">
+        <div className="max-w-7xl mx-auto px-6">
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+            {talents.map((t) => (
+              <Link
+                key={t.id}
+                href={`/talentos/${t.slug}`}
+                className="group block rounded-2xl bg-sp-off border border-sp-border overflow-hidden hover:border-sp-orange transition-colors"
+              >
+                <div className="relative aspect-[4/5] bg-sp-dark/5 overflow-hidden">
+                  {t.photoUrl ? (
+                    <Image src={t.photoUrl} alt={t.name} fill sizes="(max-width:640px) 50vw, (max-width:1024px) 33vw, 25vw" className="object-cover group-hover:scale-105 transition-transform duration-500" />
+                  ) : (
+                    <div className="w-full h-full flex items-center justify-center font-display text-3xl font-black text-sp-muted">
+                      {t.name.charAt(0)}
+                    </div>
+                  )}
+                </div>
+                <div className="p-4">
+                  <p className="font-display text-base font-black uppercase text-sp-dark truncate">{t.name}</p>
+                  <p className="text-xs text-sp-muted truncate">{t.role}</p>
+                  {t.stats && t.stats.length > 0 && (
+                    <p className="text-[11px] text-sp-orange font-semibold mt-2 truncate">
+                      {t.stats[0]?.label}: {t.stats[0]?.value}
+                    </p>
+                  )}
+                </div>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Internal links */}
+      <nav aria-label="Niche campaigns" className="bg-sp-off border-t border-sp-border py-8">
+        <div className="max-w-5xl mx-auto px-6">
+          <p className="text-[9px] font-bold uppercase tracking-[0.22em] text-sp-muted mb-4">Niche campaigns</p>
+          <div className="flex flex-wrap gap-2">
+            {[
+              { href: '/cs2-influencer-marketing', label: 'CS2 Influencer Marketing' },
+              { href: '/valorant-influencers-agency', label: 'Valorant Influencers' },
+              { href: '/betting-influencers', label: 'Betting Influencers' },
+              { href: '/esports-marketing-agency', label: 'Esports Marketing' },
+              { href: '/twitch-streamers-agency', label: 'Twitch Streamers' },
+            ].map(({ href, label }) => (
+              <Link key={href} href={href} className="text-xs font-semibold text-sp-muted hover:text-sp-orange border border-sp-border hover:border-sp-orange rounded-full px-3 py-1.5 transition-colors">
+                {label}
+              </Link>
+            ))}
+          </div>
+        </div>
+      </nav>
+
+      {/* CTA */}
+      <section className="bg-sp-black py-16 text-center">
+        <div className="max-w-2xl mx-auto px-6">
+          <h2 className="font-display text-3xl md:text-4xl font-black uppercase text-white mb-4">
+            Want to <span style={g}>work with these creators?</span>
+          </h2>
+          <p className="text-white/60 mb-8">Tell us your brand, target audience and KPIs. We deliver a custom proposal in 48 hours.</p>
+          <Link href="/contact" className="inline-block bg-sp-grad text-white font-display font-bold uppercase tracking-wider text-sm px-8 py-3 rounded-full hover:opacity-90 transition-opacity">
+            Request a proposal
+          </Link>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/src/app/twitch-streamers-agency/page.tsx
+++ b/src/app/twitch-streamers-agency/page.tsx
@@ -90,7 +90,7 @@ export default function TwitchStreamersAgencyPage() {
               </div>
             ))}
           </div>
-          <Link href="/contacto" className="inline-block bg-sp-grad text-white font-display font-bold uppercase tracking-wider text-sm px-8 py-3 rounded-full hover:opacity-90 transition-opacity">
+          <Link href="/contact" className="inline-block bg-sp-grad text-white font-display font-bold uppercase tracking-wider text-sm px-8 py-3 rounded-full hover:opacity-90 transition-opacity">
             Activate Twitch campaign
           </Link>
         </div>
@@ -135,8 +135,8 @@ export default function TwitchStreamersAgencyPage() {
           <h2 className="font-display text-3xl font-black uppercase text-white mb-4">Your brand. <span style={g}>Live on Twitch.</span></h2>
           <p className="text-white/50 mb-8">Tell us your brand, target audience and campaign goal. We match you with the right Twitch streamers and deliver a proposal in 48 hours.</p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <Link href="/contacto" className="inline-block bg-sp-grad text-white font-display font-bold uppercase tracking-wider text-sm px-8 py-3 rounded-full hover:opacity-90 transition-opacity">Get a proposal</Link>
-            <Link href="/talentos" className="inline-block border border-white/20 text-white/60 font-display font-bold uppercase tracking-wider text-sm px-8 py-3 rounded-full hover:border-white/40 hover:text-white transition-colors">View our streamers →</Link>
+            <Link href="/contact" className="inline-block bg-sp-grad text-white font-display font-bold uppercase tracking-wider text-sm px-8 py-3 rounded-full hover:opacity-90 transition-opacity">Get a proposal</Link>
+            <Link href="/talents" className="inline-block border border-white/20 text-white/60 font-display font-bold uppercase tracking-wider text-sm px-8 py-3 rounded-full hover:border-white/40 hover:text-white transition-colors">View our streamers →</Link>
           </div>
         </div>
       </section>

--- a/src/app/valorant-influencers-agency/page.tsx
+++ b/src/app/valorant-influencers-agency/page.tsx
@@ -89,7 +89,7 @@ export default function ValorantInfluencersAgencyPage() {
               </div>
             ))}
           </div>
-          <Link href="/contacto" className="inline-block bg-sp-grad text-white font-display font-bold uppercase tracking-wider text-sm px-8 py-3 rounded-full hover:opacity-90 transition-opacity">
+          <Link href="/contact" className="inline-block bg-sp-grad text-white font-display font-bold uppercase tracking-wider text-sm px-8 py-3 rounded-full hover:opacity-90 transition-opacity">
             Work with Valorant streamers
           </Link>
         </div>
@@ -135,7 +135,7 @@ export default function ValorantInfluencersAgencyPage() {
           <h2 className="font-display text-3xl font-black uppercase text-white mb-4">Launch your <span style={g}>Valorant campaign</span></h2>
           <p className="text-white/50 mb-8">Tell us your brand, target audience and KPIs. We deliver a custom Valorant influencer proposal in 48 hours.</p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <Link href="/contacto" className="inline-block bg-sp-grad text-white font-display font-bold uppercase tracking-wider text-sm px-8 py-3 rounded-full hover:opacity-90 transition-opacity">Request proposal</Link>
+            <Link href="/contact" className="inline-block bg-sp-grad text-white font-display font-bold uppercase tracking-wider text-sm px-8 py-3 rounded-full hover:opacity-90 transition-opacity">Request proposal</Link>
             <Link href="/agencia-influencers-valorant" className="inline-block border border-white/20 text-white/60 font-display font-bold uppercase tracking-wider text-sm px-8 py-3 rounded-full hover:border-white/40 hover:text-white transition-colors">Ver en español →</Link>
           </div>
         </div>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,51 +1,153 @@
+'use client';
+
 import Link from 'next/link';
 import Image from 'next/image';
+import { usePathname } from 'next/navigation';
 import { WA_HREF, CONTACT_EMAIL } from '@/lib/utils/constants';
+import { localeFromPathname, type Locale } from '@/lib/locale';
 
-const NAV_COLS = [
-  {
-    title: 'Agencia',
-    links: [
-      { href: '/talentos', label: 'Talentos' },
-      { href: '/servicios', label: 'Servicios' },
-      { href: '/casos', label: 'Casos de Éxito' },
-      { href: '/nosotros', label: 'Nosotros' },
-      { href: '/metodologia', label: 'Metodología' },
-      { href: '/blog', label: 'Blog' },
-    ],
+type NavCol = {
+  readonly title: string;
+  readonly links: readonly { readonly href: string; readonly label: string }[];
+};
+
+// IMPORTANTE: la columna "Especialidades" preserva la decisión del PR #51
+// (iGaming & Betting → /servicios/igaming como hub ES único).
+const NAV_COLS_BY_LOCALE: Record<Locale, readonly NavCol[]> = {
+  es: [
+    {
+      title: 'Agencia',
+      links: [
+        { href: '/talentos', label: 'Talentos' },
+        { href: '/servicios', label: 'Servicios' },
+        { href: '/casos', label: 'Casos de Éxito' },
+        { href: '/nosotros', label: 'Nosotros' },
+        { href: '/metodologia', label: 'Metodología' },
+        { href: '/blog', label: 'Blog' },
+      ],
+    },
+    {
+      title: 'Creadores',
+      links: [
+        { href: '/para-creadores', label: 'Para Creadores' },
+        { href: '/talentos', label: 'Ver Roster' },
+        { href: '/giveaways', label: 'Giveaways' },
+        { href: '/sorteos', label: 'Sorteos de Skins' },
+        { href: '/contacto', label: 'Trabaja con nosotros' },
+      ],
+    },
+    {
+      title: 'Marcas',
+      links: [
+        { href: '/servicios/igaming', label: 'Campañas iGaming' },
+        { href: '/servicios', label: 'Talent Management' },
+        { href: '/marcas/login', label: 'Portal de Marcas' },
+        { href: '/contacto', label: 'Solicitar propuesta' },
+      ],
+    },
+    {
+      title: 'Especialidades',
+      links: [
+        { href: '/cs2-influencer-marketing',   label: 'CS2 Influencer Marketing' },
+        { href: '/valorant-influencers-agency', label: 'Valorant Influencers' },
+        { href: '/servicios/igaming',           label: 'iGaming & Betting' },
+        { href: '/esports-marketing-agency',    label: 'Esports Marketing' },
+        { href: '/twitch-streamers-agency',     label: 'Twitch Streamers Agency' },
+        { href: '/influencers-cs2',             label: 'Influencers CS2 (ES)' },
+        { href: '/agencia-marketing-esports',   label: 'Agencia Esports (ES)' },
+      ],
+    },
+  ],
+  en: [
+    {
+      title: 'Agency',
+      links: [
+        { href: '/talents', label: 'Talent' },
+        { href: '/services', label: 'Services' },
+        { href: '/cases', label: 'Case Studies' },
+        { href: '/nosotros', label: 'About (ES)' },
+        { href: '/metodologia', label: 'Methodology (ES)' },
+        { href: '/blog', label: 'Blog (ES)' },
+      ],
+    },
+    {
+      title: 'Creators',
+      links: [
+        { href: '/para-creadores', label: 'For Creators (ES)' },
+        { href: '/talents', label: 'View Roster' },
+        { href: '/giveaways', label: 'Giveaways' },
+        { href: '/sorteos', label: 'Skin Giveaways (ES)' },
+        { href: '/contact', label: 'Work with us' },
+      ],
+    },
+    {
+      title: 'Brands',
+      links: [
+        { href: '/servicios/igaming', label: 'iGaming Campaigns (ES)' },
+        { href: '/services', label: 'Talent Management' },
+        { href: '/marcas/login', label: 'Brand Portal (ES)' },
+        { href: '/contact', label: 'Request a proposal' },
+      ],
+    },
+    {
+      title: 'Specialties',
+      links: [
+        { href: '/cs2-influencer-marketing',   label: 'CS2 Influencer Marketing' },
+        { href: '/valorant-influencers-agency', label: 'Valorant Influencers' },
+        { href: '/servicios/igaming',           label: 'iGaming & Betting (ES)' },
+        { href: '/esports-marketing-agency',    label: 'Esports Marketing' },
+        { href: '/twitch-streamers-agency',     label: 'Twitch Streamers Agency' },
+        { href: '/influencers-cs2',             label: 'Influencers CS2 (ES)' },
+        { href: '/agencia-marketing-esports',   label: 'Agencia Esports (ES)' },
+      ],
+    },
+  ],
+};
+
+const STATS_BY_LOCALE: Record<Locale, readonly { value: string; label: string }[]> = {
+  es: [
+    { value: '13+', label: 'Años de experiencia' },
+    { value: '15M', label: 'Views al mes' },
+    { value: 'ES + LatAm', label: 'Mercados activos' },
+  ],
+  en: [
+    { value: '13+', label: 'Years of experience' },
+    { value: '15M', label: 'Monthly views' },
+    { value: 'ES + LatAm', label: 'Active markets' },
+  ],
+};
+
+const COPY_BY_LOCALE: Record<Locale, {
+  readonly metricsLabel: string;
+  readonly brandIntro: string;
+  readonly socialsLabel: string;
+  readonly rights: string;
+  readonly privacy: string;
+  readonly cookies: string;
+  readonly legal: string;
+  readonly tagline: string;
+}> = {
+  es: {
+    metricsLabel: 'Métricas de la agencia',
+    brandIntro: 'Agencia de talentos gaming & esports. Conectamos creadores con marcas líderes en iGaming, periféricos y entretenimiento digital.',
+    socialsLabel: 'Redes sociales',
+    rights: 'Todos los derechos reservados.',
+    privacy: 'Privacidad',
+    cookies: 'Cookies',
+    legal: 'Aviso Legal',
+    tagline: 'Gaming & Esports · España · LatAm · Europa',
   },
-  {
-    title: 'Creadores',
-    links: [
-      { href: '/para-creadores', label: 'Para Creadores' },
-      { href: '/talentos', label: 'Ver Roster' },
-      { href: '/giveaways', label: 'Giveaways' },
-      { href: '/sorteos', label: 'Sorteos de Skins' },
-      { href: '/contacto', label: 'Trabaja con nosotros' },
-    ],
+  en: {
+    metricsLabel: 'Agency metrics',
+    brandIntro: 'Gaming & esports talent agency. We connect creators with leading iGaming, peripherals and digital entertainment brands.',
+    socialsLabel: 'Social media',
+    rights: 'All rights reserved.',
+    privacy: 'Privacy',
+    cookies: 'Cookies',
+    legal: 'Legal',
+    tagline: 'Gaming & Esports · Spain · LatAm · Europe',
   },
-  {
-    title: 'Marcas',
-    links: [
-      { href: '/servicios/igaming', label: 'Campañas iGaming' },
-      { href: '/servicios', label: 'Talent Management' },
-      { href: '/marcas/login', label: 'Portal de Marcas' },
-      { href: '/contacto', label: 'Solicitar propuesta' },
-    ],
-  },
-  {
-    title: 'Especialidades',
-    links: [
-      { href: '/cs2-influencer-marketing',   label: 'CS2 Influencer Marketing' },
-      { href: '/valorant-influencers-agency', label: 'Valorant Influencers' },
-      { href: '/servicios/igaming',           label: 'iGaming & Betting' },
-      { href: '/esports-marketing-agency',    label: 'Esports Marketing' },
-      { href: '/twitch-streamers-agency',     label: 'Twitch Streamers Agency' },
-      { href: '/influencers-cs2',             label: 'Influencers CS2 (ES)' },
-      { href: '/agencia-marketing-esports',   label: 'Agencia Esports (ES)' },
-    ],
-  },
-];
+};
 
 const SOCIALS = [
   {
@@ -90,27 +192,27 @@ const SOCIALS = [
   },
 ];
 
-const STATS = [
-  { value: '13+', label: 'Años de experiencia' },
-  { value: '15M', label: 'Views al mes' },
-  { value: 'ES + LatAm', label: 'Mercados activos' },
-];
-
 /**
- * Footer global de la web pública: stats strip, columnas de navegación,
- * datos de contacto, redes sociales y bottom bar con enlaces legales.
+ * Footer global de la web pública. Detecta locale por pathname y traduce
+ * columnas de navegación, stats y bottom bar al inglés cuando aplica.
  *
- * @kind server
+ * @kind client
  * @feature layout
  */
-export function Footer() {
+export function Footer(): React.ReactElement {
+  const pathname = usePathname() ?? '/';
+  const locale = localeFromPathname(pathname);
+  const navCols = NAV_COLS_BY_LOCALE[locale];
+  const stats   = STATS_BY_LOCALE[locale];
+  const copy    = COPY_BY_LOCALE[locale];
+
   return (
     <footer className="bg-sp-black text-white">
 
       {/* Stats strip */}
-      <section aria-label="Métricas de la agencia" className="border-t border-b border-white/5" style={{ background: 'linear-gradient(90deg,rgba(245,99,42,0.04) 0%,rgba(139,58,173,0.04) 100%)' }}>
+      <section aria-label={copy.metricsLabel} className="border-t border-b border-white/5" style={{ background: 'linear-gradient(90deg,rgba(245,99,42,0.04) 0%,rgba(139,58,173,0.04) 100%)' }}>
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 flex flex-wrap justify-center gap-12 sm:gap-24">
-          {STATS.map(({ value, label }) => (
+          {stats.map(({ value, label }) => (
             <div key={label} className="text-center">
               <p className="font-display text-3xl font-black" style={{
                 background: 'linear-gradient(90deg,#f5632a,#e03070,#8b3aad)',
@@ -132,7 +234,7 @@ export function Footer() {
 
           {/* Brand column */}
           <div className="flex flex-col gap-6">
-            <Link href="/" className="inline-block">
+            <Link href={locale === 'en' ? '/en' : '/'} className="inline-block">
               <Image
                 src="/images/logos/4.png"
                 alt="SocialPro"
@@ -143,7 +245,7 @@ export function Footer() {
             </Link>
 
             <p className="text-sm text-white/40 leading-relaxed max-w-xs">
-              Agencia de talentos gaming &amp; esports. Conectamos creadores con marcas líderes en iGaming, periféricos y entretenimiento digital.
+              {copy.brandIntro}
             </p>
 
             {/* Contact */}
@@ -171,7 +273,7 @@ export function Footer() {
             </address>
 
             {/* Socials */}
-            <nav aria-label="Redes sociales" className="flex gap-3">
+            <nav aria-label={copy.socialsLabel} className="flex gap-3">
               {SOCIALS.map(({ label, href, icon }) => (
                 <a
                   key={label}
@@ -188,7 +290,7 @@ export function Footer() {
           </div>
 
           {/* Nav columns */}
-          {NAV_COLS.map((col) => (
+          {navCols.map((col) => (
             <div key={col.title}>
               <h4 className="text-[10px] font-bold uppercase tracking-[0.2em] text-white/30 mb-5">
                 {col.title}
@@ -214,15 +316,15 @@ export function Footer() {
       <div className="border-t border-white/5">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-5 flex flex-col sm:flex-row items-center justify-between gap-3">
           <p className="text-xs text-white/25">
-            © {new Date().getFullYear()} SocialPro. Todos los derechos reservados.
+            © {new Date().getFullYear()} SocialPro. {copy.rights}
           </p>
           <div className="flex gap-5 text-xs text-white/25">
-            <Link href="/privacidad" className="hover:text-white/60 transition-colors">Privacidad</Link>
-            <Link href="/cookies" className="hover:text-white/60 transition-colors">Cookies</Link>
-            <Link href="/legal" className="hover:text-white/60 transition-colors">Aviso Legal</Link>
+            <Link href="/privacidad" className="hover:text-white/60 transition-colors">{copy.privacy}</Link>
+            <Link href="/cookies" className="hover:text-white/60 transition-colors">{copy.cookies}</Link>
+            <Link href="/legal" className="hover:text-white/60 transition-colors">{copy.legal}</Link>
           </div>
           <p className="text-xs text-white/20">
-            Gaming &amp; Esports · España · LatAm · Europa
+            {copy.tagline}
           </p>
         </div>
       </div>

--- a/src/components/layout/LangSwitch.tsx
+++ b/src/components/layout/LangSwitch.tsx
@@ -9,6 +9,18 @@ type Pair = { alt: string; targetLang: 'EN' | 'ES' };
 // Para betting el ES único es /servicios/igaming (decisión PR #51 del dev),
 // /influencers-betting redirige 301 y queda fuera del map.
 const PAIRS: Record<string, Pair> = {
+  // Marketing core (5 pares)
+  '/':          { alt: '/en',        targetLang: 'EN' },
+  '/en':        { alt: '/',          targetLang: 'ES' },
+  '/talentos':  { alt: '/talents',   targetLang: 'EN' },
+  '/talents':   { alt: '/talentos',  targetLang: 'ES' },
+  '/servicios': { alt: '/services',  targetLang: 'EN' },
+  '/services':  { alt: '/servicios', targetLang: 'ES' },
+  '/casos':     { alt: '/cases',     targetLang: 'EN' },
+  '/cases':     { alt: '/casos',     targetLang: 'ES' },
+  '/contacto':  { alt: '/contact',   targetLang: 'EN' },
+  '/contact':   { alt: '/contacto',  targetLang: 'ES' },
+  // Landings SEO existentes
   '/influencers-cs2':              { alt: '/cs2-influencer-marketing',     targetLang: 'EN' },
   '/agencia-influencers-valorant': { alt: '/valorant-influencers-agency',  targetLang: 'EN' },
   '/servicios/igaming':            { alt: '/betting-influencers',          targetLang: 'EN' },

--- a/src/components/layout/Nav.tsx
+++ b/src/components/layout/Nav.tsx
@@ -8,15 +8,36 @@ import * as m from 'motion/react-client';
 import { AnimatePresence, useMotionValue } from 'motion/react';
 
 import { LangSwitch, hasLangAlternate } from '@/components/layout/LangSwitch';
+import { localeFromPathname, type Locale } from '@/lib/locale';
 
-const NAV_LINKS = [
-  { href: '/talentos', label: 'Talentos' },
-  { href: '/servicios', label: 'Servicios' },
-  { href: '/casos', label: 'Casos de Éxito' },
-  { href: '/blog', label: 'Blog' },
-  { href: '/nosotros', label: 'Nosotros' },
-  { href: '/contacto', label: 'Contacto' },
-];
+const NAV_LINKS_BY_LOCALE: Record<Locale, readonly { href: string; label: string }[]> = {
+  es: [
+    { href: '/talentos', label: 'Talentos' },
+    { href: '/servicios', label: 'Servicios' },
+    { href: '/casos', label: 'Casos de Éxito' },
+    { href: '/blog', label: 'Blog' },
+    { href: '/nosotros', label: 'Nosotros' },
+    { href: '/contacto', label: 'Contacto' },
+  ],
+  en: [
+    { href: '/talents', label: 'Talent' },
+    { href: '/services', label: 'Services' },
+    { href: '/cases', label: 'Case Studies' },
+    { href: '/blog', label: 'Blog' },
+    { href: '/nosotros', label: 'About' },
+    { href: '/contact', label: 'Contact' },
+  ],
+};
+
+const CTA_BY_LOCALE: Record<Locale, string> = {
+  es: 'Trabajemos juntos',
+  en: 'Let’s work together',
+};
+
+const MENU_ARIA_BY_LOCALE: Record<Locale, string> = {
+  es: 'Abrir menú',
+  en: 'Open menu',
+};
 
 /**
  * Barra de navegación pública sticky con barra de progreso de scroll,
@@ -28,6 +49,12 @@ const NAV_LINKS = [
  */
 export function Nav() {
   const pathname = usePathname() ?? '/';
+  const locale = localeFromPathname(pathname);
+  const navLinks = NAV_LINKS_BY_LOCALE[locale];
+  const ctaLabel = CTA_BY_LOCALE[locale];
+  const menuAria = MENU_ARIA_BY_LOCALE[locale];
+  const homeHref = locale === 'en' ? '/en' : '/';
+  const contactHref = locale === 'en' ? '/contact' : '/contacto';
   const showLangToggle = hasLangAlternate(pathname);
 
   const [open, setOpen] = useState(false);
@@ -87,7 +114,7 @@ export function Nav() {
 
       <div className="max-w-7xl mx-auto px-6 lg:px-8 flex items-center justify-between h-16">
         {/* Logo: ícono + wordmark en JSX */}
-        <Link href="/" className="flex items-center gap-2.5 group">
+        <Link href={homeHref} className="flex items-center gap-2.5 group">
           <m.div
             whileHover={{ scale: 1.05 }}
             transition={{ type: 'spring', stiffness: 400, damping: 15 }}
@@ -113,23 +140,14 @@ export function Nav() {
 
         {/* Desktop links */}
         <ul className="hidden md:flex items-center gap-7">
-          {NAV_LINKS.map((l) => (
+          {navLinks.map((l) => (
             <li key={l.href}>
-              {l.href.startsWith('/') ? (
-                <Link
-                  href={l.href}
-                  className="text-xs font-semibold uppercase tracking-widest text-white/50 hover:text-white transition-colors duration-200"
-                >
-                  {l.label}
-                </Link>
-              ) : (
-                <a
-                  href={l.href}
-                  className="text-xs font-semibold uppercase tracking-widest text-white/50 hover:text-white transition-colors duration-200"
-                >
-                  {l.label}
-                </a>
-              )}
+              <Link
+                href={l.href}
+                className="text-xs font-semibold uppercase tracking-widest text-white/50 hover:text-white transition-colors duration-200"
+              >
+                {l.label}
+              </Link>
             </li>
           ))}
         </ul>
@@ -138,19 +156,19 @@ export function Nav() {
         <div className="hidden md:flex items-center gap-3">
           {showLangToggle && <LangSwitch />}
           <m.a
-            href="/contacto"
+            href={contactHref}
             whileHover={{ scale: 1.02 }}
             whileTap={{ scale: 0.98 }}
             className="inline-flex items-center gap-2 px-5 py-2 text-xs font-bold uppercase tracking-widest text-white bg-sp-grad"
           >
-            Trabajemos juntos
+            {ctaLabel}
           </m.a>
         </div>
 
         {/* Mobile burger */}
         <button
           className="md:hidden text-white/70 hover:text-white transition-colors p-2"
-          aria-label="Abrir menú"
+          aria-label={menuAria}
           onClick={() => setOpen((v) => !v)}
         >
           <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
@@ -173,55 +191,41 @@ export function Nav() {
             transition={{ duration: 0.18, ease: 'easeOut' }}
             className="md:hidden bg-sp-black border-t border-white/10 px-6 py-5 flex flex-col gap-5"
           >
-            {NAV_LINKS.map((l, i) =>
-              l.href.startsWith('/') ? (
-                <m.div
-                  key={l.href}
-                  initial={{ opacity: 0, x: -8 }}
-                  animate={{ opacity: 1, x: 0 }}
-                  transition={{ duration: 0.15, ease: 'easeOut', delay: i * 0.04 }}
-                >
-                  <Link
-                    href={l.href}
-                    className="text-xs font-semibold uppercase tracking-widest text-white/50 hover:text-white transition-colors block"
-                    onClick={() => setOpen(false)}
-                  >
-                    {l.label}
-                  </Link>
-                </m.div>
-              ) : (
-                <m.a
-                  key={l.href}
+            {navLinks.map((l, i) => (
+              <m.div
+                key={l.href}
+                initial={{ opacity: 0, x: -8 }}
+                animate={{ opacity: 1, x: 0 }}
+                transition={{ duration: 0.15, ease: 'easeOut', delay: i * 0.04 }}
+              >
+                <Link
                   href={l.href}
-                  initial={{ opacity: 0, x: -8 }}
-                  animate={{ opacity: 1, x: 0 }}
-                  transition={{ duration: 0.15, ease: 'easeOut', delay: i * 0.04 }}
-                  className="text-xs font-semibold uppercase tracking-widest text-white/50 hover:text-white transition-colors"
+                  className="text-xs font-semibold uppercase tracking-widest text-white/50 hover:text-white transition-colors block"
                   onClick={() => setOpen(false)}
                 >
                   {l.label}
-                </m.a>
-              )
-            )}
+                </Link>
+              </m.div>
+            ))}
             {showLangToggle && (
               <m.div
                 initial={{ opacity: 0, x: -8 }}
                 animate={{ opacity: 1, x: 0 }}
-                transition={{ duration: 0.15, ease: 'easeOut', delay: NAV_LINKS.length * 0.04 }}
+                transition={{ duration: 0.15, ease: 'easeOut', delay: navLinks.length * 0.04 }}
                 className="self-start"
               >
                 <LangSwitch onNavigate={() => setOpen(false)} />
               </m.div>
             )}
             <m.a
-              href="/contacto"
+              href={contactHref}
               initial={{ opacity: 0, x: -8 }}
               animate={{ opacity: 1, x: 0 }}
-              transition={{ duration: 0.15, ease: 'easeOut', delay: (NAV_LINKS.length + (showLangToggle ? 1 : 0)) * 0.04 }}
+              transition={{ duration: 0.15, ease: 'easeOut', delay: (navLinks.length + (showLangToggle ? 1 : 0)) * 0.04 }}
               className="text-xs font-bold uppercase tracking-widest text-white text-center py-3 bg-sp-grad"
               onClick={() => setOpen(false)}
             >
-              Trabajemos juntos
+              {ctaLabel}
             </m.a>
           </m.div>
         )}

--- a/src/features/contact/components/ContactFormEn.tsx
+++ b/src/features/contact/components/ContactFormEn.tsx
@@ -1,0 +1,173 @@
+'use client';
+
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+
+import { trpc } from '@/lib/trpc/client';
+import {
+  contactSchema,
+  inputClasses,
+  selectClasses,
+  labelClasses,
+  type ContactForm,
+} from './ContactSection.parts';
+
+const TYPES_EN = [
+  { value: 'brand',  label: 'I’m a brand / advertiser' },
+  { value: 'talent', label: 'I’m a content creator' },
+  { value: 'other',  label: 'Other / general enquiry' },
+] as const;
+
+const INFO_CARDS = [
+  {
+    title: 'Reply within 24 hours',
+    desc: 'No bots, no auto-responders. A real person reads every enquiry and follows up the same business day.',
+  },
+  {
+    title: 'No commitment',
+    desc: 'Tell us your goals and budget. We send a tailored proposal — no minimums, no hidden fees, no pressure.',
+  },
+  {
+    title: 'Performance-tracked',
+    desc: 'Every campaign ships with FTD tracking, raw-data reporting and verified reach. ROI you can audit.',
+  },
+];
+
+/**
+ * Contact form en inglés. Reusa el mismo schema Zod y endpoint tRPC
+ * `contact.submit` que la versión española.
+ *
+ * @kind client
+ * @feature contact
+ * @route /contact
+ */
+export function ContactFormEn(): React.JSX.Element {
+  const [status, setStatus] = useState<'idle' | 'sending' | 'ok' | 'error'>('idle');
+  const submitMutation = trpc.contact.submit.useMutation();
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<ContactForm>({ resolver: zodResolver(contactSchema) });
+
+  const onSubmit = async (data: ContactForm) => {
+    setStatus('sending');
+    try {
+      await submitMutation.mutateAsync(data);
+      setStatus('ok');
+      reset();
+    } catch {
+      setStatus('error');
+    }
+  };
+
+  return (
+    <section className="py-20 bg-sp-black text-white">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 md:gap-10 items-start">
+          {/* Info cards */}
+          <div className="space-y-4">
+            {INFO_CARDS.map(({ title, desc }) => (
+              <div key={title} className="rounded-2xl border border-white/10 p-6">
+                <h3 className="font-display text-lg font-black uppercase mb-2">{title}</h3>
+                <p className="text-sm text-white/60 leading-relaxed">{desc}</p>
+              </div>
+            ))}
+            <div className="rounded-2xl border border-white/10 p-6">
+              <h3 className="font-display text-lg font-black uppercase mb-2">Other channels</h3>
+              <ul className="space-y-2 text-sm text-white/60">
+                <li>Email: <a href="mailto:marketing@socialpro.es" className="text-sp-orange hover:underline">marketing@socialpro.es</a></li>
+                <li>WhatsApp: <a href="https://wa.me/34604868426" target="_blank" rel="noopener noreferrer" className="text-sp-orange hover:underline">+34 604 868 426</a></li>
+              </ul>
+            </div>
+          </div>
+
+          {/* Form */}
+          <div>
+            {status === 'ok' ? (
+              <div className="rounded-2xl border border-white/10 p-8 text-center">
+                <h3 className="font-display text-2xl font-black uppercase mb-3">Thanks — message received</h3>
+                <p className="text-white/60 leading-relaxed">
+                  We’ll get back to you within 24 hours with next steps. In the meantime, you can email us directly at{' '}
+                  <a href="mailto:marketing@socialpro.es" className="text-sp-orange hover:underline">marketing@socialpro.es</a>.
+                </p>
+              </div>
+            ) : (
+              <form onSubmit={(e) => { void handleSubmit(onSubmit)(e); }} className="space-y-5">
+                <div className="grid sm:grid-cols-2 gap-4">
+                  <div>
+                    <label className={labelClasses}>Name *</label>
+                    <input
+                      {...register('name')}
+                      placeholder="Your name"
+                      className={inputClasses}
+                    />
+                    {errors.name && <p className="text-xs text-red-400 mt-1">{errors.name.message}</p>}
+                  </div>
+                  <div>
+                    <label className={labelClasses}>Email *</label>
+                    <input
+                      {...register('email')}
+                      type="email"
+                      placeholder="you@email.com"
+                      className={inputClasses}
+                    />
+                    {errors.email && <p className="text-xs text-red-400 mt-1">{errors.email.message}</p>}
+                  </div>
+                </div>
+
+                <div>
+                  <label className={labelClasses}>I am… *</label>
+                  <select {...register('type')} className={selectClasses}>
+                    <option value="" className="bg-sp-black">Select...</option>
+                    {TYPES_EN.map((t) => (
+                      <option key={t.value} value={t.value} className="bg-sp-black">
+                        {t.label}
+                      </option>
+                    ))}
+                  </select>
+                  {errors.type && <p className="text-xs text-red-400 mt-1">{errors.type.message}</p>}
+                </div>
+
+                <div>
+                  <label className={labelClasses}>Company / Channel</label>
+                  <input
+                    {...register('company')}
+                    placeholder="Your company or channel"
+                    className={inputClasses}
+                  />
+                </div>
+
+                <div>
+                  <label className={labelClasses}>Message *</label>
+                  <textarea
+                    {...register('message')}
+                    rows={5}
+                    placeholder="Tell us what you have in mind..."
+                    className={`${inputClasses} resize-none`}
+                  />
+                  {errors.message && <p className="text-xs text-red-400 mt-1">{errors.message.message}</p>}
+                </div>
+
+                {status === 'error' && (
+                  <p className="text-sm text-red-400 text-center">Something went wrong. Please try again.</p>
+                )}
+
+                <button
+                  type="submit"
+                  disabled={status === 'sending'}
+                  className="w-full py-3.5 rounded-full font-bold text-white text-sm disabled:opacity-60 focus:outline-none transition-transform hover:scale-[1.02] active:scale-[0.98] bg-sp-grad"
+                >
+                  {status === 'sending' ? 'Sending...' : 'Send message →'}
+                </button>
+              </form>
+            )}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/lib/locale.ts
+++ b/src/lib/locale.ts
@@ -1,0 +1,27 @@
+/**
+ * Detección de idioma por pathname para el chrome (Footer/Nav) y el LangSwitch.
+ *
+ * Las páginas EN de la web se enumeran aquí. Cualquier ruta no listada se
+ * considera ES (incluida la home `/`, blog, slugs dinámicos, etc.).
+ */
+
+export type Locale = 'en' | 'es';
+
+export const EN_PATHS: ReadonlySet<string> = new Set([
+  // Páginas de marketing core
+  '/en',
+  '/services',
+  '/talents',
+  '/cases',
+  '/contact',
+  // Landings SEO con par EN
+  '/cs2-influencer-marketing',
+  '/valorant-influencers-agency',
+  '/betting-influencers',
+  '/esports-marketing-agency',
+  '/twitch-streamers-agency',
+]);
+
+export function localeFromPathname(pathname: string): Locale {
+  return EN_PATHS.has(pathname) ? 'en' : 'es';
+}


### PR DESCRIPTION
## Summary
**Stacked on top of #54** (`seo/lang-toggle-chrome`). Adds 5 self-contained EN pages and turns Footer/Nav into pathname-driven i18n so el toggle EN del Nav lleva a una versión inglesa real del sitio para las páginas comerciales clave.

> **Base branch:** `seo/lang-toggle-chrome` (PR #54). Cuando #54 se mergee a `master`, GitHub re-targeta automáticamente este PR a `master`.

## Archivos tocados (16)

**Nuevos (7):**
- `src/lib/locale.ts` — `localeFromPathname()` + `EN_PATHS` Set como única fuente de verdad para detección de locale.
- `src/app/en/page.tsx` — home EN (hero, top talents, services preview, top cases, FAQ, CTA).
- `src/app/talents/page.tsx` — roster completo con chrome EN.
- `src/app/services/page.tsx` — services + process + FAQ.
- `src/app/cases/page.tsx` — grid de case studies.
- `src/app/contact/page.tsx` — wrapper server con metadata.
- `src/features/contact/components/ContactFormEn.tsx` — form EN cliente, reusa `contactSchema` + endpoint tRPC `contact.submit`.

**Modificados (9):**
- `src/components/layout/Footer.tsx` — convertido a client, i18n por pathname. **Columna Especialidades del PR #51 preservada idéntica en ambos locales** (incluido el link `iGaming & Betting → /servicios/igaming`).
- `src/components/layout/Nav.tsx` — `NAV_LINKS_BY_LOCALE`, CTA y aria-label localizados. Logo y CTA de contacto apuntan a `/en` o `/contact` cuando `locale === 'en'`.
- `src/components/layout/LangSwitch.tsx` — `PAIRS` extendido con 5 pares core nuevos (`/`↔`/en`, `/talentos`↔`/talents`, etc.).
- `src/app/sitemap.ts` — 5 nuevos `corePairs` bilingual con `alternates.languages` y `x-default` → EN. **El bloque `bilingualLandings` del PR #51 queda intacto** (incluyendo `/betting-influencers` con `es: /servicios/igaming` y la omisión de `/influencers-betting`).
- 5 landings EN existentes (`cs2-influencer-marketing`, `valorant-influencers-agency`, `betting-influencers`, `esports-marketing-agency`, `twitch-streamers-agency`) — internal links actualizados: `/contacto → /contact`, `/talentos → /talents` (solo twitch).

## Resumen de cambios

### Comportamiento del LangSwitch (extendido)

| Origen | Destino |
|---|---|
| `/` ↔ `/en` | par directo |
| `/talentos` ↔ `/talents` | par directo |
| `/servicios` ↔ `/services` | par directo |
| `/casos` ↔ `/cases` | par directo |
| `/contacto` ↔ `/contact` | par directo |
| `/cs2-influencer-marketing` ↔ `/influencers-cs2` | par directo |
| `/valorant-influencers-agency` ↔ `/agencia-influencers-valorant` | par directo |
| `/esports-marketing-agency` ↔ `/agencia-marketing-esports` | par directo |
| `/servicios/igaming` ↔ `/betting-influencers` | par directo (hub PR #51) |
| `/blog`, `/nosotros`, `/metodologia`, slugs… | toggle oculto, sin fallback |

### Sitemap

Añade 5 entries bilingual nuevas con `alternates.languages` (ES + EN + x-default → EN) para home, talentos, servicios, casos y contacto. **No toca el bloque `bilingualLandings` del PR #51**.

### Footer

Cliente, lee pathname, traduce labels a inglés. Páginas sin versión EN se marcan con sufijo `(ES)` en su label (`About (ES)`, `Methodology (ES)`, `Blog (ES)`, etc.) para honestidad UX. **La columna Especialidades del PR #51 queda preservada idéntica** en ambos locales.

### Rutas existentes — qué se toca y qué no

| Recurso | ¿Tocado? |
|---|---|
| `src/app/sitemap.ts` | **Sí** — añade 10 entries nuevas (5 pares bilingual). Bloque del PR #51 intacto. |
| `src/components/layout/Footer.tsx` | **Sí** — convertido a client, i18n. Especialidades #51 preservada. |
| `src/components/layout/Nav.tsx` | **Sí** — i18n por pathname. |
| `src/components/layout/LangSwitch.tsx` | **Sí** — `PAIRS` extendido. |
| 5 landings EN existentes | **Sí** — solo internal links (`/contacto → /contact`, `/talentos → /talents`). Sin tocar copy ni schemas. |
| `next.config.ts` | **NO** — redirects #51 intactos. |
| `src/app/servicios/igaming/page.tsx` | **NO** — contenido del PR #51 intacto. |
| `src/app/layout.tsx` | **NO**. |
| Páginas dinámicas (`/casos/[slug]`, `/talentos/[slug]`, `/blog/*`) | **NO** — siguen ES. |
| `/nosotros`, `/metodologia`, `/para-creadores`, `/giveaways`, `/sorteos` | **NO** — siguen ES. |

## Cómo probarlo

```bash
git fetch origin
git checkout seo/en-pages
npm run dev
```

1. `/` → toggle "EN" → `/en` (home en inglés con hero, stats, top 8 talents, services preview, top 3 cases, FAQ, CTA).
2. En `/en` → click "Talent" en Nav → `/talents` (roster completo, chrome EN).
3. `/services` → CTA "Request a proposal" → `/contact` (form EN reusando schema/tRPC).
4. `/cases` → click un caso → va a `/casos/[slug]` (ES; contenido dinámico de DB no traducido por scope).
5. Footer en `/en`: stats `Years of experience / Monthly views / Active markets`. Columnas `Agency / Creators / Brands / Specialties`. Links a páginas ES marcados con `(ES)`.
6. `/blog`, `/nosotros`, `/metodologia` → siguen ES, **toggle no aparece**.
7. `/servicios/igaming` → toggle EN → `/betting-influencers` (hub #51 respetado).
8. `/betting-influencers` → toggle ES → `/servicios/igaming` (no a `/influencers-betting` que es 301).
9. Mobile menu en `/en`: nav links en inglés, toggle ES al final.

## tsc / lint / rutas
- `npx tsc --noEmit` → ✅
- `npm run lint` → ✅ 0 errors (61 warnings preexistentes)
- 5 rutas EN nuevas verificadas con `curl` → 200
- `/sitemap.xml` → 200

## Dependencia
- **Stacked sobre #54.** No mergear este PR antes de #54.
- Si #54 se mergea primero, GitHub auto-rebases este PR sobre `master`.

## Out of scope
- Slugs dinámicos (`/casos/[slug]`, `/talentos/[slug]`, `/blog/*`) — el contenido vive en DB y requeriría columnas i18n.
- Páginas `/nosotros`, `/metodologia`, `/para-creadores`, `/giveaways`, `/sorteos` — el alcance D acordó dejarlas sólo en ES.
- `next.config.ts` y contenido de `/servicios/igaming` — no se tocan; el PR #51 es la fuente de verdad para ambos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)