### PR TITLE
fix(mobile): compatibilidad móvil completa — overflow, teclado iOS, tab bars

### DIFF
--- a/src/app/admin/(dashboard)/brands/page.tsx
+++ b/src/app/admin/(dashboard)/brands/page.tsx
@@ -101,6 +101,7 @@ export default async function AdminBrandsPage(): Promise<React.ReactElement> {
                   <p className="text-sm text-sp-admin-muted">No hay marcas registradas en el portal. Invita tu primera marca.</p>
                 ) : (
                   <div className="rounded-2xl bg-sp-admin-card border border-sp-admin-border overflow-hidden">
+                    <div className="overflow-x-auto">
                     <table className="w-full text-sm">
                       <thead>
                         <tr className="border-b border-sp-admin-border bg-sp-admin-bg/50">
@@ -119,6 +120,7 @@ export default async function AdminBrandsPage(): Promise<React.ReactElement> {
                         ))}
                       </tbody>
                     </table>
+                    </div>
                   </div>
                 )}
               </div>

--- a/src/app/admin/(dashboard)/giveaways/CodesTable.tsx
+++ b/src/app/admin/(dashboard)/giveaways/CodesTable.tsx
@@ -73,6 +73,7 @@ export function CodesTable({ codes, talents, brandCatalog = [] }: Props): React.
             {`Sin resultados para "${query}"`}
           </div>
         ) : (
+        <div className="overflow-x-auto">
         <table className="w-full text-sm">
           <thead>
             <tr className="border-b border-sp-admin-border bg-sp-admin-bg/50">
@@ -129,6 +130,7 @@ export function CodesTable({ codes, talents, brandCatalog = [] }: Props): React.
             ))}
           </tbody>
         </table>
+        </div>
         )}
       </div>
 

--- a/src/app/admin/(dashboard)/giveaways/GiveawaysDashboard.tsx
+++ b/src/app/admin/(dashboard)/giveaways/GiveawaysDashboard.tsx
@@ -84,21 +84,23 @@ export function GiveawaysDashboard({
       <StatsCards giveaways={giveaways} codes={codes} winners={winners} />
 
       {/* Tab bar */}
-      <div className="flex gap-1 p-1 rounded-xl bg-sp-admin-card border border-sp-admin-border w-fit">
-        {TABS.map((tab) => (
-          <button
-            key={tab.id}
-            type="button"
-            onClick={() => setTab(tab.id)}
-            className={`px-4 py-1.5 rounded-lg text-sm font-semibold transition-colors ${
-              activeTab === tab.id
-                ? 'bg-sp-admin-accent text-white'
-                : 'text-sp-admin-muted hover:text-sp-admin-text hover:bg-sp-admin-hover'
-            }`}
-          >
-            {tab.label}
-          </button>
-        ))}
+      <div className="overflow-x-auto">
+        <div className="flex gap-1 p-1 rounded-xl bg-sp-admin-card border border-sp-admin-border w-fit">
+          {TABS.map((tab) => (
+            <button
+              key={tab.id}
+              type="button"
+              onClick={() => setTab(tab.id)}
+              className={`px-4 py-1.5 rounded-lg text-sm font-semibold transition-colors whitespace-nowrap ${
+                activeTab === tab.id
+                  ? 'bg-sp-admin-accent text-white'
+                  : 'text-sp-admin-muted hover:text-sp-admin-text hover:bg-sp-admin-hover'
+              }`}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
       </div>
 
       {/* Tab content */}

--- a/src/app/admin/(dashboard)/giveaways/WinnersTab.tsx
+++ b/src/app/admin/(dashboard)/giveaways/WinnersTab.tsx
@@ -44,6 +44,7 @@ export function WinnersTab({ winners, onRegisterWinner }: Props): React.ReactEle
           + Registrar ganador
         </button>
       </div>
+      <div className="overflow-x-auto">
       <table className="w-full text-sm">
         <thead>
           <tr className="border-b border-sp-admin-border bg-sp-admin-bg/50">
@@ -79,6 +80,7 @@ export function WinnersTab({ winners, onRegisterWinner }: Props): React.ReactEle
           ))}
         </tbody>
       </table>
+      </div>
     </div>
   );
 }

--- a/src/app/cookies/page.tsx
+++ b/src/app/cookies/page.tsx
@@ -68,6 +68,7 @@ export default function CookiesPage() {
                     Son estrictamente necesarias para el funcionamiento del sitio. No requieren consentimiento
                     y no pueden desactivarse.
                   </p>
+                  <div className="overflow-x-auto">
                   <table className="mt-3 w-full text-[12px] border-collapse">
                     <thead>
                       <tr className="border-b border-sp-border">
@@ -89,6 +90,7 @@ export default function CookiesPage() {
                       </tr>
                     </tbody>
                   </table>
+                  </div>
                 </div>
 
                 {/* Analíticas */}
@@ -104,6 +106,7 @@ export default function CookiesPage() {
                     Incluyen <strong>Google Analytics</strong> (vía Google Tag Manager) y{' '}
                     <strong>Vercel Analytics</strong>.
                   </p>
+                  <div className="overflow-x-auto">
                   <table className="mt-3 w-full text-[12px] border-collapse">
                     <thead>
                       <tr className="border-b border-sp-border">
@@ -140,6 +143,7 @@ export default function CookiesPage() {
                       </tr>
                     </tbody>
                   </table>
+                  </div>
                   <p className="mt-3 text-[12px]">
                     Google LLC puede transferir datos a servidores en EE.UU. bajo el acuerdo EU-US Data Privacy Framework.
                     Más información en{' '}

--- a/src/app/marcas/(portal)/facturas/page.tsx
+++ b/src/app/marcas/(portal)/facturas/page.tsx
@@ -68,6 +68,7 @@ export default async function BrandInvoicesPage(): Promise<React.ReactElement> {
         </div>
       ) : (
         <div className="rounded-2xl bg-white border border-sp-border overflow-hidden">
+          <div className="overflow-x-auto">
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b border-sp-border bg-sp-bg2">
@@ -111,6 +112,7 @@ export default async function BrandInvoicesPage(): Promise<React.ReactElement> {
               ))}
             </tbody>
           </table>
+          </div>
         </div>
       )}
     </div>

--- a/src/features/admin/_shared/components/EditDrawer.tsx
+++ b/src/features/admin/_shared/components/EditDrawer.tsx
@@ -154,7 +154,7 @@ export function EditDrawer({
             </div>
 
             {/* Content */}
-            <div className="flex-1 overflow-y-auto px-6 py-4">
+            <div className="flex-1 overflow-y-auto px-6 py-4 pb-20">
               {children}
             </div>
 

--- a/src/features/admin/backups/BackupsManager.tsx
+++ b/src/features/admin/backups/BackupsManager.tsx
@@ -196,6 +196,7 @@ export function BackupsManager({ files: initialFiles, initialError, isConfigured
           </div>
         ) : (
           <div className="rounded-xl border border-sp-admin-border bg-sp-admin-card overflow-hidden">
+            <div className="overflow-x-auto">
             <table className="w-full">
               <thead>
                 <tr className="border-b border-sp-admin-border bg-sp-admin-hover/30">
@@ -243,6 +244,7 @@ export function BackupsManager({ files: initialFiles, initialError, isConfigured
                 })}
               </tbody>
             </table>
+            </div>
           </div>
         )}
       </div>

--- a/src/features/admin/brands/components/BrandsCrmManager.tsx
+++ b/src/features/admin/brands/components/BrandsCrmManager.tsx
@@ -234,6 +234,7 @@ export function BrandsCrmManager({
         </div>
       ) : (
         <div className="rounded-2xl bg-sp-admin-card border border-sp-admin-border overflow-hidden">
+          <div className="overflow-x-auto">
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b border-sp-admin-border bg-sp-admin-bg/50">
@@ -271,6 +272,7 @@ export function BrandsCrmManager({
               })}
             </tbody>
           </table>
+          </div>
         </div>
       )}
 

--- a/src/features/admin/campaigns/components/CampaignDetailTabs.tsx
+++ b/src/features/admin/campaigns/components/CampaignDetailTabs.tsx
@@ -508,7 +508,8 @@ function DealFlowTimeline({
       </div>
 
       {/* Timeline */}
-      <div className="grid grid-cols-5 divide-x divide-sp-admin-border/40">
+      <div className="overflow-x-auto">
+      <div className="grid grid-cols-5 divide-x divide-sp-admin-border/40 min-w-[480px]">
         {stages.map((stage, i) => (
           <div key={stage.id} className={`px-3 py-3 relative ${stage.warning ? 'bg-amber-50/40' : ''}`}>
             {/* Línea conectora */}
@@ -545,6 +546,7 @@ function DealFlowTimeline({
             )}
           </div>
         ))}
+      </div>
       </div>
     </div>
   );

--- a/src/features/admin/invoices/components/InvoicesManager.tsx
+++ b/src/features/admin/invoices/components/InvoicesManager.tsx
@@ -183,6 +183,7 @@ export function InvoicesManager({
         />
       ) : (
         <div className="rounded-2xl bg-sp-admin-card border border-sp-admin-border overflow-hidden">
+          <div className="overflow-x-auto">
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b border-sp-admin-border bg-sp-admin-bg/50">
@@ -216,6 +217,7 @@ export function InvoicesManager({
               ))}
             </tbody>
           </table>
+          </div>
         </div>
       )}
 


### PR DESCRIPTION
## Summary

- **Overflow horizontal eliminado** en 8 tablas del panel admin y portal: CodesTable, WinnersTab, BackupsManager, BrandsCrmManager, InvoicesManager, brands/portal, cookies, marcas/facturas. Patrón: `overflow-x-auto` interior manteniendo `overflow-hidden` exterior (border-radius intacto).
- **Teclado iOS** — `pb-20` en `EditDrawer` content para que los campos del fondo no queden tapados por el teclado virtual.
- **Tab bar sorteos** — envuelto en `overflow-x-auto` + `whitespace-nowrap` para que los 4 tabs sean scrollables en pantallas ≤390px.
- **Flujo del trato** (CampaignDetailTabs) — timeline `grid-cols-5` con `overflow-x-auto` + `min-w-[480px]` para scroll horizontal en móvil.
- **brands/admin/page.tsx** — overflow-x-auto en tabla del portal (emails largos).

## Test plan

- [ ] Admin panel en 390px: tablas de Marcas, Facturas, Sorteos/Códigos/Ganadores hacen scroll horizontal sin desborde de página
- [ ] Drawer de edición en iOS: formulario scrollable con teclado virtual activo
- [ ] Página sorteos: tab bar scrollable si no caben los 4 tabs
- [ ] Detalle de campaña: "Flujo del trato" scrollable en móvil
- [ ] Portal de marcas /marcas/facturas: tabla scrollable
- [ ] Página /cookies: tablas scrollables

🤖 Generated with [Claude Code](https://claude.com/claude-code)