### PR TITLE
fix(admin/talents): métricas públicas siempre visibles + añadir stats

### DIFF
--- a/src/app/admin/(dashboard)/talents/[id]/page.tsx
+++ b/src/app/admin/(dashboard)/talents/[id]/page.tsx
@@ -232,24 +232,22 @@ export default async function TalentProfilePage({
           </section>
 
           {/* Métricas públicas */}
-          {talent.stats.length > 0 && (
-            <section className="rounded-xl bg-sp-admin-card shadow-[0_1px_3px_rgba(0,0,0,0.06)] overflow-hidden">
-              <div className="px-4 py-2.5 border-b border-sp-admin-border/60 bg-sp-admin-hover/40">
-                <h2 className="text-[10px] font-bold uppercase tracking-[0.18em] text-sp-admin-muted">Métricas públicas</h2>
-              </div>
-              <div className="px-4 py-4">
-                <TalentStatsEditor
-                  talentId={talent.id}
-                  stats={talent.stats.map((s) => ({
-                    id:    s.id,
-                    icon:  s.icon,
-                    label: s.label,
-                    value: s.value,
-                  }))}
-                />
-              </div>
-            </section>
-          )}
+          <section className="rounded-xl bg-sp-admin-card shadow-[0_1px_3px_rgba(0,0,0,0.06)] overflow-hidden">
+            <div className="px-4 py-2.5 border-b border-sp-admin-border/60 bg-sp-admin-hover/40">
+              <h2 className="text-[10px] font-bold uppercase tracking-[0.18em] text-sp-admin-muted">Métricas públicas</h2>
+            </div>
+            <div className="px-4 py-4">
+              <TalentStatsEditor
+                talentId={talent.id}
+                stats={talent.stats.map((s) => ({
+                  id:    s.id,
+                  icon:  s.icon,
+                  label: s.label,
+                  value: s.value,
+                }))}
+              />
+            </div>
+          </section>
 
           {/* Etiquetas */}
           <section className="rounded-xl bg-sp-admin-card shadow-[0_1px_3px_rgba(0,0,0,0.06)] overflow-hidden">

--- a/src/app/admin/(dashboard)/talents/actions.ts
+++ b/src/app/admin/(dashboard)/talents/actions.ts
@@ -240,6 +240,31 @@ export async function updateTalentStatsAction(
   }
 }
 
+export async function createTalentStatAction(
+  talentId: number,
+  entry: { icon: string; label: string; value: string; sortOrder: number },
+): Promise<{ ok: boolean; id?: number; error?: string }> {
+  await requirePermission('talentos', 'write');
+  if (!talentId) return { ok: false, error: 'ID inválido' };
+  const icon  = entry.icon.trim().slice(0, 10);
+  const label = entry.label.trim().slice(0, 100);
+  const value = entry.value.trim().slice(0, 50);
+  if (!label) return { ok: false, error: 'El label es obligatorio' };
+  try {
+    const current = await db.select({ slug: talents.slug }).from(talents).where(eq(talents.id, talentId)).limit(1);
+    const slug = current[0]?.slug;
+    const [row] = await db.insert(talentStats).values({ talentId, icon, label, value, sortOrder: entry.sortOrder }).returning({ id: talentStats.id });
+    if (!row) return { ok: false, error: 'Error al crear métrica' };
+    revalidatePath(`/admin/talents/${talentId}`);
+    revalidatePath('/talentos');
+    if (slug) revalidatePath(`/talentos/${slug}`);
+    return { ok: true, id: row.id };
+  } catch (err) {
+    logRedacted('error', '[admin] createTalentStat error:', err);
+    return { ok: false, error: 'Error al crear métrica' };
+  }
+}
+
 export async function bulkUpdateSortOrderAction(
   updates: Array<{ id: number; sortOrder: number }>,
 ): Promise<{ ok: boolean }> {

--- a/src/features/admin/talents/components/TalentStatsEditor.tsx
+++ b/src/features/admin/talents/components/TalentStatsEditor.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useTransition } from 'react';
-import { updateTalentStatsAction } from '@/app/admin/(dashboard)/talents/actions';
+import { updateTalentStatsAction, createTalentStatAction } from '@/app/admin/(dashboard)/talents/actions';
 
 type StatRow = {
   readonly id:    number;
@@ -18,18 +18,18 @@ type Props = {
 const inputCls = 'w-full rounded-md border border-sp-admin-border bg-sp-admin-bg px-3 py-2 text-sm text-sp-admin-text placeholder:text-sp-admin-muted/60 focus:outline-none focus:border-sp-admin-accent/50';
 const labelCls = 'block text-[10px] font-bold uppercase tracking-wider text-sp-admin-muted mb-1';
 
-/**
- * Editor inline de métricas públicas del talent (talent_stats).
- * Solo edita el campo `value`; label e icon son de solo lectura.
- *
- * @kind client
- * @feature admin/talents
- */
 export function TalentStatsEditor({ talentId, stats }: Props): React.ReactElement {
   const [rows, setRows]        = useState<StatRow[]>(stats.map((s) => ({ ...s })));
   const [isPending, startTr]   = useTransition();
   const [saved, setSaved]      = useState(false);
   const [error, setError]      = useState('');
+
+  const [showAdd, setShowAdd]   = useState(false);
+  const [newIcon, setNewIcon]   = useState('📊');
+  const [newLabel, setNewLabel] = useState('');
+  const [newValue, setNewValue] = useState('');
+  const [addPending, startAdd]  = useTransition();
+  const [addError, setAddError] = useState('');
 
   function updateValue(idx: number, value: string): void {
     setSaved(false);
@@ -46,6 +46,28 @@ export function TalentStatsEditor({ talentId, stats }: Props): React.ReactElemen
       );
       if (res.ok) setSaved(true);
       else setError(res.error ?? 'Error desconocido');
+    });
+  }
+
+  function handleCreate(): void {
+    setAddError('');
+    startAdd(async () => {
+      const res = await createTalentStatAction(talentId, {
+        icon:      newIcon,
+        label:     newLabel,
+        value:     newValue,
+        sortOrder: rows.length,
+      });
+      const newId = res.id;
+      if (res.ok && newId !== undefined) {
+        setRows((prev) => [...prev, { id: newId, icon: newIcon, label: newLabel, value: newValue }]);
+        setNewIcon('📊');
+        setNewLabel('');
+        setNewValue('');
+        setShowAdd(false);
+      } else {
+        setAddError(res.error ?? 'Error desconocido');
+      }
     });
   }
 
@@ -66,18 +88,75 @@ export function TalentStatsEditor({ talentId, stats }: Props): React.ReactElemen
         </div>
       ))}
 
+      {showAdd && (
+        <div className="rounded-lg border border-dashed border-sp-admin-accent/40 bg-sp-admin-bg/30 p-3 space-y-2">
+          <p className={labelCls}>Nueva métrica</p>
+          <div className="flex gap-2">
+            <input
+              value={newIcon}
+              onChange={(e) => setNewIcon(e.target.value)}
+              placeholder="📊"
+              maxLength={10}
+              className="w-16 rounded-md border border-sp-admin-border bg-sp-admin-bg px-2 py-2 text-sm text-sp-admin-text focus:outline-none focus:border-sp-admin-accent/50 text-center"
+            />
+            <input
+              value={newLabel}
+              onChange={(e) => setNewLabel(e.target.value)}
+              placeholder="Ej: Suscriptores YouTube"
+              maxLength={100}
+              className={`${inputCls} flex-1`}
+            />
+          </div>
+          <input
+            value={newValue}
+            onChange={(e) => setNewValue(e.target.value)}
+            placeholder="Ej: 120K"
+            maxLength={50}
+            className={inputCls}
+          />
+          {addError && <p className="text-[12px] text-red-500 font-medium">{addError}</p>}
+          <div className="flex gap-2 justify-end">
+            <button
+              type="button"
+              onClick={() => { setShowAdd(false); setAddError(''); }}
+              className="h-8 px-4 rounded-lg border border-sp-admin-border text-sp-admin-muted text-[12px] font-semibold hover:bg-sp-admin-hover transition-colors"
+            >
+              Cancelar
+            </button>
+            <button
+              type="button"
+              onClick={handleCreate}
+              disabled={addPending || !newLabel.trim()}
+              className="h-8 px-4 rounded-lg bg-sp-admin-accent text-white text-[12px] font-semibold hover:opacity-90 disabled:opacity-50 transition-opacity"
+            >
+              {addPending ? 'Creando…' : 'Crear métrica'}
+            </button>
+          </div>
+        </div>
+      )}
+
       <div className="flex items-center gap-3 pt-1">
+        <button
+          type="button"
+          onClick={() => { setShowAdd(true); setSaved(false); }}
+          disabled={showAdd}
+          className="text-[12px] text-sp-admin-accent font-semibold hover:opacity-80 disabled:opacity-40 transition-opacity"
+        >
+          + Añadir métrica
+        </button>
         <div className="flex-1" />
         {error && <p className="text-[12px] text-red-500 font-medium">{error}</p>}
         {saved && <p className="text-[12px] text-emerald-600 font-semibold">✓ Guardado</p>}
-        <button
-          type="button"
-          onClick={handleSave}
-          disabled={isPending}
-          className="h-9 px-5 rounded-lg bg-sp-admin-accent text-white text-[13px] font-semibold hover:opacity-90 disabled:opacity-50 transition-opacity"
-        >
-          {isPending ? 'Guardando…' : 'Guardar métricas'}
-        </button>
+        {rows.length > 0 && (
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={isPending}
+            className="h-9 px-5 rounded-lg bg-sp-admin-accent text-white text-[13px] font-semibold hover:opacity-90 disabled:opacity-50 transition-opacity"
+          >
+            {isPending ? 'Guardando…' : 'Guardar métricas'}
+          </button>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Elimina la condición `talent.stats.length > 0 &&` que ocultaba la sección "Métricas públicas" cuando un talent no tenía stats, bloqueando su creación desde el admin (bug que afectaba a JOLU)
- Añade `createTalentStatAction` para insertar nuevas filas en `talent_stats` (antes solo existía update)
- Actualiza `TalentStatsEditor` con botón "+ Añadir métrica" que despliega un mini-formulario inline (icono + label + valor)

## Test plan
- [ ] Abrir admin de un talent sin stats → la sección "Métricas públicas" debe aparecer con botón "+ Añadir métrica"
- [ ] Crear nueva métrica → aparece en el listado inline sin recargar
- [ ] Guardar métricas existentes → sigue funcionando igual

🤖 Generated with [Claude Code](https://claude.com/claude-code)