### PR TITLE
feat(cro): copy + cta_click tracking on 4 ES landings

### DIFF
--- a/src/app/agencia-influencers-valorant/page.tsx
+++ b/src/app/agencia-influencers-valorant/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { SITE_URL, absoluteUrl } from '@/lib/site-url';
+import { TrackedCtaLink } from '@/components/ui/TrackedCtaLink';
 
 export const metadata: Metadata = {
   title: 'Agencia de Influencers Valorant — España y LatAm',
@@ -75,11 +76,12 @@ export default function AgenciaInfluencersValorantPage() {
         <div className="max-w-4xl mx-auto px-6 text-center">
           <p className="text-sp-orange text-xs font-bold uppercase tracking-[0.2em] mb-4">Agencia de Influencers Valorant</p>
           <h1 className="font-display text-4xl md:text-6xl font-black uppercase tracking-tight text-white leading-tight mb-6">
-            Agencia de Influencers Valorant<br /><span style={g}>en España y LatAm</span>
+            Agencia de Influencers Valorant —<br /><span style={g}>Brand-Safe por Diseño</span>
           </h1>
           <p className="text-lg text-white/60 leading-relaxed max-w-2xl mx-auto mb-10">
-            Streamers de Valorant verificados con audiencias reales en el mercado hispano.
-            Brand-safe, orientado a resultados y activación en menos de 72 horas.
+            Riot impone estándares de contenido en su ecosistema. Nosotros añadimos vetting de creadores,
+            revisión de contenido y verificación de audiencia. Llega a audiencias gaming 18-30 sin
+            riesgos de brand safety.
           </p>
           <div className="flex flex-wrap justify-center gap-8 mb-10">
             {STATS.map(({ stat, label }) => (
@@ -89,9 +91,9 @@ export default function AgenciaInfluencersValorantPage() {
               </div>
             ))}
           </div>
-          <Link href="/contacto" className="inline-block bg-sp-grad text-white font-display font-bold uppercase tracking-wider text-sm px-8 py-3 rounded-full hover:opacity-90 transition-opacity">
-            Activar campaña Valorant
-          </Link>
+          <TrackedCtaLink href="/contacto" ctaId="landing_valorant_es_hero" className="inline-block bg-sp-grad text-white font-display font-bold uppercase tracking-wider text-sm px-8 py-3 rounded-full hover:opacity-90 transition-opacity">
+            Valida tu campaña con influencers de Valorant
+          </TrackedCtaLink>
         </div>
       </section>
 

--- a/src/app/agencia-marketing-esports/page.tsx
+++ b/src/app/agencia-marketing-esports/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { SITE_URL, absoluteUrl } from '@/lib/site-url';
+import { TrackedCtaLink } from '@/components/ui/TrackedCtaLink';
 
 export const metadata: Metadata = {
   title: 'Agencia de Marketing Esports — España y LatAm',
@@ -84,11 +85,12 @@ export default function AgenciaMarketingEsportsPage() {
         <div className="max-w-4xl mx-auto px-6 text-center">
           <p className="text-sp-orange text-xs font-bold uppercase tracking-[0.2em] mb-4">Agencia de Marketing Esports</p>
           <h1 className="font-display text-4xl md:text-6xl font-black uppercase tracking-tight text-white leading-tight mb-6">
-            Agencia de Marketing Esports<br /><span style={g}>con 13 Años de Resultados</span>
+            Agencia de Marketing Esports —<br /><span style={g}>Nativos del Gaming. Enfocados en Performance.</span>
           </h1>
           <p className="text-lg text-white/60 leading-relaxed max-w-2xl mx-auto mb-10">
-            Agencia de marketing esports en España y LatAm desde 2012. Campañas con influencers,
-            activaciones en torneos y gestión de talentos. Todo orientado a performance.
+            No somos una agencia generalista que añadió «esports» al portfolio. Construida exclusivamente
+            en gaming, esports e iGaming. Conocemos los creadores, las audiencias y los matices regulatorios.
+            Cada activación medible, cada métrica auditable.
           </p>
           <div className="flex flex-wrap justify-center gap-8 mb-10">
             {STATS.map(({ stat, label }) => (
@@ -98,9 +100,9 @@ export default function AgenciaMarketingEsportsPage() {
               </div>
             ))}
           </div>
-          <Link href="/contacto" className="inline-block bg-sp-grad text-white font-display font-bold uppercase tracking-wider text-sm px-8 py-3 rounded-full hover:opacity-90 transition-opacity">
-            Trabajar con nosotros
-          </Link>
+          <TrackedCtaLink href="/contacto" ctaId="landing_esports_es_hero" className="inline-block bg-sp-grad text-white font-display font-bold uppercase tracking-wider text-sm px-8 py-3 rounded-full hover:opacity-90 transition-opacity">
+            Diseñamos tu campaña en esports
+          </TrackedCtaLink>
         </div>
       </section>
 

--- a/src/app/influencers-cs2/page.tsx
+++ b/src/app/influencers-cs2/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { SITE_URL, absoluteUrl } from '@/lib/site-url';
+import { TrackedCtaLink } from '@/components/ui/TrackedCtaLink';
 
 export const metadata: Metadata = {
   title: 'Influencers CS2 España y LatAm — Marketing con Streamers CS2',
@@ -76,11 +77,11 @@ export default function InfluencersCs2Page() {
         <div className="max-w-4xl mx-auto px-6 text-center">
           <p className="text-sp-orange text-xs font-bold uppercase tracking-[0.2em] mb-4">Influencers CS2 · España y LatAm</p>
           <h1 className="font-display text-4xl md:text-6xl font-black uppercase tracking-tight text-white leading-tight mb-6">
-            Influencers CS2 para tu Marca<br /><span style={g}>Audiencia que Convierte</span>
+            Influencers CS2 —<br /><span style={g}>300+ FTDs Verificados por Activación</span>
           </h1>
           <p className="text-lg text-white/60 leading-relaxed max-w-2xl mx-auto mb-10">
-            Influencers CS2 verificados en España y LatAm. La audiencia con mayor propensión al gasto en gaming,
-            con FTD tracking y activación en menos de 72 horas.
+            Sin estimaciones. Sin capturas de pantalla. Cada FTD atribuido al streamer que lo generó,
+            con datos del operador. Activación en menos de 72 horas en España y LatAm.
           </p>
           <div className="flex flex-wrap justify-center gap-8 mb-10">
             {STATS.map(({ stat, label }) => (
@@ -90,9 +91,9 @@ export default function InfluencersCs2Page() {
               </div>
             ))}
           </div>
-          <Link href="/contacto" className="inline-block bg-sp-grad text-white font-display font-bold uppercase tracking-wider text-sm px-8 py-3 rounded-full hover:opacity-90 transition-opacity">
-            Lanza tu campaña CS2
-          </Link>
+          <TrackedCtaLink href="/contacto" ctaId="landing_cs2_es_hero" className="inline-block bg-sp-grad text-white font-display font-bold uppercase tracking-wider text-sm px-8 py-3 rounded-full hover:opacity-90 transition-opacity">
+            Encuentra streamers de CS2 para tu campaña
+          </TrackedCtaLink>
         </div>
       </section>
 

--- a/src/app/servicios/igaming/page.tsx
+++ b/src/app/servicios/igaming/page.tsx
@@ -4,6 +4,7 @@ import { SectionTag } from '@/components/ui/SectionTag';
 import { SectionHeading } from '@/components/ui/SectionHeading';
 import { GradientText } from '@/components/ui/GradientText';
 import { SITE_URL, absoluteUrl } from '@/lib/site-url';
+import { TrackedCtaLink } from '@/components/ui/TrackedCtaLink';
 
 export const metadata: Metadata = {
   title: 'Streamers iGaming, Betting y Casino España y LatAm',
@@ -194,11 +195,11 @@ export default function IgamingPage() {
         <div className="max-w-4xl mx-auto px-6 text-center">
           <SectionTag>iGaming Influencer Marketing</SectionTag>
           <h1 className="font-display text-4xl md:text-6xl font-black uppercase tracking-tight text-white leading-tight mb-6">
-            Campañas iGaming con <GradientText>Streamers que Convierten</GradientText>
+            Campañas iGaming, Betting y Casino —<br /><GradientText>Resultados que el Operador Puede Auditar</GradientText>
           </h1>
           <p className="text-lg text-white/60 leading-relaxed max-w-2xl mx-auto mb-10">
-            Diseño y ejecución de campañas para operadores iGaming con licencia en España y LatAm.
-            Compliance integrado, talentos verificados y FTDs rastreados en cada activación.
+            Compliance DGOJ integrado y FTD tracking verificable con datos del operador.
+            Reporting auditable por tu equipo de affiliate y compliance. España y LatAm.
           </p>
           <div className="flex flex-wrap justify-center gap-8 text-center mb-10">
             {[
@@ -215,12 +216,13 @@ export default function IgamingPage() {
               </div>
             ))}
           </div>
-          <Link
+          <TrackedCtaLink
             href="/#contacto"
+            ctaId="landing_igaming_es_hero"
             className="inline-block bg-sp-grad text-white font-display font-bold uppercase tracking-wider text-sm px-8 py-3 rounded-full hover:opacity-90 transition-opacity"
           >
-            Lanza tu campaña iGaming
-          </Link>
+            Solicitar propuesta iGaming (48h)
+          </TrackedCtaLink>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
Copy reescrito (H1 + subtítulo + CTA) en las 4 landings que reciben tráfico SEO en español. **Stacked sobre #56** para reusar `<TrackedCtaLink>` y añadir cobertura de `cta_click` que faltaba en las landings ES.

> **Base:** `analytics/gtm-events-min` (PR #56). Si #56 se mergea primero, GitHub re-targeta este PR a `master` automáticamente.

## Por qué este PR existe ahora

Recién detectamos tráfico SEO real (20 clicks / 28 días según GSC). Antes de optimizar a ciegas, prioridad ahora:
1. Estabilizar SEO actual (no tocar estructura).
2. Mejorar conversión del tráfico que **ya** llega.
3. Medir comportamiento real para iterar.

Por requirement explícito **NO se toca**:
- ❌ Versiones EN de las landings
- ❌ `sitemap.ts`, `hreflang`, redirects, rutas
- ❌ Layout del hero (stats, padding, animaciones)
- ❌ Schema.org descriptions, OG, Twitter cards

Sólo se reescribe **3 textos por landing** (H1, subtítulo, CTA copy) y se añade **1 evento por hero CTA** (`cta_click`).

## Archivos tocados (4)

- `src/app/influencers-cs2/page.tsx`
- `src/app/agencia-influencers-valorant/page.tsx`
- `src/app/agencia-marketing-esports/page.tsx`
- `src/app/servicios/igaming/page.tsx`

## Cambios — copy

| Landing | Antes (H1) | Después (H1) |
|---|---|---|
| `/influencers-cs2` | *Influencers CS2 para tu Marca — Audiencia que Convierte* | **Influencers CS2 — 300+ FTDs Verificados por Activación** |
| `/agencia-influencers-valorant` | *Agencia de Influencers Valorant en España y LatAm* | **Agencia de Influencers Valorant — Brand-Safe por Diseño** |
| `/agencia-marketing-esports` | *Agencia de Marketing Esports con 13 Años de Resultados* | **Agencia de Marketing Esports — Nativos del Gaming. Enfocados en Performance.** |
| `/servicios/igaming` | *Campañas iGaming con Streamers que Convierten* | **Campañas iGaming, Betting y Casino — Resultados que el Operador Puede Auditar** |

Subtítulos refinados para atacar pain point real por vertical:
- **CS2** → audit-ready data (no estimaciones, no screenshots)
- **Valorant** → brand safety estructural (Riot + capa propia)
- **Esports** → positioning vs agencias generalistas
- **iGaming** → reporting auditable por equipo de affiliate y compliance

CTAs adaptados a intención por vertical (no patrón único):
- **CS2** → \"Encuentra streamers de CS2 para tu campaña\"
- **Valorant** → \"Valida tu campaña con influencers de Valorant\"
- **Esports** → \"Diseñamos tu campaña en esports\"
- **iGaming** → \"Solicitar propuesta iGaming (48h)\" (único con plazo)

## Cambios — tracking

`<TrackedCtaLink>` aplicado en los 4 hero CTAs con `cta_id` único:

| Landing | `cta_id` |
|---|---|
| `/influencers-cs2` | `landing_cs2_es_hero` |
| `/agencia-influencers-valorant` | `landing_valorant_es_hero` |
| `/agencia-marketing-esports` | `landing_esports_es_hero` |
| `/servicios/igaming` | `landing_igaming_es_hero` |

El componente `TrackedCtaLink` viene del PR #56. Esto extiende a las ES la cobertura de `cta_click` que en #56 sólo estaba en las EN.

## Cómo probarlo

```bash
git fetch origin
git checkout cro/landings-es-copy
NEXT_PUBLIC_GTM_ID=GTM-XXXXXX npm run dev
```

1. Visita `localhost:3000/influencers-cs2` → verás nuevo H1, subtítulo y CTA.
2. Acepta cookies en el banner. Abre DevTools → Console → escribe `dataLayer`.
3. Click en el CTA hero → en `dataLayer` aparece `{ event: 'cta_click', cta_id: 'landing_cs2_es_hero', cta_destination: '/contacto' }`.
4. Repetir en las otras 3 landings.

## tsc / lint
- `npx tsc --noEmit` ✅
- `npm run lint` ✅ 0 errors (61 warnings preexistentes)

## Dependencia
- **Stacked sobre #56.** No mergear antes que #56 (necesita TrackedCtaLink).
- Si #56 se mergea primero, GitHub re-targeta este PR a `master`.

## Out of scope (follow-ups si los quieres)
- Aplicar el mismo copy en las versiones EN equivalentes (3 archivos).
- Ajuste de altura del hero en mobile (CTA borderline en iPhone SE).
- Logo strip de social proof above-the-fold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)