### PR TITLE
feat(finance): add cashflow dashboard

### DIFF
--- a/docs/finance-dashboard.md
+++ b/docs/finance-dashboard.md
@@ -1,0 +1,147 @@
+# Finance Dashboard — Documentación
+
+## Overview
+
+Dashboard financiero de solo lectura en `/admin/facturacion/dashboard`. Agrega datos de los módulos existentes (facturas internas, facturas emitidas, invoice_payments, conciliación bancaria, campañas) sin conexiones a APIs bancarias externas ni pagos automáticos.
+
+## Ruta
+
+| Ruta | Descripción |
+|---|---|
+| `/admin/facturacion/dashboard` | Dashboard completo — RSC con fetch en paralelo |
+
+## Arquitectura de datos
+
+```
+getFinanceDashboard()              ← composición en paralelo
+  ├─ getFinanceDashboardKPIs()     ← kpis.ts
+  ├─ getCashflowSeries(12)         ← cashflow.ts
+  ├─ getReceivables()              ← receivables.ts
+  ├─ getReconciliationSummary()    ← reconciliation.ts
+  ├─ getCampaignMargins()          ← campaignMargins.ts
+  └─ deriveAlerts() [in-memory]    ← alerts.ts (pure function)
+```
+
+## KPIs (`kpis.ts`)
+
+| KPI | Fuente | Base |
+|---|---|---|
+| `cobradoRealMes` | SUM(invoice_payments.amount) del mes actual | Caja |
+| `incomeTotal` | SUM(invoices.totalAmount) kind=income, no anulada | Devengado |
+| `expenseTotal` | SUM(invoices.totalAmount) kind=expense, no anulada | Devengado |
+| `netTotal` | incomeTotal − expenseTotal | Devengado |
+| `beneficioNeto` | incomeSettled − expenseCampanaSettled − expenseEmpresaSettled | Devengado |
+| `pendingCobro` | invoices income con status emitida/no_cobrada/pendiente | Devengado |
+| `pendingPago` | invoices expense con status emitida/no_pagada/pendiente | Devengado |
+| `gastosCampana` / `gastosEmpresa` | Por scope (campaign/company) | Devengado |
+| `pendingApplyPayment` | bank_transactions matched LEFT JOIN invoice_payments WHERE ip.id IS NULL | — |
+| `unconciliatedMovements` | bank_transactions con status='imported' | — |
+
+## Cashflow mensual (`cashflow.ts`)
+
+Serie de 12 meses con dos series:
+
+| Serie | Descripción |
+|---|---|
+| `cobrado` | SUM(invoice_payments.amount) agrupado por `payment_date` — **base caja real** |
+| `pagado` | SUM(invoices.totalAmount) kind=expense, no anulada, agrupado por `issue_date` — **base devengado** |
+
+**Nota:** `pagado` usa base devengado porque el "apply payment" para gastos (`expense` matchType) está pendiente de implementar ("Próximamente"). En cuanto se implemente, habrá que actualizar `cashflow.ts` para usar `invoice_payments` en el lado de los gastos también.
+
+## Cobros pendientes (`receivables.ts`)
+
+UNION en memoria de dos fuentes:
+
+| Fuente | Filtro de status | `paidAmount` |
+|---|---|---|
+| `issued_invoices` | `emitida`, `vencida`, `parcial` | SUM(invoice_payments.amount) via LEFT JOIN — calculado en query |
+| `invoices` kind=income | `PENDING_INCOME_STATUSES` | Columna `paidAmount` directa |
+
+Máximo 30 filas por fuente. Orden final: por `dueDate ASC` (nulls al final).
+
+**issuedInvoices vs invoices:** Las facturas emitidas no tienen columna `paidAmount`; el importe pagado se calcula vía `invoice_payments` en la misma query con GROUP BY.
+
+## Conciliación (`reconciliation.ts`)
+
+Wrapper sobre `getBankReconciliationKpis()` + query adicional para `pendingApplyPayment` (matched sin invoice_payment).
+
+## Márgenes campañas (`campaignMargins.ts`)
+
+Wrapper sobre `getCampaignMarginSummary()` (de `tools/campaigns.ts`) con flag `isLow = computedMarginPct < 20`.
+
+**Importante:** Los márgenes son sobre presupuesto estimado (`amountBrand`/`amountTalent`), NO sobre pagos reales.
+
+## Alertas (`alerts.ts`)
+
+Función pura — **sin queries adicionales**. Derivadas en memoria de los demás resultados:
+
+| Tipo | Condición | Severidad |
+|---|---|---|
+| `overdue_receivable` | receivables con `isOverdue=true` | high si total > €5.000, medium en otro caso |
+| `low_margin` | campaigns con `isLow=true` | medium siempre |
+| `pending_apply_payment` | kpis.pendingApplyPayment > 0 | high si > 5, low en otro caso |
+| `unreconciled` | reconciliation.importedUnmatched > 0 | medium si > 20, low en otro caso |
+
+Orden de presentación: high → medium → low.
+
+## AI Tools
+
+5 herramientas nuevas (solo lectura), registradas en `tools/index.ts`:
+
+| Tool | Descripción |
+|---|---|
+| `getFinanceDashboardSummary` | KPIs accrual + cash real + estado bancario |
+| `getCashflowTrend` | Serie mensual 12 meses (cobrado cash + pagado devengado) |
+| `getReceivablesRiskSummary` | Cobros vencidos y pendientes agrupados, top 5 vencidos |
+| `getCampaignMarginAlerts` | Campañas con margen < 20% |
+| `getFinanceAlerts` | Alertas derivadas del estado actual |
+
+## Archivos
+
+```
+src/types/financeDashboard.ts
+  FinanceDashboardKPIs, CashflowMonthPoint, ReceivableRow, CampaignMarginRow,
+  ReconciliationSummary, FinanceAlert, FinanceDashboardData
+
+src/lib/queries/financeDashboard/
+  cashflow.ts        — getCashflowSeries(months)
+  kpis.ts            — getFinanceDashboardKPIs()
+  receivables.ts     — getReceivables()
+  reconciliation.ts  — getReconciliationSummary()
+  campaignMargins.ts — getCampaignMargins(), LOW_MARGIN_THRESHOLD
+  alerts.ts          — deriveAlerts() [pure]
+  index.ts           — getFinanceDashboard() + re-exports
+
+src/lib/services/ai-assistant/tools/financeDashboard.ts
+  getFinanceDashboardSummary, getCashflowTrend, getReceivablesRiskSummary,
+  getCampaignMarginAlerts, getFinanceAlerts
+
+src/app/admin/(dashboard)/facturacion/dashboard/page.tsx
+  RSC — requirePermission('facturacion','read') + getFinanceDashboard()
+
+src/features/admin/finance-dashboard/components/
+  FinanceKPIGrid.tsx      — 10 KPI cards
+  CashflowChart.tsx       — AreaChart (recharts) cobrado vs pagado
+  ReceivablesTable.tsx    — tabla cobros pendientes con isOverdue highlight
+  ReconciliationPanel.tsx — stats + link a /bancos/conciliacion
+  CampaignMarginsTable.tsx — tabla con isLow highlight
+  FinanceAlertsList.tsx   — lista alertas por severidad
+
+src/__tests__/server/finance-dashboard.test.ts
+  22 tests — deriveAlerts (pure), LOW_MARGIN_THRESHOLD, ReceivableRow semantics,
+  CampaignMarginRow isLow flag
+```
+
+## Permisos
+
+Usa `requirePermission('facturacion', 'read')` — mismos roles que el módulo de facturación existente (admin, manager, finance).
+
+## Límites
+
+- Solo lectura — sin mutaciones desde esta página
+- Sin conexiones bancarias externas (no Wise, Stripe, Open Banking)
+- Sin auto-pagos ni auto-conciliación
+- `pagado` en el cashflow es base devengado hasta que se implemente apply-payment para gastos
+- Los márgenes de campaña son estimados (budget), no pagos reales
+- Máximo 30 receivables por fuente (60 total)
+- Moneda: EUR únicamente. Si hay registros en otra divisa, los totales pueden estar mezclados (no se hace conversión)

--- a/src/__tests__/server/finance-dashboard.test.ts
+++ b/src/__tests__/server/finance-dashboard.test.ts
@@ -1,0 +1,328 @@
+import { deriveAlerts } from '@/lib/queries/financeDashboard/alerts';
+import { LOW_MARGIN_THRESHOLD } from '@/lib/queries/financeDashboard/campaignMargins';
+import type {
+  CampaignMarginRow,
+  FinanceDashboardKPIs,
+  ReceivableRow,
+  ReconciliationSummary,
+} from '@/types/financeDashboard';
+
+// ── Fixtures ────────────────────────────────────────────────────────────
+
+function makeKPIs(overrides: Partial<FinanceDashboardKPIs> = {}): FinanceDashboardKPIs {
+  return {
+    incomeTotal: 10000,
+    expenseTotal: 4000,
+    netTotal: 6000,
+    pendingCobro: 0,
+    pendingPago: 0,
+    gastosCampana: 2000,
+    gastosEmpresa: 2000,
+    beneficioNeto: 6000,
+    cobradoRealMes: 3000,
+    pendingApplyPayment: 0,
+    unconciliatedMovements: 0,
+    ...overrides,
+  };
+}
+
+function makeReconciliation(
+  overrides: Partial<ReconciliationSummary> = {},
+): ReconciliationSummary {
+  return {
+    totalTransactions: 100,
+    importedUnmatched: 0,
+    matched: 95,
+    needsReview: 5,
+    pendingApplyPayment: 0,
+    ...overrides,
+  };
+}
+
+function makeReceivable(overrides: Partial<ReceivableRow> = {}): ReceivableRow {
+  return {
+    id: 1,
+    source: 'issued',
+    invoiceNumber: 'SP-2026-001',
+    clientName: 'Cliente SA',
+    totalAmount: 1000,
+    paidAmount: 0,
+    pendingAmount: 1000,
+    status: 'emitida',
+    dueDate: null,
+    isOverdue: false,
+    ...overrides,
+  };
+}
+
+function makeCampaign(overrides: Partial<CampaignMarginRow> = {}): CampaignMarginRow {
+  return {
+    id: 1,
+    name: 'Campaña Test',
+    brandName: 'Marca SA',
+    talentName: 'Talento',
+    status: 'activa',
+    amountBrand: 10000,
+    amountTalent: 7000,
+    computedMarginPct: 30,
+    isLow: false,
+    cobroConfirmado: false,
+    pagoTalentConfirmado: false,
+    ...overrides,
+  };
+}
+
+// ── LOW_MARGIN_THRESHOLD ─────────────────────────────────────────────────
+
+describe('LOW_MARGIN_THRESHOLD', () => {
+  it('is 20', () => {
+    expect(LOW_MARGIN_THRESHOLD).toBe(20);
+  });
+});
+
+// ── deriveAlerts ─────────────────────────────────────────────────────────
+
+describe('deriveAlerts', () => {
+  it('returns empty array when everything is healthy', () => {
+    const alerts = deriveAlerts({
+      kpis: makeKPIs(),
+      receivables: [],
+      reconciliation: makeReconciliation(),
+      campaigns: [],
+    });
+    expect(alerts).toHaveLength(0);
+  });
+
+  describe('overdue_receivable alert', () => {
+    it('fires when there are overdue receivables', () => {
+      const alerts = deriveAlerts({
+        kpis: makeKPIs(),
+        receivables: [makeReceivable({ isOverdue: true, dueDate: '2026-01-01', pendingAmount: 1000 })],
+        reconciliation: makeReconciliation(),
+        campaigns: [],
+      });
+      const alert = alerts.find((a) => a.type === 'overdue_receivable');
+      expect(alert).toBeDefined();
+      expect(alert?.count).toBe(1);
+      expect(alert?.amount).toBe(1000);
+    });
+
+    it('assigns high severity when amount > 5000', () => {
+      const alerts = deriveAlerts({
+        kpis: makeKPIs(),
+        receivables: [makeReceivable({ isOverdue: true, pendingAmount: 6000 })],
+        reconciliation: makeReconciliation(),
+        campaigns: [],
+      });
+      const alert = alerts.find((a) => a.type === 'overdue_receivable');
+      expect(alert?.severity).toBe('high');
+    });
+
+    it('assigns medium severity when amount <= 5000', () => {
+      const alerts = deriveAlerts({
+        kpis: makeKPIs(),
+        receivables: [makeReceivable({ isOverdue: true, pendingAmount: 500 })],
+        reconciliation: makeReconciliation(),
+        campaigns: [],
+      });
+      const alert = alerts.find((a) => a.type === 'overdue_receivable');
+      expect(alert?.severity).toBe('medium');
+    });
+
+    it('does not fire for non-overdue receivables', () => {
+      const alerts = deriveAlerts({
+        kpis: makeKPIs(),
+        receivables: [makeReceivable({ isOverdue: false })],
+        reconciliation: makeReconciliation(),
+        campaigns: [],
+      });
+      expect(alerts.find((a) => a.type === 'overdue_receivable')).toBeUndefined();
+    });
+
+    it('accumulates amount across multiple overdue invoices', () => {
+      const alerts = deriveAlerts({
+        kpis: makeKPIs(),
+        receivables: [
+          makeReceivable({ id: 1, isOverdue: true, pendingAmount: 2000 }),
+          makeReceivable({ id: 2, isOverdue: true, pendingAmount: 3000 }),
+          makeReceivable({ id: 3, isOverdue: false, pendingAmount: 500 }),
+        ],
+        reconciliation: makeReconciliation(),
+        campaigns: [],
+      });
+      const alert = alerts.find((a) => a.type === 'overdue_receivable');
+      expect(alert?.count).toBe(2);
+      expect(alert?.amount).toBe(5000);
+    });
+  });
+
+  describe('low_margin alert', () => {
+    it('fires when a campaign has isLow=true', () => {
+      const alerts = deriveAlerts({
+        kpis: makeKPIs(),
+        receivables: [],
+        reconciliation: makeReconciliation(),
+        campaigns: [makeCampaign({ isLow: true, computedMarginPct: 15 })],
+      });
+      const alert = alerts.find((a) => a.type === 'low_margin');
+      expect(alert).toBeDefined();
+      expect(alert?.count).toBe(1);
+      expect(alert?.severity).toBe('medium');
+    });
+
+    it('does not fire when all campaigns have isLow=false', () => {
+      const alerts = deriveAlerts({
+        kpis: makeKPIs(),
+        receivables: [],
+        reconciliation: makeReconciliation(),
+        campaigns: [makeCampaign({ isLow: false, computedMarginPct: 35 })],
+      });
+      expect(alerts.find((a) => a.type === 'low_margin')).toBeUndefined();
+    });
+  });
+
+  describe('pending_apply_payment alert', () => {
+    it('fires when pendingApplyPayment > 0', () => {
+      const alerts = deriveAlerts({
+        kpis: makeKPIs({ pendingApplyPayment: 3 }),
+        receivables: [],
+        reconciliation: makeReconciliation(),
+        campaigns: [],
+      });
+      const alert = alerts.find((a) => a.type === 'pending_apply_payment');
+      expect(alert).toBeDefined();
+      expect(alert?.count).toBe(3);
+    });
+
+    it('assigns high severity when count > 5', () => {
+      const alerts = deriveAlerts({
+        kpis: makeKPIs({ pendingApplyPayment: 6 }),
+        receivables: [],
+        reconciliation: makeReconciliation(),
+        campaigns: [],
+      });
+      const alert = alerts.find((a) => a.type === 'pending_apply_payment');
+      expect(alert?.severity).toBe('high');
+    });
+
+    it('assigns low severity when count <= 5', () => {
+      const alerts = deriveAlerts({
+        kpis: makeKPIs({ pendingApplyPayment: 5 }),
+        receivables: [],
+        reconciliation: makeReconciliation(),
+        campaigns: [],
+      });
+      const alert = alerts.find((a) => a.type === 'pending_apply_payment');
+      expect(alert?.severity).toBe('low');
+    });
+
+    it('does not fire when pendingApplyPayment is 0', () => {
+      const alerts = deriveAlerts({
+        kpis: makeKPIs({ pendingApplyPayment: 0 }),
+        receivables: [],
+        reconciliation: makeReconciliation(),
+        campaigns: [],
+      });
+      expect(alerts.find((a) => a.type === 'pending_apply_payment')).toBeUndefined();
+    });
+  });
+
+  describe('unreconciled alert', () => {
+    it('fires when importedUnmatched > 0', () => {
+      const alerts = deriveAlerts({
+        kpis: makeKPIs({ unconciliatedMovements: 5 }),
+        receivables: [],
+        reconciliation: makeReconciliation({ importedUnmatched: 5 }),
+        campaigns: [],
+      });
+      const alert = alerts.find((a) => a.type === 'unreconciled');
+      expect(alert).toBeDefined();
+      expect(alert?.count).toBe(5);
+    });
+
+    it('assigns medium severity when count > 20', () => {
+      const alerts = deriveAlerts({
+        kpis: makeKPIs({ unconciliatedMovements: 25 }),
+        receivables: [],
+        reconciliation: makeReconciliation({ importedUnmatched: 25 }),
+        campaigns: [],
+      });
+      const alert = alerts.find((a) => a.type === 'unreconciled');
+      expect(alert?.severity).toBe('medium');
+    });
+
+    it('assigns low severity when count <= 20', () => {
+      const alerts = deriveAlerts({
+        kpis: makeKPIs({ unconciliatedMovements: 10 }),
+        receivables: [],
+        reconciliation: makeReconciliation({ importedUnmatched: 10 }),
+        campaigns: [],
+      });
+      const alert = alerts.find((a) => a.type === 'unreconciled');
+      expect(alert?.severity).toBe('low');
+    });
+  });
+
+  describe('alert ordering', () => {
+    it('sorts alerts by severity: high before medium before low', () => {
+      const alerts = deriveAlerts({
+        kpis: makeKPIs({
+          pendingApplyPayment: 10, // high (> 5)
+          unconciliatedMovements: 5, // low (<= 20)
+        }),
+        receivables: [makeReceivable({ isOverdue: true, pendingAmount: 6000 })], // high
+        reconciliation: makeReconciliation({ importedUnmatched: 5 }),
+        campaigns: [makeCampaign({ isLow: true })], // medium
+      });
+
+      const severities = alerts.map((a) => a.severity);
+      const highIdx = severities.indexOf('high');
+      const medIdx = severities.indexOf('medium');
+      const lowIdx = severities.indexOf('low');
+
+      // All high before all medium, all medium before all low
+      for (let i = 0; i < severities.length - 1; i++) {
+        const order: Record<string, number> = { high: 0, medium: 1, low: 2 };
+        expect((order[severities[i] ?? ''] ?? 3) <= (order[severities[i + 1] ?? ''] ?? 3)).toBe(true);
+      }
+
+      // Basic presence check
+      expect(highIdx).toBeGreaterThanOrEqual(0);
+      expect(medIdx).toBeGreaterThanOrEqual(0);
+      expect(lowIdx).toBeGreaterThanOrEqual(0);
+    });
+  });
+});
+
+// ── ReceivableRow pendingAmount logic ───────────────────────────────────
+
+describe('ReceivableRow pendingAmount semantics', () => {
+  it('pending = totalAmount - paidAmount', () => {
+    const r = makeReceivable({ totalAmount: 1000, paidAmount: 300, pendingAmount: 700 });
+    expect(r.pendingAmount).toBe(r.totalAmount - r.paidAmount);
+  });
+
+  it('pending is 0 when fully paid', () => {
+    const r = makeReceivable({ totalAmount: 500, paidAmount: 500, pendingAmount: 0 });
+    expect(r.pendingAmount).toBe(0);
+  });
+});
+
+// ── CampaignMarginRow isLow threshold ───────────────────────────────────
+
+describe('CampaignMarginRow isLow flag', () => {
+  it('isLow=true when margin < 20', () => {
+    const c = makeCampaign({ computedMarginPct: 19.9, isLow: true });
+    expect(c.isLow).toBe(true);
+  });
+
+  it('isLow=false when margin >= 20', () => {
+    const c = makeCampaign({ computedMarginPct: 20, isLow: false });
+    expect(c.isLow).toBe(false);
+  });
+
+  it('isLow=false when margin is null', () => {
+    const c = makeCampaign({ computedMarginPct: null, isLow: false });
+    expect(c.isLow).toBe(false);
+  });
+});

--- a/src/app/admin/(dashboard)/facturacion/dashboard/page.tsx
+++ b/src/app/admin/(dashboard)/facturacion/dashboard/page.tsx
@@ -1,0 +1,60 @@
+import { requirePermission } from '@/lib/permissions';
+import { getFinanceDashboard } from '@/lib/queries/financeDashboard';
+import { FinanceKPIGrid } from '@/features/admin/finance-dashboard/components/FinanceKPIGrid';
+import { CashflowChart } from '@/features/admin/finance-dashboard/components/CashflowChart';
+import { ReceivablesTable } from '@/features/admin/finance-dashboard/components/ReceivablesTable';
+import { ReconciliationPanel } from '@/features/admin/finance-dashboard/components/ReconciliationPanel';
+import { CampaignMarginsTable } from '@/features/admin/finance-dashboard/components/CampaignMarginsTable';
+import { FinanceAlertsList } from '@/features/admin/finance-dashboard/components/FinanceAlertsList';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata = {
+  title: 'Dashboard Financiero · SocialPro Admin',
+};
+
+export default async function FinanceDashboardPage() {
+  await requirePermission('facturacion', 'read');
+
+  const data = await getFinanceDashboard();
+
+  return (
+    <div className="flex flex-col gap-6 p-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-bold text-sp-admin-fg">Dashboard Financiero</h1>
+          <p className="text-sm text-sp-admin-muted">
+            Solo lectura · Accrual + Cash real · Sin conexiones bancarias externas
+          </p>
+        </div>
+      </div>
+
+      {data.alerts.length > 0 && (
+        <section aria-label="Alertas financieras">
+          <FinanceAlertsList alerts={data.alerts} />
+        </section>
+      )}
+
+      <section aria-label="KPIs financieros">
+        <FinanceKPIGrid kpis={data.kpis} />
+      </section>
+
+      <section aria-label="Cashflow mensual">
+        <CashflowChart data={data.cashflow} />
+      </section>
+
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
+        <div className="xl:col-span-2">
+          <ReceivablesTable rows={data.receivables} />
+        </div>
+        <div>
+          <ReconciliationPanel data={data.reconciliation} />
+        </div>
+      </div>
+
+      <section aria-label="Márgenes de campañas">
+        <CampaignMarginsTable rows={data.campaigns} />
+      </section>
+    </div>
+  );
+}

--- a/src/features/admin/finance-dashboard/components/CampaignMarginsTable.tsx
+++ b/src/features/admin/finance-dashboard/components/CampaignMarginsTable.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import type { CampaignMarginRow } from '@/types/financeDashboard';
+
+const EUR = new Intl.NumberFormat('es-ES', {
+  style: 'currency',
+  currency: 'EUR',
+  maximumFractionDigits: 0,
+});
+
+type Props = {
+  readonly rows: readonly CampaignMarginRow[];
+};
+
+export function CampaignMarginsTable({ rows }: Props): React.ReactElement {
+  if (rows.length === 0) {
+    return (
+      <div className="rounded-2xl border border-sp-admin-border bg-sp-admin-card px-5 py-8 text-center text-sm text-sp-admin-muted">
+        No hay campañas activas
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-2xl border border-sp-admin-border bg-sp-admin-card">
+      <div className="border-b border-sp-admin-border px-5 py-3">
+        <h3 className="text-[11px] font-semibold uppercase tracking-[0.2em] text-sp-admin-muted">
+          Márgenes campañas · presupuesto estimado
+        </h3>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-sp-admin-border">
+              {['Campaña', 'Marca', 'Talento', 'Presup. marca', 'Presup. talento', 'Margen', 'Cobro', 'Pago talent'].map(
+                (h) => (
+                  <th
+                    key={h}
+                    className="px-4 py-2 text-left text-[10px] font-semibold uppercase tracking-[0.15em] text-sp-admin-muted"
+                  >
+                    {h}
+                  </th>
+                ),
+              )}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr
+                key={row.id}
+                className="border-b border-sp-admin-border/50 last:border-0 hover:bg-white/[0.02]"
+              >
+                <td className="max-w-[160px] truncate px-4 py-2 font-medium text-sp-admin-fg">
+                  {row.isLow && <span className="mr-1 text-amber-400">⚠</span>}
+                  {row.name}
+                </td>
+                <td className="px-4 py-2 text-sp-admin-muted">
+                  {row.brandName ?? '—'}
+                </td>
+                <td className="px-4 py-2 text-sp-admin-muted">
+                  {row.talentName ?? '—'}
+                </td>
+                <td className="px-4 py-2 text-right text-sp-admin-fg">
+                  {EUR.format(row.amountBrand)}
+                </td>
+                <td className="px-4 py-2 text-right text-sp-admin-fg">
+                  {EUR.format(row.amountTalent)}
+                </td>
+                <td className={`px-4 py-2 text-right font-semibold ${row.isLow ? 'text-amber-400' : 'text-emerald-400'}`}>
+                  {row.computedMarginPct !== null ? `${row.computedMarginPct.toFixed(1)}%` : '—'}
+                </td>
+                <td className="px-4 py-2 text-center">
+                  <span
+                    className={`inline-block h-2 w-2 rounded-full ${row.cobroConfirmado ? 'bg-emerald-400' : 'bg-sp-admin-border'}`}
+                    title={row.cobroConfirmado ? 'Cobro confirmado' : 'Pendiente cobro'}
+                  />
+                </td>
+                <td className="px-4 py-2 text-center">
+                  <span
+                    className={`inline-block h-2 w-2 rounded-full ${row.pagoTalentConfirmado ? 'bg-emerald-400' : 'bg-sp-admin-border'}`}
+                    title={row.pagoTalentConfirmado ? 'Pago confirmado' : 'Pendiente pago'}
+                  />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/features/admin/finance-dashboard/components/CashflowChart.tsx
+++ b/src/features/admin/finance-dashboard/components/CashflowChart.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import type { CashflowMonthPoint } from '@/types/financeDashboard';
+
+const EUR = new Intl.NumberFormat('es-ES', {
+  style: 'currency',
+  currency: 'EUR',
+  maximumFractionDigits: 0,
+});
+
+const MONTH_FMT = new Intl.DateTimeFormat('es-ES', { month: 'short' });
+
+function shortMonth(yyyyMm: string): string {
+  const [y, m] = yyyyMm.split('-').map(Number);
+  if (!y || !m) return yyyyMm;
+  return MONTH_FMT.format(new Date(y, m - 1, 1));
+}
+
+type Props = {
+  readonly data: readonly CashflowMonthPoint[];
+};
+
+export function CashflowChart({ data }: Props): React.ReactElement {
+  const chartData = data.map((p) => ({
+    month: shortMonth(p.month),
+    cobrado: Math.round(p.cobrado),
+    pagado: Math.round(p.pagado),
+    neto: Math.round(p.neto),
+  }));
+
+  return (
+    <div className="rounded-2xl border border-sp-admin-border bg-sp-admin-card">
+      <div className="flex items-center justify-between border-b border-sp-admin-border px-5 py-3">
+        <div>
+          <h3 className="text-[11px] font-semibold uppercase tracking-[0.2em] text-sp-admin-muted">
+            Cashflow mensual · últimos 12 meses
+          </h3>
+          <p className="mt-0.5 text-[10px] text-sp-admin-muted/60">
+            Cobros reales (base caja) · Gastos facturados (base devengado)
+          </p>
+        </div>
+      </div>
+      <div className="h-64 px-2 pb-3">
+        <ResponsiveContainer width="100%" height="100%">
+          <AreaChart data={chartData} margin={{ top: 10, right: 16, bottom: 10, left: 0 }}>
+            <defs>
+              <linearGradient id="cf-cobrado" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor="rgb(34 197 94)" stopOpacity={0.4} />
+                <stop offset="100%" stopColor="rgb(34 197 94)" stopOpacity={0} />
+              </linearGradient>
+              <linearGradient id="cf-pagado" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor="rgb(245 158 11)" stopOpacity={0.4} />
+                <stop offset="100%" stopColor="rgb(245 158 11)" stopOpacity={0} />
+              </linearGradient>
+            </defs>
+            <CartesianGrid stroke="rgba(255,255,255,0.05)" strokeDasharray="3 3" vertical={false} />
+            <XAxis
+              dataKey="month"
+              tick={{ fill: 'var(--color-sp-admin-muted, #888)', fontSize: 11 }}
+              axisLine={false}
+              tickLine={false}
+            />
+            <YAxis
+              tickFormatter={(v: number) => EUR.format(v)}
+              tick={{ fill: 'var(--color-sp-admin-muted, #888)', fontSize: 11 }}
+              axisLine={false}
+              tickLine={false}
+              width={70}
+            />
+            <Tooltip
+              contentStyle={{
+                background: 'var(--color-sp-admin-card, #111)',
+                border: '1px solid var(--color-sp-admin-border, #333)',
+                borderRadius: '8px',
+                fontSize: '12px',
+              }}
+              formatter={(value, name) => {
+                const n = typeof value === 'number' ? value : Number(value ?? 0);
+                const label =
+                  name === 'cobrado' ? 'Cobrado (cash)' : name === 'pagado' ? 'Gastos (devengado)' : String(name);
+                return [EUR.format(n), label];
+              }}
+            />
+            <Area
+              type="monotone"
+              dataKey="cobrado"
+              stroke="rgb(34 197 94)"
+              fill="url(#cf-cobrado)"
+              strokeWidth={2}
+            />
+            <Area
+              type="monotone"
+              dataKey="pagado"
+              stroke="rgb(245 158 11)"
+              fill="url(#cf-pagado)"
+              strokeWidth={2}
+            />
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}

--- a/src/features/admin/finance-dashboard/components/FinanceAlertsList.tsx
+++ b/src/features/admin/finance-dashboard/components/FinanceAlertsList.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import type { FinanceAlert } from '@/types/financeDashboard';
+
+const EUR = new Intl.NumberFormat('es-ES', {
+  style: 'currency',
+  currency: 'EUR',
+  maximumFractionDigits: 0,
+});
+
+function severityStyles(s: FinanceAlert['severity']): string {
+  if (s === 'high') return 'border-red-500/40 bg-red-500/5 text-red-300';
+  if (s === 'medium') return 'border-amber-500/40 bg-amber-500/5 text-amber-300';
+  return 'border-sp-admin-border bg-sp-admin-card text-sp-admin-muted';
+}
+
+function severityIcon(s: FinanceAlert['severity']): string {
+  if (s === 'high') return '🔴';
+  if (s === 'medium') return '🟡';
+  return '🔵';
+}
+
+type Props = {
+  readonly alerts: readonly FinanceAlert[];
+};
+
+export function FinanceAlertsList({ alerts }: Props): React.ReactElement {
+  if (alerts.length === 0) {
+    return (
+      <div className="rounded-2xl border border-sp-admin-border bg-sp-admin-card px-5 py-6 text-center text-sm text-emerald-400">
+        Sin alertas financieras activas
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {alerts.map((alert, i) => (
+        <div
+          key={`${alert.type}-${i}`}
+          className={`flex items-center justify-between rounded-xl border px-4 py-3 ${severityStyles(alert.severity)}`}
+        >
+          <div className="flex items-center gap-2 text-sm">
+            <span>{severityIcon(alert.severity)}</span>
+            <span>{alert.message}</span>
+          </div>
+          {alert.amount !== undefined && (
+            <span className="ml-4 shrink-0 text-sm font-semibold">
+              {EUR.format(alert.amount)}
+            </span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/features/admin/finance-dashboard/components/FinanceKPIGrid.tsx
+++ b/src/features/admin/finance-dashboard/components/FinanceKPIGrid.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import type { FinanceDashboardKPIs } from '@/types/financeDashboard';
+
+const EUR = new Intl.NumberFormat('es-ES', {
+  style: 'currency',
+  currency: 'EUR',
+  maximumFractionDigits: 0,
+});
+
+type KPICardProps = {
+  readonly label: string;
+  readonly value: string;
+  readonly sub?: string;
+  readonly highlight?: 'positive' | 'negative' | 'neutral' | 'warning';
+};
+
+function KPICard({ label, value, sub, highlight = 'neutral' }: KPICardProps) {
+  const valueColor =
+    highlight === 'positive'
+      ? 'text-emerald-400'
+      : highlight === 'negative'
+        ? 'text-red-400'
+        : highlight === 'warning'
+          ? 'text-amber-400'
+          : 'text-sp-admin-fg';
+
+  return (
+    <div className="flex flex-col gap-1 rounded-2xl border border-sp-admin-border bg-sp-admin-card p-4">
+      <span className="text-[10px] font-semibold uppercase tracking-[0.18em] text-sp-admin-muted">
+        {label}
+      </span>
+      <span className={`text-2xl font-bold ${valueColor}`}>{value}</span>
+      {sub && <span className="text-[11px] text-sp-admin-muted">{sub}</span>}
+    </div>
+  );
+}
+
+type Props = {
+  readonly kpis: FinanceDashboardKPIs;
+};
+
+export function FinanceKPIGrid({ kpis }: Props): React.ReactElement {
+  return (
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6">
+      <KPICard
+        label="Cobrado real (mes)"
+        value={EUR.format(kpis.cobradoRealMes)}
+        sub="Base caja — invoice_payments"
+        highlight="positive"
+      />
+      <KPICard
+        label="Ingresos facturados"
+        value={EUR.format(kpis.incomeTotal)}
+        sub="Base devengado"
+        highlight="neutral"
+      />
+      <KPICard
+        label="Gastos totales"
+        value={EUR.format(kpis.expenseTotal)}
+        highlight="negative"
+      />
+      <KPICard
+        label="Beneficio neto"
+        value={EUR.format(kpis.beneficioNeto)}
+        highlight={kpis.beneficioNeto >= 0 ? 'positive' : 'negative'}
+      />
+      <KPICard
+        label="Pendiente cobro"
+        value={EUR.format(kpis.pendingCobro)}
+        highlight={kpis.pendingCobro > 0 ? 'warning' : 'neutral'}
+      />
+      <KPICard
+        label="Pendiente pago"
+        value={EUR.format(kpis.pendingPago)}
+        highlight={kpis.pendingPago > 0 ? 'warning' : 'neutral'}
+      />
+      <KPICard
+        label="Gastos campañas"
+        value={EUR.format(kpis.gastosCampana)}
+      />
+      <KPICard
+        label="Gastos empresa"
+        value={EUR.format(kpis.gastosEmpresa)}
+      />
+      <KPICard
+        label="Sin conciliar"
+        value={String(kpis.unconciliatedMovements)}
+        sub="Movimientos bancarios"
+        highlight={kpis.unconciliatedMovements > 10 ? 'warning' : 'neutral'}
+      />
+      <KPICard
+        label="Cobros sin aplicar"
+        value={String(kpis.pendingApplyPayment)}
+        sub="Conciliados, sin factura"
+        highlight={kpis.pendingApplyPayment > 0 ? 'warning' : 'neutral'}
+      />
+    </div>
+  );
+}

--- a/src/features/admin/finance-dashboard/components/ReceivablesTable.tsx
+++ b/src/features/admin/finance-dashboard/components/ReceivablesTable.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import type { ReceivableRow } from '@/types/financeDashboard';
+
+const EUR = new Intl.NumberFormat('es-ES', {
+  style: 'currency',
+  currency: 'EUR',
+  maximumFractionDigits: 2,
+});
+
+const DATE_FMT = new Intl.DateTimeFormat('es-ES', {
+  day: '2-digit',
+  month: 'short',
+  year: '2-digit',
+});
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '—';
+  const [y, m, d] = iso.split('-').map(Number);
+  if (!y || !m || !d) return iso;
+  return DATE_FMT.format(new Date(y, m - 1, d));
+}
+
+type Props = {
+  readonly rows: readonly ReceivableRow[];
+};
+
+export function ReceivablesTable({ rows }: Props): React.ReactElement {
+  if (rows.length === 0) {
+    return (
+      <div className="rounded-2xl border border-sp-admin-border bg-sp-admin-card px-5 py-8 text-center text-sm text-sp-admin-muted">
+        No hay cobros pendientes
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-2xl border border-sp-admin-border bg-sp-admin-card">
+      <div className="border-b border-sp-admin-border px-5 py-3">
+        <h3 className="text-[11px] font-semibold uppercase tracking-[0.2em] text-sp-admin-muted">
+          Cobros pendientes
+        </h3>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-sp-admin-border">
+              {['Nº factura', 'Cliente', 'Total', 'Pagado', 'Pendiente', 'Vencimiento', 'Estado'].map((h) => (
+                <th
+                  key={h}
+                  className="px-4 py-2 text-left text-[10px] font-semibold uppercase tracking-[0.15em] text-sp-admin-muted"
+                >
+                  {h}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr
+                key={`${row.source}-${row.id}`}
+                className="border-b border-sp-admin-border/50 last:border-0 hover:bg-white/[0.02]"
+              >
+                <td className="px-4 py-2 font-mono text-xs text-sp-admin-fg">
+                  {row.invoiceNumber}
+                  {row.source === 'issued' && (
+                    <span className="ml-1 text-[9px] text-sp-admin-muted">EMI</span>
+                  )}
+                </td>
+                <td className="px-4 py-2 text-sp-admin-fg">
+                  {row.clientName ?? <span className="text-sp-admin-muted">—</span>}
+                </td>
+                <td className="px-4 py-2 text-right text-sp-admin-fg">
+                  {EUR.format(row.totalAmount)}
+                </td>
+                <td className="px-4 py-2 text-right text-emerald-400">
+                  {row.paidAmount > 0 ? EUR.format(row.paidAmount) : <span className="text-sp-admin-muted">—</span>}
+                </td>
+                <td className="px-4 py-2 text-right font-semibold text-amber-400">
+                  {EUR.format(row.pendingAmount)}
+                </td>
+                <td className={`px-4 py-2 ${row.isOverdue ? 'text-red-400' : 'text-sp-admin-muted'}`}>
+                  {row.isOverdue && <span className="mr-1 text-xs">⚠</span>}
+                  {formatDate(row.dueDate)}
+                </td>
+                <td className="px-4 py-2">
+                  <span className="rounded-full border border-sp-admin-border px-2 py-0.5 text-[10px] uppercase tracking-wider text-sp-admin-muted">
+                    {row.status}
+                  </span>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/features/admin/finance-dashboard/components/ReconciliationPanel.tsx
+++ b/src/features/admin/finance-dashboard/components/ReconciliationPanel.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import Link from 'next/link';
+import type { ReconciliationSummary } from '@/types/financeDashboard';
+
+type Props = {
+  readonly data: ReconciliationSummary;
+};
+
+type StatRowProps = {
+  readonly label: string;
+  readonly value: number;
+  readonly highlight?: boolean;
+  readonly warn?: boolean;
+};
+
+function StatRow({ label, value, highlight, warn }: StatRowProps) {
+  return (
+    <div className="flex items-center justify-between py-1.5">
+      <span className="text-sm text-sp-admin-muted">{label}</span>
+      <span
+        className={`text-sm font-semibold ${
+          warn && value > 0
+            ? 'text-amber-400'
+            : highlight
+              ? 'text-emerald-400'
+              : 'text-sp-admin-fg'
+        }`}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+export function ReconciliationPanel({ data }: Props): React.ReactElement {
+  const conciliationRate =
+    data.totalTransactions > 0
+      ? Math.round((data.matched / data.totalTransactions) * 100)
+      : 0;
+
+  return (
+    <div className="rounded-2xl border border-sp-admin-border bg-sp-admin-card">
+      <div className="border-b border-sp-admin-border px-5 py-3">
+        <h3 className="text-[11px] font-semibold uppercase tracking-[0.2em] text-sp-admin-muted">
+          Estado conciliación bancaria
+        </h3>
+      </div>
+      <div className="divide-y divide-sp-admin-border/40 px-5">
+        <StatRow label="Total movimientos" value={data.totalTransactions} />
+        <StatRow label="Conciliados" value={data.matched} highlight />
+        <StatRow label="Sin conciliar" value={data.importedUnmatched} warn />
+        <StatRow label="Requieren revisión" value={data.needsReview} warn />
+        <StatRow label="Cobros sin aplicar a factura" value={data.pendingApplyPayment} warn />
+      </div>
+      <div className="flex items-center justify-between border-t border-sp-admin-border px-5 py-3">
+        <span className="text-xs text-sp-admin-muted">
+          Tasa de conciliación: <strong className="text-sp-admin-fg">{conciliationRate}%</strong>
+        </span>
+        <Link
+          href="/admin/facturacion/bancos/conciliacion"
+          className="text-xs text-sp-blue hover:underline"
+        >
+          Ver conciliación →
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/queries/financeDashboard/alerts.ts
+++ b/src/lib/queries/financeDashboard/alerts.ts
@@ -1,0 +1,67 @@
+import type {
+  CampaignMarginRow,
+  FinanceAlert,
+  FinanceDashboardKPIs,
+  ReceivableRow,
+  ReconciliationSummary,
+} from '@/types/financeDashboard';
+
+// Pura derivación en memoria — sin queries adicionales
+export function deriveAlerts(opts: {
+  kpis: FinanceDashboardKPIs;
+  receivables: readonly ReceivableRow[];
+  reconciliation: ReconciliationSummary;
+  campaigns: readonly CampaignMarginRow[];
+}): readonly FinanceAlert[] {
+  const { kpis, receivables, reconciliation, campaigns } = opts;
+  const alerts: FinanceAlert[] = [];
+
+  // Facturas vencidas
+  const overdueRows = receivables.filter((r) => r.isOverdue);
+  if (overdueRows.length > 0) {
+    const total = overdueRows.reduce((sum, r) => sum + r.pendingAmount, 0);
+    alerts.push({
+      type: 'overdue_receivable',
+      severity: total > 5000 ? 'high' : 'medium',
+      message: `${overdueRows.length} factura${overdueRows.length > 1 ? 's' : ''} vencida${overdueRows.length > 1 ? 's' : ''} por cobrar`,
+      count: overdueRows.length,
+      amount: total,
+    });
+  }
+
+  // Campañas con margen bajo
+  const lowMarginCampaigns = campaigns.filter((c) => c.isLow);
+  if (lowMarginCampaigns.length > 0) {
+    alerts.push({
+      type: 'low_margin',
+      severity: 'medium',
+      message: `${lowMarginCampaigns.length} campaña${lowMarginCampaigns.length > 1 ? 's' : ''} con margen < 20%`,
+      count: lowMarginCampaigns.length,
+    });
+  }
+
+  // Cobros conciliados pendientes de aplicar
+  if (kpis.pendingApplyPayment > 0) {
+    alerts.push({
+      type: 'pending_apply_payment',
+      severity: kpis.pendingApplyPayment > 5 ? 'high' : 'low',
+      message: `${kpis.pendingApplyPayment} cobro${kpis.pendingApplyPayment > 1 ? 's' : ''} conciliado${kpis.pendingApplyPayment > 1 ? 's' : ''} sin aplicar a factura`,
+      count: kpis.pendingApplyPayment,
+    });
+  }
+
+  // Movimientos bancarios sin conciliar
+  if (reconciliation.importedUnmatched > 0) {
+    alerts.push({
+      type: 'unreconciled',
+      severity: reconciliation.importedUnmatched > 20 ? 'medium' : 'low',
+      message: `${reconciliation.importedUnmatched} movimiento${reconciliation.importedUnmatched > 1 ? 's' : ''} bancario${reconciliation.importedUnmatched > 1 ? 's' : ''} sin conciliar`,
+      count: reconciliation.importedUnmatched,
+    });
+  }
+
+  return alerts.sort((a, b) => {
+    const order: Record<string, number> = { high: 0, medium: 1, low: 2 };
+    return (order[a.severity] ?? 3) - (order[b.severity] ?? 3);
+  });
+}

--- a/src/lib/queries/financeDashboard/campaignMargins.ts
+++ b/src/lib/queries/financeDashboard/campaignMargins.ts
@@ -1,0 +1,25 @@
+'server-only';
+
+import { getCampaignMarginSummary } from '@/lib/services/ai-assistant/tools/campaigns';
+import type { CampaignMarginRow } from '@/types/financeDashboard';
+
+const LOW_MARGIN_THRESHOLD = 20;
+
+export async function getCampaignMargins(): Promise<readonly CampaignMarginRow[]> {
+  const rows = await getCampaignMarginSummary();
+  return rows.map((r): CampaignMarginRow => ({
+    id: r.id,
+    name: r.name,
+    brandName: r.brandName,
+    talentName: r.talentName,
+    status: r.status,
+    amountBrand: r.amountBrand,
+    amountTalent: r.amountTalent,
+    computedMarginPct: r.computedMarginPct,
+    isLow: r.computedMarginPct !== null && r.computedMarginPct < LOW_MARGIN_THRESHOLD,
+    cobroConfirmado: r.cobroConfirmado,
+    pagoTalentConfirmado: r.pagoTalentConfirmado,
+  }));
+}
+
+export { LOW_MARGIN_THRESHOLD };

--- a/src/lib/queries/financeDashboard/cashflow.ts
+++ b/src/lib/queries/financeDashboard/cashflow.ts
@@ -1,0 +1,63 @@
+'server-only';
+
+import { and, eq, gte, ne, sql } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import { invoicePayments, invoices } from '@/db/schema';
+import type { CashflowMonthPoint } from '@/types/financeDashboard';
+
+function buildMonths(count: number): string[] {
+  const months: string[] = [];
+  const now = new Date();
+  for (let i = count - 1; i >= 0; i--) {
+    const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
+    months.push(
+      `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`,
+    );
+  }
+  return months;
+}
+
+// Cobrados: cash receipts via invoice_payments grouped by payment_date
+// Pagados: expense invoices accrual grouped by issue_date
+// Nota: pagado es base devengado porque apply-payment para gastos no está implementado aún.
+export async function getCashflowSeries(
+  months = 12,
+): Promise<readonly CashflowMonthPoint[]> {
+  const series = buildMonths(months);
+  const from = `${series[0]}-01`;
+
+  const [cobradoRows, pagadoRows] = await Promise.all([
+    db
+      .select({
+        month: sql<string>`to_char(${invoicePayments.paymentDate}, 'YYYY-MM')`,
+        total: sql<string>`COALESCE(SUM(${invoicePayments.amount}), 0)::text`,
+      })
+      .from(invoicePayments)
+      .where(gte(invoicePayments.paymentDate, from))
+      .groupBy(sql`to_char(${invoicePayments.paymentDate}, 'YYYY-MM')`),
+
+    db
+      .select({
+        month: sql<string>`to_char(${invoices.issueDate}::date, 'YYYY-MM')`,
+        total: sql<string>`COALESCE(SUM(${invoices.totalAmount}), 0)::text`,
+      })
+      .from(invoices)
+      .where(
+        and(
+          gte(invoices.issueDate, from),
+          eq(invoices.kind, 'expense'),
+          ne(invoices.status, 'anulada'),
+        ),
+      )
+      .groupBy(sql`to_char(${invoices.issueDate}::date, 'YYYY-MM')`),
+  ]);
+
+  const cobradoMap = new Map(cobradoRows.map((r) => [r.month, Number(r.total)]));
+  const pagadoMap = new Map(pagadoRows.map((r) => [r.month, Number(r.total)]));
+
+  return series.map((month): CashflowMonthPoint => {
+    const cobrado = cobradoMap.get(month) ?? 0;
+    const pagado = pagadoMap.get(month) ?? 0;
+    return { month, cobrado, pagado, neto: cobrado - pagado };
+  });
+}

--- a/src/lib/queries/financeDashboard/index.ts
+++ b/src/lib/queries/financeDashboard/index.ts
@@ -1,0 +1,30 @@
+'server-only';
+
+import { getCashflowSeries } from './cashflow';
+import { getFinanceDashboardKPIs } from './kpis';
+import { getReceivables } from './receivables';
+import { getReconciliationSummary } from './reconciliation';
+import { getCampaignMargins } from './campaignMargins';
+import { deriveAlerts } from './alerts';
+import type { FinanceDashboardData } from '@/types/financeDashboard';
+
+export async function getFinanceDashboard(): Promise<FinanceDashboardData> {
+  const [kpis, cashflow, receivables, reconciliation, campaigns] = await Promise.all([
+    getFinanceDashboardKPIs(),
+    getCashflowSeries(12),
+    getReceivables(),
+    getReconciliationSummary(),
+    getCampaignMargins(),
+  ]);
+
+  const alerts = deriveAlerts({ kpis, receivables, reconciliation, campaigns });
+
+  return { kpis, cashflow, receivables, reconciliation, campaigns, alerts };
+}
+
+export { getCashflowSeries } from './cashflow';
+export { getFinanceDashboardKPIs } from './kpis';
+export { getReceivables } from './receivables';
+export { getReconciliationSummary } from './reconciliation';
+export { getCampaignMargins, LOW_MARGIN_THRESHOLD } from './campaignMargins';
+export { deriveAlerts } from './alerts';

--- a/src/lib/queries/financeDashboard/kpis.ts
+++ b/src/lib/queries/financeDashboard/kpis.ts
@@ -1,0 +1,56 @@
+'server-only';
+
+import { and, count, eq, gte, isNull, lte, sql } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import { bankTransactions, invoicePayments } from '@/db/schema';
+import { getBillingKPIs } from '@/lib/queries/invoices';
+import { getBankReconciliationKpis } from '@/lib/queries/bankReconciliation';
+import type { FinanceDashboardKPIs } from '@/types/financeDashboard';
+
+function currentMonthRange(): { from: string; to: string } {
+  const now = new Date();
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, '0');
+  const last = new Date(y, now.getMonth() + 1, 0).getDate();
+  return {
+    from: `${y}-${m}-01`,
+    to: `${y}-${m}-${String(last).padStart(2, '0')}`,
+  };
+}
+
+export async function getFinanceDashboardKPIs(): Promise<FinanceDashboardKPIs> {
+  const { from, to } = currentMonthRange();
+
+  const [billing, reconciliation, cobRow, pendingRow] = await Promise.all([
+    getBillingKPIs(),
+    getBankReconciliationKpis(),
+    db
+      .select({ total: sql<string>`COALESCE(SUM(${invoicePayments.amount}), 0)::text` })
+      .from(invoicePayments)
+      .where(
+        and(
+          gte(invoicePayments.paymentDate, from),
+          lte(invoicePayments.paymentDate, to),
+        ),
+      ),
+    db
+      .select({ cnt: count() })
+      .from(bankTransactions)
+      .leftJoin(invoicePayments, eq(invoicePayments.bankTransactionId, bankTransactions.id))
+      .where(and(eq(bankTransactions.status, 'matched'), isNull(invoicePayments.id))),
+  ]);
+
+  return {
+    incomeTotal: billing.incomeTotal,
+    expenseTotal: billing.expenseTotal,
+    netTotal: billing.netTotal,
+    pendingCobro: billing.pendingCobro,
+    pendingPago: billing.pendingPago,
+    gastosCampana: billing.gastosCampana,
+    gastosEmpresa: billing.gastosEmpresa,
+    beneficioNeto: billing.beneficioNeto,
+    cobradoRealMes: Number(cobRow[0]?.total ?? 0),
+    pendingApplyPayment: Number(pendingRow[0]?.cnt ?? 0),
+    unconciliatedMovements: reconciliation.importedUnmatched,
+  };
+}

--- a/src/lib/queries/financeDashboard/receivables.ts
+++ b/src/lib/queries/financeDashboard/receivables.ts
@@ -1,0 +1,112 @@
+'server-only';
+
+import { and, asc, eq, inArray, sql } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import { billingClients, invoicePayments, invoices, issuedInvoices } from '@/db/schema';
+import { PENDING_INCOME_FILTER } from '@/lib/utils/invoice-status';
+import type { InvoiceStatus } from '@/types';
+import type { ReceivableRow } from '@/types/financeDashboard';
+
+const LIMIT = 30;
+
+const TODAY_MADRID = new Intl.DateTimeFormat('en-CA', {
+  timeZone: 'Europe/Madrid',
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+}).format(new Date());
+
+export async function getReceivables(): Promise<readonly ReceivableRow[]> {
+  const [issuedRows, internalRows] = await Promise.all([
+    // Facturas emitidas pendientes — paid via invoice_payments (SUM per invoice)
+    db
+      .select({
+        id: issuedInvoices.id,
+        invoiceNumber: issuedInvoices.invoiceNumber,
+        clientName: billingClients.name,
+        totalAmount: issuedInvoices.totalAmount,
+        paidAmount: sql<string>`COALESCE(SUM(${invoicePayments.amount}), 0)::text`,
+        status: issuedInvoices.status,
+        dueDate: issuedInvoices.dueDate,
+      })
+      .from(issuedInvoices)
+      .leftJoin(billingClients, eq(billingClients.id, issuedInvoices.billingClientId))
+      .leftJoin(invoicePayments, eq(invoicePayments.issuedInvoiceId, issuedInvoices.id))
+      .where(inArray(issuedInvoices.status, ['emitida', 'vencida', 'parcial']))
+      .groupBy(
+        issuedInvoices.id,
+        issuedInvoices.invoiceNumber,
+        billingClients.name,
+        issuedInvoices.totalAmount,
+        issuedInvoices.status,
+        issuedInvoices.dueDate,
+      )
+      .orderBy(asc(issuedInvoices.dueDate))
+      .limit(LIMIT),
+
+    // Facturas internas (kind=income) pendientes — paidAmount column
+    db
+      .select({
+        id: invoices.id,
+        number: invoices.number,
+        totalAmount: invoices.totalAmount,
+        paidAmount: invoices.paidAmount,
+        status: invoices.status,
+        dueDate: invoices.dueDate,
+      })
+      .from(invoices)
+      .where(
+        and(
+          eq(invoices.kind, 'income'),
+          inArray(invoices.status, PENDING_INCOME_FILTER as InvoiceStatus[]),
+        ),
+      )
+      .orderBy(asc(invoices.dueDate))
+      .limit(LIMIT),
+  ]);
+
+  const today = TODAY_MADRID;
+
+  const issued: ReceivableRow[] = issuedRows.map((r) => {
+    const total = Number(r.totalAmount);
+    const paid = Number(r.paidAmount);
+    const pending = Math.max(0, total - paid);
+    return {
+      id: r.id,
+      source: 'issued',
+      invoiceNumber: r.invoiceNumber,
+      clientName: r.clientName ?? null,
+      totalAmount: total,
+      paidAmount: paid,
+      pendingAmount: pending,
+      status: r.status,
+      dueDate: r.dueDate ?? null,
+      isOverdue: r.dueDate !== null && r.dueDate < today,
+    };
+  });
+
+  const internal: ReceivableRow[] = internalRows.map((r) => {
+    const total = Number(r.totalAmount);
+    const paid = Number(r.paidAmount ?? '0');
+    const pending = Math.max(0, total - paid);
+    return {
+      id: r.id,
+      source: 'internal',
+      invoiceNumber: r.number ?? `INT-${r.id}`,
+      clientName: null,
+      totalAmount: total,
+      paidAmount: paid,
+      pendingAmount: pending,
+      status: r.status,
+      dueDate: r.dueDate ?? null,
+      isOverdue: r.dueDate !== null && r.dueDate < today,
+    };
+  });
+
+  return [...issued, ...internal].sort((a, b) => {
+    if (a.dueDate === null && b.dueDate === null) return 0;
+    if (a.dueDate === null) return 1;
+    if (b.dueDate === null) return -1;
+    return a.dueDate < b.dueDate ? -1 : 1;
+  });
+}

--- a/src/lib/queries/financeDashboard/reconciliation.ts
+++ b/src/lib/queries/financeDashboard/reconciliation.ts
@@ -1,0 +1,26 @@
+'server-only';
+
+import { and, count, eq, isNull } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import { bankTransactions, invoicePayments } from '@/db/schema';
+import { getBankReconciliationKpis } from '@/lib/queries/bankReconciliation';
+import type { ReconciliationSummary } from '@/types/financeDashboard';
+
+export async function getReconciliationSummary(): Promise<ReconciliationSummary> {
+  const [kpis, pendingRow] = await Promise.all([
+    getBankReconciliationKpis(),
+    db
+      .select({ cnt: count() })
+      .from(bankTransactions)
+      .leftJoin(invoicePayments, eq(invoicePayments.bankTransactionId, bankTransactions.id))
+      .where(and(eq(bankTransactions.status, 'matched'), isNull(invoicePayments.id))),
+  ]);
+
+  return {
+    totalTransactions: kpis.totalTransactions,
+    importedUnmatched: kpis.importedUnmatched,
+    matched: kpis.matched,
+    needsReview: kpis.needsReview,
+    pendingApplyPayment: Number(pendingRow[0]?.cnt ?? 0),
+  };
+}

--- a/src/lib/services/ai-assistant/tools/financeDashboard.ts
+++ b/src/lib/services/ai-assistant/tools/financeDashboard.ts
@@ -1,0 +1,88 @@
+'server-only';
+
+import { getFinanceDashboardKPIs } from '@/lib/queries/financeDashboard/kpis';
+import { getCashflowSeries } from '@/lib/queries/financeDashboard/cashflow';
+import { getReceivables } from '@/lib/queries/financeDashboard/receivables';
+import { getCampaignMargins } from '@/lib/queries/financeDashboard/campaignMargins';
+import { getReconciliationSummary } from '@/lib/queries/financeDashboard/reconciliation';
+import { deriveAlerts } from '@/lib/queries/financeDashboard/alerts';
+
+export async function getFinanceDashboardSummary() {
+  const [kpis, reconciliation] = await Promise.all([
+    getFinanceDashboardKPIs(),
+    getReconciliationSummary(),
+  ]);
+  return {
+    accrual: {
+      incomeTotal: kpis.incomeTotal,
+      expenseTotal: kpis.expenseTotal,
+      netTotal: kpis.netTotal,
+      beneficioNeto: kpis.beneficioNeto,
+      pendingCobro: kpis.pendingCobro,
+      pendingPago: kpis.pendingPago,
+    },
+    cash: {
+      cobradoRealMes: kpis.cobradoRealMes,
+    },
+    bank: {
+      unconciliatedMovements: kpis.unconciliatedMovements,
+      pendingApplyPayment: kpis.pendingApplyPayment,
+      matched: reconciliation.matched,
+      needsReview: reconciliation.needsReview,
+    },
+  };
+}
+
+export async function getCashflowTrend() {
+  const series = await getCashflowSeries(12);
+  return {
+    note: 'cobrado=cash real (invoice_payments), pagado=devengado (invoices expense)',
+    series,
+  };
+}
+
+export async function getReceivablesRiskSummary() {
+  const rows = await getReceivables();
+  const overdue = rows.filter((r) => r.isOverdue);
+  const pending = rows.filter((r) => !r.isOverdue);
+  const totalOverdue = overdue.reduce((s, r) => s + r.pendingAmount, 0);
+  const totalPending = pending.reduce((s, r) => s + r.pendingAmount, 0);
+  return {
+    overdueCount: overdue.length,
+    overdueAmount: totalOverdue,
+    pendingCount: pending.length,
+    pendingAmount: totalPending,
+    top5Overdue: overdue.slice(0, 5).map((r) => ({
+      invoiceNumber: r.invoiceNumber,
+      clientName: r.clientName,
+      pendingAmount: r.pendingAmount,
+      dueDate: r.dueDate,
+    })),
+  };
+}
+
+export async function getCampaignMarginAlerts() {
+  const campaigns = await getCampaignMargins();
+  const low = campaigns.filter((c) => c.isLow);
+  return {
+    totalCampaigns: campaigns.length,
+    lowMarginCount: low.length,
+    lowMarginCampaigns: low.map((c) => ({
+      id: c.id,
+      name: c.name,
+      brandName: c.brandName,
+      computedMarginPct: c.computedMarginPct,
+      cobroConfirmado: c.cobroConfirmado,
+    })),
+  };
+}
+
+export async function getFinanceAlerts() {
+  const [kpis, receivables, reconciliation, campaigns] = await Promise.all([
+    getFinanceDashboardKPIs(),
+    getReceivables(),
+    getReconciliationSummary(),
+    getCampaignMargins(),
+  ]);
+  return deriveAlerts({ kpis, receivables, reconciliation, campaigns });
+}

--- a/src/lib/services/ai-assistant/tools/index.ts
+++ b/src/lib/services/ai-assistant/tools/index.ts
@@ -12,6 +12,13 @@ import {
   getSuggestedTransactionMatches,
   getPendingPaymentMatches,
 } from './bankReconciliation';
+import {
+  getFinanceDashboardSummary,
+  getCashflowTrend,
+  getReceivablesRiskSummary,
+  getCampaignMarginAlerts,
+  getFinanceAlerts,
+} from './financeDashboard';
 
 export type ToolResult =
   | { ok: true; data: unknown }
@@ -29,7 +36,12 @@ export type ToolName =
   | 'getBankReconciliationSummary'
   | 'getUnmatchedBankTransactions'
   | 'getSuggestedTransactionMatches'
-  | 'getPendingPaymentMatches';
+  | 'getPendingPaymentMatches'
+  | 'getFinanceDashboardSummary'
+  | 'getCashflowTrend'
+  | 'getReceivablesRiskSummary'
+  | 'getCampaignMarginAlerts'
+  | 'getFinanceAlerts';
 
 export const AVAILABLE_TOOLS = [
   'getBillingSummary',
@@ -44,6 +56,11 @@ export const AVAILABLE_TOOLS = [
   'getUnmatchedBankTransactions',
   'getSuggestedTransactionMatches',
   'getPendingPaymentMatches',
+  'getFinanceDashboardSummary',
+  'getCashflowTrend',
+  'getReceivablesRiskSummary',
+  'getCampaignMarginAlerts',
+  'getFinanceAlerts',
 ] as const satisfies readonly ToolName[];
 
 async function executeTool(name: ToolName, input?: unknown): Promise<ToolResult> {
@@ -77,6 +94,16 @@ async function executeTool(name: ToolName, input?: unknown): Promise<ToolResult>
         return { ok: true, data: await getSuggestedTransactionMatches() };
       case 'getPendingPaymentMatches':
         return { ok: true, data: await getPendingPaymentMatches() };
+      case 'getFinanceDashboardSummary':
+        return { ok: true, data: await getFinanceDashboardSummary() };
+      case 'getCashflowTrend':
+        return { ok: true, data: await getCashflowTrend() };
+      case 'getReceivablesRiskSummary':
+        return { ok: true, data: await getReceivablesRiskSummary() };
+      case 'getCampaignMarginAlerts':
+        return { ok: true, data: await getCampaignMarginAlerts() };
+      case 'getFinanceAlerts':
+        return { ok: true, data: await getFinanceAlerts() };
       default:
         return { ok: false, error: `Tool desconocida: ${name as string}` };
     }
@@ -129,6 +156,11 @@ Tienes acceso a las siguientes herramientas de solo lectura del CRM SocialPro:
 - getUnmatchedBankTransactions: lista hasta 25 transacciones bancarias importadas pendientes de conciliar
 - getSuggestedTransactionMatches: top candidato de conciliación por transacción sin conciliar (hasta 25)
 - getPendingPaymentMatches: transacciones conciliadas (aprobadas) cuyo cobro/pago aún no ha sido aplicado a la factura
+- getFinanceDashboardSummary: resumen completo del dashboard financiero (accrual, cash real del mes, estado conciliación bancaria)
+- getCashflowTrend: serie mensual de los últimos 12 meses con cobros reales (cash) y gastos facturados (devengado)
+- getReceivablesRiskSummary: cobros pendientes y vencidos agrupados por riesgo (importe total, top 5 vencidos)
+- getCampaignMarginAlerts: campañas con margen inferior al 20% (presupuesto estimado)
+- getFinanceAlerts: alertas financieras derivadas automáticamente del estado actual del sistema
 
 Para usarlas, incluye en tu respuesta una línea con el formato:
 [TOOL:nombreDeLaTool]

--- a/src/types/financeDashboard.ts
+++ b/src/types/financeDashboard.ts
@@ -1,0 +1,83 @@
+export type FinanceDashboardKPIs = {
+  // Accrual basis (invoices table)
+  readonly incomeTotal: number;
+  readonly expenseTotal: number;
+  readonly netTotal: number;
+  readonly pendingCobro: number;
+  readonly pendingPago: number;
+  readonly gastosCampana: number;
+  readonly gastosEmpresa: number;
+  readonly beneficioNeto: number;
+  // Cash basis (invoice_payments)
+  readonly cobradoRealMes: number;
+  // Bank reconciliation
+  readonly pendingApplyPayment: number;
+  readonly unconciliatedMovements: number;
+};
+
+export type CashflowMonthPoint = {
+  readonly month: string; // 'YYYY-MM'
+  readonly cobrado: number; // cash receipts (invoice_payments)
+  readonly pagado: number; // expense invoices accrual (invoices kind=expense)
+  readonly neto: number;
+};
+
+export type ReceivableRow = {
+  readonly id: number;
+  readonly source: 'issued' | 'internal';
+  readonly invoiceNumber: string;
+  readonly clientName: string | null;
+  readonly totalAmount: number;
+  readonly paidAmount: number;
+  readonly pendingAmount: number;
+  readonly status: string;
+  readonly dueDate: string | null;
+  readonly isOverdue: boolean;
+};
+
+export type CampaignMarginRow = {
+  readonly id: number;
+  readonly name: string;
+  readonly brandName: string | null;
+  readonly talentName: string | null;
+  readonly status: string;
+  readonly amountBrand: number;
+  readonly amountTalent: number;
+  readonly computedMarginPct: number | null;
+  readonly isLow: boolean; // < 20%
+  readonly cobroConfirmado: boolean;
+  readonly pagoTalentConfirmado: boolean;
+};
+
+export type ReconciliationSummary = {
+  readonly totalTransactions: number;
+  readonly importedUnmatched: number;
+  readonly matched: number;
+  readonly needsReview: number;
+  readonly pendingApplyPayment: number;
+};
+
+export type FinanceAlertType =
+  | 'overdue_receivable'
+  | 'low_margin'
+  | 'pending_apply_payment'
+  | 'unreconciled';
+
+export type FinanceAlertSeverity = 'high' | 'medium' | 'low';
+
+export type FinanceAlert = {
+  readonly type: FinanceAlertType;
+  readonly severity: FinanceAlertSeverity;
+  readonly message: string;
+  readonly count?: number;
+  readonly amount?: number;
+};
+
+export type FinanceDashboardData = {
+  readonly kpis: FinanceDashboardKPIs;
+  readonly cashflow: readonly CashflowMonthPoint[];
+  readonly receivables: readonly ReceivableRow[];
+  readonly reconciliation: ReconciliationSummary;
+  readonly campaigns: readonly CampaignMarginRow[];
+  readonly alerts: readonly FinanceAlert[];
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,6 +24,7 @@ export type { BrandFollowupDerivedStatus } from '@/lib/schemas/crmBrand';
 export type { FileType, FileRelatedType } from '@/lib/schemas/file';
 export type * from './bankReconciliation';
 export type * from './invoicePayment';
+export type * from './financeDashboard';
 
 import type { InferSelectModel } from 'drizzle-orm';
 import type { files, campaigns } from '@/db/schema';


### PR DESCRIPTION
## Summary

Adds a real finance/cashflow dashboard to the admin CRM, built on top of the recently merged billing, bank reconciliation and invoice payment modules.

The dashboard gives a consolidated view of:

- invoiced amount;
- real cash collected;
- pending receivables;
- overdue invoices;
- monthly cashflow;
- reconciliation status;
- recent payments;
- low-margin campaigns;
- finance alerts.

## What changed

- Added finance dashboard query layer under `src/lib/queries/financeDashboard/`.
- Added `/admin/facturacion/dashboard`.
- Added client UI components for KPIs, cashflow, receivables, reconciliation, margins and alerts.
- Added read-only AI tools:
  - `getFinanceDashboardSummary`
  - `getCashflowTrend`
  - `getReceivablesRiskSummary`
  - `getCampaignMarginAlerts`
  - `getFinanceAlerts`
- Added tests for dashboard calculations and AI tools.
- Uses real data from invoices, issued invoices, invoice payments, bank reconciliation and campaigns.

## Safety model

This PR is read-only from a finance perspective.

It does not:

- connect bank APIs;
- execute payments;
- modify invoices;
- apply payments;
- mark invoices as paid;
- send emails.

The AI tools are also read-only.

## Validation

- `npm run lint` ✅
- `npx tsc --noEmit` ✅
- `npm test -- --passWithNoTests` ✅
- 1065 tests passing
- 0 failing tests

## How to test

1. Go to `/admin/facturacion/dashboard`.
2. Review the KPI cards.
3. Check monthly cashflow.
4. Review pending receivables.
5. Review reconciliation status.
6. Review campaign margin alerts.
7. Ask the assistant:
   - "Dame un resumen financiero del mes"
   - "Qué facturas están en riesgo"
   - "Qué campañas tienen margen bajo"
   - "Qué debería revisar esta semana"

## Limitations

- No real bank API sync yet.
- Cashflow depends on existing imported/conciliated data.
- Payments are based on `invoice_payments`.
- Some expense data may still rely on accrual invoices until bank-side payment flows are expanded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)