### PR TITLE
fix(deploy): skip database migrations in preview

### DIFF
--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -28,6 +28,11 @@ try {
   // ignore — fall back to existing env
 }
 
+if (process.env.VERCEL_ENV === 'preview') {
+  console.log('Skipping database migrations in Vercel Preview deployment.');
+  process.exit(0);
+}
+
 const url = process.env.DATABASE_URL;
 if (!url) {
   console.error('DATABASE_URL is not set');


### PR DESCRIPTION
## Problema

Los Preview Deployments de Vercel comparten la misma `DATABASE_URL` que producción. Cada build de PR ejecutaba `npm run migrate` contra la base de datos de producción antes de que el PR fuera revisado o mergeado.

Las migraciones aditivas han sido seguras hasta ahora, pero una migración destructiva (`DROP COLUMN`, `ALTER TYPE` incompatible) habría afectado producción silenciosamente en el momento del build del preview.

## Cambio

Guard en `scripts/migrate.ts`: si `VERCEL_ENV === 'preview'`, el script sale inmediatamente con log:
```
Skipping database migrations in Vercel Preview deployment.
```

- **Production**: sigue migrando automáticamente en cada deploy ✅
- **Local/development**: sin cambios ✅
- **Preview**: skip total ✅

## Fix temporal

Este PR elimina el riesgo inmediato. El paso siguiente (separado) es configurar una base de datos Preview dedicada en Neon para que los previews funcionen correctamente con schema aislado.

## Tests

- `npx tsc --noEmit` — verde
- `npm run lint` — verde
- `npm test` — 1299 tests, 77 suites, todos pasando

🤖 Generated with [Claude Code](https://claude.ai/claude-code)