### PR TITLE
chore(website): normalize legacy en redirects

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -70,10 +70,17 @@ const nextConfig: NextConfig = {
       // Old URL structure used singular /talento/; current is /talentos/.
       { source: '/talento/:slug/',              destination: '/talentos/:slug', permanent: true },
       { source: '/talento/:slug',               destination: '/talentos/:slug', permanent: true },
-      // /en/talents → /talents (301 permanent)
+      // /en/talents → /talents (308 permanent)
       // Old EN talent listing URL; current canonical is /talents.
       { source: '/en/talents/',                 destination: '/talents', permanent: true },
       { source: '/en/talents',                  destination: '/talents', permanent: true },
+      // /en/services → /services (308 permanent)
+      // /en/contact → /contact (308 permanent)
+      // Regulariza rutas /en/* sin página propia para que coincidan con /en/talents.
+      { source: '/en/services/',                destination: '/services', permanent: true },
+      { source: '/en/services',                 destination: '/services', permanent: true },
+      { source: '/en/contact/',                 destination: '/contact',  permanent: true },
+      { source: '/en/contact',                  destination: '/contact',  permanent: true },
       // /marcas/login → /admin/login (308 permanent)
       // /marcas/login page was removed in the CRM refactor; brand users log in via /admin/login
       // and are redirected to /marcas after successful auth. Keeps bookmarks and backlinks working.


### PR DESCRIPTION
## Summary

Normalizes legacy English-prefixed redirect paths discovered during post-deploy QA.

The production QA confirmed that:

* SSL is valid for both `socialpro.es` and `www.socialpro.es`.
* Core public routes return correctly.
* Locale detection works as designed.
* The language switcher persists `socialpro_locale`.
* No redirect loops were found.

This PR only fixes the minor redirect inconsistency found for legacy `/en/...` URLs.

## Changes

Adds permanent redirects:

* `/en/services` → `/services`
* `/en/services/` → `/services`
* `/en/contact` → `/contact`
* `/en/contact/` → `/contact`

This matches the existing behavior of:

* `/en/talents` → `/talents`

## Safety

This PR does not touch:

* middleware/proxy locale detection;
* admin;
* API;
* database;
* SEO metadata;
* sitemap;
* hreflang;
* SSL/DNS;
* page components.

## Validation

* `npm run lint` ✅
* `npx tsc --noEmit` ✅
* `npm test -- --passWithNoTests` ✅
* 1139 tests passing ✅

## Post-deploy check

After deploy, verify:

\`\`\`bash
curl -I https://socialpro.es/en/services
curl -I https://socialpro.es/en/contact
curl -I https://socialpro.es/en/talents
\`\`\`

Expected:

* `/en/services` → 308 → `/services`
* `/en/contact` → 308 → `/contact`
* `/en/talents` → 308 → `/talents`

🤖 Generated with [Claude Code](https://claude.com/claude-code)