### PR TITLE
fix(contracts): proxy private PDFs and harden previews

### DIFF
--- a/src/__tests__/server/admin-contracts-pdf-proxy.test.ts
+++ b/src/__tests__/server/admin-contracts-pdf-proxy.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Tests para el proxy admin de PDFs de contratos generados.
+ * Ruta: /api/admin/contratos/[id]/pdf
+ *
+ * Verifica:
+ * - Acceso denegado sin permiso → error propagado (auth guard activo)
+ * - ID inválido o no entero → 404
+ * - Contrato inexistente → 404
+ * - Contrato sin fileUrl → 404
+ * - Sin BLOB_READ_WRITE_TOKEN → 503
+ * - Contrato válido → 200 PDF inline con cabeceras correctas
+ * - BLOB_READ_WRITE_TOKEN no se expone en cabeceras de respuesta
+ * - Links admin ya no usan fileUrl directo
+ */
+
+// ── mocks ──────────────────────────────────────────────────────────────
+
+jest.mock('@/lib/db',   () => ({ db: {} }));
+jest.mock('@/lib/auth', () => ({ auth: {} }));
+
+const mockRequirePermission = jest.fn();
+jest.mock('@/lib/permissions', () => ({
+  requirePermission: (...args: unknown[]) => mockRequirePermission(...args),
+  PERMISSIONS: {},
+}));
+
+const mockGetGeneratedContract = jest.fn();
+jest.mock('@/lib/queries/generatedContracts', () => ({
+  getGeneratedContract: (...args: unknown[]) => mockGetGeneratedContract(...args),
+  listGeneratedContracts: jest.fn(),
+  CONTRACT_STATUSES: [],
+}));
+
+jest.mock('@/lib/env', () => ({
+  env: {
+    get BLOB_READ_WRITE_TOKEN() {
+      return process.env.BLOB_READ_WRITE_TOKEN ?? '';
+    },
+  },
+}));
+
+// ── imports tras mocks ─────────────────────────────────────────────────
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { NextRequest } from 'next/server';
+import { GET as adminPdfGET } from '@/app/api/admin/contratos/[id]/pdf/route';
+
+// ── helpers ────────────────────────────────────────────────────────────
+
+const makeReq = (id = '1') =>
+  new NextRequest(`http://localhost:3000/api/admin/contratos/${id}/pdf`);
+
+const makeParams = (id = '1') =>
+  ({ params: Promise.resolve({ id }) });
+
+const BLOB_SECRET = 'test-blob-token-secret-abc123';
+
+const mockBlobOk = () => {
+  (global.fetch as jest.Mock).mockResolvedValue({
+    ok: true,
+    headers: { get: (k: string) => (k === 'content-type' ? 'application/pdf' : null) },
+    arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)),
+  });
+};
+
+const validContract = (override: Record<string, unknown> = {}) => ({
+  id: 1,
+  title: 'Contrato Test',
+  status: 'draft',
+  fileName: 'contrato.pdf',
+  fileUrl: 'https://blob.example.com/contracts/1/contrato.pdf',
+  filePath: 'contracts/1/contrato.pdf',
+  createdAt: new Date(),
+  sentAt: null,
+  signedAt: null,
+  templateName: null,
+  talentName: null,
+  brandName: null,
+  content: '',
+  varsJson: null,
+  notes: null,
+  campaignId: null,
+  ...override,
+});
+
+// ── setup ──────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockRequirePermission.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+  global.fetch = jest.fn();
+  process.env.BLOB_READ_WRITE_TOKEN = BLOB_SECRET;
+});
+
+afterEach(() => {
+  delete process.env.BLOB_READ_WRITE_TOKEN;
+});
+
+// ── tests ──────────────────────────────────────────────────────────────
+
+describe('Admin PDF proxy — /api/admin/contratos/[id]/pdf', () => {
+
+  describe('autenticación y permisos', () => {
+    it('sin permiso → el handler propaga el error del guard', async () => {
+      mockRequirePermission.mockRejectedValue(new Error('forbidden:contratos:read'));
+      await expect(adminPdfGET(makeReq(), makeParams())).rejects.toThrow('forbidden');
+    });
+
+    it('requirePermission se llama con módulo "contratos" y acción "read"', async () => {
+      mockGetGeneratedContract.mockResolvedValue(null);
+      await adminPdfGET(makeReq('99'), makeParams('99'));
+      expect(mockRequirePermission).toHaveBeenCalledWith('contratos', 'read');
+    });
+  });
+
+  describe('validación del ID', () => {
+    it('ID no numérico → 404', async () => {
+      const res = await adminPdfGET(makeReq('abc'), makeParams('abc'));
+      expect(res.status).toBe(404);
+      expect(mockGetGeneratedContract).not.toHaveBeenCalled();
+    });
+
+    it('ID cero → 404', async () => {
+      const res = await adminPdfGET(makeReq('0'), makeParams('0'));
+      expect(res.status).toBe(404);
+      expect(mockGetGeneratedContract).not.toHaveBeenCalled();
+    });
+
+    it('ID negativo → 404', async () => {
+      const res = await adminPdfGET(makeReq('-5'), makeParams('-5'));
+      expect(res.status).toBe(404);
+      expect(mockGetGeneratedContract).not.toHaveBeenCalled();
+    });
+
+    it('ID flotante (1.5) → 404', async () => {
+      const res = await adminPdfGET(makeReq('1.5'), makeParams('1.5'));
+      expect(res.status).toBe(404);
+      expect(mockGetGeneratedContract).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('contrato no encontrado o sin PDF', () => {
+    it('contrato inexistente → 404', async () => {
+      mockGetGeneratedContract.mockResolvedValue(null);
+      const res = await adminPdfGET(makeReq(), makeParams());
+      expect(res.status).toBe(404);
+    });
+
+    it('contrato sin fileUrl → 404', async () => {
+      mockGetGeneratedContract.mockResolvedValue(validContract({ fileUrl: null }));
+      const res = await adminPdfGET(makeReq(), makeParams());
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('BLOB_READ_WRITE_TOKEN', () => {
+    it('sin token configurado → 503', async () => {
+      delete process.env.BLOB_READ_WRITE_TOKEN;
+      mockGetGeneratedContract.mockResolvedValue(validContract());
+      const res = await adminPdfGET(makeReq(), makeParams());
+      expect(res.status).toBe(503);
+    });
+
+    it('blob fetch falla → 404', async () => {
+      mockGetGeneratedContract.mockResolvedValue(validContract());
+      (global.fetch as jest.Mock).mockResolvedValue({ ok: false });
+      const res = await adminPdfGET(makeReq(), makeParams());
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('respuesta exitosa', () => {
+    it('contrato válido → 200 con Content-Type application/pdf', async () => {
+      mockGetGeneratedContract.mockResolvedValue(validContract());
+      mockBlobOk();
+      const res = await adminPdfGET(makeReq(), makeParams());
+      expect(res.status).toBe(200);
+      expect(res.headers.get('Content-Type')).toBe('application/pdf');
+    });
+
+    it('Content-Disposition es inline con el nombre del archivo', async () => {
+      mockGetGeneratedContract.mockResolvedValue(validContract({ fileName: 'mi_contrato.pdf' }));
+      mockBlobOk();
+      const res = await adminPdfGET(makeReq(), makeParams());
+      const cd = res.headers.get('Content-Disposition') ?? '';
+      expect(cd).toMatch(/^inline/);
+      expect(cd).toContain('mi_contrato.pdf');
+    });
+
+    it('Cache-Control es private, no-store', async () => {
+      mockGetGeneratedContract.mockResolvedValue(validContract());
+      mockBlobOk();
+      const res = await adminPdfGET(makeReq(), makeParams());
+      expect(res.headers.get('Cache-Control')).toBe('private, no-store');
+    });
+
+    it('X-Content-Type-Options es nosniff', async () => {
+      mockGetGeneratedContract.mockResolvedValue(validContract());
+      mockBlobOk();
+      const res = await adminPdfGET(makeReq(), makeParams());
+      expect(res.headers.get('X-Content-Type-Options')).toBe('nosniff');
+    });
+
+    it('el blob se descarga con Authorization Bearer (token no expuesto al cliente)', async () => {
+      const BLOB_URL = 'https://blob.example.com/private/test.pdf';
+      mockGetGeneratedContract.mockResolvedValue(validContract({ fileUrl: BLOB_URL }));
+      mockBlobOk();
+      await adminPdfGET(makeReq(), makeParams());
+      expect(global.fetch).toHaveBeenCalledWith(
+        BLOB_URL,
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: expect.stringContaining('Bearer'),
+          }),
+        }),
+      );
+    });
+
+    it('BLOB_READ_WRITE_TOKEN no aparece en ninguna cabecera de respuesta', async () => {
+      mockGetGeneratedContract.mockResolvedValue(validContract());
+      mockBlobOk();
+      const res = await adminPdfGET(makeReq(), makeParams());
+      for (const [, value] of res.headers.entries()) {
+        expect(value).not.toContain(BLOB_SECRET);
+      }
+    });
+
+    it('fileName con path traversal queda saneado en Content-Disposition', async () => {
+      mockGetGeneratedContract.mockResolvedValue(
+        validContract({ fileName: '../../../etc/passwd' }),
+      );
+      mockBlobOk();
+      const res = await adminPdfGET(makeReq(), makeParams());
+      const cd = res.headers.get('Content-Disposition') ?? '';
+      expect(cd).not.toContain('..');
+      expect(cd).not.toContain('/');
+    });
+
+    it('fileName null usa fallback "contrato.pdf"', async () => {
+      mockGetGeneratedContract.mockResolvedValue(validContract({ fileName: null }));
+      mockBlobOk();
+      const res = await adminPdfGET(makeReq(), makeParams());
+      const cd = res.headers.get('Content-Disposition') ?? '';
+      expect(cd).toContain('contrato.pdf');
+    });
+  });
+
+  describe('links admin — verificación estática', () => {
+    it('ContratosTable.tsx no usa href={c.fileUrl} directamente', () => {
+      const filePath = path.join(
+        process.cwd(),
+        'src/features/admin/contratos/components/ContratosTable.tsx',
+      );
+      const content = fs.readFileSync(filePath, 'utf-8');
+      expect(content).not.toContain('href={c.fileUrl}');
+      expect(content).toContain('/api/admin/contratos/');
+    });
+
+    it('ContratoDetailPanel.tsx no usa href={contract.fileUrl} directamente', () => {
+      const filePath = path.join(
+        process.cwd(),
+        'src/features/admin/contratos/components/ContratoDetailPanel.tsx',
+      );
+      const content = fs.readFileSync(filePath, 'utf-8');
+      expect(content).not.toContain('href={contract.fileUrl');
+      expect(content).toContain('/api/admin/contratos/');
+    });
+
+    it('ContratosTable.tsx mantiene target="_blank" en el link de PDF', () => {
+      const filePath = path.join(
+        process.cwd(),
+        'src/features/admin/contratos/components/ContratosTable.tsx',
+      );
+      const content = fs.readFileSync(filePath, 'utf-8');
+      expect(content).toContain('target="_blank"');
+    });
+
+    it('ContratoDetailPanel.tsx mantiene target="_blank" en el link de PDF', () => {
+      const filePath = path.join(
+        process.cwd(),
+        'src/features/admin/contratos/components/ContratoDetailPanel.tsx',
+      );
+      const content = fs.readFileSync(filePath, 'utf-8');
+      expect(content).toContain('target="_blank"');
+    });
+
+    it('la ruta del proxy admin usa la convención en español (contratos, no contracts)', () => {
+      const filePath = path.join(
+        process.cwd(),
+        'src/features/admin/contratos/components/ContratosTable.tsx',
+      );
+      const content = fs.readFileSync(filePath, 'utf-8');
+      expect(content).toContain('/api/admin/contratos/');
+      expect(content).not.toMatch(/\/api\/admin\/contracts\//);
+    });
+  });
+});

--- a/src/app/admin/(dashboard)/campanas/contract-actions.ts
+++ b/src/app/admin/(dashboard)/campanas/contract-actions.ts
@@ -23,6 +23,11 @@ const resend = new Resend(env.RESEND_API_KEY);
 
 type ActionState = { readonly error?: string; readonly success?: boolean; readonly id?: number };
 
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+          .replace(/"/g, '&quot;').replace(/'/g, '&#x27;');
+}
+
 const UploadContractMeta = z.object({
   campaignId: IdSchema,
   notes: z.string().max(2000).optional(),
@@ -162,7 +167,7 @@ export async function requestSignaturesAction(contractId: number, campaignId: nu
             <h2 style="font-size:20px;font-weight:800;color:#16161f;margin:0 0 8px">
               Firma de contrato pendiente
             </h2>
-            <p style="color:#72728a;margin:0 0 20px">Hola <strong>${signer.name}</strong>,</p>
+            <p style="color:#72728a;margin:0 0 20px">Hola <strong>${escapeHtml(signer.name)}</strong>,</p>
             <p style="color:#72728a;margin:0 0 20px">
               Tienes un contrato pendiente de firma. Haz clic en el botón para revisarlo y firmar.
             </p>

--- a/src/app/api/admin/contratos/[id]/pdf/route.ts
+++ b/src/app/api/admin/contratos/[id]/pdf/route.ts
@@ -1,0 +1,61 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { requirePermission } from '@/lib/permissions';
+import { getGeneratedContract } from '@/lib/queries/generatedContracts';
+import { env } from '@/lib/env';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  await requirePermission('contratos', 'read');
+
+  const { id: idStr } = await params;
+  const id = Number(idStr);
+  if (!Number.isInteger(id) || id <= 0) {
+    return new NextResponse('Not found', { status: 404 });
+  }
+
+  const contract = await getGeneratedContract(id);
+  if (!contract) {
+    return new NextResponse('Not found', { status: 404 });
+  }
+
+  const fileUrl = contract.fileUrl;
+  if (!fileUrl) {
+    return new NextResponse('PDF no disponible', { status: 404 });
+  }
+
+  const blobToken = env.BLOB_READ_WRITE_TOKEN;
+  if (!blobToken) {
+    return new NextResponse('Servicio no disponible', { status: 503 });
+  }
+
+  const blobRes = await fetch(fileUrl, {
+    headers: { Authorization: `Bearer ${blobToken}` },
+  });
+
+  if (!blobRes.ok) {
+    return new NextResponse('PDF no disponible', { status: 404 });
+  }
+
+  const contentType = blobRes.headers.get('content-type') ?? 'application/pdf';
+  const buffer = await blobRes.arrayBuffer();
+
+  const safeName = (contract.fileName ?? 'contrato.pdf')
+    .replace(/[^\w.\-]/g, '_')
+    .replace(/\.+/g, '.')
+    .slice(0, 200);
+
+  return new NextResponse(buffer, {
+    status: 200,
+    headers: {
+      'Content-Type': contentType,
+      'Content-Disposition': `inline; filename="${safeName}"`,
+      'Cache-Control': 'private, no-store',
+      'X-Content-Type-Options': 'nosniff',
+    },
+  });
+}

--- a/src/features/admin/contratos/components/ContratoDetailPanel.tsx
+++ b/src/features/admin/contratos/components/ContratoDetailPanel.tsx
@@ -38,6 +38,8 @@ export function ContratoDetailPanel({ contract }: Props): React.ReactElement {
 
   const statusStyle = STATUS_STYLE[contract.status as StatusKey] ?? STATUS_STYLE.draft;
   const statusLabel = CONTRACT_STATUSES.find((s) => s.value === contract.status)?.label ?? contract.status;
+  let parsedVars: Record<string, string> = {};
+  try { parsedVars = JSON.parse(contract.varsJson ?? '{}') as Record<string, string>; } catch { /* corrupt JSON — show empty */ }
 
   function handleDelete(): void {
     if (!confirm(`¿Eliminar el contrato "${contract.title}"? Esta acción no se puede deshacer.`)) return;
@@ -58,7 +60,7 @@ export function ContratoDetailPanel({ contract }: Props): React.ReactElement {
             </span>
             {contract.fileName && (
               <a
-                href={contract.fileUrl ?? '#'}
+                href={`/api/admin/contratos/${contract.id}/pdf`}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-1 text-[11px] text-sp-admin-accent hover:underline"
@@ -165,7 +167,7 @@ export function ContratoDetailPanel({ contract }: Props): React.ReactElement {
             Variables usadas en la generación
           </summary>
           <div className="px-4 py-3 grid grid-cols-2 md:grid-cols-3 gap-2">
-            {Object.entries(JSON.parse(contract.varsJson) as Record<string, string>).map(([k, v]) => (
+            {Object.entries(parsedVars).map(([k, v]) => (
               <div key={k} className="rounded-lg bg-sp-admin-hover/30 px-2.5 py-1.5">
                 <p className="text-[9px] font-mono font-bold text-sp-admin-accent">{`{{${k}}}`}</p>
                 <p className="text-[11px] text-sp-admin-text truncate" title={v}>{v}</p>

--- a/src/features/admin/contratos/components/ContratosTable.tsx
+++ b/src/features/admin/contratos/components/ContratosTable.tsx
@@ -148,7 +148,7 @@ export function ContratosTable({ contracts }: Props): React.ReactElement {
                     <div className="flex items-center justify-end gap-1.5 opacity-0 group-hover:opacity-100 transition-opacity">
                       {c.fileUrl && (
                         <a
-                          href={c.fileUrl}
+                          href={`/api/admin/contratos/${c.id}/pdf`}
                           target="_blank"
                           rel="noopener noreferrer"
                           className="h-7 px-2.5 rounded-lg border border-sp-admin-border text-[11px] font-semibold text-sp-admin-muted hover:text-sp-admin-text hover:bg-sp-admin-hover transition-colors inline-flex items-center"


### PR DESCRIPTION
## Summary

Fixes contract module issues discovered during validation and makes generated contract PDFs accessible through a secure admin proxy instead of linking directly to private Vercel Blob URLs.

## Changes

* Adds secure admin PDF proxy:
  * `/api/admin/contratos/[id]/pdf`
* Replaces direct private `fileUrl` links in admin contract UI with the proxy route.
* Escapes signer names in signature email HTML.
* Makes `varsJson` parsing resilient in the contract detail panel.
* Adds tests for the admin PDF proxy and related security behavior.

## Why

Direct links to private Vercel Blob URLs can return `401/403` in the browser. The CRM should serve contract PDFs through an authenticated server-side proxy, similar to the public signer PDF proxy.

This also avoids exposing private blob URLs or blob tokens to the client.

## Security

The admin PDF proxy:

* requires authenticated admin permission;
* validates contract ID;
* checks the contract exists and has a PDF;
* fetches the private blob server-side with `BLOB_READ_WRITE_TOKEN`;
* serves the PDF inline;
* sets safe headers:
  * `Content-Type: application/pdf`
  * `Content-Disposition: inline`
  * `Cache-Control: private, no-store`
  * `X-Content-Type-Options: nosniff`
* does not expose `BLOB_READ_WRITE_TOKEN`.

## Validation

* `npm run lint` ✅
* `npx tsc --noEmit` ✅
* `npm test -- --passWithNoTests` ✅
* 1195 tests passing ✅

## Notes

Full end-to-end validation of the contract generation/signing flow still requires a connected DB/staging environment and a real generated contract.

Out of scope for this PR:

* email resend idempotency;
* double-signature race condition;
* refactor of duplicated internal action names;
* electronic signature integrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)