### PR TITLE
feat(facturacion): número de factura manual en crear y editar

### DIFF
--- a/src/app/admin/(dashboard)/facturacion/issued-invoices-actions.ts
+++ b/src/app/admin/(dashboard)/facturacion/issued-invoices-actions.ts
@@ -87,7 +87,7 @@ export async function createIssuedInvoiceAction(
     return { error: firstError(parsed.fieldErrors) };
   }
 
-  const { linesJson, vatRate, withholdingRate, issuerCompanyId, ...invoiceData } = parsed.data;
+  const { linesJson, vatRate, withholdingRate, issuerCompanyId, invoiceNumber: manualNumber, ...invoiceData } = parsed.data;
 
   const lines = parseLines(linesJson);
   if (!lines || lines.length === 0) return { error: 'La factura debe tener al menos una línea' };
@@ -95,7 +95,8 @@ export async function createIssuedInvoiceAction(
   const amounts = computeAmounts(lines, Number(vatRate), Number(withholdingRate));
 
   try {
-    const invoiceNumber = await allocateInvoiceNumber(issuerCompanyId);
+    const invoiceNumber = manualNumber ?? await allocateInvoiceNumber(issuerCompanyId);
+    const series = invoiceNumber.includes('-') ? (invoiceNumber.split('-')[0] ?? null) : null;
     const row = await createIssuedInvoice({
       invoice: {
         issuerCompanyId,
@@ -104,7 +105,7 @@ export async function createIssuedInvoiceAction(
         relatedTalentId:   invoiceData.relatedTalentId   ?? null,
         relatedDealId:     invoiceData.relatedDealId     ?? null,
         invoiceNumber,
-        series:            invoiceNumber.split('-')[0] ?? null,
+        series,
         status:            invoiceData.status,
         issueDate:         invoiceData.issueDate,
         dueDate:           invoiceData.dueDate ?? null,
@@ -152,7 +153,7 @@ export async function updateIssuedInvoiceAction(
     return { error: firstError(parsed.fieldErrors) };
   }
 
-  const { id, linesJson, vatRate, withholdingRate, issuerCompanyId, ...invoiceData } = parsed.data;
+  const { id, linesJson, vatRate, withholdingRate, issuerCompanyId, invoiceNumber, ...invoiceData } = parsed.data;
   if (!id) return { error: 'ID requerido' };
 
   let lines: InvoiceLineInput[] | undefined;
@@ -171,6 +172,7 @@ export async function updateIssuedInvoiceAction(
       id,
       {
         ...(issuerCompanyId && { issuerCompanyId }),
+        ...(invoiceNumber   && { invoiceNumber, series: invoiceNumber.includes('-') ? (invoiceNumber.split('-')[0] ?? null) : null }),
         relatedBrandId:  invoiceData.relatedBrandId  ?? null,
         relatedTalentId: invoiceData.relatedTalentId ?? null,
         relatedDealId:   invoiceData.relatedDealId   ?? null,

--- a/src/features/admin/invoices/components/IssuedInvoiceForm.tsx
+++ b/src/features/admin/invoices/components/IssuedInvoiceForm.tsx
@@ -265,6 +265,18 @@ export function IssuedInvoiceForm({ invoice, issuers, clients, brands, talents, 
           <div>
             <p className={S}>D · Datos de factura</p>
             <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+              <div>
+                <label className={LB}>
+                  Nº Factura
+                  {mode === 'create' && <span className="ml-1 font-normal normal-case text-sp-admin-muted/60"> (opcional)</span>}
+                </label>
+                <input
+                  name="invoiceNumber"
+                  defaultValue={invoice?.invoiceNumber ?? ''}
+                  placeholder={mode === 'create' ? 'Auto si se deja vacío' : ''}
+                  className={I}
+                />
+              </div>
               <div><label className={LB}>Fecha emisión *</label><input name="issueDate" type="date" required defaultValue={invoice?.issueDate ?? today} className={I} /></div>
               <div><label className={LB}>Vencimiento</label><input name="dueDate" type="date" defaultValue={invoice?.dueDate ?? ''} className={I} /></div>
               <div>

--- a/src/lib/schemas/issuedInvoice.ts
+++ b/src/lib/schemas/issuedInvoice.ts
@@ -61,6 +61,10 @@ export type InvoiceLineInput = z.infer<typeof invoiceLineSchema>;
 export const createIssuedInvoiceSchema = z.object({
   issuerCompanyId:   z.coerce.number().int().positive(),
   billingClientId:   z.coerce.number().int().positive(),
+  invoiceNumber:     z.preprocess(
+    (v) => (typeof v === 'string' && v.trim() === '' ? undefined : v),
+    z.string().min(1).max(60).optional(),
+  ),
   relatedBrandId:    z.preprocess((v) => (v === '' || v == null ? undefined : Number(v)), z.number().int().positive().optional()),
   relatedTalentId:   z.preprocess((v) => (v === '' || v == null ? undefined : Number(v)), z.number().int().positive().optional()),
   relatedDealId:     z.preprocess((v) => (v === '' || v == null ? undefined : Number(v)), z.number().int().positive().optional()),


### PR DESCRIPTION
## Summary

Permite introducir un número de factura personalizado en lugar del autogenerado — útil para continuar una secuencia existente (ej: venías por la #11 en Excel y quieres que la siguiente sea la #12).

- **Al crear**: campo «Nº Factura (opcional)» en la sección D. Si se deja vacío, se genera automáticamente (`SP-2026-0001`). Si se rellena, se usa ese valor directamente
- **Al editar**: el campo muestra el número actual y permite cambiarlo
- El campo `series` se extrae del número automáticamente si contiene guiones (`F-12` → series `F`), o queda `null` si no

## Test plan

- [ ] Crear factura sin rellenar el campo → número auto-generado (`SP-2026-XXXX`)
- [ ] Crear factura con `12` en el campo → número guardado como `12`
- [ ] Crear factura con `F-2026-012` → número guardado, series `F`
- [ ] Editar factura existente → puede cambiar el número
- [ ] Número duplicado → error «El número de factura ya existe para esta empresa»

🤖 Generated with [Claude Code](https://claude.com/claude-code)