### PR TITLE
fix(ocr): incluir tesseract.js completo en bundle NFT de Vercel

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -133,6 +133,7 @@ const nextConfig: NextConfig = {
     '/admin/finanzas/nominas/importar': [
       './node_modules/pdfjs-dist/legacy/build/pdf.worker.mjs',
       './node_modules/mupdf/dist/mupdf-wasm.wasm',
+      './node_modules/tesseract.js/**/*',
       './node_modules/tesseract.js-core/tesseract-core*.wasm',
       './node_modules/tesseract.js-core/tesseract-core*.wasm.js',
       './eng.traineddata',


### PR DESCRIPTION
## Problema

El OCR de nóminas ELEVATEX fallaba en producción con `MODULE_NOT_FOUND`:
```
Error: Cannot find module '..'
Require stack:
- /var/task/node_modules/tesseract.js/src/worker-script/node/index.js
```

## Causa raíz

`tesseract.js` spawnea un proceso hijo que ejecuta `worker-script/node/index.js`. Este script hace `require('..')` para cargar `worker-script/` internamente. El NFT (Node File Tracing) de Vercel solo traza dependencias estáticas del proceso principal — no entra en procesos hijo dinámicos, así que `src/worker-script/` quedaba excluido del lambda.

## Fix

Añadir `./node_modules/tesseract.js/**/*` a `outputFileTracingIncludes` para la ruta `/admin/finanzas/nominas/importar`. Esto fuerza la inclusión de todos los archivos del paquete en el bundle de Vercel, incluidos los que el worker necesita resolver.

## Test plan

- [ ] CI verde
- [ ] Subir `NOMINA ELEVATEX MARZO 2026.pdf` → click "Autocompletar con OCR"
- [ ] El OCR completa sin timeout ni error MODULE_NOT_FOUND
- [ ] Los datos se precargan en el formulario para revisión

🤖 Generated with [Claude Code](https://claude.com/claude-code)