### PR TITLE
fix(blog): polish hero, remove duplicate labels, SocialPro logo on generic thumbnails

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -53,7 +53,7 @@ const breadcrumbJsonLd = buildBreadcrumbJsonLd([
 export default async function BlogPage() {
   const posts = await getPosts();
   const sorted = [...posts].sort((a, b) => (b.sortOrder ?? 0) - (a.sortOrder ?? 0));
-  const recent = sorted.slice(0, 5);
+  const recent = sorted.slice(0, 3);
 
   return (
     <>
@@ -80,7 +80,7 @@ export default async function BlogPage() {
         </svg>
 
         <div className="relative max-w-6xl mx-auto px-4 sm:px-6">
-          <div className="grid grid-cols-1 lg:grid-cols-[1fr_300px] gap-0 items-start">
+          <div className="grid grid-cols-1 lg:grid-cols-[1fr_300px] gap-0 lg:items-center">
 
             {/* Izquierda: cabecera editorial */}
             <div className="py-6 lg:pr-10 lg:border-r lg:border-white/[0.06]">
@@ -99,7 +99,7 @@ export default async function BlogPage() {
               {/* Posts recientes — visible en mobile (apilados), ocultos en lg (panel derecho los muestra) */}
               {recent.length > 0 && (
                 <div className="lg:hidden flex flex-col gap-0 mb-2 rounded-xl overflow-hidden border border-white/[0.07]">
-                  {recent.slice(0, 3).map((post) => {
+                  {recent.map((post) => {
                     const cat = deriveCategory(post.slug, post.title);
                     return (
                       <Link

--- a/src/features/blog/components/CategoryThumbnail.tsx
+++ b/src/features/blog/components/CategoryThumbnail.tsx
@@ -214,27 +214,8 @@ export function CategoryThumbnail({ category, slug, title, brand, variant = 'car
           variant={variant}
         />
       ) : (
-        <EditorialComposition
-          title={title}
-          category={category}
-          accent={style.accent}
-          variant={variant}
-        />
+        <EditorialComposition variant={variant} />
       )}
-
-      {/* ── Etiqueta de categoría top-left ───────────────────────────── */}
-      <div className={`absolute ${isHero ? 'top-5 left-5' : 'top-3.5 left-3.5'} flex items-center gap-2 z-20`}>
-        <span
-          className="block w-1.5 h-1.5 rounded-full"
-          style={{ background: style.accent, boxShadow: `0 0 8px ${style.glow}` }}
-        />
-        <span
-          className="font-display text-[10px] font-black uppercase tracking-[0.3em]"
-          style={{ color: style.accent, opacity: 0.92 }}
-        >
-          {category.label}
-        </span>
-      </div>
 
       {/* ── Wordmark SocialPro bottom-right — branding ────────────────── */}
       <div
@@ -323,57 +304,27 @@ function BrandedComposition({
 }
 
 /* ─────────────────────────────────────────────────────────────────────── */
-/* Composición editorial sin marca — tipografía dominante                  */
+/* Composición editorial sin marca — logo SocialPro centrado en blanco     */
 
-function EditorialComposition({
-  title,
-  category,
-  accent,
-  variant,
-}: {
-  title: string;
-  category: BlogCategory;
-  accent: string;
-  variant: Variant;
-}) {
-  // Iniciales del título — acento tipográfico fantasma
-  const initials =
-    title
-      .split(' ')
-      .filter((w) => w.length > 3)
-      .slice(0, 2)
-      .map((w) => w[0]?.toUpperCase() ?? '')
-      .join('') || category.label.slice(0, 1).toUpperCase();
-
-  const initialsSize =
-    variant === 'hero' ? 'clamp(8rem, 28vw, 22rem)'
-    : variant === 'featured' ? 'clamp(6rem, 22vw, 16rem)'
-    : 'clamp(5rem, 20vw, 14rem)';
+function EditorialComposition({ variant }: { variant: Variant }) {
+  const logoSize =
+    variant === 'hero'     ? 'w-[55%] max-w-[420px]'
+    : variant === 'featured' ? 'w-[55%] max-w-[260px]'
+    : 'w-[52%] max-w-[180px]';
 
   return (
     <div className="relative w-full h-full flex items-center justify-center">
-      <span
-        className="absolute font-display font-black uppercase select-none pointer-events-none"
-        style={{
-          fontSize: initialsSize,
-          lineHeight: 0.85,
-          color: accent,
-          opacity: 0.07,
-          letterSpacing: '-0.06em',
-          mixBlendMode: 'screen',
-        }}
-      >
-        {initials}
-      </span>
-
-      {/* Línea acento horizontal */}
-      <div
-        className="absolute bottom-1/3 left-8 right-8 h-px"
-        style={{
-          background: `linear-gradient(90deg, transparent, ${accent}, transparent)`,
-          opacity: 0.35,
-        }}
-      />
+      <div className={`relative ${logoSize}`}>
+        <Image
+          src="/images/logos/socialpro-full.png"
+          alt="SocialPro"
+          width={420}
+          height={120}
+          sizes="(max-width: 640px) 180px, (max-width: 1024px) 260px, 420px"
+          className="w-full h-auto object-contain"
+          style={{ filter: 'brightness(0) invert(1)', opacity: 0.38 }}
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- **Hero**: cambia `items-start` → `lg:items-center` para alinear columna texto y panel de posts; reduce panel a 3 posts
- **Etiquetas duplicadas**: elimina el bloque de categoría `absolute top-3.5 left-3.5` de `CategoryThumbnail` — las cards padre ya renderizan sus propias pills
- **Miniaturas genéricas**: reemplaza las iniciales fantasma (opacidad 0.07) con el logo `/images/logos/socialpro-full.png` en blanco (`filter: brightness(0) invert(1)`, opacidad 0.38) centrado en cada thumbnail sin marca de cliente

## Test plan

- [ ] `/blog` — hero desktop: texto y panel de posts centrados verticalmente
- [ ] `/blog` — panel de posts muestra 3 entradas (no 5)
- [ ] Cards con cover real: sin cambio
- [ ] Cards sin cover (thumbnails generados): logo SocialPro blanco centrado visible
- [ ] Cards de marcas (Razer, 1WIN, etc.): `BrandedComposition` sin cambios, logo de marca + `× SocialPro`
- [ ] Sin etiquetas duplicadas en ninguna card

🤖 Generated with [Claude Code](https://claude.com/claude-code)