### PR TITLE
feat(analytics): GTM events — form_submit + cta_click on key buttons

### DIFF
--- a/src/app/betting-influencers/page.tsx
+++ b/src/app/betting-influencers/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { SITE_URL, absoluteUrl } from '@/lib/site-url';
+import { TrackedCtaLink } from '@/components/ui/TrackedCtaLink';
 
 export const metadata: Metadata = {
   title: 'Betting Influencers Agency — Sports Betting & Casino Streamers',
@@ -90,9 +91,9 @@ export default function BettingInfluencersPage() {
               </div>
             ))}
           </div>
-          <Link href="/contacto" className="inline-block bg-sp-grad text-white font-display font-bold uppercase tracking-wider text-sm px-8 py-3 rounded-full hover:opacity-90 transition-opacity">
+          <TrackedCtaLink href="/contacto" ctaId="landing_betting_en_hero" className="inline-block bg-sp-grad text-white font-display font-bold uppercase tracking-wider text-sm px-8 py-3 rounded-full hover:opacity-90 transition-opacity">
             Activate betting campaign
-          </Link>
+          </TrackedCtaLink>
         </div>
       </section>
 

--- a/src/app/cs2-influencer-marketing/page.tsx
+++ b/src/app/cs2-influencer-marketing/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { SITE_URL, absoluteUrl } from '@/lib/site-url';
+import { TrackedCtaLink } from '@/components/ui/TrackedCtaLink';
 
 export const metadata: Metadata = {
   title: 'CS2 Influencer Marketing Agency — Spain & LatAm',
@@ -92,9 +93,9 @@ export default function Cs2InfluencerMarketingPage() {
               </div>
             ))}
           </div>
-          <Link href="/contacto" className="inline-block bg-sp-grad text-white font-display font-bold uppercase tracking-wider text-sm px-8 py-3 rounded-full hover:opacity-90 transition-opacity">
+          <TrackedCtaLink href="/contacto" ctaId="landing_cs2_en_hero" className="inline-block bg-sp-grad text-white font-display font-bold uppercase tracking-wider text-sm px-8 py-3 rounded-full hover:opacity-90 transition-opacity">
             Launch your CS2 campaign
-          </Link>
+          </TrackedCtaLink>
         </div>
       </section>
 

--- a/src/app/esports-marketing-agency/page.tsx
+++ b/src/app/esports-marketing-agency/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { SITE_URL, absoluteUrl } from '@/lib/site-url';
+import { TrackedCtaLink } from '@/components/ui/TrackedCtaLink';
 
 export const metadata: Metadata = {
   title: 'Esports Marketing Agency — Spain & LatAm Performance Marketing',
@@ -92,9 +93,9 @@ export default function EsportsMarketingAgencyPage() {
               </div>
             ))}
           </div>
-          <Link href="/contacto" className="inline-block bg-sp-grad text-white font-display font-bold uppercase tracking-wider text-sm px-8 py-3 rounded-full hover:opacity-90 transition-opacity">
+          <TrackedCtaLink href="/contacto" ctaId="landing_esports_en_hero" className="inline-block bg-sp-grad text-white font-display font-bold uppercase tracking-wider text-sm px-8 py-3 rounded-full hover:opacity-90 transition-opacity">
             Work with us
-          </Link>
+          </TrackedCtaLink>
         </div>
       </section>
 

--- a/src/app/valorant-influencers-agency/page.tsx
+++ b/src/app/valorant-influencers-agency/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { SITE_URL, absoluteUrl } from '@/lib/site-url';
+import { TrackedCtaLink } from '@/components/ui/TrackedCtaLink';
 
 export const metadata: Metadata = {
   title: 'Valorant Influencers Agency — Spain & LatAm',
@@ -89,9 +90,9 @@ export default function ValorantInfluencersAgencyPage() {
               </div>
             ))}
           </div>
-          <Link href="/contacto" className="inline-block bg-sp-grad text-white font-display font-bold uppercase tracking-wider text-sm px-8 py-3 rounded-full hover:opacity-90 transition-opacity">
+          <TrackedCtaLink href="/contacto" ctaId="landing_valorant_en_hero" className="inline-block bg-sp-grad text-white font-display font-bold uppercase tracking-wider text-sm px-8 py-3 rounded-full hover:opacity-90 transition-opacity">
             Work with Valorant streamers
-          </Link>
+          </TrackedCtaLink>
         </div>
       </section>
 

--- a/src/components/layout/Nav.tsx
+++ b/src/components/layout/Nav.tsx
@@ -6,6 +6,8 @@ import Image from 'next/image';
 import * as m from 'motion/react-client';
 import { AnimatePresence, useMotionValue } from 'motion/react';
 
+import { trackEvent } from '@/lib/analytics';
+
 const NAV_LINKS = [
   { href: '/talentos', label: 'Talentos' },
   { href: '/servicios', label: 'Servicios' },
@@ -131,6 +133,7 @@ export function Nav() {
         {/* CTA */}
         <m.a
           href="/contacto"
+          onClick={() => trackEvent('cta_click', { cta_id: 'nav_header', cta_destination: '/contacto' })}
           whileHover={{ scale: 1.02 }}
           whileTap={{ scale: 0.98 }}
           className="hidden md:inline-flex items-center gap-2 px-5 py-2 text-xs font-bold uppercase tracking-widest text-white bg-sp-grad"
@@ -200,7 +203,10 @@ export function Nav() {
               animate={{ opacity: 1, x: 0 }}
               transition={{ duration: 0.15, ease: 'easeOut', delay: NAV_LINKS.length * 0.04 }}
               className="text-xs font-bold uppercase tracking-widest text-white text-center py-3 bg-sp-grad"
-              onClick={() => setOpen(false)}
+              onClick={() => {
+                trackEvent('cta_click', { cta_id: 'nav_mobile', cta_destination: '/contacto' });
+                setOpen(false);
+              }}
             >
               Trabajemos juntos
             </m.a>

--- a/src/components/ui/TrackedCtaLink.tsx
+++ b/src/components/ui/TrackedCtaLink.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import Link from 'next/link';
+import type { ReactNode } from 'react';
+import { trackEvent } from '@/lib/analytics';
+
+type Props = {
+  readonly href: string;
+  readonly ctaId: string;
+  readonly className?: string;
+  readonly children: ReactNode;
+};
+
+/**
+ * `<Link>` con tracking de `cta_click` automático en click.
+ * Útil para Server Components que no pueden usar `onClick` directo.
+ *
+ * @kind client
+ * @feature ui
+ */
+export function TrackedCtaLink({ href, ctaId, className, children }: Props): React.JSX.Element {
+  return (
+    <Link
+      href={href}
+      onClick={() => trackEvent('cta_click', { cta_id: ctaId, cta_destination: href })}
+      {...(className ? { className } : {})}
+    >
+      {children}
+    </Link>
+  );
+}

--- a/src/features/contact/components/ContactSection.tsx
+++ b/src/features/contact/components/ContactSection.tsx
@@ -11,6 +11,7 @@ import { SectionHeading } from '@/components/ui/SectionHeading';
 import { GradientText } from '@/components/ui/GradientText';
 import { FadeInOnScroll } from '@/components/ui/FadeInOnScroll';
 import { trpc } from '@/lib/trpc/client';
+import { trackEvent } from '@/lib/analytics';
 import {
   contactSchema,
   TYPES,
@@ -55,6 +56,7 @@ export function ContactSection(): React.JSX.Element {
     setStatus('sending');
     try {
       await submitMutation.mutateAsync(data);
+      trackEvent('form_submit', { form_id: 'contact', visitor_type: data.type });
       setStatus('ok');
       reset();
     } catch {

--- a/src/features/marketing-site/components/CtaSection.tsx
+++ b/src/features/marketing-site/components/CtaSection.tsx
@@ -6,6 +6,7 @@ import { useReducedMotion } from 'motion/react';
 import { GradientText } from '@/components/ui/GradientText';
 import { useVisibilityFailSafe } from '@/lib/utils/use-visibility-failsafe';
 import { DURATION, EASE, fadeUp, staggerContainer } from '@/lib/utils/animation';
+import { trackEvent } from '@/lib/analytics';
 
 /**
  * Final CTA. Animations are wired through controlled `animate=` (not
@@ -53,6 +54,7 @@ export function CtaSection(): React.JSX.Element {
         </m.p>
         <m.a
           href="/contacto"
+          onClick={() => trackEvent('cta_click', { cta_id: 'home_cta_section', cta_destination: '/contacto' })}
           variants={fadeUp}
           transition={{ duration: DURATION.slow, ease: EASE.out }}
           whileHover={{ scale: 1.05 }}

--- a/src/features/marketing-site/components/Hero.tsx
+++ b/src/features/marketing-site/components/Hero.tsx
@@ -5,6 +5,8 @@ import * as m from 'motion/react-client';
 import { useMotionValue, useSpring, useTransform, useReducedMotion } from 'motion/react';
 import Image from 'next/image';
 
+import { trackEvent } from '@/lib/analytics';
+
 const HERO_STATS = [
   { value: '13+', label: 'AÑOS' },
   { value: '15M', label: 'VIEWS/MES' },
@@ -145,6 +147,7 @@ export function Hero() {
           >
             <m.a
               href="/contacto"
+              onClick={() => trackEvent('cta_click', { cta_id: 'hero_home_primary', cta_destination: '/contacto' })}
               whileHover={{ scale: 1.05, boxShadow: '0 0 30px rgba(224,48,112,0.3)' }}
               whileTap={{ scale: 0.95 }}
               className="px-10 py-4 rounded-full font-bold text-white text-sm tracking-widest uppercase transition-shadow bg-sp-grad"

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,32 @@
+/**
+ * Cliente para enviar eventos a Google Tag Manager.
+ *
+ * GTM se monta desde `<CookieConsent>` solo si el usuario ha aceptado y
+ * `NEXT_PUBLIC_GTM_ID` está configurado. Si GTM no está cargado (consent
+ * pendiente, rechazado o env var ausente), `trackEvent` es un no-op
+ * seguro — no se acumulan eventos en cola ni se rompe nada.
+ *
+ * Los eventos van a `window.dataLayer`. En GTM hay que crear los triggers
+ * y mapearlos a tags GA4 con los nombres definidos abajo.
+ */
+
+type DataLayerEvent = { event: string } & Record<string, unknown>;
+
+declare global {
+  interface Window {
+    dataLayer?: DataLayerEvent[];
+  }
+}
+
+/**
+ * Empuja un evento al dataLayer de GTM. Seguro de llamar en cualquier
+ * contexto: si GTM no está cargado retorna sin hacer nada.
+ */
+export function trackEvent(
+  name: string,
+  payload: Readonly<Record<string, unknown>> = {},
+): void {
+  if (typeof window === 'undefined') return;
+  if (!Array.isArray(window.dataLayer)) return;
+  window.dataLayer.push({ event: name, ...payload });
+}


### PR DESCRIPTION
## Summary
Setup mínimo de medición. Empuja eventos a `window.dataLayer` (GTM). No-op seguro si GTM no está cargado (consent pendiente, `NEXT_PUBLIC_GTM_ID` no configurado, etc.).

**Independiente** de #53, #54, #55. No toca lógica crítica, no toca BD, no toca rutas, no toca SEO.

## Archivos tocados (10)

**Nuevos (2):**
- `src/lib/analytics.ts` — helper `trackEvent(name, payload)` que pushea a `window.dataLayer`. Type-safe, no-op si GTM no está montado.
- `src/components/ui/TrackedCtaLink.tsx` — wrapper cliente de `<Link>` con `cta_click` automático en click. Necesario para CTAs en Server Components.

**Modificados (8):**
- `src/features/contact/components/ContactSection.tsx` — emite `form_submit` tras éxito de la mutación tRPC.
- `src/features/marketing-site/components/Hero.tsx` — `cta_click` en CTA "Iniciar Propuesta".
- `src/features/marketing-site/components/CtaSection.tsx` — `cta_click` en CTA final.
- `src/components/layout/Nav.tsx` — `cta_click` en "Trabajemos juntos" (desktop + mobile).
- `src/app/cs2-influencer-marketing/page.tsx` — Hero CTA con `<TrackedCtaLink>`.
- `src/app/valorant-influencers-agency/page.tsx` — Hero CTA con `<TrackedCtaLink>`.
- `src/app/betting-influencers/page.tsx` — Hero CTA con `<TrackedCtaLink>`.
- `src/app/esports-marketing-agency/page.tsx` — Hero CTA con `<TrackedCtaLink>`.

## Eventos emitidos

### `form_submit`
Disparado en `ContactSection` tras `submitMutation.mutateAsync` OK.
```js
{ event: 'form_submit', form_id: 'contact', visitor_type: 'brand' | 'creator' | 'other' }
```

### `cta_click`
Disparado en cada CTA principal al hacer click.
```js
{ event: 'cta_click', cta_id: '<cta_id>', cta_destination: '/contacto' }
```

| `cta_id` | Origen |
|---|---|
| `hero_home_primary` | Hero home — \"Iniciar Propuesta\" |
| `home_cta_section` | CtaSection home — \"Iniciar Propuesta →\" |
| `nav_header` | Nav desktop — \"Trabajemos juntos\" |
| `nav_mobile` | Nav mobile menu — \"Trabajemos juntos\" |
| `landing_cs2_en_hero` | Landing CS2 EN — \"Launch your CS2 campaign\" |
| `landing_valorant_en_hero` | Landing Valorant EN — \"Work with Valorant streamers\" |
| `landing_betting_en_hero` | Landing Betting EN — \"Activate betting campaign\" |
| `landing_esports_en_hero` | Landing Esports EN — \"Work with us\" |

## Activación (fuera del código)

Para que los eventos lleguen a GA4 hay que:

1. **Verificar `NEXT_PUBLIC_GTM_ID` en Vercel** → Settings → Environment Variables. Formato: `GTM-XXXXXX`.
2. **En Google Tag Manager UI**:
   - Crear GA4 Configuration tag con tu Measurement ID
   - Triggers \"Custom Event\" con event name `form_submit` y `cta_click`
   - GA4 Event tags conectados a esos triggers
3. **Aceptar cookies** en el banner de consent al probar (sin consent, GTM no carga).

Si `NEXT_PUBLIC_GTM_ID` no está configurado, el código compila y funciona sin errores — `trackEvent` es no-op.

## Out of scope (follow-ups si se quieren)
- `lang_switch` event en el toggle EN/ES.
- Tracking en `ContactFormEn` (vive en PR #55, no en master aún).
- CTAs hero de las **landings ES** (4 archivos: `influencers-cs2`, `agencia-influencers-valorant`, `influencers-betting`, `agencia-marketing-esports`). Mismo patrón con `<TrackedCtaLink>`.
- CTAs secundarios (\"Ver casos\", \"View case studies\", etc.).

## tsc / lint
- `npx tsc --noEmit` ✅
- `npm run lint` ✅ 0 errors (61 warnings preexistentes)

## Cómo probarlo

```bash
git fetch origin
git checkout analytics/gtm-events-min
NEXT_PUBLIC_GTM_ID=GTM-XXXXXX npm run dev
```

1. Abre el navegador en `localhost:3000` → acepta cookies en el banner.
2. Abre DevTools → Console → escribe `dataLayer` y enter. Debe ser un array.
3. Click en \"Trabajemos juntos\" en el Nav → en DevTools verás un nuevo objeto en `dataLayer` con `event: 'cta_click', cta_id: 'nav_header'`.
4. Llena el form de `/contacto` y envía → `dataLayer` recibe `event: 'form_submit', form_id: 'contact', visitor_type: 'brand'`.
5. Sin cookies aceptadas: `dataLayer` no existe — `trackEvent` es no-op silencioso, sin errores.

## Independencia
- No depende de #53 (CRM)
- No depende de #54 (lang toggle)
- No depende de #55 (EN pages)
- Mergeable directo a `master`

🤖 Generated with [Claude Code](https://claude.com/claude-code)