### PR TITLE
fix(blog): reduce article hero cover to compact strip

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -149,8 +149,8 @@ export default async function BlogPostPage({ params }: PageProps) {
           </div>
         </div>
 
-        {/* Cover — aspect ratio cinematic para mejor presencia visual */}
-        <div className="relative w-full overflow-hidden" style={{ aspectRatio: '21/8' }}>
+        {/* Cover — franja compacta: cap 200px desktop, proporcional mobile */}
+        <div className="relative w-full overflow-hidden" style={{ aspectRatio: '21/8', maxHeight: '200px' }}>
           <BlogCover
             coverUrl={post.coverUrl}
             category={category}


### PR DESCRIPTION
## Summary

El cover del artículo ocupaba demasiado viewport antes de llegar al contenido. Reducido de ~457px a máximo 200px en desktop (más de la mitad menos).

- `aspectRatio: '21/8'` se mantiene para mobile (proporcional, ~143px en 375px de ancho)
- `maxHeight: '200px'` limita el alto en desktop/tablet

## Test plan

- [ ] Abrir cualquier artículo — cover visible pero compacto (~200px alto)
- [ ] En mobile — cover proporcional sin corte brusco
- [ ] Artículos con foto real — `object-cover` mantiene recorte correcto

🤖 Generated with [Claude Code](https://claude.com/claude-code)