### PR TITLE
feat(finance): add 2026 expense setup wizard

### DIFF
--- a/src/__tests__/server/setup2026-generator.test.ts
+++ b/src/__tests__/server/setup2026-generator.test.ts
@@ -1,0 +1,210 @@
+import {
+  calcTotal,
+  estimateGross,
+  makeTxId,
+  generateHistoricalRows,
+  generateRecurringTemplates,
+  summarize,
+  DEFAULT_HISTORICAL_CONFIG,
+  monthLabel,
+} from '@/lib/finance/setup2026/generator';
+
+describe('calcTotal', () => {
+  it('calcula total con IVA sin retención', () => {
+    expect(calcTotal(100, 21, 0)).toBe('121.00');
+  });
+
+  it('calcula total con retención (gestoría sin IVA)', () => {
+    // net * (1 + (0 - 15) / 100) = net * 0.85
+    expect(calcTotal(1000, 0, 15)).toBe('850.00');
+  });
+
+  it('calcula total con IVA 21% y retención 15%', () => {
+    // net * (1 + (21 - 15) / 100) = net * 1.06
+    expect(calcTotal(500, 21, 15)).toBe('530.00');
+  });
+
+  it('devuelve el neto cuando IVA y retención son 0', () => {
+    expect(calcTotal(250, 0, 0)).toBe('250.00');
+  });
+});
+
+describe('estimateGross', () => {
+  it('calcula bruto de Pablo al 22% IRPF', () => {
+    const gross = estimateGross(1000, 22);
+    expect(gross).toBeCloseTo(1282.05, 1);
+  });
+
+  it('calcula bruto de Alfonso al 6% IRPF', () => {
+    const gross = estimateGross(1000, 6);
+    expect(gross).toBeCloseTo(1063.83, 1);
+  });
+
+  it('retorna el neto cuando irpf=0', () => {
+    expect(estimateGross(1500, 0)).toBe(1500);
+  });
+
+  it('retorna el neto cuando irpf>=100 (guard)', () => {
+    expect(estimateGross(1000, 100)).toBe(1000);
+  });
+});
+
+describe('makeTxId', () => {
+  it('incluye persona cuando se proporciona', () => {
+    expect(makeTxId('nomina_socio', 'pablo', '2026-01')).toBe('setup2026:nomina_socio:pablo:2026-01');
+  });
+
+  it('omite persona cuando es null', () => {
+    expect(makeTxId('gestoria', null, '2026-03')).toBe('setup2026:gestoria:2026-03');
+  });
+
+  it('es estable (mismos inputs → mismo output)', () => {
+    const id1 = makeTxId('cuota_autonomo', 'alfonso', '2026-06');
+    const id2 = makeTxId('cuota_autonomo', 'alfonso', '2026-06');
+    expect(id1).toBe(id2);
+  });
+
+  it('distingue por mes', () => {
+    const jan = makeTxId('gestoria', null, '2026-01');
+    const feb = makeTxId('gestoria', null, '2026-02');
+    expect(jan).not.toBe(feb);
+  });
+});
+
+describe('generateHistoricalRows — estructura básica', () => {
+  const rows = generateHistoricalRows(DEFAULT_HISTORICAL_CONFIG);
+
+  it('genera filas para los dos socios (pablo y alfonso)', () => {
+    const pablo = rows.filter((r) => r.personKey === 'pablo');
+    const alfonso = rows.filter((r) => r.personKey === 'alfonso');
+    expect(pablo.length).toBeGreaterThan(0);
+    expect(alfonso.length).toBeGreaterThan(0);
+  });
+
+  it('todos los txIds empiezan por setup2026:', () => {
+    for (const row of rows) {
+      expect(row.txId).toMatch(/^setup2026:/);
+    }
+  });
+
+  it('todos los txIds son únicos', () => {
+    const ids = rows.map((r) => r.txId);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('todos los rows tienen expenseGroup operational', () => {
+    for (const row of rows) {
+      expect(row.expenseGroup).toBe('operational');
+    }
+  });
+
+  it('cuota_autonomo tiene vatPct=0.00 y withholdingPct=0.00', () => {
+    const autonomo = rows.filter((r) => r.expenseSubtype === 'cuota_autonomo');
+    for (const row of autonomo) {
+      expect(row.vatPct).toBe('0.00');
+      expect(row.withholdingPct).toBe('0.00');
+    }
+  });
+
+  it('nomina_socio usa estimateGross para netAmount', () => {
+    const nominas = rows.filter((r) => r.expenseSubtype === 'nomina_socio');
+    expect(nominas.length).toBeGreaterThan(0);
+    for (const row of nominas) {
+      const net = Number(row.netAmount);
+      expect(net).toBeGreaterThan(1000); // siempre bruto > neto (con IRPF > 0)
+    }
+  });
+});
+
+describe('generateHistoricalRows — totales por mes/subtipo', () => {
+  it('summarize cuenta exactamente las filas include=true', () => {
+    const rows = generateHistoricalRows(DEFAULT_HISTORICAL_CONFIG);
+    const s = summarize(rows);
+    const includedCount = rows.filter((r) => r.include).length;
+    expect(s.invoiceCount).toBe(includedCount);
+  });
+
+  it('grandTotal es la suma de totalAmount de todas las filas included', () => {
+    const rows = generateHistoricalRows(DEFAULT_HISTORICAL_CONFIG);
+    const expected = rows
+      .filter((r) => r.include)
+      .reduce((acc, r) => acc + Number(r.totalAmount), 0);
+    const s = summarize(rows);
+    expect(s.grandTotal).toBeCloseTo(expected, 1);
+  });
+
+  it('ebitdaImpact es la suma de netAmount de filas included', () => {
+    const rows = generateHistoricalRows(DEFAULT_HISTORICAL_CONFIG);
+    const expected = rows
+      .filter((r) => r.include)
+      .reduce((acc, r) => acc + Number(r.netAmount), 0);
+    const s = summarize(rows);
+    expect(s.ebitdaImpact).toBeCloseTo(expected, 1);
+  });
+
+  it('totalBySubtype tiene clave nomina_socio cuando hay nóminas', () => {
+    const rows = generateHistoricalRows(DEFAULT_HISTORICAL_CONFIG);
+    const s = summarize(rows);
+    expect(s.totalBySubtype).toHaveProperty('nomina_socio');
+  });
+});
+
+describe('generateRecurringTemplates', () => {
+  const gestoria = { ...DEFAULT_HISTORICAL_CONFIG.gestoria, startDate: '2026-07-01' };
+  const seguro = { ...DEFAULT_HISTORICAL_CONFIG.seguro, startDate: '2026-07-01' };
+  const templates = generateRecurringTemplates(gestoria, seguro);
+
+  it('genera exactamente 2 templates', () => {
+    expect(templates).toHaveLength(2);
+  });
+
+  it('gestoria tiene vatPct y withholdingPct del config', () => {
+    const g = templates.find((t) => t.expenseSubtype === 'gestoria');
+    expect(g).toBeDefined();
+    expect(g!.vatPct).toBe(DEFAULT_HISTORICAL_CONFIG.gestoria.vatPct);
+  });
+
+  it('seguro_medico tiene vatPct=0.00 y withholdingPct=0.00', () => {
+    const s = templates.find((t) => t.expenseSubtype === 'seguro_medico');
+    expect(s).toBeDefined();
+    expect(s!.vatPct).toBe('0.00');
+    expect(s!.withholdingPct).toBe('0.00');
+  });
+
+  it('las keys empiezan por setup2026:recurring:', () => {
+    for (const t of templates) {
+      expect(t.key).toMatch(/^setup2026:recurring:/);
+    }
+  });
+});
+
+describe('summarize — filas parcialmente excluidas', () => {
+  it('ignora filas con include=false', () => {
+    const rows = generateHistoricalRows(DEFAULT_HISTORICAL_CONFIG).map((r, i) =>
+      i === 0 ? { ...r, include: false } : r,
+    );
+    const s = summarize(rows);
+    const expected = rows.filter((r) => r.include).length;
+    expect(s.invoiceCount).toBe(expected);
+  });
+
+  it('devuelve grandTotal=0 si todas están excluidas', () => {
+    const rows = generateHistoricalRows(DEFAULT_HISTORICAL_CONFIG).map((r) => ({
+      ...r,
+      include: false,
+    }));
+    const s = summarize(rows);
+    expect(s.grandTotal).toBe(0);
+    expect(s.invoiceCount).toBe(0);
+  });
+});
+
+describe('monthLabel', () => {
+  it('formatea enero correctamente', () => {
+    expect(monthLabel('2026-01')).toBe('ene 2026');
+  });
+
+  it('formatea junio correctamente', () => {
+    expect(monthLabel('2026-06')).toBe('jun 2026');
+  });
+});

--- a/src/app/admin/(dashboard)/finanzas/FinanzasNav.tsx
+++ b/src/app/admin/(dashboard)/finanzas/FinanzasNav.tsx
@@ -8,6 +8,7 @@ const TABS = [
   { href: '/admin/finanzas/pl',                label: 'P&L' },
   { href: '/admin/finanzas/costes',            label: 'Costes campaña' },
   { href: '/admin/finanzas/gastos-operativos', label: 'Gastos operativos' },
+  { href: '/admin/finanzas/setup-2026',        label: 'Setup 2026' },
 ] as const;
 
 export function FinanzasNav(): React.ReactElement {

--- a/src/app/admin/(dashboard)/finanzas/setup-2026/actions.ts
+++ b/src/app/admin/(dashboard)/finanzas/setup-2026/actions.ts
@@ -1,0 +1,141 @@
+'use server';
+
+import { z } from 'zod';
+import { revalidatePath } from 'next/cache';
+import { requirePermission } from '@/lib/permissions';
+import { logRedacted } from '@/lib/log';
+import {
+  applySetup2026,
+  getExistingSetupTxIds,
+  getExistingRecurringNames,
+  previewSetup2026,
+} from '@/lib/queries/setup2026';
+import { EXPENSE_SUBTYPES } from '@/lib/schemas/invoice';
+import type { HistoricalExpenseRow, RecurringExpenseRow, ApplyResult } from '@/lib/finance/setup2026/types';
+
+type ActionResult<T = void> =
+  | { readonly ok: true; readonly data: T }
+  | { readonly ok: false; readonly error: string };
+
+// ── Zod schemas ───────────────────────────────────────────────────────────────
+
+const historicalRowSchema = z.object({
+  txId: z.string().min(1),
+  include: z.boolean(),
+  issueDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  concept: z.string().min(1),
+  counterpartyName: z.string().min(1),
+  netAmount: z.string().regex(/^\d+(\.\d{1,2})?$/),
+  vatPct: z.string().regex(/^\d+(\.\d{1,2})?$/),
+  withholdingPct: z.string().regex(/^\d+(\.\d{1,2})?$/),
+  totalAmount: z.string().regex(/^\d+(\.\d{1,2})?$/),
+  expenseGroup: z.literal('operational'),
+  expenseSubtype: z.enum(EXPENSE_SUBTYPES),
+  notes: z.string(),
+  label: z.string(),
+  month: z.string().regex(/^\d{4}-\d{2}$/),
+  personKey: z.enum(['pablo', 'alfonso']).nullable(),
+  categoryKey: z.string(),
+});
+
+const recurringRowSchema = z.object({
+  key: z.string().min(1),
+  include: z.boolean(),
+  name: z.string().min(1),
+  concept: z.string().min(1),
+  counterpartyName: z.string().min(1),
+  amount: z.string().regex(/^\d+(\.\d{1,2})?$/),
+  vatPct: z.string().regex(/^\d+(\.\d{1,2})?$/),
+  withholdingPct: z.string().regex(/^\d+(\.\d{1,2})?$/),
+  expenseGroup: z.literal('operational'),
+  expenseSubtype: z.enum(EXPENSE_SUBTYPES),
+  dayOfMonth: z.number().int().min(1).max(31),
+  startDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  notes: z.string(),
+  label: z.string(),
+  categoryKey: z.string(),
+});
+
+const payloadSchema = z.object({
+  historical: z.array(historicalRowSchema),
+  recurring: z.array(recurringRowSchema),
+});
+
+// ── Actions ───────────────────────────────────────────────────────────────────
+
+/**
+ * Preview: returns which txIds already exist and how many rows would be created.
+ * Does NOT write to DB.
+ */
+export async function previewSetup2026Action(
+  rawPayload: string,
+): Promise<ActionResult<{ existing: readonly string[]; toCreate: number; recurringToCreate: number }>> {
+  await requirePermission('facturacion', 'write');
+
+  let parsed: z.infer<typeof payloadSchema>;
+  try {
+    parsed = payloadSchema.parse(JSON.parse(rawPayload));
+  } catch {
+    return { ok: false, error: 'Payload inválido' };
+  }
+
+  try {
+    const result = await previewSetup2026(
+      parsed.historical as HistoricalExpenseRow[],
+      parsed.recurring as RecurringExpenseRow[],
+    );
+    return { ok: true, data: result };
+  } catch (err) {
+    logRedacted('error', '[setup2026] previewSetup2026 error:', err instanceof Error ? err.message : 'unknown');
+    return { ok: false, error: 'Error al calcular el preview' };
+  }
+}
+
+/**
+ * Apply: creates invoices and recurring templates for rows that don't exist yet.
+ * Idempotent via txId / name dedup.
+ */
+export async function applySetup2026Action(
+  rawPayload: string,
+): Promise<ActionResult<ApplyResult>> {
+  await requirePermission('facturacion', 'write');
+
+  let parsed: z.infer<typeof payloadSchema>;
+  try {
+    parsed = payloadSchema.parse(JSON.parse(rawPayload));
+  } catch {
+    return { ok: false, error: 'Payload inválido' };
+  }
+
+  const hasAnyIncluded =
+    parsed.historical.some((r) => r.include) ||
+    parsed.recurring.some((r) => r.include);
+  if (!hasAnyIncluded) {
+    return { ok: false, error: 'No hay filas seleccionadas para crear' };
+  }
+
+  let result: ApplyResult;
+  try {
+    const [existingTxIds, existingRecurringNames] = await Promise.all([
+      getExistingSetupTxIds(),
+      getExistingRecurringNames(),
+    ]);
+
+    result = await applySetup2026(
+      parsed.historical as HistoricalExpenseRow[],
+      parsed.recurring as RecurringExpenseRow[],
+      existingTxIds,
+      existingRecurringNames,
+    );
+  } catch (err) {
+    logRedacted('error', '[setup2026] applySetup2026 error:', err instanceof Error ? err.message : 'unknown');
+    return { ok: false, error: 'Error al crear los gastos' };
+  }
+
+  revalidatePath('/admin/finanzas');
+  revalidatePath('/admin/finanzas/resumen');
+  revalidatePath('/admin/finanzas/pl');
+  revalidatePath('/admin/finanzas/gastos-operativos');
+
+  return { ok: true, data: result };
+}

--- a/src/app/admin/(dashboard)/finanzas/setup-2026/page.tsx
+++ b/src/app/admin/(dashboard)/finanzas/setup-2026/page.tsx
@@ -1,0 +1,24 @@
+import { requirePermission } from '@/lib/permissions';
+import { getExistingSetupTxIds } from '@/lib/queries/setup2026';
+import { Setup2026Wizard } from '@/features/admin/finance-setup/Setup2026Wizard';
+
+export const metadata = { title: 'Setup gastos 2026 | Admin' };
+
+export default async function Setup2026Page(): Promise<React.ReactElement> {
+  await requirePermission('facturacion', 'write');
+
+  const existingTxIds = await getExistingSetupTxIds();
+
+  return (
+    <div className="space-y-6 pt-2">
+      <div>
+        <h1 className="text-lg font-bold text-sp-admin-fg">Configuración gastos 2026</h1>
+        <p className="text-xs text-sp-admin-muted mt-0.5">
+          Carga histórica de gastos operativos 2026 con preview editable antes de guardar.
+          Los datos reales solo se insertan al confirmar explícitamente.
+        </p>
+      </div>
+      <Setup2026Wizard existingTxIds={[...existingTxIds]} />
+    </div>
+  );
+}

--- a/src/features/admin/finance-setup/Setup2026Wizard.tsx
+++ b/src/features/admin/finance-setup/Setup2026Wizard.tsx
@@ -1,0 +1,662 @@
+'use client';
+
+import { useState, useTransition, useCallback } from 'react';
+import Link from 'next/link';
+import {
+  generateHistoricalRows,
+  generateRecurringTemplates,
+  summarize,
+  calcTotal,
+  DEFAULT_HISTORICAL_CONFIG,
+} from '@/lib/finance/setup2026/generator';
+import { previewSetup2026Action, applySetup2026Action } from '@/app/admin/(dashboard)/finanzas/setup-2026/actions';
+import { EXPENSE_SUBTYPES_OPERATIONAL, EXPENSE_SUBTYPE_LABELS } from '@/lib/schemas/invoice';
+import type { HistoricalExpenseRow, RecurringExpenseRow } from '@/lib/finance/setup2026/types';
+import type { ExpenseSubtypeValue } from '@/lib/schemas/invoice';
+
+type Props = {
+  readonly existingTxIds: readonly string[];
+};
+
+type Step = 'config' | 'preview' | 'confirm' | 'result';
+
+type ConfigState = {
+  nomina_pablo_net: string;
+  nomina_pablo_irpf: string;
+  nomina_pablo_name: string;
+  nomina_pablo_months: string;
+  nomina_alfonso_net: string;
+  nomina_alfonso_irpf: string;
+  nomina_alfonso_name: string;
+  nomina_alfonso_months: string;
+  autonomo_pablo_amount: string;
+  autonomo_pablo_name: string;
+  autonomo_pablo_months: string;
+  autonomo_alfonso_amount: string;
+  autonomo_alfonso_name: string;
+  autonomo_alfonso_months: string;
+  gestoria_amount: string;
+  gestoria_vat: string;
+  gestoria_withholding: string;
+  gestoria_name: string;
+  gestoria_months: string;
+  seguro_amount: string;
+  seguro_name: string;
+  seguro_months: string;
+  create_historical: boolean;
+  create_recurring: boolean;
+  recurring_start: string;
+};
+
+const MONTHS_JAN_MAR = '2026-01,2026-02,2026-03';
+const MONTHS_JAN_JUN = '2026-01,2026-02,2026-03,2026-04,2026-05,2026-06';
+
+const DEFAULT_CONFIG: ConfigState = {
+  nomina_pablo_net: '1000.00',
+  nomina_pablo_irpf: '22',
+  nomina_pablo_name: 'Pablo García',
+  nomina_pablo_months: MONTHS_JAN_MAR,
+  nomina_alfonso_net: '1000.00',
+  nomina_alfonso_irpf: '6',
+  nomina_alfonso_name: 'Alfonso',
+  nomina_alfonso_months: MONTHS_JAN_MAR,
+  autonomo_pablo_amount: '',
+  autonomo_pablo_name: 'RETA Pablo García',
+  autonomo_pablo_months: MONTHS_JAN_JUN,
+  autonomo_alfonso_amount: '',
+  autonomo_alfonso_name: 'RETA Alfonso',
+  autonomo_alfonso_months: MONTHS_JAN_JUN,
+  gestoria_amount: '180.00',
+  gestoria_vat: '21.00',
+  gestoria_withholding: '0.00',
+  gestoria_name: 'Gestoría',
+  gestoria_months: MONTHS_JAN_JUN,
+  seguro_amount: '54.00',
+  seguro_name: 'Aseguradora',
+  seguro_months: MONTHS_JAN_JUN,
+  create_historical: true,
+  create_recurring: true,
+  recurring_start: '2026-07-01',
+};
+
+function parseMonths(csv: string): string[] {
+  return csv.split(',').map((m) => m.trim()).filter(Boolean);
+}
+
+function configToHistoricalConfig(c: ConfigState) {
+  return {
+    nomina: {
+      pablo: { netSalary: c.nomina_pablo_net, irpfRate: c.nomina_pablo_irpf, months: parseMonths(c.nomina_pablo_months), counterpartyName: c.nomina_pablo_name },
+      alfonso: { netSalary: c.nomina_alfonso_net, irpfRate: c.nomina_alfonso_irpf, months: parseMonths(c.nomina_alfonso_months), counterpartyName: c.nomina_alfonso_name },
+    },
+    autonomo: {
+      pablo: { amount: c.autonomo_pablo_amount, months: parseMonths(c.autonomo_pablo_months), counterpartyName: c.autonomo_pablo_name, expenseSubtype: 'cuota_autonomo' as const },
+      alfonso: { amount: c.autonomo_alfonso_amount, months: parseMonths(c.autonomo_alfonso_months), counterpartyName: c.autonomo_alfonso_name, expenseSubtype: 'cuota_autonomo' as const },
+    },
+    gestoria: { amount: c.gestoria_amount, vatPct: c.gestoria_vat, withholdingPct: c.gestoria_withholding, months: parseMonths(c.gestoria_months), counterpartyName: c.gestoria_name },
+    seguro: { amount: c.seguro_amount, months: parseMonths(c.seguro_months), counterpartyName: c.seguro_name },
+  } satisfies typeof DEFAULT_HISTORICAL_CONFIG;
+}
+
+function fmt(n: number): string {
+  return n.toLocaleString('es-ES', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+}
+
+// ── Field helpers ─────────────────────────────────────────────────────────────
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <label className="text-[10px] text-sp-admin-muted uppercase tracking-wider font-semibold">{label}</label>
+      {children}
+    </div>
+  );
+}
+
+const INPUT_CLS = 'text-xs border border-sp-admin-border rounded px-2 py-1 bg-sp-admin-bg text-sp-admin-fg w-full';
+
+// ── Step 1 — Config ───────────────────────────────────────────────────────────
+
+function Step1Config({ config, onChange, onNext }: {
+  config: ConfigState;
+  onChange: (patch: Partial<ConfigState>) => void;
+  onNext: () => void;
+}) {
+  const set = (k: keyof ConfigState) => (e: React.ChangeEvent<HTMLInputElement>) =>
+    onChange({ [k]: e.target.type === 'checkbox' ? e.target.checked : e.target.value });
+
+  return (
+    <div className="space-y-6">
+      {/* Opciones globales */}
+      <div className="border border-sp-admin-border rounded-xl p-4 space-y-3">
+        <h2 className="text-xs font-semibold text-sp-admin-fg">Opciones</h2>
+        <div className="flex gap-6 flex-wrap">
+          <label className="flex items-center gap-2 text-xs text-sp-admin-fg cursor-pointer">
+            <input type="checkbox" checked={config.create_historical} onChange={set('create_historical')} className="rounded" />
+            Crear facturas históricas (ene–jun 2026)
+          </label>
+          <label className="flex items-center gap-2 text-xs text-sp-admin-fg cursor-pointer">
+            <input type="checkbox" checked={config.create_recurring} onChange={set('create_recurring')} className="rounded" />
+            Crear templates recurrentes (gestoría + seguro)
+          </label>
+        </div>
+        {config.create_recurring && (
+          <Field label="Inicio templates recurrentes">
+            <input type="date" value={config.recurring_start} onChange={set('recurring_start')} className={INPUT_CLS} />
+          </Field>
+        )}
+      </div>
+
+      {/* Nóminas */}
+      <div className="border border-sp-admin-border rounded-xl p-4 space-y-4">
+        <h2 className="text-xs font-semibold text-sp-admin-fg">Nóminas (nomina_socio)</h2>
+        {(['pablo', 'alfonso'] as const).map((p) => (
+          <div key={p} className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            <Field label={`Nombre ${p}`}>
+              <input value={config[`nomina_${p}_name`]} onChange={set(`nomina_${p}_name`)} className={INPUT_CLS} />
+            </Field>
+            <Field label="Neto mensual (€)">
+              <input type="number" step="0.01" value={config[`nomina_${p}_net`]} onChange={set(`nomina_${p}_net`)} className={INPUT_CLS} />
+            </Field>
+            <Field label="IRPF (%)">
+              <input type="number" step="0.01" value={config[`nomina_${p}_irpf`]} onChange={set(`nomina_${p}_irpf`)} className={INPUT_CLS} />
+            </Field>
+            <Field label="Meses (YYYY-MM separados por coma)">
+              <input value={config[`nomina_${p}_months`]} onChange={set(`nomina_${p}_months`)} className={INPUT_CLS} placeholder="2026-01,2026-02,2026-03" />
+            </Field>
+          </div>
+        ))}
+      </div>
+
+      {/* Cuotas autónomo */}
+      <div className="border border-sp-admin-border rounded-xl p-4 space-y-4">
+        <h2 className="text-xs font-semibold text-sp-admin-fg">Cuotas autónomo societario RETA (cuota_autonomo)</h2>
+        <p className="text-[10px] text-sp-admin-muted">VAT 0%, retención 0%. Pago directo a Seguridad Social.</p>
+        {(['pablo', 'alfonso'] as const).map((p) => (
+          <div key={p} className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+            <Field label={`Nombre ${p}`}>
+              <input value={config[`autonomo_${p}_name`]} onChange={set(`autonomo_${p}_name`)} className={INPUT_CLS} />
+            </Field>
+            <Field label="Importe mensual (€) — dejar vacío si desconocido">
+              <input type="number" step="0.01" value={config[`autonomo_${p}_amount`]} onChange={set(`autonomo_${p}_amount`)} className={INPUT_CLS} placeholder="ej. 294.00" />
+            </Field>
+            <Field label="Meses">
+              <input value={config[`autonomo_${p}_months`]} onChange={set(`autonomo_${p}_months`)} className={INPUT_CLS} />
+            </Field>
+          </div>
+        ))}
+      </div>
+
+      {/* Gestoría */}
+      <div className="border border-sp-admin-border rounded-xl p-4 space-y-3">
+        <h2 className="text-xs font-semibold text-sp-admin-fg">Gestoría (gestoria)</h2>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <Field label="Nombre/proveedor">
+            <input value={config.gestoria_name} onChange={set('gestoria_name')} className={INPUT_CLS} />
+          </Field>
+          <Field label="Importe neto (€)">
+            <input type="number" step="0.01" value={config.gestoria_amount} onChange={set('gestoria_amount')} className={INPUT_CLS} />
+          </Field>
+          <Field label="IVA (%)">
+            <input type="number" step="0.01" value={config.gestoria_vat} onChange={set('gestoria_vat')} className={INPUT_CLS} />
+          </Field>
+          <Field label="Retención (%)">
+            <input type="number" step="0.01" value={config.gestoria_withholding} onChange={set('gestoria_withholding')} className={INPUT_CLS} />
+          </Field>
+          <Field label="Meses" >
+            <input value={config.gestoria_months} onChange={set('gestoria_months')} className={`${INPUT_CLS} col-span-3`} />
+          </Field>
+        </div>
+      </div>
+
+      {/* Seguro médico */}
+      <div className="border border-sp-admin-border rounded-xl p-4 space-y-3">
+        <h2 className="text-xs font-semibold text-sp-admin-fg">Seguro médico (seguro_medico)</h2>
+        <p className="text-[10px] text-sp-admin-muted">VAT 0%, retención 0%.</p>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+          <Field label="Aseguradora">
+            <input value={config.seguro_name} onChange={set('seguro_name')} className={INPUT_CLS} />
+          </Field>
+          <Field label="Importe mensual (€)">
+            <input type="number" step="0.01" value={config.seguro_amount} onChange={set('seguro_amount')} className={INPUT_CLS} />
+          </Field>
+          <Field label="Meses">
+            <input value={config.seguro_months} onChange={set('seguro_months')} className={INPUT_CLS} />
+          </Field>
+        </div>
+      </div>
+
+      <div className="flex justify-end">
+        <button onClick={onNext} className="text-sm px-4 py-2 rounded-lg bg-sp-orange text-white font-semibold hover:bg-sp-orange/90 transition-colors">
+          Generar preview →
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── Step 2 — Preview ──────────────────────────────────────────────────────────
+
+function Step2Preview({ rows, recurringRows, existingTxIds, onRowChange, onBack, onNext }: {
+  rows: HistoricalExpenseRow[];
+  recurringRows: RecurringExpenseRow[];
+  existingTxIds: ReadonlySet<string>;
+  onRowChange: (idx: number, patch: Partial<HistoricalExpenseRow>) => void;
+  onBack: () => void;
+  onNext: () => void;
+}) {
+  const summary = summarize(rows);
+
+  return (
+    <div className="space-y-5">
+      <p className="text-xs text-sp-admin-muted">
+        Revisa y edita los gastos propuestos. Los marcados con <span className="text-amber-400 font-semibold">⚠ ya existe</span> se omitirán.
+        Desmarca las filas que no quieras crear.
+      </p>
+
+      <div className="overflow-x-auto">
+        <table className="w-full text-xs border-collapse">
+          <thead>
+            <tr className="border-b border-sp-admin-border text-sp-admin-muted text-left">
+              <th className="py-1.5 pr-2 w-6">✓</th>
+              <th className="py-1.5 pr-3">Concepto</th>
+              <th className="py-1.5 pr-2">Fecha</th>
+              <th className="py-1.5 pr-2">Proveedor</th>
+              <th className="py-1.5 pr-2">Neto €</th>
+              <th className="py-1.5 pr-2">IVA%</th>
+              <th className="py-1.5 pr-2">Ret%</th>
+              <th className="py-1.5 pr-2">Total €</th>
+              <th className="py-1.5 pr-2">Subtipo</th>
+              <th className="py-1.5">Notas</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, idx) => {
+              const isExisting = existingTxIds.has(row.txId);
+              const rowCls = isExisting
+                ? 'opacity-50 bg-sp-admin-hover/30'
+                : row.include ? '' : 'opacity-40';
+              return (
+                <tr key={row.txId} className={`border-b border-sp-admin-border/50 ${rowCls}`}>
+                  <td className="py-1 pr-2">
+                    <input
+                      type="checkbox"
+                      checked={row.include && !isExisting}
+                      disabled={isExisting}
+                      onChange={(e) => onRowChange(idx, { include: e.target.checked })}
+                      className="rounded"
+                    />
+                  </td>
+                  <td className="py-1 pr-3">
+                    {isExisting && <span className="text-amber-400 mr-1">⚠</span>}
+                    <input
+                      value={row.concept}
+                      onChange={(e) => onRowChange(idx, { concept: e.target.value })}
+                      disabled={isExisting}
+                      className="bg-transparent border-b border-transparent hover:border-sp-admin-border focus:border-sp-orange outline-none w-48"
+                    />
+                  </td>
+                  <td className="py-1 pr-2">
+                    <input
+                      type="date"
+                      value={row.issueDate}
+                      onChange={(e) => onRowChange(idx, { issueDate: e.target.value })}
+                      disabled={isExisting}
+                      className="bg-transparent border-b border-transparent hover:border-sp-admin-border focus:border-sp-orange outline-none w-28"
+                    />
+                  </td>
+                  <td className="py-1 pr-2">
+                    <input
+                      value={row.counterpartyName}
+                      onChange={(e) => onRowChange(idx, { counterpartyName: e.target.value })}
+                      disabled={isExisting}
+                      className="bg-transparent border-b border-transparent hover:border-sp-admin-border focus:border-sp-orange outline-none w-32"
+                    />
+                  </td>
+                  <td className="py-1 pr-2">
+                    <input
+                      type="number"
+                      step="0.01"
+                      value={row.netAmount}
+                      disabled={isExisting}
+                      onChange={(e) => {
+                        const net = Number(e.target.value);
+                        const total = calcTotal(net, Number(row.vatPct), Number(row.withholdingPct));
+                        onRowChange(idx, { netAmount: e.target.value, totalAmount: total });
+                      }}
+                      className="bg-transparent border-b border-transparent hover:border-sp-admin-border focus:border-sp-orange outline-none w-20 text-right"
+                    />
+                  </td>
+                  <td className="py-1 pr-2">
+                    <input
+                      type="number"
+                      step="0.01"
+                      value={row.vatPct}
+                      disabled={isExisting}
+                      onChange={(e) => {
+                        const total = calcTotal(Number(row.netAmount), Number(e.target.value), Number(row.withholdingPct));
+                        onRowChange(idx, { vatPct: e.target.value, totalAmount: total });
+                      }}
+                      className="bg-transparent border-b border-transparent hover:border-sp-admin-border focus:border-sp-orange outline-none w-12 text-right"
+                    />
+                  </td>
+                  <td className="py-1 pr-2">
+                    <input
+                      type="number"
+                      step="0.01"
+                      value={row.withholdingPct}
+                      disabled={isExisting}
+                      onChange={(e) => {
+                        const total = calcTotal(Number(row.netAmount), Number(row.vatPct), Number(e.target.value));
+                        onRowChange(idx, { withholdingPct: e.target.value, totalAmount: total });
+                      }}
+                      className="bg-transparent border-b border-transparent hover:border-sp-admin-border focus:border-sp-orange outline-none w-12 text-right"
+                    />
+                  </td>
+                  <td className="py-1 pr-2 font-mono text-right">{fmt(Number(row.totalAmount))}</td>
+                  <td className="py-1 pr-2">
+                    <select
+                      value={row.expenseSubtype}
+                      disabled={isExisting}
+                      onChange={(e) => onRowChange(idx, { expenseSubtype: e.target.value })}
+                      className="bg-transparent border-b border-transparent hover:border-sp-admin-border focus:border-sp-orange outline-none text-xs"
+                    >
+                      {EXPENSE_SUBTYPES_OPERATIONAL.map((s) => (
+                        <option key={s} value={s}>{EXPENSE_SUBTYPE_LABELS[s as ExpenseSubtypeValue] ?? s}</option>
+                      ))}
+                    </select>
+                  </td>
+                  <td className="py-1">
+                    <input
+                      value={row.notes}
+                      onChange={(e) => onRowChange(idx, { notes: e.target.value })}
+                      disabled={isExisting}
+                      className="bg-transparent border-b border-transparent hover:border-sp-admin-border focus:border-sp-orange outline-none w-40"
+                    />
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Recurring templates */}
+      {recurringRows.length > 0 && (
+        <div className="border border-sp-admin-border rounded-xl p-4 space-y-2">
+          <h2 className="text-xs font-semibold text-sp-admin-fg">Templates recurrentes a crear</h2>
+          {recurringRows.map((r) => (
+            <div key={r.key} className="flex items-center gap-3 text-xs text-sp-admin-muted">
+              <span className="font-medium text-sp-admin-fg">{r.label}</span>
+              <span>— {r.amount} € | IVA {r.vatPct}% | Ret {r.withholdingPct}%</span>
+              <span>desde {r.startDate}</span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Mini-resumen */}
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4 text-xs">
+        {Object.entries(summary.totalBySubtype).map(([sub, total]) => (
+          <div key={sub} className="border border-sp-admin-border rounded-lg p-3 space-y-1">
+            <div className="text-sp-admin-muted">{EXPENSE_SUBTYPE_LABELS[sub as ExpenseSubtypeValue] ?? sub}</div>
+            <div className="font-semibold text-sp-admin-fg">{fmt(total)} €</div>
+          </div>
+        ))}
+      </div>
+      <div className="flex justify-between text-xs text-sp-admin-muted">
+        <span><span className="font-semibold text-sp-admin-fg">{summary.invoiceCount}</span> facturas seleccionadas</span>
+        <span>Total caja: <span className="font-semibold text-sp-admin-fg">{fmt(summary.grandTotal)} €</span> | Impacto EBITDA: <span className="font-semibold text-sp-orange">{fmt(summary.ebitdaImpact)} €</span></span>
+      </div>
+
+      <div className="flex justify-between">
+        <button onClick={onBack} className="text-xs px-3 py-1.5 border border-sp-admin-border rounded hover:bg-sp-admin-hover transition-colors">
+          ← Volver a configuración
+        </button>
+        <button
+          onClick={onNext}
+          disabled={summary.invoiceCount === 0}
+          className="text-sm px-4 py-2 rounded-lg bg-sp-orange text-white font-semibold hover:bg-sp-orange/90 disabled:opacity-50 transition-colors"
+        >
+          Revisar y confirmar →
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── Step 3 — Confirm ──────────────────────────────────────────────────────────
+
+function Step3Confirm({ rows, recurringRows, onBack, onApply, isPending, previewData }: {
+  rows: HistoricalExpenseRow[];
+  recurringRows: RecurringExpenseRow[];
+  onBack: () => void;
+  onApply: () => void;
+  isPending: boolean;
+  previewData: { existing: readonly string[]; toCreate: number; recurringToCreate: number } | null;
+}) {
+  const summary = summarize(rows);
+  const included = rows.filter((r) => r.include);
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 p-4 text-xs text-amber-300 space-y-1">
+        <p className="font-semibold">⚠ Esta operación insertará datos reales en la base de datos.</p>
+        <p>Los registros ya existentes (mismo txId) serán ignorados automáticamente.</p>
+      </div>
+
+      {/* Resumen por subtipo */}
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        {Object.entries(summary.totalBySubtype).map(([sub, total]) => (
+          <div key={sub} className="border border-sp-admin-border rounded-xl p-3 space-y-1">
+            <div className="text-[10px] text-sp-admin-muted uppercase tracking-wider">{EXPENSE_SUBTYPE_LABELS[sub as ExpenseSubtypeValue] ?? sub}</div>
+            <div className="text-base font-bold text-sp-admin-fg">{fmt(total)} €</div>
+          </div>
+        ))}
+      </div>
+
+      {/* Resumen por mes */}
+      <div className="border border-sp-admin-border rounded-xl p-4">
+        <h3 className="text-xs font-semibold text-sp-admin-fg mb-3">Total por mes</h3>
+        <div className="grid grid-cols-3 gap-2 sm:grid-cols-6">
+          {Object.entries(summary.totalByMonth).sort(([a], [b]) => a.localeCompare(b)).map(([month, total]) => (
+            <div key={month} className="text-center">
+              <div className="text-[10px] text-sp-admin-muted">{month.slice(5)}/{month.slice(0, 4)}</div>
+              <div className="text-xs font-semibold text-sp-admin-fg">{fmt(total)} €</div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Totales globales */}
+      <div className="flex gap-6 text-sm">
+        <div>
+          <div className="text-sp-admin-muted text-xs">Facturas a crear</div>
+          <div className="font-bold text-sp-admin-fg">{previewData?.toCreate ?? included.length}</div>
+        </div>
+        {recurringRows.filter(r => r.include).length > 0 && (
+          <div>
+            <div className="text-sp-admin-muted text-xs">Templates recurrentes</div>
+            <div className="font-bold text-sp-admin-fg">{previewData?.recurringToCreate ?? recurringRows.filter(r => r.include).length}</div>
+          </div>
+        )}
+        {(previewData?.existing.length ?? 0) > 0 && (
+          <div>
+            <div className="text-sp-admin-muted text-xs">Ya existentes (omitir)</div>
+            <div className="font-bold text-amber-400">{previewData?.existing.length}</div>
+          </div>
+        )}
+        <div>
+          <div className="text-sp-admin-muted text-xs">Total caja</div>
+          <div className="font-bold text-sp-admin-fg">{fmt(summary.grandTotal)} €</div>
+        </div>
+        <div>
+          <div className="text-sp-admin-muted text-xs">Impacto EBITDA</div>
+          <div className="font-bold text-sp-orange">{fmt(summary.ebitdaImpact)} €</div>
+        </div>
+      </div>
+
+      <div className="flex justify-between">
+        <button onClick={onBack} disabled={isPending} className="text-xs px-3 py-1.5 border border-sp-admin-border rounded hover:bg-sp-admin-hover transition-colors disabled:opacity-50">
+          ← Volver al preview
+        </button>
+        <button
+          onClick={onApply}
+          disabled={isPending || (previewData?.toCreate === 0 && (previewData?.recurringToCreate ?? 0) === 0)}
+          className="text-sm px-6 py-2 rounded-lg bg-sp-orange text-white font-semibold hover:bg-sp-orange/90 disabled:opacity-50 transition-colors"
+        >
+          {isPending ? 'Aplicando…' : `Confirmar y aplicar ${previewData?.toCreate ?? included.length} facturas`}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── Step 4 — Result ───────────────────────────────────────────────────────────
+
+function Step4Result({ result, onReset }: {
+  result: { invoicesCreated: number; invoicesSkipped: number; recurringCreated: number; recurringSkipped: number };
+  onReset: () => void;
+}) {
+  return (
+    <div className="space-y-6">
+      <div className="rounded-xl border border-green-500/30 bg-green-500/10 p-4 text-xs text-green-300 space-y-1">
+        <p className="font-semibold text-sm">✓ Operación completada</p>
+        <p>{result.invoicesCreated} facturas creadas, {result.invoicesSkipped} omitidas (ya existían).</p>
+        {result.recurringCreated > 0 && <p>{result.recurringCreated} templates recurrentes creados.</p>}
+        {result.recurringSkipped > 0 && <p>{result.recurringSkipped} templates omitidos (ya existían).</p>}
+      </div>
+      <div className="flex gap-3">
+        <Link href="/admin/finanzas/gastos-operativos" className="text-xs px-3 py-1.5 border border-sp-admin-border rounded hover:bg-sp-admin-hover transition-colors text-sp-admin-fg">
+          Ver gastos operativos →
+        </Link>
+        <button onClick={onReset} className="text-xs px-3 py-1.5 text-sp-admin-muted hover:text-sp-admin-fg transition-colors">
+          Volver a configuración
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── Main wizard ───────────────────────────────────────────────────────────────
+
+export function Setup2026Wizard({ existingTxIds }: Props) {
+  const existingSet = new Set(existingTxIds);
+  const [step, setStep] = useState<Step>('config');
+  const [config, setConfig] = useState<ConfigState>(DEFAULT_CONFIG);
+  const [rows, setRows] = useState<HistoricalExpenseRow[]>([]);
+  const [recurringRows, setRecurringRows] = useState<RecurringExpenseRow[]>([]);
+  const [previewData, setPreviewData] = useState<{ existing: readonly string[]; toCreate: number; recurringToCreate: number } | null>(null);
+  const [applyResult, setApplyResult] = useState<{ invoicesCreated: number; invoicesSkipped: number; recurringCreated: number; recurringSkipped: number } | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const patchConfig = useCallback((patch: Partial<ConfigState>) => {
+    setConfig((prev) => ({ ...prev, ...patch }));
+  }, []);
+
+  const patchRow = useCallback((idx: number, patch: Partial<HistoricalExpenseRow>) => {
+    setRows((prev) => prev.map((r, i) => (i === idx ? { ...r, ...patch } : r)));
+  }, []);
+
+  function handleNext1() {
+    const histConfig = configToHistoricalConfig(config);
+    const generated = generateHistoricalRows(histConfig);
+    setRows(generated);
+
+    if (config.create_recurring) {
+      const recurring = generateRecurringTemplates(
+        { ...histConfig.gestoria, startDate: config.recurring_start },
+        { ...histConfig.seguro, startDate: config.recurring_start },
+      );
+      setRecurringRows(recurring);
+    } else {
+      setRecurringRows([]);
+    }
+
+    setStep('preview');
+    setError(null);
+  }
+
+  function handleNext2() {
+    setError(null);
+    startTransition(async () => {
+      const payload = JSON.stringify({ historical: rows, recurring: recurringRows });
+      const result = await previewSetup2026Action(payload);
+      if (!result.ok) { setError(result.error); return; }
+      setPreviewData(result.data);
+      setStep('confirm');
+    });
+  }
+
+  function handleApply() {
+    setError(null);
+    startTransition(async () => {
+      const payload = JSON.stringify({ historical: rows, recurring: recurringRows });
+      const result = await applySetup2026Action(payload);
+      if (!result.ok) { setError(result.error); return; }
+      setApplyResult(result.data);
+      setStep('result');
+    });
+  }
+
+  function handleReset() {
+    setStep('config');
+    setRows([]);
+    setRecurringRows([]);
+    setPreviewData(null);
+    setApplyResult(null);
+    setError(null);
+  }
+
+  const STEP_LABELS: Record<Step, string> = {
+    config: '1. Configuración',
+    preview: '2. Preview',
+    confirm: '3. Confirmar',
+    result: '4. Resultado',
+  };
+
+  return (
+    <div className="space-y-5">
+      {/* Step indicator */}
+      <div className="flex gap-1 text-[10px] text-sp-admin-muted">
+        {(Object.keys(STEP_LABELS) as Step[]).map((s) => (
+          <span key={s} className={step === s ? 'text-sp-orange font-semibold' : ''}>
+            {STEP_LABELS[s]}{s !== 'result' ? ' →' : ''}
+          </span>
+        ))}
+      </div>
+
+      {error && (
+        <div className="text-xs text-red-400 border border-red-400/30 rounded-lg px-3 py-2">{error}</div>
+      )}
+
+      {step === 'config' && (
+        <Step1Config config={config} onChange={patchConfig} onNext={handleNext1} />
+      )}
+      {step === 'preview' && (
+        <Step2Preview
+          rows={rows}
+          recurringRows={recurringRows}
+          existingTxIds={existingSet}
+          onRowChange={patchRow}
+          onBack={() => setStep('config')}
+          onNext={handleNext2}
+        />
+      )}
+      {step === 'confirm' && (
+        <Step3Confirm
+          rows={rows}
+          recurringRows={recurringRows}
+          onBack={() => setStep('preview')}
+          onApply={handleApply}
+          isPending={isPending}
+          previewData={previewData}
+        />
+      )}
+      {step === 'result' && applyResult && (
+        <Step4Result result={applyResult} onReset={handleReset} />
+      )}
+    </div>
+  );
+}

--- a/src/lib/finance/setup2026/generator.ts
+++ b/src/lib/finance/setup2026/generator.ts
@@ -1,0 +1,288 @@
+import type {
+  HistoricalExpenseRow,
+  RecurringExpenseRow,
+  Setup2026HistoricalConfig,
+  Setup2026Summary,
+  CategoryKey,
+} from './types';
+
+// ── Pure math helpers ─────────────────────────────────────────────────────────
+
+/** net × (1 + (vatPct − withholdingPct) / 100) */
+export function calcTotal(net: number, vatPct: number, withholdingPct: number): string {
+  return (net * (1 + (vatPct - withholdingPct) / 100)).toFixed(2);
+}
+
+/** Estimated gross from net salary and IRPF rate. Formula: net / (1 - irpf/100) */
+export function estimateGross(netSalary: number, irpfRate: number): number {
+  if (irpfRate <= 0) return netSalary;
+  if (irpfRate >= 100) return netSalary;
+  return netSalary / (1 - irpfRate / 100);
+}
+
+/** Stable idempotency key: setup2026:{category}:{person}:{YYYY-MM} */
+export function makeTxId(category: string, person: string | null, month: string): string {
+  return person
+    ? `setup2026:${category}:${person}:${month}`
+    : `setup2026:${category}:${month}`;
+}
+
+// ── Display helpers ───────────────────────────────────────────────────────────
+
+const MONTH_NAMES = ['ene', 'feb', 'mar', 'abr', 'may', 'jun', 'jul', 'ago', 'sep', 'oct', 'nov', 'dic'];
+
+export function monthLabel(month: string): string {
+  const parts = month.split('-');
+  const y = parts[0] ?? month;
+  const mNum = Number(parts[1] ?? '1');
+  return `${MONTH_NAMES[mNum - 1] ?? parts[1]} ${y}`;
+}
+
+function issueDate(month: string, day: number): string {
+  const [y, m] = month.split('-') as [string, string];
+  const lastDay = new Date(Number(y), Number(m), 0).getDate();
+  const d = Math.min(day, lastDay);
+  return `${y}-${m}-${String(d).padStart(2, '0')}`;
+}
+
+// ── Row generators ────────────────────────────────────────────────────────────
+
+function generateNominaRows(
+  personRaw: 'pablo' | 'alfonso',
+  config: Setup2026HistoricalConfig['nomina']['pablo'],
+): HistoricalExpenseRow[] {
+  const net = Number(config.netSalary);
+  const irpf = Number(config.irpfRate);
+  const gross = estimateGross(net, irpf);
+  const total = calcTotal(gross, 0, irpf);
+
+  return config.months.map((month) => ({
+    txId: makeTxId('nomina_socio', personRaw, month),
+    include: true,
+    issueDate: issueDate(month, 28),
+    concept: `Nómina ${config.counterpartyName} — ${monthLabel(month)}`,
+    counterpartyName: config.counterpartyName,
+    netAmount: gross.toFixed(2),
+    vatPct: '0.00',
+    withholdingPct: irpf.toFixed(2),
+    totalAmount: total,
+    expenseGroup: 'operational' as const,
+    expenseSubtype: 'nomina_socio',
+    notes: `Neto empleado: ${net.toFixed(2)} EUR. Bruto estimado con IRPF ${irpf}%.`,
+    label: `Nómina ${config.counterpartyName} ${monthLabel(month)}`,
+    month,
+    personKey: personRaw,
+    categoryKey: 'nomina_socio' as CategoryKey,
+  }));
+}
+
+function generateAutonomoRows(
+  personRaw: 'pablo' | 'alfonso',
+  config: Setup2026HistoricalConfig['autonomo']['pablo'],
+): HistoricalExpenseRow[] {
+  const amount = Number(config.amount) || 0;
+  const conceptLabel = config.expenseSubtype === 'cuota_autonomo' ? 'Cuota autónomo' : 'Seguridad Social';
+
+  return config.months.map((month) => ({
+    txId: makeTxId(config.expenseSubtype, personRaw, month),
+    include: true,
+    issueDate: issueDate(month, 1),
+    concept: `${conceptLabel} ${config.counterpartyName} — ${monthLabel(month)}`,
+    counterpartyName: config.counterpartyName,
+    netAmount: amount.toFixed(2),
+    vatPct: '0.00',
+    withholdingPct: '0.00',
+    totalAmount: amount.toFixed(2),
+    expenseGroup: 'operational' as const,
+    expenseSubtype: config.expenseSubtype,
+    notes: '',
+    label: `${conceptLabel} ${config.counterpartyName} ${monthLabel(month)}`,
+    month,
+    personKey: personRaw,
+    categoryKey: 'cuota_autonomo' as CategoryKey,
+  }));
+}
+
+function generateGestoriaRows(config: Setup2026HistoricalConfig['gestoria']): HistoricalExpenseRow[] {
+  const net = Number(config.amount);
+  const vat = Number(config.vatPct);
+  const w = Number(config.withholdingPct);
+
+  return config.months.map((month) => ({
+    txId: makeTxId('gestoria', null, month),
+    include: true,
+    issueDate: issueDate(month, 5),
+    concept: `Gestoría — ${monthLabel(month)}`,
+    counterpartyName: config.counterpartyName,
+    netAmount: net.toFixed(2),
+    vatPct: vat.toFixed(2),
+    withholdingPct: w.toFixed(2),
+    totalAmount: calcTotal(net, vat, w),
+    expenseGroup: 'operational' as const,
+    expenseSubtype: 'gestoria',
+    notes: '',
+    label: `Gestoría ${monthLabel(month)}`,
+    month,
+    personKey: null,
+    categoryKey: 'gestoria' as CategoryKey,
+  }));
+}
+
+function generateSeguroRows(config: Setup2026HistoricalConfig['seguro']): HistoricalExpenseRow[] {
+  const amount = Number(config.amount);
+
+  return config.months.map((month) => ({
+    txId: makeTxId('seguro_medico', null, month),
+    include: true,
+    issueDate: issueDate(month, 1),
+    concept: `Seguro médico — ${monthLabel(month)}`,
+    counterpartyName: config.counterpartyName,
+    netAmount: amount.toFixed(2),
+    vatPct: '0.00',
+    withholdingPct: '0.00',
+    totalAmount: amount.toFixed(2),
+    expenseGroup: 'operational' as const,
+    expenseSubtype: 'seguro_medico',
+    notes: '',
+    label: `Seguro médico ${monthLabel(month)}`,
+    month,
+    personKey: null,
+    categoryKey: 'seguro_medico' as CategoryKey,
+  }));
+}
+
+/** Generates all proposed historical invoice rows from config. Pure, no DB calls. */
+export function generateHistoricalRows(config: Setup2026HistoricalConfig): HistoricalExpenseRow[] {
+  return [
+    ...generateNominaRows('pablo', config.nomina.pablo),
+    ...generateNominaRows('alfonso', config.nomina.alfonso),
+    ...generateAutonomoRows('pablo', config.autonomo.pablo),
+    ...generateAutonomoRows('alfonso', config.autonomo.alfonso),
+    ...generateGestoriaRows(config.gestoria),
+    ...generateSeguroRows(config.seguro),
+  ];
+}
+
+/** Generates proposed recurring expense templates. Pure, no DB calls. */
+export function generateRecurringTemplates(
+  gestoria: Setup2026HistoricalConfig['gestoria'] & { startDate: string },
+  seguro: Setup2026HistoricalConfig['seguro'] & { startDate: string },
+): RecurringExpenseRow[] {
+  const net = Number(gestoria.amount);
+  const vat = Number(gestoria.vatPct);
+  const w = Number(gestoria.withholdingPct);
+
+  const gestoriaRow: RecurringExpenseRow = {
+    key: 'setup2026:recurring:gestoria',
+    include: true,
+    name: 'Gestoría mensual',
+    concept: 'Honorarios gestoría',
+    counterpartyName: gestoria.counterpartyName,
+    amount: net.toFixed(2),
+    vatPct: vat.toFixed(2),
+    withholdingPct: w.toFixed(2),
+    expenseGroup: 'operational',
+    expenseSubtype: 'gestoria',
+    dayOfMonth: 5,
+    startDate: gestoria.startDate,
+    notes: '[setup2026:recurring:gestoria]',
+    label: 'Template recurrente: Gestoría mensual',
+    categoryKey: 'gestoria',
+  };
+
+  const seguroAmount = Number(seguro.amount);
+  const seguroRow: RecurringExpenseRow = {
+    key: 'setup2026:recurring:seguro_medico',
+    include: true,
+    name: 'Seguro médico mensual',
+    concept: 'Prima seguro médico',
+    counterpartyName: seguro.counterpartyName,
+    amount: seguroAmount.toFixed(2),
+    vatPct: '0.00',
+    withholdingPct: '0.00',
+    expenseGroup: 'operational',
+    expenseSubtype: 'seguro_medico',
+    dayOfMonth: 1,
+    startDate: seguro.startDate,
+    notes: '[setup2026:recurring:seguro_medico]',
+    label: 'Template recurrente: Seguro médico mensual',
+    categoryKey: 'seguro_medico',
+  };
+
+  return [gestoriaRow, seguroRow];
+}
+
+/** Summarizes included historical rows: totals by subtype, by month, EBITDA impact. */
+export function summarize(rows: readonly HistoricalExpenseRow[]): Setup2026Summary {
+  const included = rows.filter((r) => r.include);
+  const totalBySubtype: Record<string, number> = {};
+  const totalByMonth: Record<string, number> = {};
+  let grandTotal = 0;
+  let ebitdaImpact = 0;
+
+  for (const row of included) {
+    const net = Number(row.netAmount);
+    const total = Number(row.totalAmount);
+
+    totalBySubtype[row.expenseSubtype] = (totalBySubtype[row.expenseSubtype] ?? 0) + net;
+    totalByMonth[row.month] = (totalByMonth[row.month] ?? 0) + total;
+    grandTotal += total;
+    ebitdaImpact += net;
+  }
+
+  return {
+    totalBySubtype,
+    totalByMonth,
+    grandTotal: Math.round(grandTotal * 100) / 100,
+    invoiceCount: included.length,
+    ebitdaImpact: Math.round(ebitdaImpact * 100) / 100,
+  };
+}
+
+// ── Default config ────────────────────────────────────────────────────────────
+
+const JAN_MAR = ['2026-01', '2026-02', '2026-03'] as const;
+const JAN_JUN = ['2026-01', '2026-02', '2026-03', '2026-04', '2026-05', '2026-06'] as const;
+
+export const DEFAULT_HISTORICAL_CONFIG: Setup2026HistoricalConfig = {
+  nomina: {
+    pablo: {
+      netSalary: '1000.00',
+      irpfRate: '22',
+      months: JAN_MAR,
+      counterpartyName: 'Pablo García',
+    },
+    alfonso: {
+      netSalary: '1000.00',
+      irpfRate: '6',
+      months: JAN_MAR,
+      counterpartyName: 'Alfonso',
+    },
+  },
+  autonomo: {
+    pablo: {
+      amount: '',
+      months: JAN_JUN,
+      counterpartyName: 'RETA Pablo García',
+      expenseSubtype: 'cuota_autonomo',
+    },
+    alfonso: {
+      amount: '',
+      months: JAN_JUN,
+      counterpartyName: 'RETA Alfonso',
+      expenseSubtype: 'cuota_autonomo',
+    },
+  },
+  gestoria: {
+    amount: '180.00',
+    vatPct: '21.00',
+    withholdingPct: '0.00',
+    months: JAN_JUN,
+    counterpartyName: 'Gestoría',
+  },
+  seguro: {
+    amount: '54.00',
+    months: JAN_JUN,
+    counterpartyName: 'Aseguradora',
+  },
+};

--- a/src/lib/finance/setup2026/types.ts
+++ b/src/lib/finance/setup2026/types.ts
@@ -1,0 +1,105 @@
+export type PersonKey = 'pablo' | 'alfonso';
+
+export type CategoryKey = 'nomina_socio' | 'cuota_autonomo' | 'gestoria' | 'seguro_medico';
+
+// ── Row models ────────────────────────────────────────────────────────────────
+
+export type HistoricalExpenseRow = {
+  txId: string;
+  include: boolean;
+  issueDate: string;        // YYYY-MM-DD
+  concept: string;
+  counterpartyName: string;
+  netAmount: string;        // base imponible (bruto para nóminas)
+  vatPct: string;
+  withholdingPct: string;
+  totalAmount: string;      // auto-computed: net * (1 + (vat - w) / 100)
+  expenseGroup: 'operational';
+  expenseSubtype: string;
+  notes: string;
+  // display helpers
+  label: string;
+  month: string;            // YYYY-MM
+  personKey: PersonKey | null;
+  categoryKey: CategoryKey;
+};
+
+export type RecurringExpenseRow = {
+  key: string;              // stable key for dedup, e.g. 'setup2026:gestoria'
+  include: boolean;
+  name: string;
+  concept: string;
+  counterpartyName: string;
+  amount: string;
+  vatPct: string;
+  withholdingPct: string;
+  expenseGroup: 'operational';
+  expenseSubtype: string;
+  dayOfMonth: number;
+  startDate: string;        // YYYY-MM-DD
+  notes: string;
+  label: string;
+  categoryKey: CategoryKey;
+};
+
+// ── Config types ──────────────────────────────────────────────────────────────
+
+export type NominaPersonConfig = {
+  readonly netSalary: string;        // neto mensual a cobrar
+  readonly irpfRate: string;         // % como string, e.g. '22'
+  readonly months: readonly string[]; // YYYY-MM
+  readonly counterpartyName: string;
+};
+
+export type AutonomoConfig = {
+  readonly amount: string;           // vacío por defecto, el admin lo rellena
+  readonly months: readonly string[];
+  readonly counterpartyName: string;
+  readonly expenseSubtype: 'cuota_autonomo' | 'seguridad_social';
+};
+
+export type GestoriaConfig = {
+  readonly amount: string;
+  readonly vatPct: string;
+  readonly withholdingPct: string;
+  readonly months: readonly string[];
+  readonly counterpartyName: string;
+};
+
+export type SeguroConfig = {
+  readonly amount: string;
+  readonly months: readonly string[];
+  readonly counterpartyName: string;
+};
+
+export type Setup2026HistoricalConfig = {
+  readonly nomina: {
+    readonly pablo: NominaPersonConfig;
+    readonly alfonso: NominaPersonConfig;
+  };
+  readonly autonomo: {
+    readonly pablo: AutonomoConfig;
+    readonly alfonso: AutonomoConfig;
+  };
+  readonly gestoria: GestoriaConfig;
+  readonly seguro: SeguroConfig;
+};
+
+// ── Summary ───────────────────────────────────────────────────────────────────
+
+export type Setup2026Summary = {
+  readonly totalBySubtype: Record<string, number>;
+  readonly totalByMonth: Record<string, number>;
+  readonly grandTotal: number;
+  readonly invoiceCount: number;
+  readonly ebitdaImpact: number; // sum of netAmount (cost base)
+};
+
+// ── Apply result ──────────────────────────────────────────────────────────────
+
+export type ApplyResult = {
+  readonly invoicesCreated: number;
+  readonly invoicesSkipped: number;
+  readonly recurringCreated: number;
+  readonly recurringSkipped: number;
+};

--- a/src/lib/queries/setup2026.ts
+++ b/src/lib/queries/setup2026.ts
@@ -1,0 +1,111 @@
+'server-only';
+
+import { like, eq } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import { invoices, recurringExpenses } from '@/db/schema';
+import type { HistoricalExpenseRow, RecurringExpenseRow, ApplyResult } from '@/lib/finance/setup2026/types';
+
+/** Returns the set of setup2026 txIds that already exist in the invoices table. */
+export async function getExistingSetupTxIds(): Promise<ReadonlySet<string>> {
+  const rows = await db
+    .select({ txId: invoices.txId })
+    .from(invoices)
+    .where(like(invoices.txId, 'setup2026:%'));
+
+  return new Set(rows.map((r) => r.txId).filter((t): t is string => t !== null && t !== undefined));
+}
+
+/** Returns the set of recurring template names that already exist (active). */
+export async function getExistingRecurringNames(): Promise<ReadonlySet<string>> {
+  const rows = await db
+    .select({ name: recurringExpenses.name })
+    .from(recurringExpenses)
+    .where(eq(recurringExpenses.active, true));
+
+  return new Set(rows.map((r) => r.name));
+}
+
+/**
+ * Applies the setup: creates invoices and recurring templates that don't exist yet.
+ * Returns counts of created vs skipped.
+ */
+export async function applySetup2026(
+  historicalRows: readonly HistoricalExpenseRow[],
+  recurringRows: readonly RecurringExpenseRow[],
+  existingTxIds: ReadonlySet<string>,
+  existingRecurringNames: ReadonlySet<string>,
+): Promise<ApplyResult> {
+  const toInsert = historicalRows.filter((r) => r.include && !existingTxIds.has(r.txId));
+  const toSkip = historicalRows.filter((r) => r.include && existingTxIds.has(r.txId));
+
+  const recurringToInsert = recurringRows.filter((r) => r.include && !existingRecurringNames.has(r.name));
+  const recurringToSkip = recurringRows.filter((r) => r.include && existingRecurringNames.has(r.name));
+
+  if (toInsert.length > 0) {
+    await db.insert(invoices).values(
+      toInsert.map((row) => ({
+        kind: 'expense' as const,
+        scope: 'company' as const,
+        concept: row.concept,
+        counterpartyName: row.counterpartyName,
+        expenseGroup: row.expenseGroup,
+        expenseSubtype: row.expenseSubtype as (typeof invoices.$inferInsert)['expenseSubtype'],
+        netAmount: row.netAmount,
+        vatPct: row.vatPct,
+        withholdingPct: row.withholdingPct,
+        totalAmount: row.totalAmount,
+        paidAmount: '0.00',
+        currency: 'EUR',
+        issueDate: row.issueDate,
+        status: 'pagada' as const,
+        txId: row.txId,
+        notes: row.notes || null,
+      })),
+    );
+  }
+
+  if (recurringToInsert.length > 0) {
+    await db.insert(recurringExpenses).values(
+      recurringToInsert.map((row) => ({
+        name: row.name,
+        concept: row.concept,
+        counterpartyName: row.counterpartyName,
+        expenseGroup: row.expenseGroup,
+        expenseSubtype: row.expenseSubtype as (typeof recurringExpenses.$inferInsert)['expenseSubtype'],
+        amount: row.amount,
+        vatPct: row.vatPct,
+        withholdingPct: row.withholdingPct,
+        scope: 'company' as const,
+        dayOfMonth: row.dayOfMonth,
+        startDate: row.startDate,
+        active: true,
+        notes: row.notes || null,
+      })),
+    );
+  }
+
+  return {
+    invoicesCreated: toInsert.length,
+    invoicesSkipped: toSkip.length,
+    recurringCreated: recurringToInsert.length,
+    recurringSkipped: recurringToSkip.length,
+  };
+}
+
+/** Preview: returns which rows would be created vs. skipped without writing. */
+export async function previewSetup2026(
+  historicalRows: readonly HistoricalExpenseRow[],
+  recurringRows: readonly RecurringExpenseRow[],
+): Promise<{ existing: readonly string[]; toCreate: number; recurringToCreate: number }> {
+  const existing = await getExistingSetupTxIds();
+  const existingRecurring = await getExistingRecurringNames();
+
+  const toCreate = historicalRows.filter((r) => r.include && !existing.has(r.txId)).length;
+  const recurringToCreate = recurringRows.filter((r) => r.include && !existingRecurring.has(r.name)).length;
+
+  return {
+    existing: historicalRows.filter((r) => existing.has(r.txId)).map((r) => r.txId),
+    toCreate,
+    recurringToCreate,
+  };
+}


### PR DESCRIPTION
## Summary

* Adds `/admin/finanzas/setup-2026`.
* Adds a safe wizard to preview and create historical 2026 operating expenses.
* Supports payroll/member salaries, autónomo fees, gestoría and medical insurance.
* Adds editable preview before applying.
* Adds idempotent txId-based duplicate protection for invoices.
* Adds duplicate protection for recurring templates.
* Adds `facturacion:write` permission guard.
* Adds 30 tests for generator/calculation/idempotency logic.
* No migration.
* No schema changes.
* No changes to EBITDA/P&L calculations.
* No changes to reconciliation.
* No automatic inserts on page load.

## Test plan

- [x] `npx tsc --noEmit` — green
- [x] `npm run lint` — green
- [x] `npm test` — 1355 tests, 79 suites, 0 failures
- [ ] Page loads without inserting data
- [ ] Only "Confirmar y crear" (Step 3) triggers `applySetup2026Action`
- [ ] `applySetup2026Action` requires `facturacion:write`
- [ ] Preview does not write to DB
- [ ] Apply filters duplicates by txId
- [ ] No changes in `drizzle/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)