### PR TITLE
refactor(talents): TalentCard usa followers de socials, elimina métricas públicas

### DIFF
--- a/src/app/admin/(dashboard)/talents/[id]/page.tsx
+++ b/src/app/admin/(dashboard)/talents/[id]/page.tsx
@@ -10,7 +10,6 @@ import { getFlagImageUrl, countryFlagEmoji } from '@/lib/flag-images';
 import { TALENT_VERTICAL_LABELS } from '@/lib/schemas/talentBusiness';
 import { TalentPhotoUpload } from '@/features/admin/talents/components/TalentPhotoUpload';
 import { TalentSocialsEditor } from '@/features/admin/talents/components/TalentSocialsEditor';
-import { TalentStatsEditor } from '@/features/admin/talents/components/TalentStatsEditor';
 import { TalentTagsEditor } from '@/features/admin/talents/components/TalentTagsEditor';
 import { getTalentLiveStatus, getFeaturedFallbackCount } from '@/lib/queries/live';
 import { setFeaturedLiveAction, setFeaturedFallbackAction, setExcludeFromLiveAction } from '@/app/admin/(dashboard)/live/actions';
@@ -226,24 +225,6 @@ export default async function TalentProfilePage({
                   profileUrl:       s.profileUrl ?? null,
                   followersDisplay: s.followersDisplay,
                   sortOrder:        s.sortOrder,
-                }))}
-              />
-            </div>
-          </section>
-
-          {/* Métricas públicas */}
-          <section className="rounded-xl bg-sp-admin-card shadow-[0_1px_3px_rgba(0,0,0,0.06)] overflow-hidden">
-            <div className="px-4 py-2.5 border-b border-sp-admin-border/60 bg-sp-admin-hover/40">
-              <h2 className="text-[10px] font-bold uppercase tracking-[0.18em] text-sp-admin-muted">Métricas públicas</h2>
-            </div>
-            <div className="px-4 py-4">
-              <TalentStatsEditor
-                talentId={talent.id}
-                stats={talent.stats.map((s) => ({
-                  id:    s.id,
-                  icon:  s.icon,
-                  label: s.label,
-                  value: s.value,
                 }))}
               />
             </div>

--- a/src/features/talents-public/components/TalentCard.tsx
+++ b/src/features/talents-public/components/TalentCard.tsx
@@ -70,24 +70,23 @@ export function TalentCard({ talent, onOpen, priority = false }: TalentCardProps
           {[talent.role, talent.role2].filter(Boolean).join(' · ')}
         </p>
 
-        {/* Stats */}
-        <div className="grid grid-cols-3 gap-3 mb-4">
-          {talent.stats.slice(0, 3).map((stat) => {
-            const lower = stat.label.toLowerCase();
-            const platform = lower.includes('twitch') ? 'twitch'
-              : lower.includes('youtube') ? 'youtube'
-              : null;
-            return (
-              <div key={stat.id} className="text-center">
-                <div className="text-sm font-bold text-sp-dark">{stat.value}</div>
+        {/* Stats — from social followers */}
+        {talent.socials.length > 0 && (
+          <div
+            className="grid gap-3 mb-4"
+            style={{ gridTemplateColumns: `repeat(${Math.min(talent.socials.length, 3)}, minmax(0, 1fr))` }}
+          >
+            {talent.socials.slice(0, 3).map((social) => (
+              <div key={social.id} className="text-center">
+                <div className="text-sm font-bold text-sp-dark">{social.followersDisplay}</div>
                 <div className="flex items-center justify-center gap-0.5 text-[10px] text-sp-muted leading-tight mt-0.5">
-                  {platform && <SocialIcon type={platform} size={9} />}
-                  <span>{stat.label.split(' ')[0]}</span>
+                  <SocialIcon type={social.platform} size={9} />
+                  <span>{social.platform === 'youtube' ? 'Suscriptores' : 'Seguidores'}</span>
                 </div>
               </div>
-            );
-          })}
-        </div>
+            ))}
+          </div>
+        )}
 
         {/* Socials */}
         <nav aria-label="Redes sociales" className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- `TalentCard` ahora muestra `followersDisplay` de `talent_socials` en lugar de `talent_stats`: los números de la tarjeta pública se obtienen directamente de las redes configuradas en el admin, sin duplicación
- Grid de columnas adapta su ancho al número de redes del talent (1–3)
- Elimina la sección "Métricas públicas" del admin `/talents/[id]` (ya no necesaria)
- JOLU y cualquier talent con solo una red social muestran correctamente su única métrica

## Test plan
- [ ] JOLU → tarjeta pública muestra `9.6K Suscriptores` con icono YouTube
- [ ] MIRAI/EVELYN → tarjeta sigue mostrando Twitch + YouTube correctamente
- [ ] Admin → talent detail ya no muestra sección "Métricas públicas"

🤖 Generated with [Claude Code](https://claude.com/claude-code)