### PR TITLE
feat(auth): rol admin_limited_tasks con guards de propiedad en tareas

### DIFF
--- a/src/__tests__/server/task-ownership.test.ts
+++ b/src/__tests__/server/task-ownership.test.ts
@@ -1,0 +1,195 @@
+jest.mock('@/lib/auth', () => ({ auth: {} }));
+jest.mock('next/cache', () => ({ revalidatePath: jest.fn() }));
+
+const mockRequireAnyRole = jest.fn();
+jest.mock('@/lib/auth-guard', () => ({
+  requireAnyRole: (...args: unknown[]) => mockRequireAnyRole(...args),
+}));
+
+const mockGetTaskById = jest.fn();
+const mockGetTasksByIds = jest.fn();
+const mockUpdateTask = jest.fn();
+const mockCompleteTask = jest.fn();
+const mockDeleteTask = jest.fn();
+const mockDeleteTasks = jest.fn();
+const mockIsAssignableTaskUser = jest.fn();
+const mockResetRolledOver = jest.fn();
+const mockResetRolledOverBulk = jest.fn();
+
+jest.mock('@/lib/queries/crmTasks', () => ({
+  getTaskById:         (...args: unknown[]) => mockGetTaskById(...args),
+  getTasksByIds:       (...args: unknown[]) => mockGetTasksByIds(...args),
+  updateTask:          (...args: unknown[]) => mockUpdateTask(...args),
+  completeTask:        (...args: unknown[]) => mockCompleteTask(...args),
+  deleteTask:          (...args: unknown[]) => mockDeleteTask(...args),
+  deleteTasks:         (...args: unknown[]) => mockDeleteTasks(...args),
+  isAssignableTaskUser:(...args: unknown[]) => mockIsAssignableTaskUser(...args),
+  resetRolledOver:     (...args: unknown[]) => mockResetRolledOver(...args),
+  resetRolledOverBulk: (...args: unknown[]) => mockResetRolledOverBulk(...args),
+}));
+
+jest.mock('@/lib/queries/alerts', () => ({ createAlert: jest.fn() }));
+
+import {
+  updateTaskAction,
+  updateTaskPartialAction,
+  completeTaskAction,
+  deleteTaskAction,
+  bulkDeleteTasksAction,
+  resetRolledOverAction,
+  resetRolledOverBulkAction,
+} from '@/app/admin/(dashboard)/tareas/actions';
+
+function makeSession(role: string, id = 'user-1') {
+  return { user: { id, email: `${role}@test.com`, name: role, role } };
+}
+
+const OWN_TASK  = { id: 1, ownerId: 'user-1', assignedToUserId: 'user-1' };
+const FOREIGN_TASK = { id: 2, ownerId: 'other', assignedToUserId: 'other' };
+
+const VALID_TASK_INPUT = {
+  title: 'Test task', description: null, ownerId: 'user-1',
+  dueDate: null, priority: 'media' as const, status: 'pendiente' as const,
+  category: 'ops', relatedType: 'general' as const,
+};
+
+describe('task ownership guards — admin_limited_tasks', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsAssignableTaskUser.mockResolvedValue(true);
+    mockUpdateTask.mockResolvedValue({ id: 1 });
+    mockCompleteTask.mockResolvedValue({ id: 1 });
+    mockDeleteTask.mockResolvedValue(undefined);
+    mockDeleteTasks.mockResolvedValue(undefined);
+    mockResetRolledOver.mockResolvedValue(undefined);
+    mockResetRolledOverBulk.mockResolvedValue(undefined);
+  });
+
+  // T1
+  it('updateTaskAction: admin_limited_tasks puede editar tarea propia', async () => {
+    mockRequireAnyRole.mockResolvedValue(makeSession('admin_limited_tasks', 'user-1'));
+    mockGetTaskById.mockResolvedValue(OWN_TASK);
+
+    const result = await updateTaskAction(1, VALID_TASK_INPUT);
+
+    expect(result).toEqual({});
+    expect(mockUpdateTask).toHaveBeenCalledWith(1, expect.any(Object));
+  });
+
+  // T2
+  it('updateTaskAction: admin_limited_tasks bloqueado en tarea ajena', async () => {
+    mockRequireAnyRole.mockResolvedValue(makeSession('admin_limited_tasks', 'user-1'));
+    mockGetTaskById.mockResolvedValue(FOREIGN_TASK);
+
+    const result = await updateTaskAction(2, VALID_TASK_INPUT);
+
+    expect(result).toEqual({ error: 'Sin permiso para modificar esta tarea' });
+    expect(mockUpdateTask).not.toHaveBeenCalled();
+  });
+
+  // T3
+  it('updateTaskPartialAction: admin_limited_tasks puede parchear tarea propia', async () => {
+    mockRequireAnyRole.mockResolvedValue(makeSession('admin_limited_tasks', 'user-1'));
+    mockGetTaskById.mockResolvedValue(OWN_TASK);
+
+    const result = await updateTaskPartialAction(1, { status: 'en_progreso' });
+
+    expect(result).toEqual({});
+    expect(mockUpdateTask).toHaveBeenCalled();
+  });
+
+  // T4
+  it('updateTaskPartialAction: admin_limited_tasks bloqueado en tarea ajena', async () => {
+    mockRequireAnyRole.mockResolvedValue(makeSession('admin_limited_tasks', 'user-1'));
+    mockGetTaskById.mockResolvedValue(FOREIGN_TASK);
+
+    const result = await updateTaskPartialAction(2, { status: 'en_progreso' });
+
+    expect(result).toEqual({ error: 'Sin permiso para modificar esta tarea' });
+    expect(mockUpdateTask).not.toHaveBeenCalled();
+  });
+
+  // T5
+  it('completeTaskAction: admin_limited_tasks puede completar tarea propia', async () => {
+    mockRequireAnyRole.mockResolvedValue(makeSession('admin_limited_tasks', 'user-1'));
+    mockGetTaskById.mockResolvedValue(OWN_TASK);
+
+    const result = await completeTaskAction(1);
+
+    expect(result).toEqual({});
+    expect(mockCompleteTask).toHaveBeenCalledWith(1);
+  });
+
+  // T6
+  it('completeTaskAction: admin_limited_tasks bloqueado en tarea ajena', async () => {
+    mockRequireAnyRole.mockResolvedValue(makeSession('admin_limited_tasks', 'user-1'));
+    mockGetTaskById.mockResolvedValue(FOREIGN_TASK);
+
+    const result = await completeTaskAction(2);
+
+    expect(result).toEqual({ error: 'Sin permiso para completar esta tarea' });
+    expect(mockCompleteTask).not.toHaveBeenCalled();
+  });
+
+  // T7
+  it('deleteTaskAction: admin_limited_tasks puede eliminar tarea propia', async () => {
+    mockRequireAnyRole.mockResolvedValue(makeSession('admin_limited_tasks', 'user-1'));
+    mockGetTaskById.mockResolvedValue(OWN_TASK);
+
+    const result = await deleteTaskAction(1);
+
+    expect(result).toEqual({});
+    expect(mockDeleteTask).toHaveBeenCalledWith(1);
+  });
+
+  // T8
+  it('deleteTaskAction: admin_limited_tasks bloqueado en tarea ajena', async () => {
+    mockRequireAnyRole.mockResolvedValue(makeSession('admin_limited_tasks', 'user-1'));
+    mockGetTaskById.mockResolvedValue(FOREIGN_TASK);
+
+    const result = await deleteTaskAction(2);
+
+    expect(result).toEqual({ error: 'Sin permiso para eliminar esta tarea' });
+    expect(mockDeleteTask).not.toHaveBeenCalled();
+  });
+
+  // T9
+  it('bulkDeleteTasksAction: admin_limited_tasks puede borrar en lote tareas propias', async () => {
+    mockRequireAnyRole.mockResolvedValue(makeSession('admin_limited_tasks', 'user-1'));
+    mockGetTasksByIds.mockResolvedValue([OWN_TASK, { ...OWN_TASK, id: 2 }]);
+
+    const result = await bulkDeleteTasksAction([1, 2]);
+
+    expect(result).toEqual({});
+    expect(mockDeleteTasks).toHaveBeenCalledWith([1, 2]);
+  });
+
+  // T10
+  it('bulkDeleteTasksAction: rechaza todo el lote si alguna tarea es ajena', async () => {
+    mockRequireAnyRole.mockResolvedValue(makeSession('admin_limited_tasks', 'user-1'));
+    mockGetTasksByIds.mockResolvedValue([OWN_TASK, FOREIGN_TASK]);
+
+    const result = await bulkDeleteTasksAction([1, 2]);
+
+    expect(result).toHaveProperty('error');
+    expect(mockDeleteTasks).not.toHaveBeenCalled();
+  });
+
+  // T11
+  it('resetRolledOverAction: rol no-admin pasa callerId al filtro de propiedad', async () => {
+    mockRequireAnyRole.mockResolvedValue(makeSession('admin_limited_tasks', 'user-1'));
+
+    await resetRolledOverAction(5);
+
+    expect(mockResetRolledOver).toHaveBeenCalledWith(5, 'user-1');
+  });
+
+  // T12
+  it('resetRolledOverBulkAction: rol no-admin pasa callerId al filtro de propiedad', async () => {
+    mockRequireAnyRole.mockResolvedValue(makeSession('admin_limited_tasks', 'user-1'));
+
+    await resetRolledOverBulkAction([3, 4]);
+
+    expect(mockResetRolledOverBulk).toHaveBeenCalledWith([3, 4], 'user-1');
+  });
+});

--- a/src/app/admin/(dashboard)/equipo/page.tsx
+++ b/src/app/admin/(dashboard)/equipo/page.tsx
@@ -36,10 +36,10 @@ export default async function EquipoAdminPage(): Promise<ReactElement> {
   const weekStr = weekStart.toLocaleDateString('es-ES', { day: 'numeric', month: 'long' });
 
   const rawSummary = await getTeamTasksSummary(weekLabel);
-  // Staff solo ve su propio card — no expone métricas ni datos de otros empleados
-  const summary = session.user.role === 'staff'
-    ? rawSummary.filter((m) => m.userId === session.user.id)
-    : rawSummary;
+  // Solo admin y manager ven todos los cards del equipo
+  const summary = session.user.role === 'admin' || session.user.role === 'manager'
+    ? rawSummary
+    : rawSummary.filter((m) => m.userId === session.user.id);
 
   const totalDone    = summary.reduce((s, m) => s + m.completed, 0);
   const totalPending = summary.reduce((s, m) => s + m.pending, 0);

--- a/src/app/admin/(dashboard)/tareas/actions.ts
+++ b/src/app/admin/(dashboard)/tareas/actions.ts
@@ -3,7 +3,7 @@
 import { revalidatePath } from 'next/cache';
 
 import { requirePermission } from '@/lib/permissions';
-import { assertCanDelete, needsVisibilityFilter } from '@/lib/permissions';
+import { assertCanDelete } from '@/lib/permissions';
 import { logRedacted } from '@/lib/log';
 import {
   completeTask,
@@ -11,6 +11,7 @@ import {
   createTaskTemplate,
   deleteTask,
   getTaskById,
+  getTasksByIds,
   isAssignableTaskUser,
   deleteTasks,
   deleteTaskTemplate,
@@ -113,6 +114,13 @@ export async function updateTaskAction(id: number, input: unknown): Promise<Acti
 
   const prevTask = await getTaskById(id);
 
+  if (session.user.role !== 'admin') {
+    if (!prevTask) return { error: 'Tarea no encontrada' };
+    if (prevTask.ownerId !== session.user.id && prevTask.assignedToUserId !== session.user.id) {
+      return { error: 'Sin permiso para modificar esta tarea' };
+    }
+  }
+
   const newCoResponsable = parsed.data.assignedToUserId && parsed.data.assignedToUserId !== parsed.data.ownerId
     ? parsed.data.assignedToUserId
     : null;
@@ -155,7 +163,7 @@ export async function updateTaskPartialAction(
   id: unknown,
   input: unknown,
 ): Promise<ActionResult> {
-  await requirePermission('tareas', 'read');
+  const session = await requirePermission('tareas', 'read');
 
   const parsedId = IdSchema.safeParse(id);
   if (!parsedId.success) return { error: 'ID inválido' };
@@ -166,6 +174,14 @@ export async function updateTaskPartialAction(
   if (parsed.data.ownerId !== undefined) {
     const ownerErr = await assertStaffOwner(parsed.data.ownerId);
     if (ownerErr) return { error: ownerErr };
+  }
+
+  if (session.user.role !== 'admin') {
+    const task = await getTaskById(parsedId.data);
+    if (!task) return { error: 'Tarea no encontrada' };
+    if (task.ownerId !== session.user.id && task.assignedToUserId !== session.user.id) {
+      return { error: 'Sin permiso para modificar esta tarea' };
+    }
   }
 
   const updated = await updateTask(
@@ -182,7 +198,14 @@ export async function updateTaskPartialAction(
 }
 
 export async function completeTaskAction(id: number): Promise<ActionResult> {
-  await requirePermission('tareas', 'read');
+  const session = await requirePermission('tareas', 'read');
+  if (session.user.role !== 'admin') {
+    const task = await getTaskById(id);
+    if (!task) return { error: 'Tarea no encontrada' };
+    if (task.ownerId !== session.user.id && task.assignedToUserId !== session.user.id) {
+      return { error: 'Sin permiso para completar esta tarea' };
+    }
+  }
   await completeTask(id);
   revalidateAll();
   return {};
@@ -195,6 +218,13 @@ export async function deleteTaskAction(id: number): Promise<ActionResult> {
   } catch {
     return { error: 'Sin permiso para eliminar' };
   }
+  if (session.user.role !== 'admin') {
+    const task = await getTaskById(id);
+    if (!task) return { error: 'Tarea no encontrada' };
+    if (task.ownerId !== session.user.id && task.assignedToUserId !== session.user.id) {
+      return { error: 'Sin permiso para eliminar esta tarea' };
+    }
+  }
   try {
     await deleteTask(id);
     revalidateAll();
@@ -206,8 +236,23 @@ export async function deleteTaskAction(id: number): Promise<ActionResult> {
 }
 
 export async function bulkDeleteTasksAction(ids: number[]): Promise<ActionResult> {
-  await requirePermission('tareas', 'read');
+  const session = await requirePermission('tareas', 'read');
+  try {
+    assertCanDelete(session.user.role);
+  } catch {
+    return { error: 'Sin permiso para eliminar' };
+  }
   if (ids.length === 0) return {};
+  if (session.user.role !== 'admin') {
+    const tasks = await getTasksByIds(ids);
+    if (tasks.length !== ids.length) return { error: 'Una o más tareas no encontradas' };
+    const forbidden = tasks.filter(
+      (t) => t.ownerId !== session.user.id && t.assignedToUserId !== session.user.id,
+    );
+    if (forbidden.length > 0) {
+      return { error: `No puedes eliminar ${forbidden.length} tarea(s) de otros miembros` };
+    }
+  }
   await deleteTasks(ids);
   revalidateAll();
   return {};
@@ -319,7 +364,7 @@ export async function resetRolledOverAction(id: unknown): Promise<ActionResult> 
   const session = await requirePermission('tareas', 'read');
   const parsed = IdSchema.safeParse(id);
   if (!parsed.success) return { error: 'ID inválido' };
-  const callerId = needsVisibilityFilter(session.user.role) ? session.user.id : undefined;
+  const callerId = session.user.role !== 'admin' ? session.user.id : undefined;
   await resetRolledOver(parsed.data, callerId);
   revalidateAll();
   return {};
@@ -330,7 +375,7 @@ export async function resetRolledOverBulkAction(ids: unknown): Promise<ActionRes
   const session = await requirePermission('tareas', 'read');
   const parsed = IdSchema.array().safeParse(ids);
   if (!parsed.success) return { error: 'IDs inválidos' };
-  const callerId = needsVisibilityFilter(session.user.role) ? session.user.id : undefined;
+  const callerId = session.user.role !== 'admin' ? session.user.id : undefined;
   await resetRolledOverBulk(parsed.data, callerId);
   revalidateAll();
   return {};

--- a/src/lib/auth-guard.ts
+++ b/src/lib/auth-guard.ts
@@ -12,11 +12,13 @@ export type Role =
   | 'finance'
   | 'analyst'
   | 'ops'
-  | 'talent_manager';
+  | 'talent_manager'
+  | 'admin_limited_tasks';
 
 export const ROLES = [
   'admin', 'manager', 'staff', 'brand',
   'editor', 'finance', 'analyst', 'ops', 'talent_manager',
+  'admin_limited_tasks',
 ] as const satisfies readonly Role[];
 
 // NODE_ENV and ENABLE_DEV_AUTH_BYPASS are exempt from lib/env — they control
@@ -88,15 +90,16 @@ type SessionWithNarrowedRole<R extends Role> = {
 };
 
 function homeForRole(role: Role | null | undefined): string | null {
-  if (role === 'admin')          return '/admin';
-  if (role === 'manager')        return '/admin';
-  if (role === 'staff')          return '/admin/mi-semana';
-  if (role === 'brand')          return '/marcas';
-  if (role === 'editor')         return '/admin/noticias';
-  if (role === 'finance')        return '/admin/facturas';
-  if (role === 'analyst')        return '/admin/analytics';
-  if (role === 'ops')            return '/admin/agenda';
-  if (role === 'talent_manager') return '/admin/talentos';
+  if (role === 'admin')                return '/admin';
+  if (role === 'manager')              return '/admin';
+  if (role === 'admin_limited_tasks')  return '/admin';
+  if (role === 'staff')                return '/admin/mi-semana';
+  if (role === 'brand')                return '/marcas';
+  if (role === 'editor')               return '/admin/noticias';
+  if (role === 'finance')              return '/admin/facturas';
+  if (role === 'analyst')              return '/admin/analytics';
+  if (role === 'ops')                  return '/admin/agenda';
+  if (role === 'talent_manager')       return '/admin/talentos';
   return null;
 }
 

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -4,11 +4,11 @@ import { requireAnyRole } from '@/lib/auth-guard';
 // ── Legacy helpers (kept for all existing call sites) ────────────────────────
 
 export function canSeeAll(role: Role): boolean {
-  return role === 'admin' || role === 'manager';
+  return role === 'admin' || role === 'manager' || role === 'admin_limited_tasks';
 }
 
 export function canDelete(role: Role): boolean {
-  return role === 'admin';
+  return role === 'admin' || role === 'admin_limited_tasks';
 }
 
 export function assertCanDelete(role: Role): void {
@@ -56,94 +56,94 @@ type PermissionsMap = Record<Module, Partial<Record<Action, readonly Role[]>>>;
 
 export const PERMISSIONS = {
   noticias: {
-    read:    ['admin', 'manager', 'staff', 'editor', 'ops', 'talent_manager', 'analyst'],
-    write:   ['admin', 'manager', 'editor'],
-    publish: ['admin', 'manager', 'editor'],
-    delete:  ['admin', 'manager'],
+    read:    ['admin', 'admin_limited_tasks', 'manager', 'staff', 'editor', 'ops', 'talent_manager', 'analyst'],
+    write:   ['admin', 'admin_limited_tasks', 'manager', 'editor'],
+    publish: ['admin', 'admin_limited_tasks', 'manager', 'editor'],
+    delete:  ['admin', 'admin_limited_tasks', 'manager'],
   },
   sorteos: {
-    read:    ['admin', 'manager', 'staff', 'ops'],
-    write:   ['admin', 'manager', 'ops'],
-    publish: ['admin', 'manager'],
-    delete:  ['admin', 'manager'],
+    read:    ['admin', 'admin_limited_tasks', 'manager', 'staff', 'ops'],
+    write:   ['admin', 'admin_limited_tasks', 'manager', 'ops'],
+    publish: ['admin', 'admin_limited_tasks', 'manager'],
+    delete:  ['admin', 'admin_limited_tasks', 'manager'],
   },
   codigos: {
-    read:    ['admin', 'manager', 'staff', 'ops'],
-    write:   ['admin', 'manager', 'ops'],
-    delete:  ['admin', 'manager'],
+    read:    ['admin', 'admin_limited_tasks', 'manager', 'staff', 'ops'],
+    write:   ['admin', 'admin_limited_tasks', 'manager', 'ops'],
+    delete:  ['admin', 'admin_limited_tasks', 'manager'],
   },
   talentos: {
-    read:    ['admin', 'manager', 'staff', 'talent_manager'],
-    write:   ['admin', 'manager', 'staff', 'talent_manager'],
-    delete:  ['admin'],
+    read:    ['admin', 'admin_limited_tasks', 'manager', 'staff', 'talent_manager'],
+    write:   ['admin', 'admin_limited_tasks', 'manager', 'staff', 'talent_manager'],
+    delete:  ['admin', 'admin_limited_tasks'],
   },
   campanas: {
-    read:    ['admin', 'manager', 'staff', 'ops', 'talent_manager', 'finance'],
-    write:   ['admin', 'manager', 'staff', 'ops'],
-    delete:  ['admin'],
+    read:    ['admin', 'admin_limited_tasks', 'manager', 'staff', 'ops', 'talent_manager', 'finance'],
+    write:   ['admin', 'admin_limited_tasks', 'manager', 'staff', 'ops'],
+    delete:  ['admin', 'admin_limited_tasks'],
   },
   facturacion: {
-    read:    ['admin', 'manager', 'finance'],
-    write:   ['admin', 'manager', 'finance'],
-    delete:  ['admin'],
+    read:    ['admin', 'admin_limited_tasks', 'manager', 'finance'],
+    write:   ['admin', 'admin_limited_tasks', 'manager', 'finance'],
+    delete:  ['admin', 'admin_limited_tasks'],
   },
   analytics: {
-    read:    ['admin', 'manager', 'analyst', 'finance', 'talent_manager'],
-    write:   ['admin', 'manager'],
+    read:    ['admin', 'admin_limited_tasks', 'manager', 'analyst', 'finance', 'talent_manager'],
+    write:   ['admin', 'admin_limited_tasks', 'manager'],
   },
   agenda: {
-    read:    ['admin', 'manager', 'staff', 'ops', 'editor'],
-    write:   ['admin', 'manager', 'ops', 'editor'],
-    delete:  ['admin', 'manager'],
+    read:    ['admin', 'admin_limited_tasks', 'manager', 'staff', 'ops', 'editor'],
+    write:   ['admin', 'admin_limited_tasks', 'manager', 'ops', 'editor'],
+    delete:  ['admin', 'admin_limited_tasks', 'manager'],
   },
   rankings: {
-    read:    ['admin', 'manager', 'staff', 'editor', 'analyst'],
-    write:   ['admin', 'manager', 'editor'],
-    delete:  ['admin', 'manager'],
+    read:    ['admin', 'admin_limited_tasks', 'manager', 'staff', 'editor', 'analyst'],
+    write:   ['admin', 'admin_limited_tasks', 'manager', 'editor'],
+    delete:  ['admin', 'admin_limited_tasks', 'manager'],
   },
   equipo: {
-    read:    ['admin', 'manager', 'staff'],
-    write:   ['admin', 'manager'],
-    delete:  ['admin'],
+    read:    ['admin', 'admin_limited_tasks', 'manager', 'staff'],
+    write:   ['admin', 'admin_limited_tasks', 'manager'],
+    delete:  ['admin', 'admin_limited_tasks'],
   },
   ajustes: {
-    read:    ['admin', 'manager'],
-    write:   ['admin'],
-    delete:  ['admin'],
+    read:    ['admin', 'admin_limited_tasks', 'manager'],
+    write:   ['admin', 'admin_limited_tasks'],
+    delete:  ['admin', 'admin_limited_tasks'],
   },
   tareas: {
-    read:    ['admin', 'manager', 'staff', 'editor', 'ops', 'talent_manager'],
-    write:   ['admin', 'manager', 'ops'],
-    delete:  ['admin', 'manager'],
+    read:    ['admin', 'admin_limited_tasks', 'manager', 'staff', 'editor', 'ops', 'talent_manager'],
+    write:   ['admin', 'admin_limited_tasks', 'manager', 'ops'],
+    delete:  ['admin', 'admin_limited_tasks', 'manager'],
   },
   usuarios: {
-    read:         ['admin'],
-    write:        ['admin'],
-    delete:       ['admin'],
-    manage_users: ['admin'],
+    read:         ['admin', 'admin_limited_tasks'],
+    write:        ['admin', 'admin_limited_tasks'],
+    delete:       ['admin', 'admin_limited_tasks'],
+    manage_users: ['admin', 'admin_limited_tasks'],
   },
   targets: {
-    read:   ['admin', 'manager', 'staff'],
-    write:  ['admin', 'manager', 'staff'],
-    delete: ['admin'],
+    read:   ['admin', 'admin_limited_tasks', 'manager', 'staff'],
+    write:  ['admin', 'admin_limited_tasks', 'manager', 'staff'],
+    delete: ['admin', 'admin_limited_tasks'],
   },
   prensa_targets: {
-    read:   ['admin', 'manager', 'staff'],
-    write:  ['admin', 'manager', 'staff'],
-    delete: ['admin', 'manager'],
+    read:   ['admin', 'admin_limited_tasks', 'manager', 'staff'],
+    write:  ['admin', 'admin_limited_tasks', 'manager', 'staff'],
+    delete: ['admin', 'admin_limited_tasks', 'manager'],
   },
   dashboard: {
-    read: ['admin', 'manager', 'staff'],
+    read: ['admin', 'admin_limited_tasks', 'manager', 'staff'],
   },
   bancos: {
-    read:   ['admin', 'manager', 'finance'],
-    write:  ['admin', 'manager', 'finance'],
-    delete: ['admin'],
+    read:   ['admin', 'admin_limited_tasks', 'manager', 'finance'],
+    write:  ['admin', 'admin_limited_tasks', 'manager', 'finance'],
+    delete: ['admin', 'admin_limited_tasks'],
   },
   contratos: {
-    read:   ['admin', 'manager', 'finance', 'ops'],
-    write:  ['admin', 'manager', 'ops'],
-    delete: ['admin'],
+    read:   ['admin', 'admin_limited_tasks', 'manager', 'finance', 'ops'],
+    write:  ['admin', 'admin_limited_tasks', 'manager', 'ops'],
+    delete: ['admin', 'admin_limited_tasks'],
   },
 } as const satisfies PermissionsMap;
 

--- a/src/lib/queries/crmTasks.ts
+++ b/src/lib/queries/crmTasks.ts
@@ -267,7 +267,7 @@ export async function isAssignableTaskUser(userId: string): Promise<boolean> {
     .where(eq(user.id, userId))
     .limit(1);
   if (!row) return false;
-  return row.role === 'admin' || row.role === 'manager' || row.role === 'staff';
+  return row.role === 'admin' || row.role === 'manager' || row.role === 'staff' || row.role === 'admin_limited_tasks';
 }
 
 /**
@@ -295,6 +295,16 @@ export async function getTaskById(id: number): Promise<CrmTask | null> {
     .where(eq(crmTasks.id, id))
     .limit(1);
   return row ?? null;
+}
+
+/** Obtiene múltiples tareas por IDs en una sola query. */
+export async function getTasksByIds(ids: readonly number[]): Promise<CrmTask[]> {
+  if (ids.length === 0) return [];
+  return db
+    .select({ ...getTableColumns(crmTasks), recurrence: crmTaskTemplates.recurrence })
+    .from(crmTasks)
+    .leftJoin(crmTaskTemplates, eq(crmTaskTemplates.id, crmTasks.recurrenceTemplateId))
+    .where(inArray(crmTasks.id, [...ids]));
 }
 
 /**


### PR DESCRIPTION
## Resumen

- **Nuevo rol** `admin_limited_tasks`: permisos de admin en todos los módulos CRM, con restricción en tareas (solo ve/edita/completa/elimina sus propias tareas asignadas)
- **Guards de propiedad** en `updateTaskAction`, `updateTaskPartialAction`, `completeTaskAction`, `deleteTaskAction`, `bulkDeleteTasksAction`: roles no-admin solo pueden operar sobre tareas donde son owner o assignee
- **Bulk delete atómico**: si cualquier tarea del lote pertenece a otro usuario, se rechaza toda la operación (sin borrado parcial silencioso)
- **`resetRolledOver`/`resetRolledOverBulk`**: todos los roles no-admin pasan `callerId` para filtro de propiedad (antes solo lo hacía `staff`)
- **Página equipo**: `admin_limited_tasks` ve solo su propio card (no los métricas del equipo)
- **`isAssignableTaskUser`**: `admin_limited_tasks` puede recibir tareas asignadas
- **12 tests nuevos** cubriendo todos los paths de ownership guard

## Archivos modificados

| Archivo | Cambio |
|---|---|
| `src/lib/auth-guard.ts` | Añade `admin_limited_tasks` al `Role` union, `ROLES`, y `homeForRole` |
| `src/lib/permissions.ts` | `canSeeAll`, `canDelete` + todos los módulos del PERMISSIONS map |
| `src/lib/queries/crmTasks.ts` | Nueva query `getTasksByIds`, `isAssignableTaskUser` incluye nuevo rol |
| `src/app/admin/(dashboard)/tareas/actions.ts` | Guards en 5 actions + fix `resetRolledOver` callerId |
| `src/app/admin/(dashboard)/equipo/page.tsx` | Filtro equipo usa `admin\|manager` en lugar de `!== staff` |
| `src/__tests__/server/task-ownership.test.ts` | 12 tests nuevos (T1–T12) |

## ⚠️ Acción requerida ANTES de mergear — DB data change

El rol `admin_limited_tasks` existe como string en la columna `role TEXT` de la tabla `user`. No requiere migración de schema. Pero para activarlo para Alfonso hay que ejecutar este UPDATE **en producción**:

```sql
UPDATE "user"
SET role = 'admin_limited_tasks'
WHERE email = 'arias@socialpro.es';
```

**No aplicar automáticamente.** Confirmar con el equipo antes de ejecutar.

Alternativa segura para probar antes: ejecutar en dev/staging primero y verificar en `/admin/tareas` que Alfonso solo ve sus tareas.

## Plan de pruebas

- [ ] CI verde en este PR
- [ ] Confirmar que el test `deleteTaskAction blocks manager deletes` sigue pasando (regresión manager)
- [ ] Ejecutar UPDATE en staging, iniciar sesión como Alfonso (`arias@socialpro.es`), verificar:
  - Ve todas las secciones del CRM (campañas, talentos, finanzas, etc.)
  - En `/admin/tareas`: solo ve sus propias tareas
  - Puede editar/completar/eliminar sus tareas
  - NO puede editar/completar/eliminar tareas de otros (devuelve error)
- [ ] Confirmar `homeForRole` redirige a `/admin` tras login
- [ ] Mergear con confirmación explícita
- [ ] Ejecutar UPDATE en producción
- [ ] Verificar con `scripts/check-alfonso-role.ts` que el rol quedó correcto

🤖 Generated with [Claude Code](https://claude.com/claude-code)