### PR TITLE
feat(blog): redesign editorial layout

### DIFF
--- a/src/__tests__/server/blog-utils.test.ts
+++ b/src/__tests__/server/blog-utils.test.ts
@@ -1,0 +1,116 @@
+import { deriveCategory, detectBrand, readTime } from '@/lib/utils/blog';
+import { escapeHtml, renderInline, linkifyInternal } from '@/lib/utils/blog-renderer';
+
+describe('deriveCategory', () => {
+  it('post CS2 con "streamer" en slug → esports, no youtube', () => {
+    const cat = deriveCategory(
+      'cuanto-cobra-streamer-cs2-patrocinio-2026',
+      '¿Cuánto cobra un streamer de CS2 por una integración en 2026?',
+    );
+    expect(cat.slug).toBe('esports');
+  });
+
+  it('post con "igaming" en slug → igaming', () => {
+    expect(deriveCategory('trackeo-ftds-campanas-igaming-influencers-metodologia', 'Título').slug).toBe('igaming');
+  });
+
+  it('post con "youtube" puro en slug → youtube', () => {
+    expect(deriveCategory('crecer-en-youtube-gaming', 'Título').slug).toBe('youtube');
+  });
+
+  it('post con "activacion" → caso-exito', () => {
+    expect(deriveCategory('activacion-razer-socialpro', 'Título').slug).toBe('caso-exito');
+  });
+
+  it('post con "guia" → guia', () => {
+    expect(deriveCategory('guia-marketing-gaming', 'Título').slug).toBe('guia');
+  });
+
+  it('post con "tendencia" → tendencias', () => {
+    expect(deriveCategory('tendencias-gaming-2026', 'Título').slug).toBe('tendencias');
+  });
+
+  it('post genérico → noticias (fallback)', () => {
+    expect(deriveCategory('nuevo-partnership-socialpro', 'Noticia sin categoría clara').slug).toBe('noticias');
+  });
+
+  it('streamer sin cs2 ni esports → youtube', () => {
+    expect(deriveCategory('los-mejores-streamers-twitch-2026', 'Título').slug).toBe('youtube');
+  });
+
+  it('post con "esports" en slug → esports (aunque tenga año)', () => {
+    expect(deriveCategory('torneo-esports-gaming-2026', 'Título').slug).toBe('esports');
+  });
+});
+
+describe('detectBrand', () => {
+  it('detecta 1win desde slug', () => {
+    const brand = detectBrand('socialpro-x-1win-cs2-340-ftds', 'Título sin marca');
+    expect(brand).not.toBeNull();
+    expect(brand?.name).toBe('1WIN');
+  });
+
+  it('detecta razer desde title', () => {
+    const brand = detectBrand('caso-exito-campaña', 'Campaña Razer × SocialPro');
+    expect(brand).not.toBeNull();
+    expect(brand?.slug).toBe('razer');
+  });
+
+  it('devuelve null cuando no hay marca', () => {
+    expect(detectBrand('post-sin-marca', 'Artículo sin marca conocida')).toBeNull();
+  });
+
+  it('detecta keydrop', () => {
+    expect(detectBrand('keydrop-campaign-2026', 'Título')).not.toBeNull();
+  });
+
+  it('detecta hellcase desde slug', () => {
+    expect(detectBrand('hellcase-activation-streamers', 'Título')).not.toBeNull();
+  });
+});
+
+describe('readTime', () => {
+  it('texto vacío → 1 min', () => {
+    expect(readTime('')).toBe(1);
+  });
+
+  it('texto de 400 palabras → 2 min', () => {
+    const text = Array(400).fill('palabra').join(' ');
+    expect(readTime(text)).toBe(2);
+  });
+
+  it('texto de 200 palabras → 1 min', () => {
+    const text = Array(200).fill('palabra').join(' ');
+    expect(readTime(text)).toBe(1);
+  });
+});
+
+describe('escapeHtml', () => {
+  it('escapa caracteres especiales', () => {
+    expect(escapeHtml('<b>hola & "mundo"</b>')).toBe('&lt;b&gt;hola &amp; &quot;mundo&quot;&lt;/b&gt;');
+  });
+});
+
+describe('renderInline', () => {
+  it('convierte **bold** a strong', () => {
+    expect(renderInline('**texto**')).toContain('<strong');
+  });
+
+  it('convierte [link](/ruta) a anchor interno', () => {
+    const html = renderInline('[ver más](/casos)');
+    expect(html).toContain('href="/casos"');
+    expect(html).toContain('ver más');
+  });
+});
+
+describe('linkifyInternal', () => {
+  it('convierte socialpro.es/casos a link interno', () => {
+    const html = linkifyInternal('visita socialpro.es/casos para más info');
+    expect(html).toContain('href="/casos"');
+  });
+
+  it('no linkifica URLs de terceros', () => {
+    const html = linkifyInternal('visita google.com para buscar');
+    expect(html).not.toContain('<a');
+  });
+});

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { BlogCard } from '@/features/blog/components/BlogCard';
 import { BlogCover } from '@/features/blog/components/BlogCover';
 import { ExploraMas } from '@/features/blog/components/ExploraMas';
 import { deriveCategory, readTime, detectBrand } from '@/lib/utils/blog';
+import { renderParagraph } from '@/lib/utils/blog-renderer';
 import { SectionTag } from '@/components/ui/SectionTag';
 import { TalentMiniCard } from '@/features/blog/components/TalentMiniCard';
 import { buildBreadcrumbJsonLd } from '@/lib/utils/breadcrumbs';
@@ -43,84 +44,6 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     },
     twitter: { card: 'summary_large_image', title, description, images: [absoluteUrl(`/api/og-image/blog?slug=${slug}`)] },
   };
-}
-
-/** Render a single body paragraph — handles ## h2, ### h3, **bold**, bullet lists */
-function renderParagraph(text: string, key: number) {
-  if (text.startsWith('## ')) {
-    return (
-      <h2 key={key} className="font-display text-2xl md:text-3xl font-black uppercase text-sp-dark mt-12 mb-3 pb-2 border-b border-sp-border">
-        {text.slice(3)}
-      </h2>
-    );
-  }
-  if (text.startsWith('### ')) {
-    return (
-      <h3 key={key} className="font-display text-xl font-black uppercase text-sp-dark mt-8 mb-2">
-        {text.slice(4)}
-      </h3>
-    );
-  }
-  // Bullet list block
-  if (text.includes('\n- ') || text.startsWith('- ')) {
-    const items = text.split('\n').filter(l => l.startsWith('- ')).map(l => l.slice(2));
-    return (
-      <ul key={key} className="space-y-2 my-4 pl-1">
-        {items.map((item, i) => (
-          <li key={i} className="flex gap-2 text-sp-muted text-base leading-relaxed">
-            <span className="mt-1.5 w-1.5 h-1.5 rounded-full bg-sp-orange flex-shrink-0" />
-            <span dangerouslySetInnerHTML={{ __html: renderInline(item) }} />
-          </li>
-        ))}
-      </ul>
-    );
-  }
-  return (
-    <p key={key} className="text-base text-sp-muted leading-relaxed"
-       dangerouslySetInnerHTML={{ __html: renderInline(text) }} />
-  );
-}
-
-/** Escape HTML entities to prevent XSS before injecting into the DOM */
-function escapeHtml(text: string): string {
-  return text
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;');
-}
-
-const INLINE_LINK_CLASS =
-  'text-sp-orange font-medium underline decoration-sp-orange/35 underline-offset-[3px] hover:decoration-sp-orange transition-colors';
-
-/**
- * Auto-linkify URLs propias en el cuerpo del post.
- *
- * Detecta menciones tipo `socialpro.es/casos`, `socialpro.es/contacto/X` etc.
- * y las convierte en enlaces internos hacia rutas relativas. No depende del
- * dominio configurado: cualquier mención literal `socialpro.es/...` queda
- * canonizada como href interno.
- *
- * Input ya viene HTML-escaped, así que sólo opera sobre texto plano seguro.
- */
-function linkifyInternal(html: string): string {
-  // Opcionalmente con `https://` o `www.` delante. Capturamos el path tras `/`.
-  const pattern = /(?:https?:\/\/)?(?:www\.)?socialpro\.es(\/[a-z0-9/_-]+)/gi;
-  return html.replace(pattern, (_match, path: string) => {
-    const cleanPath = path.replace(/[.,;:)]+$/, '');
-    return `<a href="${cleanPath}" class="${INLINE_LINK_CLASS}">socialpro.es${cleanPath}</a>`;
-  });
-}
-
-/** Convert **bold**, *italic*, and [label](/path) markdown to HTML (input is pre-escaped) */
-function renderInline(text: string): string {
-  return linkifyInternal(
-    escapeHtml(text)
-      .replace(/\*\*(.+?)\*\*/g, '<strong class="font-semibold text-sp-dark">$1</strong>')
-      .replace(/\*(.+?)\*/g, '<em>$1</em>')
-      .replace(/\[([^\]]+)\]\((\/[^)\s]+)\)/g, `<a href="$2" class="${INLINE_LINK_CLASS}">$1</a>`),
-  );
 }
 
 function extractPodcastBlock(blocksJson: unknown): PodcastBlock | null {
@@ -165,19 +88,9 @@ export default async function BlogPostPage({ params }: PageProps) {
       '@type': 'PodcastSeries',
       name: podcast.showName,
       ...(podcast.showUrl ? { url: podcast.showUrl } : {}),
-      publisher: {
-        '@type': 'Organization',
-        name: podcast.network,
-      },
+      publisher: { '@type': 'Organization', name: podcast.network },
     },
-    mentions: [
-      {
-        '@type': 'Organization',
-        '@id': absoluteUrl('/#organization'),
-        name: 'SocialPro',
-        url: absoluteUrl('/'),
-      },
-    ],
+    mentions: [{ '@type': 'Organization', '@id': absoluteUrl('/#organization'), name: 'SocialPro', url: absoluteUrl('/') }],
   } : null;
 
   const jsonLd = {
@@ -191,24 +104,12 @@ export default async function BlogPostPage({ params }: PageProps) {
     author: post.author && post.author !== 'SocialPro' && post.author !== 'Redacción'
       ? { '@type': 'Person', name: post.author, worksFor: { '@type': 'Organization', '@id': absoluteUrl('/#organization'), name: 'SocialPro' } }
       : { '@type': 'Organization', '@id': absoluteUrl('/#organization'), name: 'SocialPro' },
-    publisher: {
-      '@type': 'Organization',
-      '@id': absoluteUrl('/#organization'),
-      name: 'SocialPro',
-      url: absoluteUrl('/'),
-    },
+    publisher: { '@type': 'Organization', '@id': absoluteUrl('/#organization'), name: 'SocialPro', url: absoluteUrl('/') },
     datePublished: post.publishedAt?.toISOString(),
     dateModified: post.updatedAt.toISOString(),
     ...(schemaImageUrl(post.coverUrl) ? { image: schemaImageUrl(post.coverUrl) } : {}),
     ...(post.talentAvatars.length > 0
-      ? {
-          mentions: post.talentAvatars.map((t) => ({
-            '@type': 'Person',
-            name: t.name,
-            url: absoluteUrl(`/talentos/${t.slug}`),
-            jobTitle: t.role,
-          })),
-        }
+      ? { mentions: post.talentAvatars.map((t) => ({ '@type': 'Person', name: t.name, url: absoluteUrl(`/talentos/${t.slug}`), jobTitle: t.role })) }
       : {}),
   };
 
@@ -227,7 +128,6 @@ export default async function BlogPostPage({ params }: PageProps) {
           <Link href="/blog" className="inline-flex items-center gap-1.5 text-sm text-white/40 hover:text-white transition-colors mb-5">
             <span aria-hidden="true">←</span> Volver al blog
           </Link>
-          {/* Category + meta */}
           <div className="flex flex-wrap items-center gap-3 mb-4">
             <span className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[10px] font-black uppercase tracking-[0.12em] border ${category.bg} ${category.text} ${category.border}`}>
               <span className={`w-1 h-1 rounded-full ${category.text.replace('text-', 'bg-')}`} aria-hidden />
@@ -249,11 +149,12 @@ export default async function BlogPostPage({ params }: PageProps) {
           </div>
         </div>
 
-        {/* Cover image — con fallback editorial cuando no hay coverUrl */}
-        <div className="relative w-full h-72 md:h-96 overflow-hidden">
+        {/* Cover — aspect ratio cinematic para mejor presencia visual */}
+        <div className="relative w-full overflow-hidden" style={{ aspectRatio: '21/8' }}>
           <BlogCover
             coverUrl={post.coverUrl}
             category={category}
+            slug={slug}
             title={post.title}
             variant="hero"
             priority
@@ -288,7 +189,7 @@ export default async function BlogPostPage({ params }: PageProps) {
           )}
 
           {/* Body */}
-          <div className="space-y-5">
+          <div className="space-y-6">
             {paragraphs.map((p, i) => renderParagraph(p, i))}
           </div>
 
@@ -306,7 +207,7 @@ export default async function BlogPostPage({ params }: PageProps) {
             </div>
           )}
 
-          {/* ── EXPLORA MÁS — interlinking editorial ── */}
+          {/* ── EXPLORA MÁS ── */}
           <ExploraMas
             brand={detectBrand(post.slug, post.title)}
             categorySlug={category.slug}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,12 +1,12 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import { Suspense } from 'react';
 import { getPosts } from '@/lib/queries/posts';
-import { BlogCard } from '@/features/blog/components/BlogCard';
-import { FeaturedBlogCard } from '@/features/blog/components/FeaturedBlogCard';
 import { absoluteUrl } from '@/lib/site-url';
 import { safeJsonLd } from '@/lib/safeJsonLd';
 import { buildBreadcrumbJsonLd } from '@/lib/utils/breadcrumbs';
 import { deriveCategory, formatBlogDate } from '@/lib/utils/blog';
+import { BlogContent } from '@/features/blog/components/BlogContent';
 
 export const revalidate = 3600;
 
@@ -50,34 +50,26 @@ const breadcrumbJsonLd = buildBreadcrumbJsonLd([
   { name: 'Blog', url: absoluteUrl('/blog') },
 ]);
 
-const CATEGORY_LABELS = [
-  'Todos', 'Casos de éxito', 'Guías', 'iGaming', 'Tendencias', 'YouTube',
-] as const;
-
 export default async function BlogPage() {
   const posts = await getPosts();
-
-  const sorted   = [...posts].sort((a, b) => (b.sortOrder ?? 0) - (a.sortOrder ?? 0));
-  const featured = sorted[0] ?? null;
-  // rest: artículos que NO son el featured — para hero derecho y grid
-  const rest     = sorted.slice(1);
+  const sorted = [...posts].sort((a, b) => (b.sortOrder ?? 0) - (a.sortOrder ?? 0));
+  const recent = sorted.slice(0, 5);
 
   return (
     <>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: safeJsonLd(blogJsonLd) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: safeJsonLd(breadcrumbJsonLd) }} />
-      {/* ── HERO compacto — split ───────────────────────────────────── */}
+
+      {/* ── HERO ─────────────────────────────────────────────────────── */}
       <section className="relative bg-sp-black pt-8 pb-0 border-b border-white/[0.05] overflow-hidden">
 
-        {/* Microdetalles visuales premium — no tocar sin motivo */}
-
-        {/* Glow naranja/rosa detrás del contenido izquierdo */}
+        {/* Glow naranja/rosa */}
         <div
           className="absolute left-0 top-1/2 -translate-y-1/2 w-[520px] h-[320px] rounded-full pointer-events-none"
           style={{ background: 'radial-gradient(ellipse, rgba(245,99,42,0.07) 0%, rgba(196,40,128,0.04) 50%, transparent 70%)', filter: 'blur(60px)' }}
         />
 
-        {/* Dot grid muy suave — textura editorial */}
+        {/* Dot grid */}
         <svg className="absolute inset-0 w-full h-full opacity-[0.035] pointer-events-none" xmlns="http://www.w3.org/2000/svg" aria-hidden>
           <defs>
             <pattern id="hero-dots" x="0" y="0" width="22" height="22" patternUnits="userSpaceOnUse">
@@ -88,10 +80,10 @@ export default async function BlogPage() {
         </svg>
 
         <div className="relative max-w-6xl mx-auto px-4 sm:px-6">
-          <div className="grid grid-cols-1 lg:grid-cols-[1fr_300px] gap-0 items-center">
+          <div className="grid grid-cols-1 lg:grid-cols-[1fr_300px] gap-0 items-start">
 
             {/* Izquierda: cabecera editorial */}
-            <div className="py-4 lg:pr-10 lg:border-r lg:border-white/[0.06]">
+            <div className="py-6 lg:pr-10 lg:border-r lg:border-white/[0.06]">
               <p className="text-[10px] font-black uppercase tracking-[0.35em] text-sp-orange mb-2">
                 SocialPro · Blog
               </p>
@@ -99,33 +91,52 @@ export default async function BlogPage() {
                 Insights &amp;<br />
                 <span className="gradient-text">Tendencias</span>
               </h1>
-              <p className="text-[13px] sm:text-sm text-white/55 mb-4 leading-relaxed max-w-sm">
+              <p className="text-[13px] sm:text-sm text-white/55 mb-5 leading-relaxed max-w-sm">
                 Marketing gaming, iGaming y ecosistema creator en España y LatAm.
                 Casos reales, guías y análisis de la agencia SocialPro.
               </p>
-              <div className="flex flex-wrap gap-1.5">
-                {CATEGORY_LABELS.map((cat, i) => (
-                  <span
-                    key={cat}
-                    className={`inline-flex px-2.5 py-1 rounded-full text-[9px] font-bold uppercase tracking-[0.1em] border cursor-default transition-colors ${
-                      i === 0
-                        ? 'bg-sp-orange/15 border-sp-orange/40 text-sp-orange'
-                        : 'bg-white/[0.03] border-white/[0.07] text-white/30 hover:border-white/15 hover:text-white/50'
-                    }`}
-                  >
-                    {cat}
-                  </span>
-                ))}
-              </div>
+
+              {/* Posts recientes — visible en mobile (apilados), ocultos en lg (panel derecho los muestra) */}
+              {recent.length > 0 && (
+                <div className="lg:hidden flex flex-col gap-0 mb-2 rounded-xl overflow-hidden border border-white/[0.07]">
+                  {recent.slice(0, 3).map((post) => {
+                    const cat = deriveCategory(post.slug, post.title);
+                    return (
+                      <Link
+                        key={post.id}
+                        href={`/blog/${post.slug}`}
+                        className="group flex items-start gap-2.5 py-2.5 px-3 border-b border-white/[0.05] last:border-0 hover:bg-white/[0.04] transition-colors"
+                      >
+                        <span
+                          className={`shrink-0 mt-0.5 inline-flex px-1.5 py-0.5 rounded text-[7px] font-black uppercase tracking-[0.08em] border ${cat.bg} ${cat.text} ${cat.border}`}
+                          style={{ whiteSpace: 'nowrap' }}
+                        >
+                          {cat.label.split(' ')[0]}
+                        </span>
+                        <div className="flex-1 min-w-0">
+                          <p className="text-[11px] font-bold text-white/80 leading-tight line-clamp-2 group-hover:text-sp-orange transition-colors duration-150">
+                            {post.title}
+                          </p>
+                          {post.publishedAt && (
+                            <time className="text-[9px] text-white/25 mt-0.5 block">
+                              {formatBlogDate(post.publishedAt)}
+                            </time>
+                          )}
+                        </div>
+                      </Link>
+                    );
+                  })}
+                </div>
+              )}
             </div>
 
-            {/* Derecha: últimas publicaciones — distintas al featured */}
-            {rest.length > 0 && (
-              <div className="hidden lg:flex flex-col pl-8 py-2 gap-0">
+            {/* Derecha: últimas publicaciones — solo en lg */}
+            {recent.length > 0 && (
+              <div className="hidden lg:flex flex-col pl-8 py-6 gap-0">
                 <p className="text-[9px] font-black uppercase tracking-[0.3em] text-white/25 mb-3">
                   Últimas publicaciones
                 </p>
-                {rest.slice(0, 5).map((post) => {
+                {recent.map((post) => {
                   const cat = deriveCategory(post.slug, post.title);
                   return (
                     <Link
@@ -158,33 +169,10 @@ export default async function BlogPage() {
         </div>
       </section>
 
-      {/* ── CONTENIDO ───────────────────────────────────────────────── */}
-      <section className="bg-white py-6 md:py-8">
-        <div className="max-w-6xl mx-auto px-4 sm:px-6 space-y-6 md:space-y-8">
-
-          {posts.length === 0 ? (
-            <div className="py-24 text-center">
-              <p className="font-display text-2xl font-black uppercase text-sp-muted">
-                Próximamente nuevos artículos.
-              </p>
-            </div>
-          ) : (
-            <>
-              {/* Featured horizontal */}
-              {featured != null && <FeaturedBlogCard post={featured} />}
-
-              {/* Grid 3-col uniforme — mismo peso, sin secondary gigante */}
-              {rest.length > 0 && (
-                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-                  {rest.map((post) => (
-                    <BlogCard key={post.id} post={post} />
-                  ))}
-                </div>
-              )}
-            </>
-          )}
-        </div>
-      </section>
+      {/* ── CONTENIDO (Client: filtros + grid) ──────────────────────── */}
+      <Suspense fallback={<div className="min-h-[400px] bg-white" />}>
+        <BlogContent posts={posts} />
+      </Suspense>
     </>
   );
 }

--- a/src/features/blog/components/BlogCard.tsx
+++ b/src/features/blog/components/BlogCard.tsx
@@ -30,6 +30,7 @@ export function BlogCard({ post }: BlogCardProps) {
         <BlogCover
           coverUrl={post.coverUrl}
           category={category}
+          slug={post.slug}
           title={post.title}
           variant="card"
         />

--- a/src/features/blog/components/BlogContent.tsx
+++ b/src/features/blog/components/BlogContent.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { useSearchParams } from 'next/navigation';
+import Link from 'next/link';
+import type { PostListItem } from '@/lib/queries/posts';
+import { deriveCategory } from '@/lib/utils/blog';
+import { BlogCard } from './BlogCard';
+import { FeaturedBlogCard } from './FeaturedBlogCard';
+
+type Category = { key: string; label: string };
+
+const CATEGORIES: readonly Category[] = [
+  { key: 'todos',      label: 'Todos' },
+  { key: 'caso-exito', label: 'Casos de éxito' },
+  { key: 'guia',       label: 'Guías' },
+  { key: 'igaming',    label: 'iGaming' },
+  { key: 'tendencias', label: 'Tendencias' },
+  { key: 'youtube',    label: 'YouTube' },
+  { key: 'esports',    label: 'Esports/CS2' },
+] as const;
+
+type Props = { posts: PostListItem[] };
+
+export function BlogContent({ posts }: Props) {
+  const searchParams = useSearchParams();
+  const activeCat = searchParams.get('cat') ?? 'todos';
+
+  const sorted = [...posts].sort((a, b) => (b.sortOrder ?? 0) - (a.sortOrder ?? 0));
+
+  const filtered =
+    activeCat === 'todos'
+      ? sorted
+      : sorted.filter((p) => deriveCategory(p.slug, p.title).slug === activeCat);
+
+  const featured = filtered[0] ?? null;
+  const rest     = filtered.slice(1);
+
+  function catHref(key: string): string {
+    const params = new URLSearchParams(searchParams.toString());
+    if (key === 'todos') params.delete('cat');
+    else params.set('cat', key);
+    const qs = params.toString();
+    return qs ? `/blog?${qs}` : '/blog';
+  }
+
+  return (
+    <section className="bg-white py-6 md:py-8">
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 space-y-6 md:space-y-8">
+
+        {/* ── Category filter chips ──────────────────────────────────── */}
+        <div className="flex flex-wrap gap-1.5">
+          {CATEGORIES.map(({ key, label }) => {
+            const isActive = activeCat === key;
+            return (
+              <Link
+                key={key}
+                href={catHref(key)}
+                scroll={false}
+                className={`inline-flex px-3 py-1 rounded-full text-[10px] font-bold uppercase tracking-[0.1em] border transition-colors ${
+                  isActive
+                    ? 'bg-sp-orange/15 border-sp-orange/50 text-sp-orange'
+                    : 'bg-sp-off border-sp-border text-sp-muted hover:border-sp-orange/30 hover:text-sp-dark'
+                }`}
+              >
+                {label}
+              </Link>
+            );
+          })}
+        </div>
+
+        {/* ── Posts ───────────────────────────────────────────────────── */}
+        {filtered.length === 0 ? (
+          <div className="py-20 text-center">
+            <p className="font-display text-2xl font-black uppercase text-sp-muted">
+              No hay artículos en esta categoría todavía.
+            </p>
+          </div>
+        ) : (
+          <>
+            {featured != null && <FeaturedBlogCard post={featured} />}
+            {rest.length > 0 && (
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                {rest.map((post) => (
+                  <BlogCard key={post.id} post={post} />
+                ))}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/features/blog/components/BlogCover.tsx
+++ b/src/features/blog/components/BlogCover.tsx
@@ -7,6 +7,7 @@ type Variant = 'card' | 'featured' | 'hero';
 type Props = {
   readonly coverUrl: string | null;
   readonly category: BlogCategory;
+  readonly slug: string;
   readonly title: string;
   readonly brand?: string;
   readonly variant?: Variant;
@@ -32,6 +33,7 @@ type Props = {
 export function BlogCover({
   coverUrl,
   category,
+  slug,
   title,
   brand,
   variant = 'card',
@@ -66,6 +68,7 @@ export function BlogCover({
       ) : (
         <CategoryThumbnail
           category={category}
+          slug={slug}
           title={title}
           variant={variant}
           {...(brand ? { brand } : {})}

--- a/src/features/blog/components/CategoryThumbnail.tsx
+++ b/src/features/blog/components/CategoryThumbnail.tsx
@@ -22,6 +22,7 @@ type Variant = 'card' | 'featured' | 'hero';
 
 type Props = {
   readonly category: BlogCategory;
+  readonly slug: string;
   readonly title: string;
   readonly brand?: string;
   readonly variant?: Variant;
@@ -172,10 +173,10 @@ function PatternSvg({ kind, accent, id }: { kind: CategoryStyle['pattern']; acce
   }
 }
 
-export function CategoryThumbnail({ category, title, brand, variant = 'card' }: Props) {
+export function CategoryThumbnail({ category, slug, title, brand, variant = 'card' }: Props) {
   const style = CATEGORY_STYLES[category.slug] ?? FALLBACK_STYLE;
   const patternId = `pat-${category.slug}-${variant}`;
-  const detected = detectBrand(title, title);
+  const detected = detectBrand(slug, title);
 
   // Tamaños por variant — reglas editoriales
   const isHero = variant === 'hero';

--- a/src/features/blog/components/FeaturedBlogCard.tsx
+++ b/src/features/blog/components/FeaturedBlogCard.tsx
@@ -29,7 +29,7 @@ export function FeaturedBlogCard({ post }: Props) {
   return (
     <Link
       href={`/blog/${post.slug}`}
-      className="group block rounded-2xl overflow-hidden border border-sp-border hover:border-sp-orange/35 hover:shadow-[0_16px_70px_-16px_rgba(245,99,42,0.28)] hover:-translate-y-0.5 transition-all duration-400 will-change-transform"
+      className="group block rounded-2xl overflow-hidden border border-sp-border hover:border-sp-orange/35 hover:shadow-[0_16px_70px_-16px_rgba(245,99,42,0.28)] hover:-translate-y-0.5 transition-all duration-300 will-change-transform"
       aria-label={post.title}
     >
       <div className="grid grid-cols-1 md:grid-cols-[3fr_4fr]">
@@ -39,6 +39,7 @@ export function FeaturedBlogCard({ post }: Props) {
           <BlogCover
             coverUrl={post.coverUrl}
             category={category}
+            slug={post.slug}
             title={post.title}
             variant="featured"
             priority
@@ -55,9 +56,9 @@ export function FeaturedBlogCard({ post }: Props) {
 
         {/* ── Texto — editorial oscuro ─────────────────────────────── */}
         <div className="relative flex flex-col justify-center gap-4 p-6 sm:p-8 bg-sp-dark overflow-hidden">
-          {/* Línea acento superior */}
+          {/* Línea acento superior — oculta en mobile donde la imagen está arriba */}
           <div
-            className="absolute top-0 left-0 right-0 h-[2px]"
+            className="absolute top-0 left-0 right-0 h-[2px] hidden md:block"
             style={{ background: `linear-gradient(90deg, transparent 0%, ${accentHex} 35%, ${accentHex} 65%, transparent 100%)` }}
           />
 

--- a/src/features/blog/components/TalentMiniCard.tsx
+++ b/src/features/blog/components/TalentMiniCard.tsx
@@ -28,7 +28,7 @@ export function TalentMiniCard({ talent }: Props) {
 
   return (
     <Link
-      href={`/#talentos`}
+      href={talent.slug ? `/talentos/${talent.slug}` : '/talentos'}
       className="group flex flex-col items-center text-center rounded-2xl border border-sp-border bg-white hover:shadow-lg hover:-translate-y-0.5 transition-all overflow-hidden w-36 flex-shrink-0"
     >
       {/* Photo */}

--- a/src/lib/utils/blog-renderer.tsx
+++ b/src/lib/utils/blog-renderer.tsx
@@ -1,0 +1,97 @@
+/**
+ * Blog body renderer — custom markdown-like parser para posts.
+ * Sin dependencias de librería de markdown.
+ * Handles: ## h2, ### h3, #### h4, ---hr, - bullets, **bold**, *italic*,
+ * [link](/path), socialpro.es/... autolinks, bold-lead paragraphs.
+ */
+
+import type { JSX } from 'react';
+
+/** Escape HTML entities to prevent XSS before injecting into the DOM */
+export function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+const INLINE_LINK_CLASS =
+  'text-sp-orange font-medium underline decoration-sp-orange/35 underline-offset-[3px] hover:decoration-sp-orange transition-colors';
+
+/**
+ * Auto-linkify URLs propias en el cuerpo del post.
+ * Input ya viene HTML-escaped — solo opera sobre texto plano seguro.
+ */
+export function linkifyInternal(html: string): string {
+  const pattern = /(?:https?:\/\/)?(?:www\.)?socialpro\.es(\/[a-z0-9/_-]+)/gi;
+  return html.replace(pattern, (_match, path: string) => {
+    const cleanPath = path.replace(/[.,;:)]+$/, '');
+    return `<a href="${cleanPath}" class="${INLINE_LINK_CLASS}">socialpro.es${cleanPath}</a>`;
+  });
+}
+
+/** Convert **bold**, *italic*, and [label](/path) markdown to HTML (input is pre-escaped) */
+export function renderInline(text: string): string {
+  return linkifyInternal(
+    escapeHtml(text)
+      .replace(/\*\*(.+?)\*\*/g, '<strong class="font-semibold text-sp-dark">$1</strong>')
+      .replace(/\*(.+?)\*/g, '<em>$1</em>')
+      .replace(/\[([^\]]+)\]\((\/[^)\s]+)\)/g, `<a href="$2" class="${INLINE_LINK_CLASS}">$1</a>`),
+  );
+}
+
+/** Render a single body paragraph — handles headings, hr, bullets, bold-lead, inline */
+export function renderParagraph(text: string, key: number): JSX.Element | null {
+  if (text.startsWith('## ')) {
+    return (
+      <h2 key={key} className="font-display text-2xl md:text-3xl font-black uppercase text-sp-dark mt-12 mb-3 pb-2 border-b border-sp-border">
+        {text.slice(3)}
+      </h2>
+    );
+  }
+  if (text.startsWith('### ')) {
+    return (
+      <h3 key={key} className="font-display text-xl font-black uppercase text-sp-dark mt-8 mb-2">
+        {text.slice(4)}
+      </h3>
+    );
+  }
+  if (text.startsWith('#### ')) {
+    return (
+      <h4 key={key} className="font-display text-base font-black uppercase text-sp-dark mt-6 mb-1.5">
+        {text.slice(5)}
+      </h4>
+    );
+  }
+  // Horizontal rule
+  if (text === '---') {
+    return <hr key={key} className="my-10 border-t border-sp-border" />;
+  }
+  // Bullet list block
+  if (text.includes('\n- ') || text.startsWith('- ')) {
+    const items = text.split('\n').filter(l => l.startsWith('- ')).map(l => l.slice(2));
+    return (
+      <ul key={key} className="space-y-2 my-4 pl-1">
+        {items.map((item, i) => (
+          <li key={i} className="flex gap-2 text-sp-muted text-base leading-relaxed">
+            <span className="mt-1.5 w-1.5 h-1.5 rounded-full bg-sp-orange flex-shrink-0" />
+            <span dangerouslySetInnerHTML={{ __html: renderInline(item) }} />
+          </li>
+        ))}
+      </ul>
+    );
+  }
+  // Bold-lead paragraph: **Título.** resto del texto
+  if (/^\*\*([^*]+)\*\*\s/.test(text)) {
+    return (
+      <p key={key} className="text-base text-sp-muted leading-relaxed pl-3 border-l-2 border-sp-orange/25"
+         dangerouslySetInnerHTML={{ __html: renderInline(text) }} />
+    );
+  }
+  return (
+    <p key={key} className="text-base text-sp-muted leading-relaxed"
+       dangerouslySetInnerHTML={{ __html: renderInline(text) }} />
+  );
+}

--- a/src/lib/utils/blog.ts
+++ b/src/lib/utils/blog.ts
@@ -42,14 +42,17 @@ export function deriveCategory(slug: string, title: string): BlogCategory {
   if (s.includes('guia') || s.includes('como-') || s.includes('conseguir') || s.includes('monetizar') || s.includes('elegir')) {
     return cat('guia');
   }
+  // Esports antes de youtube/tendencias: CS2 posts con año o 'streamer' en slug no deben caer
+  // en youtube (por 'streamer') ni en tendencias (por '-2026'). Palabras clave de esports son
+  // más específicas que las de fecha o plataforma.
+  if (s.includes('esports') || s.includes('cs2') || s.includes('gaming-hardware')) {
+    return cat('esports');
+  }
   if (s.includes('youtube') || s.includes('streamer') || s.includes('twitch') || s.includes('streaming')) {
     return cat('youtube');
   }
   if (s.includes('tendencia') || s.includes('latam') || s.includes('-2025') || s.includes('-2026')) {
     return cat('tendencias');
-  }
-  if (s.includes('esports') || s.includes('cs2') || s.includes('gaming-hardware')) {
-    return cat('esports');
   }
 
   return cat('noticias');


### PR DESCRIPTION
## Summary

Redesigns and normalizes the public SocialPro blog experience.

This PR improves the blog listing, featured article card, category filters, thumbnail fallback system and article detail rendering while keeping routes, slugs, SEO/GEO and content unchanged.

## Changes

### Blog listing

* Improves `/blog` hero composition.
* Makes recent posts visible on mobile.
* Adds functional category filters using `?cat=...`.
* Adds empty state for categories without posts.
* Keeps ISR with `revalidate = 3600`.

### Cards and thumbnails

* Normalizes blog card behavior.
* Fixes the featured card mobile accent line issue.
* Fixes invalid Tailwind class `duration-400` → `duration-300`.
* Improves category fallback thumbnails.
* Passes `slug` into thumbnail brand detection.
* Fixes brand detection for Razer/1WIN/etc.
* Fixes CS2 pricing post category so it appears as esports/CS2 instead of YouTube.

### Article pages

* Extracts custom blog rendering into `blog-renderer.tsx`.
* Reduces `/blog/[slug]` page size.
* Adds support for:

  * `####` headings;
  * `---` separators;
  * bold-lead paragraphs like `**Title.** text`.
* Improves article cover ratio and reading rhythm.

### Bugs fixed

* `deriveCategory()` now evaluates esports/CS2 before YouTube/streamer.
* `CategoryThumbnail` now calls `detectBrand(slug, title)` instead of `detectBrand(title, title)`.
* `TalentMiniCard` links to `/talentos/[slug]` instead of `/#talentos`.
* `FeaturedBlogCard` uses a valid Tailwind transition class.

## Safety

This PR does not touch:

* admin;
* contracts;
* billing/finance;
* database schema;
* slugs;
* SEO/GEO metadata;
* sitemap;
* hreflang;
* public article URLs.

## Tests

Adds `blog-utils.test.ts` covering:

* category derivation;
* CS2 regression case;
* brand detection;
* reading time;
* HTML escaping;
* inline rendering;
* internal linkification.

## Validation

* `npm run lint` ✅
* `npx tsc --noEmit` ✅
* `npm test -- --passWithNoTests` ✅
* 1217 tests passing ✅
* `next build` TypeScript compilation ✅
* Local build still fails later during page-data collection because DB/env vars are unavailable in local shell; unrelated to this PR.

## Visual QA checklist

After Vercel Preview is ready, check:

* `/blog` desktop 1440px;
* `/blog` mobile 375px;
* `/blog?cat=igaming`;
* `/blog?cat=esports`;
* empty category state if possible;
* a single article page;
* CS2 pricing post thumbnail appears blue/esports;
* Razer/1WIN posts show brand thumbnails;
* no card text overlap;
* no horizontal overflow;
* featured card looks correct on mobile.