### PR TITLE
feat(website): improve agency UX and locale detection

### DIFF
--- a/src/__tests__/server/middleware.test.ts
+++ b/src/__tests__/server/middleware.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Tests para el sistema de geo-detección de idioma.
+ * Cubre las 12 situaciones definidas en la especificación del middleware.
+ *
+ * Se testean funciones puras de @/lib/locale-detection (sin dependencias de Next.js).
+ * El middleware (src/middleware.ts) es una capa fina sobre estas funciones.
+ */
+import {
+  LOCALE_COOKIE,
+  LOCALE_COOKIE_MAX_AGE,
+  LOCALE_MIDDLEWARE_MATCHER,
+  SPANISH_COUNTRIES,
+  detectPreferredLocale,
+  getLocaleDecision,
+} from '@/lib/locale-detection';
+
+// ── Constantes ────────────────────────────────────────────────────────────────
+
+describe('LOCALE_COOKIE', () => {
+  it('tiene el nombre correcto', () => {
+    expect(LOCALE_COOKIE).toBe('socialpro_locale');
+  });
+});
+
+describe('LOCALE_COOKIE_MAX_AGE', () => {
+  it('es de un año (31536000 segundos)', () => {
+    expect(LOCALE_COOKIE_MAX_AGE).toBe(31536000);
+  });
+});
+
+describe('LOCALE_MIDDLEWARE_MATCHER', () => {
+  it('solo incluye / y /en', () => {
+    expect(LOCALE_MIDDLEWARE_MATCHER).toEqual(['/', '/en']);
+  });
+
+  // Tests 7-9: rutas excluidas del middleware
+  it('no incluye /admin (test 7)', () => {
+    expect(LOCALE_MIDDLEWARE_MATCHER).not.toContain('/admin/login');
+    expect(LOCALE_MIDDLEWARE_MATCHER as readonly string[]).not.toContain('/admin');
+  });
+
+  it('no incluye /api (test 8)', () => {
+    expect(LOCALE_MIDDLEWARE_MATCHER as readonly string[]).not.toContain('/api');
+  });
+
+  it('no incluye /_next (test 9)', () => {
+    expect(LOCALE_MIDDLEWARE_MATCHER as readonly string[]).not.toContain('/_next');
+  });
+});
+
+// ── SPANISH_COUNTRIES ─────────────────────────────────────────────────────────
+
+describe('SPANISH_COUNTRIES', () => {
+  const es = ['ES', 'MX', 'AR', 'CO', 'CL', 'PE', 'UY', 'PY', 'BO', 'EC',
+              'VE', 'CR', 'PA', 'DO', 'GT', 'HN', 'SV', 'NI', 'CU', 'PR'];
+  const en = ['US', 'GB', 'DE', 'FR', 'BR', 'PT', 'JP', 'AU', 'CA', 'IT'];
+
+  it.each(es)('incluye %s (hispanohablante)', (country) => {
+    expect(SPANISH_COUNTRIES.has(country)).toBe(true);
+  });
+
+  it.each(en)('no incluye %s (no hispanohablante)', (country) => {
+    expect(SPANISH_COUNTRIES.has(country)).toBe(false);
+  });
+});
+
+// ── detectPreferredLocale ─────────────────────────────────────────────────────
+
+describe('detectPreferredLocale', () => {
+  it('devuelve es para España (ES)', () => {
+    expect(detectPreferredLocale('ES', null)).toBe('es');
+  });
+
+  it('devuelve es para México (MX)', () => {
+    expect(detectPreferredLocale('MX', null)).toBe('es');
+  });
+
+  it('devuelve es para todos los países LATAM hispanohablantes', () => {
+    const latam = ['AR', 'CO', 'CL', 'PE', 'UY', 'PY', 'BO', 'EC', 'VE', 'CR', 'PA', 'DO', 'GT', 'HN', 'SV', 'NI', 'CU', 'PR'];
+    for (const c of latam) {
+      expect(detectPreferredLocale(c, null)).toBe('es');
+    }
+  });
+
+  it('devuelve en para US', () => {
+    expect(detectPreferredLocale('US', null)).toBe('en');
+  });
+
+  it('devuelve en para GB', () => {
+    expect(detectPreferredLocale('GB', null)).toBe('en');
+  });
+
+  it('devuelve en para otros países no hispanohablantes', () => {
+    for (const c of ['DE', 'FR', 'IT', 'JP', 'AU', 'CA']) {
+      expect(detectPreferredLocale(c, null)).toBe('en');
+    }
+  });
+
+  // Test 4: accept-language es fuera de país conocido → ES
+  it('sin país, accept-language es-AR → es (test 4)', () => {
+    expect(detectPreferredLocale(null, 'es-AR,es;q=0.9')).toBe('es');
+  });
+
+  it('sin país, accept-language es → es', () => {
+    expect(detectPreferredLocale(null, 'es')).toBe('es');
+  });
+
+  it('sin país, accept-language es-MX,en;q=0.8 → es', () => {
+    expect(detectPreferredLocale(undefined, 'es-MX,en;q=0.8')).toBe('es');
+  });
+
+  it('sin país, accept-language en-US → es (default, no es)', () => {
+    expect(detectPreferredLocale(null, 'en-US,en;q=0.9')).toBe('es');
+  });
+
+  it('sin país ni accept-language → es (default)', () => {
+    expect(detectPreferredLocale(null, null)).toBe('es');
+  });
+
+  it('sin país ni accept-language (undefined) → es (default)', () => {
+    expect(detectPreferredLocale(undefined, undefined)).toBe('es');
+  });
+});
+
+// ── getLocaleDecision ─────────────────────────────────────────────────────────
+
+describe('getLocaleDecision — homepages sin cookie', () => {
+  // Test 1: Visitante España en / → no redirige, cookie es
+  it('visitante ES en / → pass, cookie es (test 1)', () => {
+    const d = getLocaleDecision({
+      pathname: '/',
+      cookieLocale: undefined,
+      country: 'ES',
+      acceptLanguage: null,
+    });
+    expect(d.action).toBe('pass');
+    expect(d.locale).toBe('es');
+    if (d.action === 'pass') expect(d.writeCookie).toBe(true);
+  });
+
+  // Test 2: Visitante LATAM en / → no redirige, cookie es
+  it('visitante MX en / → pass, cookie es (test 2)', () => {
+    const d = getLocaleDecision({
+      pathname: '/',
+      cookieLocale: undefined,
+      country: 'MX',
+      acceptLanguage: null,
+    });
+    expect(d.action).toBe('pass');
+    expect(d.locale).toBe('es');
+    if (d.action === 'pass') expect(d.writeCookie).toBe(true);
+  });
+
+  // Test 3: Visitante US/GB en / → redirige a /en, cookie en
+  it('visitante US en / → redirect /en, cookie en (test 3)', () => {
+    const d = getLocaleDecision({
+      pathname: '/',
+      cookieLocale: undefined,
+      country: 'US',
+      acceptLanguage: null,
+    });
+    expect(d.action).toBe('redirect');
+    expect(d.locale).toBe('en');
+    if (d.action === 'redirect') expect(d.to).toBe('/en');
+  });
+
+  it('visitante GB en / → redirect /en, cookie en (test 3)', () => {
+    const d = getLocaleDecision({
+      pathname: '/',
+      cookieLocale: undefined,
+      country: 'GB',
+      acceptLanguage: null,
+    });
+    expect(d.action).toBe('redirect');
+    if (d.action === 'redirect') expect(d.to).toBe('/en');
+  });
+
+  // Test 4: Sin país, accept-language es-AR → no redirige
+  it('sin país, accept-language es-AR en / → pass, cookie es (test 4)', () => {
+    const d = getLocaleDecision({
+      pathname: '/',
+      cookieLocale: undefined,
+      country: null,
+      acceptLanguage: 'es-AR,es;q=0.9',
+    });
+    expect(d.action).toBe('pass');
+    expect(d.locale).toBe('es');
+  });
+
+  // Test 10: /en con country GB → no redirige, ya está bien
+  it('/en con country GB → pass, cookie en (test 10)', () => {
+    const d = getLocaleDecision({
+      pathname: '/en',
+      cookieLocale: undefined,
+      country: 'GB',
+      acceptLanguage: null,
+    });
+    expect(d.action).toBe('pass');
+    expect(d.locale).toBe('en');
+    if (d.action === 'pass') expect(d.writeCookie).toBe(true);
+  });
+
+  // Test 11: /en con country ES sin cookie → redirige a /
+  it('/en con country ES sin cookie → redirect /, cookie es (test 11)', () => {
+    const d = getLocaleDecision({
+      pathname: '/en',
+      cookieLocale: undefined,
+      country: 'ES',
+      acceptLanguage: null,
+    });
+    expect(d.action).toBe('redirect');
+    expect(d.locale).toBe('es');
+    if (d.action === 'redirect') expect(d.to).toBe('/');
+  });
+});
+
+describe('getLocaleDecision — cookie presente (respeto de preferencia manual)', () => {
+  // Test 5: Cookie manual en, country ES en / → no redirige (respeta cookie)
+  it('cookie=en, country ES en / → pass sin cookie write (test 5)', () => {
+    const d = getLocaleDecision({
+      pathname: '/',
+      cookieLocale: 'en',
+      country: 'ES',
+      acceptLanguage: null,
+    });
+    expect(d.action).toBe('pass');
+    expect(d.locale).toBe('en');
+    if (d.action === 'pass') expect(d.writeCookie).toBe(false);
+  });
+
+  // Test 6: Cookie manual es, country US en /en → no redirige (respeta cookie)
+  it('cookie=es, country US en /en → pass sin cookie write (test 6)', () => {
+    const d = getLocaleDecision({
+      pathname: '/en',
+      cookieLocale: 'es',
+      country: 'US',
+      acceptLanguage: null,
+    });
+    expect(d.action).toBe('pass');
+    expect(d.locale).toBe('es');
+    if (d.action === 'pass') expect(d.writeCookie).toBe(false);
+  });
+
+  it('cookie=es, country ES en / → pass sin redirect', () => {
+    const d = getLocaleDecision({
+      pathname: '/',
+      cookieLocale: 'es',
+      country: 'ES',
+      acceptLanguage: null,
+    });
+    expect(d.action).toBe('pass');
+    if (d.action === 'pass') expect(d.writeCookie).toBe(false);
+  });
+});
+
+describe('getLocaleDecision — anti-bucle (test 12)', () => {
+  // Simula el flujo completo: US llega a /, middleware redirige a /en + escribe cookie.
+  // La siguiente request a /en tiene cookie=en → debe pasar sin redirigir.
+  it('después de redirect / → /en con cookie=en, no vuelve a redirigir', () => {
+    // Primera request: US sin cookie en /
+    const first = getLocaleDecision({
+      pathname: '/',
+      cookieLocale: undefined,
+      country: 'US',
+      acceptLanguage: null,
+    });
+    expect(first.action).toBe('redirect');
+    if (first.action === 'redirect') expect(first.to).toBe('/en');
+
+    // Segunda request: /en con cookie=en (escrita por el redirect)
+    const second = getLocaleDecision({
+      pathname: '/en',
+      cookieLocale: first.locale, // 'en'
+      country: 'US',
+      acceptLanguage: null,
+    });
+    expect(second.action).toBe('pass');
+    if (second.action === 'pass') expect(second.writeCookie).toBe(false);
+  });
+
+  it('después de redirect /en → / con cookie=es, no vuelve a redirigir', () => {
+    // Primera request: ES sin cookie en /en
+    const first = getLocaleDecision({
+      pathname: '/en',
+      cookieLocale: undefined,
+      country: 'ES',
+      acceptLanguage: null,
+    });
+    expect(first.action).toBe('redirect');
+    if (first.action === 'redirect') expect(first.to).toBe('/');
+
+    // Segunda request: / con cookie=es
+    const second = getLocaleDecision({
+      pathname: '/',
+      cookieLocale: first.locale, // 'es'
+      country: 'ES',
+      acceptLanguage: null,
+    });
+    expect(second.action).toBe('pass');
+    if (second.action === 'pass') expect(second.writeCookie).toBe(false);
+  });
+
+  it('cookie inválida (valor inesperado) no bloquea la detección', () => {
+    // Si la cookie tiene un valor no reconocido, cae a detección normal
+    const d = getLocaleDecision({
+      pathname: '/',
+      cookieLocale: 'fr', // valor no válido
+      country: 'US',
+      acceptLanguage: null,
+    });
+    // 'fr' no es 'es' ni 'en', así que sigue la detección → US → redirect /en
+    expect(d.action).toBe('redirect');
+    expect(d.locale).toBe('en');
+  });
+});

--- a/src/__tests__/server/proxy-locale.test.ts
+++ b/src/__tests__/server/proxy-locale.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Tests de integración del proxy: verifica que la detección de locale
+ * se aplica SOLO a '/' y '/en', nunca a /admin ni /api.
+ *
+ * Importa `proxy` directamente desde src/proxy.ts.
+ */
+
+import { NextRequest } from 'next/server';
+
+// next/server trae dependencias de auth en test; mock necesario para evitar init errors
+jest.mock('@/lib/auth', () => ({ auth: {} }));
+
+import { proxy } from '@/proxy';
+import { LOCALE_COOKIE } from '@/lib/locale-detection';
+
+function req(
+  pathname: string,
+  opts: {
+    country?: string;
+    acceptLanguage?: string;
+    cookieLocale?: 'es' | 'en';
+  } = {},
+): NextRequest {
+  const url = new URL(pathname, 'http://localhost:3000');
+  const headers: Record<string, string> = {};
+  if (opts.country)        headers['x-vercel-ip-country'] = opts.country;
+  if (opts.acceptLanguage) headers['accept-language'] = opts.acceptLanguage;
+  if (opts.cookieLocale)   headers['cookie'] = `${LOCALE_COOKIE}=${opts.cookieLocale}`;
+  return new NextRequest(url, { headers });
+}
+
+// ── Aislamiento: /api y /admin nunca reciben cookie de locale ─────────────────
+
+describe('proxy — locale isolation: /api y /admin', () => {
+  it('/api/contact no recibe Set-Cookie socialpro_locale', () => {
+    const res = proxy(req('/api/contact', { country: 'US' }));
+    expect(res?.headers.get('set-cookie') ?? '').not.toContain(LOCALE_COOKIE);
+  });
+
+  it('/api/auth/sign-in no recibe Set-Cookie socialpro_locale', () => {
+    const res = proxy(req('/api/auth/sign-in', { country: 'ES' }));
+    expect(res?.headers.get('set-cookie') ?? '').not.toContain(LOCALE_COOKIE);
+  });
+
+  it('/api/contact no redirige por locale', () => {
+    const res = proxy(req('/api/contact', { country: 'US' }));
+    // Puede ser 429 si hay rate-limit, pero nunca un redirect de locale (307 a /en)
+    expect(res?.headers.get('location') ?? '').not.toMatch(/^\/en/);
+  });
+
+  it('/admin/login no recibe Set-Cookie socialpro_locale', () => {
+    // /admin/login está en PUBLIC_ADMIN_PATHS → checkAdminSession retorna null → NextResponse.next()
+    const res = proxy(req('/admin/login', { country: 'US' }));
+    expect(res?.headers.get('set-cookie') ?? '').not.toContain(LOCALE_COOKIE);
+  });
+
+  it('/admin/login no redirige a /en ni a /', () => {
+    const res = proxy(req('/admin/login', { country: 'US' }));
+    const location = res?.headers.get('location') ?? '';
+    expect(location).not.toBe('/en');
+    expect(location).not.toBe('/');
+  });
+});
+
+// ── Homepages: locale detection correcta ─────────────────────────────────────
+
+describe('proxy — locale detection en homepages', () => {
+  it('/ con country US → 307 a /en + cookie=en', () => {
+    const res = proxy(req('/', { country: 'US' }));
+    expect(res?.status).toBe(307);
+    expect(res?.headers.get('location')).toContain('/en');
+    expect(res?.headers.get('set-cookie')).toContain(`${LOCALE_COOKIE}=en`);
+  });
+
+  it('/ con country ES → pass (no redirect)', () => {
+    const res = proxy(req('/', { country: 'ES' }));
+    expect(res?.status).not.toBe(307);
+    expect(res?.status).not.toBe(308);
+  });
+
+  it('/en con country ES → 307 a / + cookie=es', () => {
+    const res = proxy(req('/en', { country: 'ES' }));
+    expect(res?.status).toBe(307);
+    expect(res?.headers.get('set-cookie')).toContain(`${LOCALE_COOKIE}=es`);
+  });
+
+  it('/en con country GB → pass (no redirect)', () => {
+    const res = proxy(req('/en', { country: 'GB' }));
+    expect(res?.status).not.toBe(307);
+    expect(res?.status).not.toBe(308);
+  });
+
+  // Cookie manda sobre geo
+
+  it('cookie=en, country ES en / → pass, sin redirect', () => {
+    const res = proxy(req('/', { country: 'ES', cookieLocale: 'en' }));
+    expect(res?.status).not.toBe(307);
+  });
+
+  it('cookie=es, country US en /en → pass, sin redirect', () => {
+    const res = proxy(req('/en', { country: 'US', cookieLocale: 'es' }));
+    expect(res?.status).not.toBe(307);
+  });
+
+  // Anti-bucle: cookie presente → no reescribe cookie
+
+  it('anti-bucle: / cookie=es país ES → no escribe Set-Cookie', () => {
+    const res = proxy(req('/', { country: 'ES', cookieLocale: 'es' }));
+    expect(res?.status).not.toBe(307);
+    expect(res?.headers.get('set-cookie') ?? '').not.toContain(LOCALE_COOKIE);
+  });
+
+  it('anti-bucle: /en cookie=en país GB → no escribe Set-Cookie', () => {
+    const res = proxy(req('/en', { country: 'GB', cookieLocale: 'en' }));
+    expect(res?.status).not.toBe(307);
+    expect(res?.headers.get('set-cookie') ?? '').not.toContain(LOCALE_COOKIE);
+  });
+});

--- a/src/components/layout/LangSwitch.tsx
+++ b/src/components/layout/LangSwitch.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { LOCALE_COOKIE, LOCALE_COOKIE_MAX_AGE } from '@/lib/locale-detection';
 
 type Pair = { alt: string; targetLang: 'EN' | 'ES' };
 
@@ -57,13 +58,20 @@ export function LangSwitch({ className, onNavigate }: Props): React.JSX.Element 
 
   const currentLang = pair.targetLang === 'EN' ? 'ES' : 'EN';
   const ariaLabel = pair.targetLang === 'EN' ? 'Switch to English' : 'Cambiar a español';
+  const targetLocale = pair.targetLang.toLowerCase() as 'es' | 'en';
+
+  const handleClick = (): void => {
+    // Escribir preferencia de idioma — leída por el middleware en visitas futuras
+    document.cookie = `${LOCALE_COOKIE}=${targetLocale}; path=/; max-age=${LOCALE_COOKIE_MAX_AGE}; SameSite=Lax`;
+    onNavigate?.();
+  };
 
   return (
     <Link
       href={pair.alt}
       hrefLang={pair.targetLang.toLowerCase()}
       aria-label={ariaLabel}
-      {...(onNavigate ? { onClick: onNavigate } : {})}
+      onClick={handleClick}
       className={
         className ??
         'inline-flex items-center gap-1.5 px-3 py-1.5 text-[11px] font-bold uppercase tracking-widest border border-white/15 hover:border-white/40 rounded-full transition-colors group'

--- a/src/lib/locale-detection.ts
+++ b/src/lib/locale-detection.ts
@@ -1,0 +1,79 @@
+/**
+ * Lógica pura de detección de idioma para el middleware de geo-redirección.
+ * Sin dependencias de Next.js — importable en tests y en edge runtime.
+ */
+
+export const LOCALE_COOKIE = 'socialpro_locale';
+
+export const LOCALE_COOKIE_MAX_AGE = 31536000; // 1 año
+
+/** Rutas a las que aplica el middleware de detección. */
+export const LOCALE_MIDDLEWARE_MATCHER = ['/', '/en'] as const;
+
+/**
+ * Países hispanohablantes — visitantes de estos países reciben ES.
+ * Resto → EN (si el país es conocido y no está aquí).
+ */
+export const SPANISH_COUNTRIES: ReadonlySet<string> = new Set([
+  'ES', 'MX', 'AR', 'CO', 'CL', 'PE', 'UY', 'PY', 'BO', 'EC',
+  'VE', 'CR', 'PA', 'DO', 'GT', 'HN', 'SV', 'NI', 'CU', 'PR',
+]);
+
+/**
+ * Devuelve el locale preferido basado en:
+ * 1. x-vercel-ip-country (si está disponible)
+ * 2. accept-language (si empieza por 'es')
+ * 3. Default ES (mercado principal)
+ *
+ * No hace llamadas externas ni almacena IP.
+ */
+export function detectPreferredLocale(
+  country: string | null | undefined,
+  acceptLanguage: string | null | undefined,
+): 'es' | 'en' {
+  // País conocido → decide directamente
+  if (country) {
+    return SPANISH_COUNTRIES.has(country) ? 'es' : 'en';
+  }
+  // Sin país: fallback a accept-language
+  if (acceptLanguage?.toLowerCase().startsWith('es')) return 'es';
+  // Sin información → default ES
+  return 'es';
+}
+
+export type LocaleDecision =
+  | { action: 'pass'; locale: 'es' | 'en'; writeCookie: boolean }
+  | { action: 'redirect'; to: '/' | '/en'; locale: 'es' | 'en' };
+
+/**
+ * Función pura que decide si redirigir o pasar, y qué cookie escribir.
+ * Usada tanto por el middleware como por los tests.
+ */
+export function getLocaleDecision(opts: {
+  readonly pathname: string;
+  readonly cookieLocale: string | undefined;
+  readonly country: string | null | undefined;
+  readonly acceptLanguage: string | null | undefined;
+}): LocaleDecision {
+  const { pathname, cookieLocale, country, acceptLanguage } = opts;
+
+  // Cookie válida presente → respetar siempre, sin redirigir ni reescribir
+  if (cookieLocale === 'es' || cookieLocale === 'en') {
+    return { action: 'pass', locale: cookieLocale, writeCookie: false };
+  }
+
+  const preferred = detectPreferredLocale(country, acceptLanguage);
+  const currentLocale: 'es' | 'en' = pathname === '/en' ? 'en' : 'es';
+
+  // Ya en el locale correcto → pasar y establecer cookie para no recalcular
+  if (currentLocale === preferred) {
+    return { action: 'pass', locale: preferred, writeCookie: true };
+  }
+
+  // Locale incorrecto → redirigir y establecer cookie
+  return {
+    action: 'redirect',
+    to: preferred === 'en' ? '/en' : '/',
+    locale: preferred,
+  };
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { getLocaleDecision, LOCALE_COOKIE, LOCALE_COOKIE_MAX_AGE } from '@/lib/locale-detection';
 
 /* -------------------------------------------------------------------------- */
 /*  In-memory sliding-window rate limiter (per-IP, per-route bucket)          */
@@ -92,13 +93,44 @@ function checkAdminSession(req: NextRequest): NextResponse | null {
   return null;
 }
 
+/* ---------- Locale detection for homepages --------------------------------- */
+
+const LOCALE_COOKIE_OPTS = { path: '/', maxAge: LOCALE_COOKIE_MAX_AGE, sameSite: 'lax' as const };
+
+function handleLocaleDetection(req: NextRequest): NextResponse {
+  const decision = getLocaleDecision({
+    pathname: req.nextUrl.pathname,
+    cookieLocale: req.cookies.get(LOCALE_COOKIE)?.value,
+    country: req.headers.get('x-vercel-ip-country'),
+    acceptLanguage: req.headers.get('accept-language'),
+  });
+
+  if (decision.action === 'pass') {
+    if (!decision.writeCookie) return NextResponse.next();
+    const res = NextResponse.next();
+    res.cookies.set(LOCALE_COOKIE, decision.locale, LOCALE_COOKIE_OPTS);
+    return res;
+  }
+
+  const url = req.nextUrl.clone();
+  url.pathname = decision.to;
+  const redirectRes = NextResponse.redirect(url);
+  redirectRes.cookies.set(LOCALE_COOKIE, decision.locale, LOCALE_COOKIE_OPTS);
+  return redirectRes;
+}
+
 /* ---------- Main proxy ------------------------------------------------------ */
 
 export function proxy(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+
+  // Locale detection — only for public homepages, before any other middleware
+  if (pathname === '/' || pathname === '/en') {
+    return handleLocaleDetection(req);
+  }
+
   const adminRedirect = checkAdminSession(req);
   if (adminRedirect) return adminRedirect;
-
-  const { pathname } = req.nextUrl;
 
   for (const rule of RATE_LIMITS) {
     if (rule.pattern.test(pathname)) {
@@ -119,5 +151,5 @@ export function proxy(req: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/api/:path*', '/admin/:path*'],
+  matcher: ['/', '/en', '/api/:path*', '/admin/:path*'],
 };


### PR DESCRIPTION
## Summary

Improves the public SocialPro website experience and adds safe homepage-level locale detection.

This PR focuses on low-risk UX, accessibility and conversion improvements for the agency website, plus automatic ES/EN homepage routing based on country/language signals.

## UX improvements

* Adds active state to navigation links.
* Allows closing the mobile menu with Escape.
* Adds empty state to the public TalentGrid.
* Adds `iGaming (general)` as a contact form vertical.
* Improves contact success state with a next action.
* Improves social link aria-labels in TalentCard.
* Updates ServicesSection copy from "Gestión YouTube" to "Tengo un Canal de YouTube".
* Adds differentiated CTAs for brands and creators.

## Locale detection

Adds homepage-only locale detection using the existing `src/proxy.ts` edge entrypoint.

Rules:

* Spain and Spanish-speaking LATAM → Spanish.
* Other countries → English.
* `accept-language: es-*` fallback keeps Spanish.
* Existing `socialpro_locale` cookie always wins.
* `/` may redirect to `/en` for international visitors.
* `/en` may redirect to `/` for Spanish visitors.
* Admin, API, assets, `_next`, robots and sitemap are not affected.

No external geolocation services are used.
No IP addresses are stored.
No tracking is added.
The cookie only stores language preference: `socialpro_locale=es|en`.

## Safety

This PR does not:

* change database schema;
* touch admin/finance logic;
* add dependencies;
* change sitemap/hreflang;
* change internal routes;
* add SEO/GEO automation;
* use external IP lookup;
* store personal data.

## Tests

Added tests for:

* pure locale decision logic;
* proxy integration;
* country-based homepage routing;
* cookie override behaviour;
* admin/API isolation;
* loop prevention;
* updated landing fail-safe copy expectations.

## Validation

* `npm run lint` ✅
* `npx tsc --noEmit` ✅
* `npm test -- --passWithNoTests` ✅
* 1139 tests passing ✅
* `next build` TypeScript/Next compilation ✅
* local `Collecting page data` fails only because dummy DB/Neon is unavailable locally, not due to this PR.

## How to test

1. Visit `/` without cookie from a Spanish/LATAM country header → stays Spanish.
2. Visit `/` without cookie from a US/GB country header → redirects to `/en`.
3. Visit `/en` without cookie from Spain → redirects to `/`.
4. Change language manually using the language switcher → preference persists.
5. Visit `/admin/login` → no locale cookie or locale redirect.
6. Visit `/api/...` → no locale cookie or locale redirect.
7. Test mobile nav → Escape closes the menu.
8. Filter talents to an empty result → empty state appears.
9. Submit contact form → success state shows next action.

## Known limitations

* Detection only applies to `/` and `/en`, not internal pages.
* `<html lang="es">` remains a known limitation of the current root layout architecture.
* Full i18n routing cleanup should be handled separately if needed.
* Build page-data collection requires real DB env vars and is not expected to fully pass with dummy local credentials.