### PR TITLE
fix(campanas): exclude cancelled deals from all KPI calculations

### DIFF
--- a/src/__tests__/client/campaign-kpis.test.ts
+++ b/src/__tests__/client/campaign-kpis.test.ts
@@ -1,0 +1,129 @@
+import { computeKpis } from '@/features/admin/campaigns/components/CampaignsList.parts';
+import type { CampaignWithRelations } from '@/types';
+
+function makeCampaign(overrides: Partial<CampaignWithRelations> = {}): CampaignWithRelations {
+  const base: CampaignWithRelations = {
+    id: 1,
+    name: 'Test',
+    brandId: 1,
+    talentId: 1,
+    brandContactId: null,
+    responsibleUserId: null,
+    createdByUserId: null,
+    assignedToUserId: null,
+    sector: null,
+    geo: null,
+    actionType: 'stream',
+    status: 'activa',
+    startDate: null,
+    endDate: null,
+    deliveryDeadline: null,
+    briefingUrl: null,
+    contentUrl: null,
+    notes: null,
+    currency: 'EUR',
+    amountBrand: '10000',
+    amountTalent: '7000',
+    amountInKindTalent: null,
+    amountInKindCommunity: null,
+    estimatedCostAgency: null,
+    estimatedMarginPct: null,
+    cnmcChecklistOk: false,
+    cnmcChecklistAt: null,
+    cnmcChecklistUserId: null,
+    brandPaymentMethod: null,
+    talentPaymentMethod: null,
+    cobroConfirmado: false,
+    pagoTalentConfirmado: false,
+    visibility: 'team',
+    archivedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    brandName: 'Marca Test',
+    talentName: 'Talent Test',
+    ownerName: null,
+    brandPaid: 'no',
+    talentPaid: 'no',
+    totalInvoicedBrand: 0,
+    totalPaidTalent: 0,
+    commissionAmount: 3000,
+    commissionPct: 30,
+    ...overrides,
+  };
+  return base;
+}
+
+describe('computeKpis — tratos cancelados', () => {
+  it('un trato cancelado no suma al total', () => {
+    const campaigns = [makeCampaign({ status: 'cancelada' })];
+    const kpis = computeKpis(campaigns);
+    expect(kpis.total).toBe(0);
+  });
+
+  it('un trato cancelado no suma a revenue', () => {
+    const campaigns = [makeCampaign({ status: 'cancelada', amountBrand: '75000' })];
+    const kpis = computeKpis(campaigns);
+    expect(kpis.revenueBruto).toBe(0);
+  });
+
+  it('un trato cancelado no suma al margen', () => {
+    const campaigns = [makeCampaign({ status: 'cancelada', amountBrand: '75000', amountTalent: '60000' })];
+    const kpis = computeKpis(campaigns);
+    expect(kpis.margenTotal).toBe(0);
+  });
+
+  it('un trato cancelado no suma a pendiente de cobro', () => {
+    const campaigns = [makeCampaign({ status: 'cancelada' })];
+    const kpis = computeKpis(campaigns);
+    expect(kpis.pendienteCobro).toBe(0);
+  });
+
+  it('un trato cancelado no suma a pendiente de talent', () => {
+    const campaigns = [makeCampaign({ status: 'cancelada' })];
+    const kpis = computeKpis(campaigns);
+    expect(kpis.pendienteTalent).toBe(0);
+  });
+
+  it('mezcla: activo + cancelado — solo el activo contabiliza', () => {
+    const campaigns = [
+      makeCampaign({ id: 1, status: 'activa',    amountBrand: '10000', amountTalent: '7000' }),
+      makeCampaign({ id: 2, status: 'cancelada', amountBrand: '75000', amountTalent: '60000' }),
+    ];
+    const kpis = computeKpis(campaigns);
+    expect(kpis.total).toBe(1);
+    expect(kpis.activos).toBe(1);
+    expect(kpis.revenueBruto).toBe(10000);
+    expect(kpis.margenTotal).toBe(3000);
+    expect(kpis.pendienteCobro).toBe(10000);
+    expect(kpis.pendienteTalent).toBe(7000);
+  });
+
+  it('trato cancelado archivado tampoco contabiliza', () => {
+    const campaigns = [makeCampaign({ status: 'cancelada', archivedAt: new Date() })];
+    const kpis = computeKpis(campaigns);
+    expect(kpis.total).toBe(0);
+    expect(kpis.revenueBruto).toBe(0);
+  });
+});
+
+describe('computeKpis — otros estados no afectados', () => {
+  it('trato pagado sí suma a revenue y margen, no a pendientes', () => {
+    const campaigns = [makeCampaign({ status: 'pagada', amountBrand: '10000', amountTalent: '7000' })];
+    const kpis = computeKpis(campaigns);
+    expect(kpis.revenueBruto).toBe(10000);
+    expect(kpis.margenTotal).toBe(3000);
+    expect(kpis.pendienteCobro).toBe(0);
+    expect(kpis.pendienteTalent).toBe(0);
+  });
+
+  it('trato activo suma a todo', () => {
+    const campaigns = [makeCampaign({ status: 'activa', amountBrand: '10000', amountTalent: '7000' })];
+    const kpis = computeKpis(campaigns);
+    expect(kpis.total).toBe(1);
+    expect(kpis.activos).toBe(1);
+    expect(kpis.revenueBruto).toBe(10000);
+    expect(kpis.margenTotal).toBe(3000);
+    expect(kpis.pendienteCobro).toBe(10000);
+    expect(kpis.pendienteTalent).toBe(7000);
+  });
+});

--- a/src/features/admin/campaigns/components/CampaignsList.parts.tsx
+++ b/src/features/admin/campaigns/components/CampaignsList.parts.tsx
@@ -60,7 +60,7 @@ export type CampaignKpis = {
 
 const ACTIVE_STATUSES   = new Set<CampaignStatus>(['activa', 'aprobada']);
 const FINISHED_STATUSES = new Set<CampaignStatus>(['completada', 'pagada']);
-const PAID_STATUSES     = new Set<CampaignStatus>(['pagada', 'cancelada']);
+const PAID_STATUSES     = new Set<CampaignStatus>(['pagada']);
 
 export function computeKpis(campaigns: readonly CampaignWithRelations[], rate?: number): CampaignKpis {
   let activos = 0, negociacion = 0, finalizados = 0, countEUR = 0, countUSD = 0;
@@ -71,6 +71,7 @@ export function computeKpis(campaigns: readonly CampaignWithRelations[], rate?: 
 
   for (const c of campaigns) {
     if (c.archivedAt !== null) continue;
+    if (c.status === 'cancelada') continue;
 
     const cur       = c.currency ?? 'EUR';
     const isUSD     = cur === 'USD';
@@ -103,7 +104,7 @@ export function computeKpis(campaigns: readonly CampaignWithRelations[], rate?: 
     }
   }
 
-  const active = campaigns.filter((c) => c.archivedAt === null);
+  const active = campaigns.filter((c) => c.archivedAt === null && c.status !== 'cancelada');
   return {
     total: active.length, activos, negociacion, finalizados,
     countEUR, countUSD,


### PR DESCRIPTION
## Summary

Cancelled deals (`status = 'cancelada'`) were incorrectly included in revenue, margin, and total deal count KPIs on the deals dashboard.

- Cancelled deals now contribute **zero** to all KPIs: total, revenue, margin, pending cobro, pending talent.
- The only way to see cancelled deals is by filtering explicitly by status or by archiving them.

## Root cause

`computeKpis` only excluded cancelled deals from the pending KPIs (via `PAID_STATUSES`), but still accumulated their `amountBrand` into `revenueBruto` and `margenTotal`, and counted them in `total`.

## Changes

`src/features/admin/campaigns/components/CampaignsList.parts.tsx`
- Removed `cancelada` from `PAID_STATUSES`
- Added `if (c.status === 'cancelada') continue` at the top of the KPI loop
- Excluded `cancelada` from the `total` count filter

`src/__tests__/client/campaign-kpis.test.ts` *(new)*
- 9 tests covering cancelled exclusion for all KPIs
- Tests for mixed active+cancelled scenarios
- Tests confirming `pagada` still accumulates revenue/margin correctly

## Validation

- `npm run lint` ✅
- `npx tsc --noEmit` ✅
- `npm test` ✅ — 1148/1148 passing (9 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)