### PR TITLE
fix(blog): clear legacy cover_url, editorial thumbnails for all posts

### DIFF
--- a/src/features/blog/components/CategoryThumbnail.tsx
+++ b/src/features/blog/components/CategoryThumbnail.tsx
@@ -5,7 +5,7 @@
  *  - Gradiente multicapa por categoría
  *  - Patrón geométrico distintivo (lines/hex/grid/wave/play/dots)
  *  - Logo de marca cuando se detecta (Razer, 1WIN, SkinsMonkey, Keydrop, Hellcase, Skinplace)
- *  - Tipografía dominante (título en mayúsculas si no hay logo, sino branding)
+ *  - Logo SocialPro en blanco centrado cuando no se detecta marca de cliente
  *  - Wordmark SocialPro discreto bottom-right
  *
  * Hook IA: cuando exista `cover_url` real en la BD, BlogCover usa la imagen.


### PR DESCRIPTION
## Summary

- **BD actualizada**: `cover_url = NULL` para 11 posts con imágenes del branding antiguo (`/images/blog/*.jpg` + `/images/logos/2.png`)
- Posts de marca (Razer, 1WIN, SkinsMonkey) → `BrandedComposition` con logo de cliente
- Posts editoriales → `EditorialComposition` con logo SocialPro blanco sobre gradiente de categoría
- Este commit fuerza una nueva build de Vercel que invalida la caché ISR del blog

## Posts actualizados

| ID | Slug | Resultado |
|---|---|---|
| 15 | socialpro-razer-activacion... | Razer logo |
| 20 | 1win-socialpro-100-influencers... | 1WIN logo |
| 21 | skinsmonkey-socialpro-200000... | SkinsMonkey logo |
| 1,2,3,7,12,13,14,24 | tendencias/guias/igaming/... | White SocialPro logo |

## Test plan

- [ ] `/blog` — cards sin cover real muestran logo SocialPro blanco centrado
- [ ] Cards Razer/1WIN/SkinsMonkey muestran logo de marca (no cover image antigua)
- [ ] Sin texto ni branding antiguo visible en ninguna miniatura

🤖 Generated with [Claude Code](https://claude.com/claude-code)