### PR TITLE
fix(payroll): eliminar valores demo del formulario manual

### DIFF
--- a/src/__tests__/server/payroll-manual-rows.test.ts
+++ b/src/__tests__/server/payroll-manual-rows.test.ts
@@ -1,0 +1,190 @@
+import { emptyManualRow, manualRowToPayrollRow, normalizeAmount } from '@/lib/finance/payroll/manualRow';
+import type { ManualRow } from '@/lib/finance/payroll/manualRow';
+
+// ── emptyManualRow ────────────────────────────────────────────────────────────
+
+describe('emptyManualRow — campos económicos vacíos', () => {
+  it('todos los importes son cadena vacía (no valores demo)', () => {
+    const row = emptyManualRow(1);
+    expect(row.costoEmpresa).toBe('');
+    expect(row.liquidoPercibir).toBe('');
+    expect(row.totalDevengado).toBe('');
+    expect(row.totalDeducciones).toBe('');
+    expect(row.irpfPct).toBe('');
+  });
+
+  it('nombre del trabajador está vacío', () => {
+    expect(emptyManualRow(1).counterpartyName).toBe('');
+  });
+
+  it('solo pre-rellena yearMonth cuando se pasa suggestedYearMonth', () => {
+    const row = emptyManualRow(1, '2026-03');
+    expect(row.yearMonth).toBe('2026-03');
+  });
+
+  it('yearMonth queda vacío si no se pasa suggestedYearMonth', () => {
+    expect(emptyManualRow(1).yearMonth).toBe('');
+  });
+
+  it('no contiene valores demo de enero (1.667,51 / 1.500,00 / 350,00 / 15)', () => {
+    const row = emptyManualRow(1, '2026-03');
+    const allFields = Object.values(row).join('|');
+    expect(allFields).not.toContain('1.667');
+    expect(allFields).not.toContain('1.500');
+    expect(allFields).not.toContain('350');
+    // irpf=15 podría colisionar con el id, comparamos específicamente el campo
+    expect(row.irpfPct).not.toBe('15');
+    expect(row.costoEmpresa).not.toBe('1667.51');
+  });
+});
+
+// ── manualRowToPayrollRow — validación de campos obligatorios ─────────────────
+
+const BASE_ROW: ManualRow = {
+  id: 1,
+  counterpartyName: 'CAMACHO CARRION PABLO',
+  yearMonth: '2026-03',
+  costoEmpresa: '1.696,55',
+  liquidoPercibir: '1.000,00',
+  totalDevengado: '1.696,55',
+  totalDeducciones: '696,55',
+  irpfPct: '22,49',
+  notes: '',
+};
+
+describe('manualRowToPayrollRow — fila vacía → include=false', () => {
+  it('fila completamente vacía tiene include=false', () => {
+    const result = manualRowToPayrollRow(emptyManualRow(1));
+    expect(result.include).toBe(false);
+  });
+
+  it('fila solo con yearMonth tiene include=false (faltan nombre y coste)', () => {
+    const result = manualRowToPayrollRow(emptyManualRow(1, '2026-03'));
+    expect(result.include).toBe(false);
+  });
+
+  it('fila vacía tiene netAmount=0.00 (no valores demo)', () => {
+    const result = manualRowToPayrollRow(emptyManualRow(1, '2026-03'));
+    expect(result.netAmount).toBe('0.00');
+    expect(result.totalAmount).toBe('0.00');
+  });
+});
+
+describe('manualRowToPayrollRow — submit falla si falta trabajador', () => {
+  it('sin nombre → include=false aunque coste y yearMonth estén presentes', () => {
+    const row: ManualRow = { ...BASE_ROW, counterpartyName: '' };
+    expect(manualRowToPayrollRow(row).include).toBe(false);
+  });
+
+  it('nombre solo espacios → include=false', () => {
+    const row: ManualRow = { ...BASE_ROW, counterpartyName: '   ' };
+    expect(manualRowToPayrollRow(row).include).toBe(false);
+  });
+
+  it('warning indica campos obligatorios faltantes', () => {
+    const row: ManualRow = { ...BASE_ROW, counterpartyName: '' };
+    expect(manualRowToPayrollRow(row).warning).toContain('trabajador');
+  });
+});
+
+describe('manualRowToPayrollRow — submit falla si falta coste empresa', () => {
+  it('costoEmpresa vacío → include=false', () => {
+    const row: ManualRow = { ...BASE_ROW, costoEmpresa: '' };
+    expect(manualRowToPayrollRow(row).include).toBe(false);
+  });
+
+  it('costoEmpresa = 0 → include=false', () => {
+    const row: ManualRow = { ...BASE_ROW, costoEmpresa: '0,00' };
+    expect(manualRowToPayrollRow(row).include).toBe(false);
+  });
+
+  it('costoEmpresa = "0.00" → include=false', () => {
+    const row: ManualRow = { ...BASE_ROW, costoEmpresa: '0.00' };
+    expect(manualRowToPayrollRow(row).include).toBe(false);
+  });
+});
+
+describe('manualRowToPayrollRow — submit falla si falta mes/año', () => {
+  it('yearMonth vacío → include=false', () => {
+    const row: ManualRow = { ...BASE_ROW, yearMonth: '' };
+    expect(manualRowToPayrollRow(row).include).toBe(false);
+  });
+
+  it('yearMonth resultante "desconocido" → include=false', () => {
+    const row: ManualRow = { ...BASE_ROW, yearMonth: '' };
+    expect(manualRowToPayrollRow(row).yearMonth).toBe('desconocido');
+  });
+});
+
+describe('manualRowToPayrollRow — datos reales de marzo', () => {
+  it('Pablo Camacho: include=true con coste 1.696,55', () => {
+    const pablo = manualRowToPayrollRow(BASE_ROW);
+    expect(pablo.include).toBe(true);
+    expect(pablo.netAmount).toBe('1696.55');
+    expect(pablo.totalAmount).toBe('1696.55');
+    expect(pablo.counterpartyName).toBe('CAMACHO CARRION PABLO');
+    expect(pablo.yearMonth).toBe('2026-03');
+  });
+
+  it('Alfonso Arias: include=true con coste 1.369,00', () => {
+    const alfRow: ManualRow = {
+      id: 2,
+      counterpartyName: 'ARIAS EPIFANIO ALFONSO',
+      yearMonth: '2026-03',
+      costoEmpresa: '1.369,00',
+      liquidoPercibir: '1.000,00',
+      totalDevengado: '1.369,00',
+      totalDeducciones: '369,00',
+      irpfPct: '',
+      notes: '',
+    };
+    const alfonso = manualRowToPayrollRow(alfRow);
+    expect(alfonso.include).toBe(true);
+    expect(alfonso.netAmount).toBe('1369.00');
+    expect(alfonso.counterpartyName).toBe('ARIAS EPIFANIO ALFONSO');
+  });
+
+  it('txId usa formato payroll:{slug}:{YYYY-MM}', () => {
+    const pablo = manualRowToPayrollRow(BASE_ROW);
+    expect(pablo.txId).toBe('payroll:camacho-carrion-pablo:2026-03');
+  });
+
+  it('issueDate es el primer día del mes', () => {
+    expect(manualRowToPayrollRow(BASE_ROW).issueDate).toBe('2026-03-01');
+  });
+
+  it('notes incluye "Entrada manual"', () => {
+    expect(manualRowToPayrollRow(BASE_ROW).notes).toContain('Entrada manual');
+  });
+
+  it('notas opcionales vacías no generan warnings', () => {
+    const row: ManualRow = { ...BASE_ROW, liquidoPercibir: '', irpfPct: '' };
+    const result = manualRowToPayrollRow(row);
+    expect(result.include).toBe(true);
+    expect(result.warning).toBeNull();
+  });
+});
+
+// ── normalizeAmount ───────────────────────────────────────────────────────────
+
+describe('normalizeAmount — formato español', () => {
+  it('convierte formato español con miles (1.696,55) → 1696.55', () => {
+    expect(normalizeAmount('1.696,55')).toBe('1696.55');
+  });
+
+  it('convierte formato sin miles con coma (1369,00) → 1369.00', () => {
+    expect(normalizeAmount('1369,00')).toBe('1369.00');
+  });
+
+  it('acepta punto decimal estándar (1696.55) → 1696.55', () => {
+    expect(normalizeAmount('1696.55')).toBe('1696.55');
+  });
+
+  it('cadena vacía → 0.00', () => {
+    expect(normalizeAmount('')).toBe('0.00');
+  });
+
+  it('cero → 0.00', () => {
+    expect(normalizeAmount('0,00')).toBe('0.00');
+  });
+});

--- a/src/features/admin/finance-payroll/PayrollImportWizard.tsx
+++ b/src/features/admin/finance-payroll/PayrollImportWizard.tsx
@@ -4,102 +4,8 @@ import React, { useRef, useState, useTransition } from 'react';
 import Link from 'next/link';
 import { parsePayrollPdfAction, applyPayrollImportAction } from '@/app/admin/(dashboard)/finanzas/nominas/importar/actions';
 import type { PayrollImportRow, PayrollApplyResult, FilenameWarning } from '@/lib/finance/payroll/types';
-
-// ── Pure helpers (mirrors server-only parser, safe in client) ─────────────────
-
-function slugify(name: string): string {
-  return name
-    .toLowerCase()
-    .normalize('NFD')
-    .replace(/[̀-ͯ]/g, '')
-    .replace(/[^a-z0-9\s]/g, '')
-    .trim()
-    .replace(/\s+/g, '-');
-}
-
-function makeTxId(slug: string, yearMonth: string): string {
-  return `payroll:${slug}:${yearMonth}`;
-}
-
-// ── Manual entry row (mutable, pre-conversion) ────────────────────────────────
-
-type ManualRow = {
-  id: number;
-  counterpartyName: string;
-  yearMonth: string;
-  liquidoPercibir: string;
-  costoEmpresa: string;
-  totalDevengado: string;
-  totalDeducciones: string;
-  irpfPct: string;
-  notes: string;
-};
-
-function manualRowToPayrollRow(row: ManualRow): PayrollImportRow {
-  const name = row.counterpartyName.trim();
-  const slug = name ? slugify(name) : `trabajador-${row.id}`;
-  const ym = row.yearMonth.trim() || 'desconocido';
-  const txId = makeTxId(slug, ym);
-  const costoStr = row.costoEmpresa.trim() || '0.00';
-  const concept = name ? `Nómina ${name} ${ym}` : `Nómina pág. ${row.id} ${ym}`;
-  const isoDate = ym !== 'desconocido' ? `${ym}-01` : new Date().toISOString().slice(0, 10);
-
-  const noteParts: string[] = [];
-  if (ym !== 'desconocido') noteParts.push(`Período: ${ym}`);
-  if (costoStr !== '0.00') noteParts.push(`Coste empresa: ${costoStr}`);
-  if (row.liquidoPercibir) noteParts.push(`Líquido: ${row.liquidoPercibir}`);
-  if (row.totalDevengado) noteParts.push(`T.Devengado: ${row.totalDevengado}`);
-  if (row.totalDeducciones) noteParts.push(`T.Deducciones: ${row.totalDeducciones}`);
-  if (row.irpfPct) noteParts.push(`IRPF: ${row.irpfPct}%`);
-  if (row.notes) noteParts.push(row.notes);
-  noteParts.push('Entrada manual');
-
-  const missingRequired = !name || costoStr === '0.00' || ym === 'desconocido';
-
-  // Handles Spanish format (1.696,55) and plain decimals (1363.00 or 1363,00).
-  const normalizeAmount = (s: string): string => {
-    const trimmed = s.trim();
-    const cleaned = trimmed.includes(',')
-      ? trimmed.replace(/\./g, '').replace(',', '.') // remove thousands dots, swap decimal comma
-      : trimmed;
-    const n = parseFloat(cleaned);
-    return isNaN(n) ? '0.00' : n.toFixed(2);
-  };
-
-  return {
-    page: row.id,
-    include: !missingRequired,
-    slug,
-    yearMonth: ym,
-    txId,
-    counterpartyName: name,
-    concept,
-    issueDate: isoDate,
-    netAmount: normalizeAmount(costoStr),
-    totalAmount: normalizeAmount(costoStr),
-    vatPct: '0.00',
-    withholdingPct: '0.00',
-    expenseGroup: 'operational',
-    expenseSubtype: 'nomina_socio',
-    status: 'pagada',
-    notes: noteParts.join(' | '),
-    warning: missingRequired ? 'Faltan campos obligatorios (trabajador, mes/año, coste empresa)' : null,
-  };
-}
-
-function emptyManualRow(id: number, suggestedYearMonth?: string): ManualRow {
-  return {
-    id,
-    counterpartyName: '',
-    yearMonth: suggestedYearMonth ?? '',
-    liquidoPercibir: '',
-    costoEmpresa: '',
-    totalDevengado: '',
-    totalDeducciones: '',
-    irpfPct: '',
-    notes: '',
-  };
-}
+import { emptyManualRow, manualRowToPayrollRow } from '@/lib/finance/payroll/manualRow';
+import type { ManualRow } from '@/lib/finance/payroll/manualRow';
 
 // ── Step discriminator ────────────────────────────────────────────────────────
 
@@ -480,7 +386,8 @@ function StepManualEntry({ file, fileName, pageCount, suggestedYearMonth, existi
                     type="text"
                     value={row.costoEmpresa}
                     onChange={(e) => updateManualField(row.id, 'costoEmpresa', e.target.value)}
-                    placeholder="1.667,51"
+                    placeholder="Ej. 1.696,55"
+                    autoComplete="off"
                     className="w-full rounded border border-sp-border bg-transparent px-2 py-1 focus:outline-none focus:border-sp-orange font-mono"
                   />
                 </label>
@@ -490,7 +397,8 @@ function StepManualEntry({ file, fileName, pageCount, suggestedYearMonth, existi
                     type="text"
                     value={row.liquidoPercibir}
                     onChange={(e) => updateManualField(row.id, 'liquidoPercibir', e.target.value)}
-                    placeholder="1.000,00"
+                    placeholder="Ej. 1.000,00"
+                    autoComplete="off"
                     className="w-full rounded border border-sp-border bg-transparent px-2 py-1 focus:outline-none focus:border-sp-orange font-mono"
                   />
                 </label>
@@ -500,7 +408,8 @@ function StepManualEntry({ file, fileName, pageCount, suggestedYearMonth, existi
                     type="text"
                     value={row.totalDevengado}
                     onChange={(e) => updateManualField(row.id, 'totalDevengado', e.target.value)}
-                    placeholder="1.500,00"
+                    placeholder="Ej. 1.696,55"
+                    autoComplete="off"
                     className="w-full rounded border border-sp-border bg-transparent px-2 py-1 focus:outline-none focus:border-sp-orange font-mono"
                   />
                 </label>
@@ -510,7 +419,8 @@ function StepManualEntry({ file, fileName, pageCount, suggestedYearMonth, existi
                     type="text"
                     value={row.totalDeducciones}
                     onChange={(e) => updateManualField(row.id, 'totalDeducciones', e.target.value)}
-                    placeholder="350,00"
+                    placeholder="Ej. 696,55"
+                    autoComplete="off"
                     className="w-full rounded border border-sp-border bg-transparent px-2 py-1 focus:outline-none focus:border-sp-orange font-mono"
                   />
                 </label>
@@ -520,7 +430,8 @@ function StepManualEntry({ file, fileName, pageCount, suggestedYearMonth, existi
                     type="text"
                     value={row.irpfPct}
                     onChange={(e) => updateManualField(row.id, 'irpfPct', e.target.value)}
-                    placeholder="15"
+                    placeholder="Ej. 22,49"
+                    autoComplete="off"
                     className="w-full rounded border border-sp-border bg-transparent px-2 py-1 focus:outline-none focus:border-sp-orange font-mono"
                   />
                 </label>

--- a/src/lib/finance/payroll/manualRow.ts
+++ b/src/lib/finance/payroll/manualRow.ts
@@ -1,0 +1,90 @@
+import type { PayrollImportRow } from './types';
+
+export type ManualRow = {
+  readonly id: number;
+  readonly counterpartyName: string;
+  readonly yearMonth: string;
+  readonly liquidoPercibir: string;
+  readonly costoEmpresa: string;
+  readonly totalDevengado: string;
+  readonly totalDeducciones: string;
+  readonly irpfPct: string;
+  readonly notes: string;
+};
+
+function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9\s]/g, '')
+    .trim()
+    .replace(/\s+/g, '-');
+}
+
+// Handles Spanish format (1.696,55) and plain decimals (1363.00 / 1363,00).
+export function normalizeAmount(s: string): string {
+  const trimmed = s.trim();
+  if (!trimmed) return '0.00';
+  const cleaned = trimmed.includes(',')
+    ? trimmed.replace(/\./g, '').replace(',', '.')
+    : trimmed;
+  const n = parseFloat(cleaned);
+  return isNaN(n) ? '0.00' : n.toFixed(2);
+}
+
+export function emptyManualRow(id: number, suggestedYearMonth?: string): ManualRow {
+  return {
+    id,
+    counterpartyName: '',
+    yearMonth: suggestedYearMonth ?? '',
+    liquidoPercibir: '',
+    costoEmpresa: '',
+    totalDevengado: '',
+    totalDeducciones: '',
+    irpfPct: '',
+    notes: '',
+  };
+}
+
+export function manualRowToPayrollRow(row: ManualRow): PayrollImportRow {
+  const name = row.counterpartyName.trim();
+  const slug = name ? slugify(name) : `trabajador-${row.id}`;
+  const ym = row.yearMonth.trim() || 'desconocido';
+  const txId = `payroll:${slug}:${ym}`;
+  const costoStr = normalizeAmount(row.costoEmpresa);
+  const concept = name ? `Nómina ${name} ${ym}` : `Nómina pág. ${row.id} ${ym}`;
+  const isoDate = ym !== 'desconocido' ? `${ym}-01` : new Date().toISOString().slice(0, 10);
+
+  const noteParts: string[] = [];
+  if (ym !== 'desconocido') noteParts.push(`Período: ${ym}`);
+  if (costoStr !== '0.00') noteParts.push(`Coste empresa: ${costoStr}`);
+  if (row.liquidoPercibir) noteParts.push(`Líquido: ${row.liquidoPercibir}`);
+  if (row.totalDevengado) noteParts.push(`T.Devengado: ${row.totalDevengado}`);
+  if (row.totalDeducciones) noteParts.push(`T.Deducciones: ${row.totalDeducciones}`);
+  if (row.irpfPct) noteParts.push(`IRPF: ${row.irpfPct}%`);
+  if (row.notes) noteParts.push(row.notes);
+  noteParts.push('Entrada manual');
+
+  const missingRequired = !name || costoStr === '0.00' || ym === 'desconocido';
+
+  return {
+    page: row.id,
+    include: !missingRequired,
+    slug,
+    yearMonth: ym,
+    txId,
+    counterpartyName: name,
+    concept,
+    issueDate: isoDate,
+    netAmount: costoStr,
+    totalAmount: costoStr,
+    vatPct: '0.00',
+    withholdingPct: '0.00',
+    expenseGroup: 'operational',
+    expenseSubtype: 'nomina_socio',
+    status: 'pagada',
+    notes: noteParts.join(' | '),
+    warning: missingRequired ? 'Faltan campos obligatorios (trabajador, mes/año, coste empresa)' : null,
+  };
+}


### PR DESCRIPTION
## Causa raíz

Los `placeholder` de los campos económicos en `StepManualEntry` contenían valores concretos de enero:
- `placeholder="1.667,51"` — coste empresa (dato de enero de Pablo)
- `placeholder="1.500,00"` — total devengado
- `placeholder="350,00"` — total a deducir
- `placeholder="15"` — IRPF %

Estos placeholders no son `value` y no se envían al servidor, pero visualmente aparecen dentro del campo vacío y el usuario los confunde con valores pre-rellenados.

Además, las funciones `emptyManualRow` y `manualRowToPayrollRow` estaban definidas localmente en el componente y no podían testearse unitariamente.

## Archivos tocados

**`src/lib/finance/payroll/manualRow.ts`** (nuevo)
- Extrae `emptyManualRow`, `manualRowToPayrollRow`, `normalizeAmount` como funciones puras exportadas
- Sin dependencias de DOM/React — testeables directamente con Jest

**`src/features/admin/finance-payroll/PayrollImportWizard.tsx`**
- Importa las funciones del helper en lugar de definirlas inline
- Placeholders cambiados: `1.667,51` → `Ej. 1.696,55`, `350,00` → `Ej. 696,55`, `15` → `Ej. 22,49`
- `autoComplete="off"` en todos los campos monetarios

## Confirmaciones

- No hay migración DB
- No crea facturas
- No toca datos reales
- `emptyManualRow` siempre devuelve campos económicos `''` — sin valores pre-rellenados
- Modo manual solo pre-rellena `yearMonth` desde filename
- Submit falla (include=false) si falta cualquiera de: trabajador, mes/año, coste empresa

## Tests añadidos (27 nuevos — total 1502)

- `emptyManualRow`: todos los importes son `''`, solo `yearMonth` pre-rellenado
- No contiene valores demo de enero (1.667, 1.500, 350)
- `manualRowToPayrollRow`: include=false sin nombre, sin coste, sin mes
- Datos reales de marzo: Pablo 1.696,55 → `include:true`, Alfonso 1.369,00 → `include:true`
- `normalizeAmount`: formato español con/sin miles, coma decimal, vacío

## CI

- `npx tsc --noEmit` ✓
- `npm run lint` ✓
- `npm test` 1502/1502 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)