### PR TITLE
feat(campaigns): tipos de acción actualizados + fix responsable Alfonso

### DIFF
--- a/drizzle/0102_dry_fabian_cortez.sql
+++ b/drizzle/0102_dry_fabian_cortez.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."campaign_action_type" ADD VALUE 'preroll' BEFORE 'video_youtube';

--- a/src/app/admin/(dashboard)/campanas/[id]/page.tsx
+++ b/src/app/admin/(dashboard)/campanas/[id]/page.tsx
@@ -71,7 +71,7 @@ export default async function CampaignDetailPage({
     db
       .select({ id: userTable.id, name: userTable.name })
       .from(userTable)
-      .where(inArray(userTable.role, ['admin', 'manager', 'staff']))
+      .where(inArray(userTable.role, ['admin', 'admin_limited_tasks', 'manager', 'staff']))
       .orderBy(userTable.name),
     getContractByCampaign(campaignId),
     listContractTemplates(),

--- a/src/app/admin/(dashboard)/campanas/page.tsx
+++ b/src/app/admin/(dashboard)/campanas/page.tsx
@@ -26,7 +26,7 @@ export default async function AdminCampanasPage(): Promise<React.ReactElement> {
     db
       .select({ id: userTable.id, name: userTable.name })
       .from(userTable)
-      .where(inArray(userTable.role, ['admin', 'manager', 'staff']))
+      .where(inArray(userTable.role, ['admin', 'admin_limited_tasks', 'manager', 'staff']))
       .orderBy(userTable.name),
     getAllCampaignSplits(),
     getPartnersOwed(),

--- a/src/db/schema/campaigns.ts
+++ b/src/db/schema/campaigns.ts
@@ -9,7 +9,7 @@ export const campaignStatusEnum = pgEnum('campaign_status', [
 ]);
 
 export const campaignActionTypeEnum = pgEnum('campaign_action_type', [
-  'stream', 'video_youtube', 'short_reel_tiktok', 'tweet',
+  'stream', 'preroll', 'video_youtube', 'short_reel_tiktok', 'tweet',
   'story_instagram', 'pack_mensual', 'afiliacion', 'otro',
 ]);
 

--- a/src/lib/schemas/campaign.ts
+++ b/src/lib/schemas/campaign.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 export const CAMPAIGN_STATUSES = ['propuesta','negociacion','aprobada','activa','completada','cancelada','pendiente_pago','pagada'] as const;
-export const CAMPAIGN_ACTION_TYPES = ['stream','video_youtube','short_reel_tiktok','tweet','story_instagram','pack_mensual','afiliacion','otro'] as const;
+export const CAMPAIGN_ACTION_TYPES = ['stream','preroll','video_youtube','short_reel_tiktok','tweet','story_instagram','pack_mensual','afiliacion','otro'] as const;
 export const CAMPAIGN_PAYMENT_METHODS = ['banco','crypto','banco_agencia','banco_stark','crypto_agencia','crypto_zack','otro'] as const;
 
 export type CampaignStatus = (typeof CAMPAIGN_STATUSES)[number];
@@ -22,12 +22,13 @@ export const CAMPAIGN_STATUS_LABELS: Record<CampaignStatus, string> = {
 };
 
 export const CAMPAIGN_ACTION_LABELS: Record<CampaignActionType, string> = {
-  stream: 'Stream',
-  video_youtube: 'Vídeo YouTube',
-  short_reel_tiktok: 'Short/Reel/TikTok',
+  stream: 'Streams',
+  preroll: 'Prerolls',
+  video_youtube: 'Video Dedicado',
+  short_reel_tiktok: 'Short/TikTok',
   tweet: 'Tweet',
   story_instagram: 'Historia Instagram',
-  pack_mensual: 'Pack mensual',
+  pack_mensual: 'Pack Completo',
   afiliacion: 'Afiliación',
   otro: 'Otro',
 };


### PR DESCRIPTION
## Summary

- **Tipos de acción** en formulario de campaña actualizados:
  Streams · Prerolls (nuevo) · Video Dedicado · Short/TikTok · Tweet · Historia Instagram · Pack Completo · Afiliación · Otro
- **Responsable**: Alfonso (`admin_limited_tasks`) vuelve a aparecer en el selector — el filtro de staffUsers ahora incluye su rol

## Cambios técnicos

- `drizzle/0102` — `ALTER TYPE campaign_action_type ADD VALUE 'preroll'`
- `src/db/schema/campaigns.ts` — añade `preroll` al enum
- `src/lib/schemas/campaign.ts` — actualiza `CAMPAIGN_ACTION_TYPES` y `CAMPAIGN_ACTION_LABELS`
- `campanas/page.tsx` y `campanas/[id]/page.tsx` — `admin_limited_tasks` en el filtro `inArray` de staffUsers

## Test plan

- [ ] CI verde
- [ ] Crear campaña → Tipo de acción muestra las 9 opciones correctas
- [ ] "Responsable" muestra a Alfonso, Miguel, Pablo
- [ ] Campañas existentes con tipos anteriores siguen mostrándose correctamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)