### PR TITLE
feat(web-publica): auditoría UX — nav activo, empty states, accesibilidad, CTAs

### DIFF
--- a/src/__tests__/client/LandingFailSafe.test.tsx
+++ b/src/__tests__/client/LandingFailSafe.test.tsx
@@ -79,7 +79,7 @@ describe('CtaSection (broken-observer regression)', () => {
   it('keeps the CTA content in the DOM and tags the wrapper for CSS fallback', () => {
     render(<CtaSection />);
 
-    expect(screen.getByText(/Iniciar Propuesta/i)).toBeInTheDocument();
+    expect(screen.getByText(/Soy marca/i)).toBeInTheDocument();
 
     const wrappers = document.querySelectorAll('[data-motion-fallback]');
     expect(wrappers.length).toBeGreaterThan(0);

--- a/src/components/layout/Nav.tsx
+++ b/src/components/layout/Nav.tsx
@@ -66,6 +66,23 @@ export function Nav() {
   // useScroll on Safari iOS, where momentum scrolling delays motion events).
   const scrollProgress = useMotionValue(0);
 
+  // Normalizar pathname quitando el prefijo /en para comparar con hrefs del nav
+  const basePath = locale === 'en' ? pathname.replace(/^\/en/, '') || '/' : pathname;
+  const isActive = (href: string): boolean =>
+    href === '/'
+      ? basePath === '/'
+      : basePath === href || basePath.startsWith(`${href}/`);
+
+  // Cerrar menu mobile al presionar Escape
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [open]);
+
   useEffect(() => {
     let rafId = 0;
     let pending = false;
@@ -147,7 +164,10 @@ export function Nav() {
             <li key={l.href}>
               <Link
                 href={l.href}
-                className="whitespace-nowrap text-xs font-semibold uppercase tracking-wide text-white/50 hover:text-white transition-colors duration-200"
+                aria-current={isActive(l.href) ? 'page' : undefined}
+                className={`whitespace-nowrap text-xs font-semibold uppercase tracking-wide transition-colors duration-200 ${
+                  isActive(l.href) ? 'text-white' : 'text-white/50 hover:text-white'
+                }`}
               >
                 {l.label}
               </Link>
@@ -205,7 +225,10 @@ export function Nav() {
               >
                 <Link
                   href={l.href}
-                  className="text-xs font-semibold uppercase tracking-widest text-white/50 hover:text-white transition-colors block"
+                  aria-current={isActive(l.href) ? 'page' : undefined}
+                  className={`text-xs font-semibold uppercase tracking-widest block transition-colors ${
+                    isActive(l.href) ? 'text-white' : 'text-white/50 hover:text-white'
+                  }`}
                   onClick={() => setOpen(false)}
                 >
                   {l.label}

--- a/src/features/contact/components/ContactSection.parts.tsx
+++ b/src/features/contact/components/ContactSection.parts.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import * as m from 'motion/react-client';
 import { Target, Gamepad2 } from 'lucide-react';
 import { z } from 'zod';
@@ -47,6 +48,7 @@ export const TIMELINE_OPTIONS = [
 ];
 
 export const VERTICAL_OPTIONS = [
+  { value: 'igaming', label: 'iGaming (general)' },
   { value: 'cs2_skins', label: 'CS2 Skins' },
   { value: 'betting', label: 'Apuestas / Betting' },
   { value: 'casino', label: 'Casino' },
@@ -264,7 +266,15 @@ export function SuccessMessage(): React.JSX.Element {
         <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#10b981" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
       </div>
       <h3 className="font-bold text-white mb-2">¡Mensaje enviado!</h3>
-      <p className="text-sm text-sp-muted2">Te respondemos en menos de 24h.</p>
+      <p className="text-sm text-sp-muted2 mb-5">
+        Te respondemos en menos de 24h. Mientras tanto, explora nuestros talentos.
+      </p>
+      <Link
+        href="/talentos"
+        className="inline-flex items-center gap-1.5 px-5 py-2.5 rounded-xl text-sm font-semibold text-white border border-white/10 bg-white/5 hover:bg-white/10 transition-colors"
+      >
+        Ver talentos →
+      </Link>
     </div>
   );
 }

--- a/src/features/marketing-site/components/CtaSection.tsx
+++ b/src/features/marketing-site/components/CtaSection.tsx
@@ -53,17 +53,30 @@ export function CtaSection(): React.JSX.Element {
           2. Propuesta con creadores seleccionados en 48h ·
           3. Sin compromiso — decides si avanzar.
         </m.p>
-        <m.a
-          href="/contacto?type=brand"
-          onClick={() => trackEvent('cta_click', { cta_id: 'home_cta_section', cta_destination: '/contacto?type=brand' })}
+        <m.div
           variants={fadeUp}
           transition={{ duration: DURATION.slow, ease: EASE.out }}
-          whileHover={{ scale: 1.05 }}
-          whileTap={{ scale: 0.97 }}
-          className="inline-flex items-center justify-center px-10 py-4 rounded-full font-bold text-white text-base bg-sp-grad"
+          className="flex flex-col sm:flex-row items-center justify-center gap-4"
         >
-          Iniciar Propuesta →
-        </m.a>
+          <m.a
+            href="/contacto?type=brand"
+            onClick={() => trackEvent('cta_click', { cta_id: 'home_cta_brand', cta_destination: '/contacto?type=brand' })}
+            whileHover={{ scale: 1.05 }}
+            whileTap={{ scale: 0.97 }}
+            className="inline-flex w-full sm:w-auto items-center justify-center px-10 py-4 rounded-full font-bold text-white text-base bg-sp-grad"
+          >
+            Soy marca — Iniciar campaña →
+          </m.a>
+          <m.a
+            href="/contacto?type=talent"
+            onClick={() => trackEvent('cta_click', { cta_id: 'home_cta_talent', cta_destination: '/contacto?type=talent' })}
+            whileHover={{ scale: 1.05 }}
+            whileTap={{ scale: 0.97 }}
+            className="inline-flex w-full sm:w-auto items-center justify-center px-10 py-4 rounded-full font-bold text-base text-sp-muted2 border border-white/20 hover:text-white hover:border-white/40 transition-colors"
+          >
+            Soy creador →
+          </m.a>
+        </m.div>
         <m.p
           variants={fadeUp}
           transition={{ duration: DURATION.slow, ease: EASE.out }}

--- a/src/features/marketing-site/components/ServicesSection.tsx
+++ b/src/features/marketing-site/components/ServicesSection.tsx
@@ -37,14 +37,14 @@ const SERVICES = [
   },
   {
     id: 'youtube',
-    label: 'Gestión YouTube',
-    title: 'Gestión integral de canal YouTube',
+    label: 'Tengo un Canal de YouTube',
+    title: 'Para creadores de YouTube',
     steps: [
-      'Auditoría y optimización SEO del canal.',
-      'Estrategia de contenido y calendario editorial.',
-      'Producción de vídeos: edición, miniaturas y copywriting.',
-      'Gestión de monetización y partnerships.',
-      'Analytics mensuales y reporting de crecimiento.',
+      'Auditoría de tu canal: optimización, posicionamiento y oportunidades de crecimiento.',
+      'Estrategia de contenido y calendario editorial adaptado a tu nicho.',
+      'Producción profesional: edición, miniaturas y copywriting de títulos.',
+      'Gestión de monetización, partnerships y acuerdos con marcas.',
+      'Reporting mensual de analytics y plan de acción para el siguiente periodo.',
     ],
   },
 ];

--- a/src/features/talents-public/components/TalentCard.tsx
+++ b/src/features/talents-public/components/TalentCard.tsx
@@ -112,7 +112,7 @@ export function TalentCard({ talent, priority = false }: TalentCardProps) {
               onClick={(e) => e.stopPropagation()}
               className="w-6 h-6 rounded-full flex items-center justify-center hover:scale-110 transition-transform"
               style={{ backgroundColor: `${s.hexColor}20` }}
-              aria-label={s.platform}
+              aria-label={`Ver en ${s.platform.charAt(0).toUpperCase() + s.platform.slice(1)}`}
             >
               <SocialIcon type={s.platform} color={s.hexColor} size={12} />
             </a>

--- a/src/features/talents-public/components/TalentGrid.tsx
+++ b/src/features/talents-public/components/TalentGrid.tsx
@@ -38,29 +38,35 @@ export function TalentGrid({ talents }: TalentGridProps): React.JSX.Element {
 
       {/* Grid: wrapper plano para no tapar el contenido en móvil con whileInView */}
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-        <AnimatePresence mode="popLayout">
-          {visible.map((talent, index) => (
-            <m.div
-              key={talent.id}
-              layout
-              data-motion-fallback=""
-              initial={{ opacity: 0, scale: 0.95 }}
-              animate={{ opacity: 1, scale: 1 }}
-              exit={{ opacity: 0, scale: 0.95 }}
-              transition={{
-                duration: DURATION.base,
-                ease: EASE.out,
-                // Cap del stagger a 8 items: evita delays >0.4s en móvil con muchas cards
-                delay: Math.min(index, 8) * STAGGER.tight,
-              }}
-            >
-              <TalentCard
-                talent={talent}
-                priority={index < 4}
-              />
-            </m.div>
-          ))}
-        </AnimatePresence>
+        {visible.length === 0 ? (
+          <div className="col-span-full py-20 text-center">
+            <p className="text-sp-muted text-sm font-semibold">Sin talentos en esta plataforma por el momento.</p>
+          </div>
+        ) : (
+          <AnimatePresence mode="popLayout">
+            {visible.map((talent, index) => (
+              <m.div
+                key={talent.id}
+                layout
+                data-motion-fallback=""
+                initial={{ opacity: 0, scale: 0.95 }}
+                animate={{ opacity: 1, scale: 1 }}
+                exit={{ opacity: 0, scale: 0.95 }}
+                transition={{
+                  duration: DURATION.base,
+                  ease: EASE.out,
+                  // Cap del stagger a 8 items: evita delays >0.4s en móvil con muchas cards
+                  delay: Math.min(index, 8) * STAGGER.tight,
+                }}
+              >
+                <TalentCard
+                  talent={talent}
+                  priority={index < 4}
+                />
+              </m.div>
+            ))}
+          </AnimatePresence>
+        )}
       </div>
 
     </>


### PR DESCRIPTION
## Resumen

Auditoría UX/conversión de la web pública tras análisis exhaustivo de componentes. Sin cambios de SEO/GEO, sin migraciones de DB, sin dependencias nuevas.

- **Nav activo**: los links muestran `text-white` en la sección actual + `aria-current="page"`; Escape cierra el menú mobile
- **TalentGrid**: empty state cuando el filtro de plataforma no devuelve resultados (evita pantalla en blanco)
- **ContactSection**: `iGaming (general)` añadido a VERTICAL_OPTIONS como primera opción; SuccessMessage incluye link a `/talentos` tras el envío
- **TalentCard**: `aria-label` en social icons pasa de `"twitch"` a `"Ver en Twitch"` (accesibilidad WCAG)
- **ServicesSection**: tab renombrada de `"Gestión YouTube"` a `"Tengo un Canal de YouTube"` para mantener coherencia de patrón persona (Soy una Marca / Soy Creador / Tengo un Canal)
- **CtaSection**: un único CTA genérico → dos CTAs diferenciados (`Soy marca — Iniciar campaña →` / `Soy creador →`) con `w-full sm:w-auto` para mobile correcto

## Validaciones

- `npm run lint` ✅
- `npx tsc --noEmit` ✅
- `npm test` ✅ 1065/1065
- Build: compilación y TypeScript OK; page data falla solo por secretos de servidor ausentes en local (preexistente)

## Test plan

- [ ] Nav: navegar entre secciones y verificar que el link activo aparece en blanco
- [ ] Nav mobile: abrir menú, presionar Escape, verificar que se cierra
- [ ] TalentGrid: filtrar por "YouTube" o "Twitch" si no hay talentos en esa plataforma — debe aparecer mensaje en lugar de pantalla vacía
- [ ] Formulario /contacto → tipo "Marca" → verificar que "iGaming (general)" aparece en el selector Vertical
- [ ] Formulario /contacto → enviar → verificar SuccessMessage con botón "Ver talentos →"
- [ ] Home → scroll al final → verificar dos CTAs side-by-side en desktop, apilados en mobile
- [ ] ServicesSection → click en tercera tab → verificar "Tengo un Canal de YouTube"

🤖 Generated with [Claude Code](https://claude.com/claude-code)