### PR TITLE
perf(home): unblock LCP on mobile + minor security tweaks

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -33,6 +33,7 @@ const securityHeaders = [
 ];
 
 const nextConfig: NextConfig = {
+  poweredByHeader: false,
   async redirects() {
     return [
       // /gaming/cs2 → /influencers-cs2 (301 permanent)

--- a/src/features/marketing-site/components/Hero.tsx
+++ b/src/features/marketing-site/components/Hero.tsx
@@ -40,6 +40,9 @@ export function Hero() {
 
   useEffect(() => {
     if (reduced) return;
+    // Skip mousemove listener on touch devices (no cursor → no parallax payoff,
+    // saves listener overhead on mobile and the corresponding paint work).
+    if (typeof window === 'undefined' || !window.matchMedia('(hover: hover)').matches) return;
     const onMouseMove = (e: MouseEvent) => {
       mouseX.set(e.clientX / window.innerWidth);
       mouseY.set(e.clientY / window.innerHeight);
@@ -57,21 +60,21 @@ export function Hero() {
           className="absolute top-1/2 left-1/2 -ml-[500px] -mt-[500px] will-change-transform"
           style={{ x: pinkX, y: pinkY }}
         >
-          <div className="hero-aura-pink hero-aura-pink-bg w-[700px] h-[700px] rounded-full blur-[30px] sm:blur-[60px]" />
+          <div className="hero-aura-pink hero-aura-pink-bg w-[700px] h-[700px] rounded-full blur-[16px] sm:blur-[60px]" />
         </m.div>
         <m.div
           className="absolute top-[-10%] right-[-10%] will-change-transform"
           style={{ x: orangeX, y: orangeY }}
         >
-          <div className="hero-aura-orange hero-aura-orange-bg w-[600px] h-[600px] rounded-full blur-[35px] sm:blur-[70px]" />
+          <div className="hero-aura-orange hero-aura-orange-bg w-[600px] h-[600px] rounded-full blur-[20px] sm:blur-[70px]" />
         </m.div>
       </div>
 
       <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 w-full flex-1 flex flex-col items-center justify-center text-center pb-20">
 
         <m.div
-          initial={{ opacity: 0, scale: 0.8, y: 20 }}
-          animate={{ opacity: 1, scale: 1, y: 0 }}
+          initial={{ scale: 0.8, y: 20 }}
+          animate={{ scale: 1, y: 0 }}
           transition={{ duration: 1, ease: [0.16, 1, 0.3, 1] }}
           className="relative mb-8"
         >
@@ -80,8 +83,8 @@ export function Hero() {
             <Image
               src="/images/logos/2.png"
               alt="SocialPro Mark"
-              width={100}
-              height={100}
+              width={80}
+              height={80}
               priority
               className="w-16 h-16 sm:w-20 sm:h-20 object-contain drop-shadow-[0_0_25px_rgba(224,48,112,0.4)]"
             />
@@ -89,35 +92,33 @@ export function Hero() {
           <div className="absolute inset-0 bg-sp-pink/20 blur-2xl rounded-full" />
         </m.div>
 
-        <m.span
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ duration: 1, delay: 0.2 }}
-          className="inline-block text-[10px] font-bold uppercase tracking-[0.4em] text-sp-muted2 mb-6"
-        >
+        <span className="inline-block text-[10px] font-bold uppercase tracking-[0.4em] text-sp-muted2 mb-6">
           Gaming &amp; Esports · Europa · LatAm · Turquía
-        </m.span>
+        </span>
 
+        {/* Hero H1 = LCP element. Mantenemos el slide-in (y: 40 → 0) pero
+            quitamos opacity:0 inicial: si el elemento empieza invisible, el
+            navegador no contabiliza el LCP hasta que la animación termina. */}
         <h1 className="font-display text-[2.75rem] xs:text-[3.5rem] sm:text-[5rem] md:text-[7rem] lg:text-[10rem] font-black uppercase leading-[0.85] tracking-tight mb-10">
           <m.span
-            initial={{ opacity: 0, y: 40 }}
-            animate={{ opacity: 1, y: 0 }}
+            initial={{ y: 40 }}
+            animate={{ y: 0 }}
             transition={{ duration: 0.8, ease: [0.16, 1, 0.3, 1], delay: 0.3 }}
             className="block text-white"
           >
             CONECTAMOS
           </m.span>
           <m.span
-            initial={{ opacity: 0, y: 40 }}
-            animate={{ opacity: 1, y: 0 }}
+            initial={{ y: 40 }}
+            animate={{ y: 0 }}
             transition={{ duration: 0.8, ease: [0.16, 1, 0.3, 1], delay: 0.45 }}
             className="block hero-headline-gradient"
           >
             CREADORES
           </m.span>
           <m.span
-            initial={{ opacity: 0, y: 40 }}
-            animate={{ opacity: 1, y: 0 }}
+            initial={{ y: 40 }}
+            animate={{ y: 0 }}
             transition={{ duration: 0.8, ease: [0.16, 1, 0.3, 1], delay: 0.6 }}
             className="block text-white"
           >


### PR DESCRIPTION
## Summary
Fixes targeted for the **4.4s mobile LCP** reported by monitor.works en la home. Independiente de #53–#58. No toca SEO, sitemap, hreflang, redirects, landings, DB ni CRM.

| Métrica monitor.works | Estado |
|---|---|
| LCP mobile | **4.4s** ⚠️ (target post-fix: ~2.0-2.5s) |
| Speed Index | 4.5s |
| FCP | 1.6s |
| TBT | 126ms |
| CLS | 0.000 |
| SEO | 100/100 |

## Causa probable del LCP

El `<h1>` *\"CONECTAMOS / CREADORES / CON MARCAS\"* es el elemento LCP en mobile. Cada `<m.span>` tenía:

```js
initial={{ opacity: 0, y: 40 }}
animate={{ opacity: 1, y: 0 }}
delay: 0.3, 0.45, 0.6s
duration: 0.8s
```

**Mientras `opacity = 0`, el navegador no contabiliza el LCP**. Cálculo:
```
FCP 1.6s + ~500ms hidratación + 0.6s delay + 0.8s duration
= 3.5–4.5s LCP   ← coincide con 4.4s reportado
```

## Archivos tocados (2)

- `src/features/marketing-site/components/Hero.tsx`
- `next.config.ts`

## Cambios — performance

### 1. H1 LCP fix (la clave del 80% del impacto)

```diff
  <m.span
-   initial={{ opacity: 0, y: 40 }}
-   animate={{ opacity: 1, y: 0 }}
+   initial={{ y: 40 }}
+   animate={{ y: 0 }}
    transition={{ duration: 0.8, ease: [0.16, 1, 0.3, 1], delay: 0.3 }}
    className=\"block text-white\"
  >
    CONECTAMOS
  </m.span>
```
*(× 3 spans del H1)*

El H1 está visible/pintable desde el primer render. Mantiene el slide-up; sólo elimina el fade-in. Diferencia visual mínima.

Mismo cambio en logo wrapper (sin `opacity:0` inicial) y la tag-line (era `<m.span>` solo por fade — ahora `<span>` estático).

### 2. Skip mousemove listener en touch devices

```diff
  useEffect(() => {
    if (reduced) return;
+   if (typeof window === 'undefined' || !window.matchMedia('(hover: hover)').matches) return;
    const onMouseMove = (e: MouseEvent) => { ... };
```

En mobile no hay cursor; el listener era trabajo sin payoff. Ahorra paint work continuo y memoria.

### 3. Reducir blur de auras en mobile

```diff
- blur-[30px] sm:blur-[60px]   (pink)
+ blur-[16px] sm:blur-[60px]
- blur-[35px] sm:blur-[70px]   (orange)
+ blur-[20px] sm:blur-[70px]
```

Desktop sin cambios. El blur grande sobre divs 600-700px es desproporcionadamente caro en GPUs móviles.

### 4. Logo image size accuracy

```diff
- <Image src=\"/images/logos/2.png\" width={100} height={100} priority />
+ <Image src=\"/images/logos/2.png\" width={80} height={80} priority />
```

El logo se renderiza máx 80px (`w-16 h-16 sm:w-20 sm:h-20`). Antes Next/Image servía AVIF de mayor tamaño del necesario.

## Cambios — seguridad

### 5. Ocultar `X-Powered-By`

```diff
  const nextConfig: NextConfig = {
+   poweredByHeader: false,
    async redirects() { ... },
```

Buena práctica defensiva. Sin impacto funcional.

## Diseño visual

🟢 **Sin cambios visibles intencionados**. El hero se ve idéntico al usuario:
- H1: ya tenía animación slide-up; sólo desaparece el fade-in inicial.
- Logo: idem.
- Tag-line: aparece directamente (antes había un fade de 1s).
- Auras blur: en mobile el blur es ligeramente más nítido — apenas perceptible visualmente, claramente perceptible en perf.

Si la animación del H1 se siente \"plana\" sin fade, se puede revertir solo ese cambio fácilmente.

## Lo que NO toca el PR

❌ `sitemap.ts`, `hreflang`, redirects existentes
❌ Las 9 landings (cualquier copy, schema, OG, Twitter)
❌ BD, CRM, auth, admin
❌ Otros componentes marketing-site (`Marquee`, `BrandsCarousel`, `MetricsSection`, `TalentSection`, etc.)
❌ Fuentes (5 weights de Barlow Condensed dejado para auditoría posterior)
❌ Slugs dinámicos

## Estimación de impacto

| Métrica | Antes | Después estimado | Δ |
|---|---|---|---|
| **LCP mobile** | 4.4s | **~2.0-2.5s** | **−45 a −55%** |
| Speed Index | 4.5s | ~2.8s | −38% |
| FCP | 1.6s | ~1.4s | −12% |
| TBT | 126ms | ~80ms | −36% |
| CLS | 0.000 | 0.000 | sin cambio |

> **Nota honesta:** mi entorno actual no tiene Chrome/Lighthouse instalados. La medición real la haces tú con los comandos de abajo. Las estimaciones se basan en el patrón conocido `motion + opacity:0 + delay` que es exactamente el bloqueo identificado.

## Cómo medir antes/después

```bash
# Instalar Lighthouse + Chrome (una vez)
npm install -g lighthouse
# (Chrome ya viene en Vercel preview; en local: chrome instalado del sistema)

# BASELINE (master)
git checkout master
npm run build && npm start &
sleep 5
npx lighthouse http://localhost:3000 \
  --form-factor=mobile \
  --throttling.cpuSlowdownMultiplier=4 \
  --output=html --output-path=./lighthouse-baseline.html \
  --view
# Cierra el server (Ctrl+C)

# AFTER (este PR)
git checkout perf/home-mobile-lcp
npm run build && npm start &
sleep 5
npx lighthouse http://localhost:3000 \
  --form-factor=mobile \
  --throttling.cpuSlowdownMultiplier=4 \
  --output=html --output-path=./lighthouse-after.html \
  --view
```

Comparar lado a lado: foco en **LCP** (esperar < 2.5s post-fix) y filmstrip del hero (confirmar que el H1 aparece inmediatamente).

Alternativa rápida en producción: usa el **Vercel Preview URL** que aparecerá en este PR + tu herramienta favorita (PageSpeed Insights, monitor.works, WebPageTest mobile).

## tsc / lint
- `npx tsc --noEmit` ✅
- `npm run lint` ✅ 0 errors (61 warnings preexistentes)

## Riesgo
🟢 **Bajo**.
- Cambios en motion = revert de un commit si el efecto visual no convence.
- Reducir blur mobile = visualmente casi imperceptible.
- `poweredByHeader: false` = 0 riesgo.
- Listener skip en mobile = 0 efecto visual (no había cursor para empezar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)