### PR TITLE
feat(campaigns): eliminar sección Reparto de socios

### DIFF
--- a/src/app/admin/(dashboard)/campanas/[id]/page.tsx
+++ b/src/app/admin/(dashboard)/campanas/[id]/page.tsx
@@ -15,8 +15,6 @@ import { db } from '@/lib/db';
 import { invoices, user as userTable } from '@/db/schema';
 import { listCrmBrands, getBrandContacts } from '@/lib/queries/crmBrands';
 import { getAllTalents } from '@/lib/queries/talents';
-import { getCampaignSplits } from '@/lib/queries/campaignSplits';
-import { getUsdEurRate } from '@/lib/exchangeRate';
 import { CampaignDetailTabs } from '@/features/admin/campaigns/components/CampaignDetailTabs';
 
 import type { CrmBrandContact } from '@/types';
@@ -55,8 +53,6 @@ export default async function CampaignDetailPage({
     contractTemplates,
     issuedInvoices,
     issuerCompanies,
-    splits,
-    exchangeRate,
   ] = await Promise.all([
     getCampaignWithRelations(campaignId),
     listFilesByEntity('campaign', campaignId),
@@ -77,8 +73,6 @@ export default async function CampaignDetailPage({
     listContractTemplates(),
     listIssuedInvoicesByDeal(campaignId),
     getIssuerCompanies(),
-    getCampaignSplits(campaignId),
-    getUsdEurRate(),
   ]);
 
   if (!campaign) notFound();
@@ -122,8 +116,6 @@ export default async function CampaignDetailPage({
         contractVars={contractVars}
         issuedInvoices={issuedInvoices}
         issuerCompanies={issuerCompanies}
-        splits={splits}
-        rate={exchangeRate.rate}
       />
     </div>
   );

--- a/src/app/admin/(dashboard)/campanas/page.tsx
+++ b/src/app/admin/(dashboard)/campanas/page.tsx
@@ -7,7 +7,6 @@ import { listCampaigns } from '@/lib/queries/campaigns';
 import { listCrmBrands, getBrandContacts } from '@/lib/queries/crmBrands';
 import { getAllTalents } from '@/lib/queries/talents';
 import { listInvoices } from '@/lib/queries/invoices';
-import { getAllCampaignSplits, getPartnersOwed } from '@/lib/queries/campaignSplits';
 import { getUsdEurRate } from '@/lib/exchangeRate';
 import { CampaignsList } from '@/features/admin/campaigns/components/CampaignsList';
 
@@ -18,7 +17,7 @@ export default async function AdminCampanasPage(): Promise<React.ReactElement> {
   const role = session.user.role;
   const isManager = role === 'manager';
 
-  const [rawCampaigns, invoices, crmBrandsList, allTalents, staffUsers, splitsMap, partnersOwed, exchangeRate] = await Promise.all([
+  const [rawCampaigns, invoices, crmBrandsList, allTalents, staffUsers, exchangeRate] = await Promise.all([
     listCampaigns({ session: { userId: session.user.id, role } }),
     listInvoices({}),
     listCrmBrands(),
@@ -28,8 +27,6 @@ export default async function AdminCampanasPage(): Promise<React.ReactElement> {
       .from(userTable)
       .where(inArray(userTable.role, ['admin', 'admin_limited_tasks', 'manager', 'staff']))
       .orderBy(userTable.name),
-    getAllCampaignSplits(),
-    getPartnersOwed(),
     getUsdEurRate(),
   ]);
 
@@ -75,8 +72,6 @@ export default async function AdminCampanasPage(): Promise<React.ReactElement> {
       talents={talents}
       staffUsers={staffUsers}
       contactsByBrand={contactsByBrand}
-      splitsMap={splitsMap}
-      partnersOwed={partnersOwed}
       rate={exchangeRate.rate}
       rateDate={exchangeRate.date}
       rateIsEstimated={exchangeRate.isEstimated}

--- a/src/features/admin/campaigns/components/CampaignDetailTabs.tsx
+++ b/src/features/admin/campaigns/components/CampaignDetailTabs.tsx
@@ -12,7 +12,6 @@ import { CampaignDrawer }        from '@/features/admin/campaigns/components/Cam
 import { CampaignCnmcChecklist } from '@/features/admin/campaigns/components/CampaignCnmcChecklist';
 import { CampaignDeliverables }  from '@/features/admin/campaigns/components/CampaignDeliverables';
 import { CampaignActivity }      from '@/features/admin/campaigns/components/CampaignActivity';
-import { CampaignSplitPanel }    from '@/features/admin/campaigns/components/CampaignSplitPanel';
 import { ContractTab }           from '@/features/admin/_shared/components/campaigns/ContractTab';
 import { DealInvoicePanel }      from '@/features/admin/_shared/components/campaigns/DealInvoicePanel';
 import { CAMPAIGN_STATUS_LABELS } from '@/lib/schemas/campaign';
@@ -61,7 +60,6 @@ type Props = {
   readonly campaignFiles:       readonly FileRecord[];
   readonly campaignInvoices:    readonly Invoice[];
   readonly campaignDeliverables: readonly DeliverableWithComments[];
-  readonly splits:              readonly { party: string; percentage: number }[]; // safe: CampaignSplit compatible
   readonly isManager:           boolean;
   readonly isAdmin:             boolean;
   readonly brands:              readonly BrandOption[];
@@ -73,7 +71,6 @@ type Props = {
   readonly contractVars:        Readonly<Record<string, string>>;
   readonly issuedInvoices:      readonly IssuedInvoiceWithRelations[];
   readonly issuerCompanies:     readonly IssuerCompany[];
-  readonly rate?:               number;
 };
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -115,7 +112,6 @@ export function CampaignDetailTabs({
   campaign, campaignFiles, campaignInvoices, campaignDeliverables,
   isManager, isAdmin, brands, talents, staffUsers, contactsByBrand,
   contract, contractTemplates, contractVars, issuedInvoices, issuerCompanies,
-  splits, rate,
 }: Props): React.ReactElement {
   const router = useRouter();
   const [, startTransition] = useTransition();
@@ -328,14 +324,6 @@ export function CampaignDetailTabs({
         {activeTab === 'pagos' && (
           <div className="space-y-6">
             <CampaignPayments invoices={campaignInvoices} campaign={campaign} />
-            <CampaignSplitPanel
-              campaignId={campaign.id}
-              splits={splits as import('@/lib/queries/campaignSplits').CampaignSplit[]}
-              amountBrand={Number(campaign.amountBrand ?? 0)}
-              amountTalent={Number(campaign.amountTalent ?? 0)}
-              currency={campaign.currency ?? 'EUR'}
-              {...(rate !== undefined && { rate })}
-            />
           </div>
         )}
 
@@ -397,7 +385,6 @@ export function CampaignDetailTabs({
         staffUsers={staffUsers}
         contactsByBrand={contactsByBrand}
         isManager={isManager}
-        splits={splits as import('@/lib/queries/campaignSplits').CampaignSplit[]}
       />
     </div>
   );

--- a/src/features/admin/campaigns/components/CampaignDrawer.parts.tsx
+++ b/src/features/admin/campaigns/components/CampaignDrawer.parts.tsx
@@ -16,10 +16,7 @@ import {
   updateCampaignAction,
   archiveCampaignAction,
 } from '@/app/admin/(dashboard)/campanas/actions';
-import { CampaignSplitPanel } from '@/features/admin/campaigns/components/CampaignSplitPanel';
-
 import type { CampaignRow, CrmBrandContact } from '@/types';
-import type { CampaignSplit } from '@/lib/queries/campaignSplits';
 
 // ── Shared types ───────────────────────────────────────────────────────────────
 
@@ -87,8 +84,6 @@ export type CampaignFormProps = {
   readonly staffUsers: readonly StaffOption[];
   readonly contactsByBrand: Readonly<Record<number, readonly CrmBrandContact[]>>;
   readonly isManager: boolean;
-  readonly splits: readonly CampaignSplit[];
-  readonly rate?: number;
 };
 
 export function CampaignForm({
@@ -100,8 +95,6 @@ export function CampaignForm({
   staffUsers,
   contactsByBrand,
   isManager,
-  splits,
-  rate,
 }: CampaignFormProps): React.ReactElement {
   const router = useRouter();
   const [, startTransition] = useTransition();
@@ -558,23 +551,6 @@ export function CampaignForm({
           className={`${inputCls} resize-none`}
         />
       </Field>
-
-      {/* Reparto socios — solo al editar un trato existente */}
-      {isEditing && (
-        <div className="border-t border-sp-admin-border/50 pt-4 space-y-2">
-          <p className="text-[11px] uppercase tracking-wider font-semibold text-sp-admin-muted">
-            Reparto socios
-          </p>
-          <CampaignSplitPanel
-            campaignId={campaign.id}
-            splits={splits}
-            amountBrand={Number(amountBrand) || 0}
-            amountTalent={Number(amountTalent) || 0}
-            currency={currency}
-            {...(rate !== undefined && { rate })}
-          />
-        </div>
-      )}
 
       {/* Footer actions (inside form so submit button works) */}
       <div className="flex items-center gap-3 pt-2 border-t border-sp-admin-border">

--- a/src/features/admin/campaigns/components/CampaignDrawer.tsx
+++ b/src/features/admin/campaigns/components/CampaignDrawer.tsx
@@ -2,7 +2,6 @@
 
 import { EditDrawer } from '@/features/admin/_shared/components/EditDrawer';
 import type { CampaignRow, CrmBrandContact } from '@/types';
-import type { CampaignSplit } from '@/lib/queries/campaignSplits';
 
 import { CampaignForm, type BrandOption, type TalentOption, type StaffOption } from './CampaignDrawer.parts';
 
@@ -15,8 +14,6 @@ type Props = {
   readonly staffUsers: readonly StaffOption[];
   readonly contactsByBrand: Readonly<Record<number, readonly CrmBrandContact[]>>;
   readonly isManager: boolean;
-  readonly splits: readonly CampaignSplit[];
-  readonly rate?: number;
 };
 
 /**
@@ -34,8 +31,6 @@ export function CampaignDrawer({
   staffUsers,
   contactsByBrand,
   isManager,
-  splits,
-  rate,
 }: Props): React.ReactElement {
   // Use campaign id (or 'new') as key so the form remounts on each open/switch
   const formKey = isOpen ? (campaign ? String(campaign.id) : 'new') : 'closed';
@@ -56,8 +51,6 @@ export function CampaignDrawer({
         staffUsers={staffUsers}
         contactsByBrand={contactsByBrand}
         isManager={isManager}
-        splits={splits}
-        {...(rate !== undefined && { rate })}
       />
     </EditDrawer>
   );

--- a/src/features/admin/campaigns/components/CampaignsList.tsx
+++ b/src/features/admin/campaigns/components/CampaignsList.tsx
@@ -15,7 +15,6 @@ import {
 import type { CampaignWithRelations } from '@/types';
 import type { CampaignFilterState } from '@/features/admin/campaigns/components/CampaignFilters';
 import type { CrmBrandContact }     from '@/types';
-import type { CampaignSplit, PartnerOwed } from '@/lib/queries/campaignSplits';
 
 import {
   EUR,
@@ -47,8 +46,6 @@ type Props = {
   readonly talents:         readonly TalentOption[];
   readonly staffUsers:      readonly StaffOption[];
   readonly contactsByBrand: Readonly<Record<number, readonly CrmBrandContact[]>>;
-  readonly splitsMap:       Readonly<Record<number, CampaignSplit[]>>;
-  readonly partnersOwed:    readonly PartnerOwed[];
   readonly rate?:            number;
   readonly rateDate?:        string;
   readonly rateIsEstimated?: boolean;
@@ -101,52 +98,6 @@ function isActive(f: CampaignFilterState): boolean {
   );
 }
 
-// ── PartnerOwedBlock ──────────────────────────────────────────────────────────
-
-const PARTY_LABELS: Record<string, string> = {
-  pablo:    'Pablo',
-  alfonso:  'Alfonso',
-  giuliano: 'Giuliano',
-  stark:    'Stark',
-};
-const PARTY_ACCENTS: Record<string, string> = {
-  pablo:    '#8b3aad',
-  alfonso:  '#f5632a',
-  giuliano: '#e03070',
-  stark:    '#5b9bd5',
-};
-
-function PartnerOwedBlock({ partnersOwed }: { readonly partnersOwed: readonly PartnerOwed[] }): React.ReactElement | null {
-  if (partnersOwed.length === 0) return null;
-  return (
-    <div className="rounded-xl bg-sp-admin-card border border-sp-admin-border overflow-hidden">
-      <div className="px-4 py-2.5 border-b border-sp-admin-border bg-sp-admin-hover/30">
-        <p className="text-[10px] font-bold uppercase tracking-wider text-sp-admin-muted">
-          Reparto socios — lo que debe cobrar cada uno
-        </p>
-      </div>
-      <div className="grid grid-cols-2 sm:grid-cols-4 divide-x divide-sp-admin-border">
-        {partnersOwed.map((p) => (
-          <div key={p.party} className="px-4 py-3">
-            <p className="text-[10px] font-bold uppercase tracking-wide text-sp-admin-muted">
-              {PARTY_LABELS[p.party] ?? p.party}
-            </p>
-            <p
-              className="text-lg font-bold mt-0.5 tabular-nums"
-              style={{ color: PARTY_ACCENTS[p.party] ?? '#8b3aad' }}
-            >
-              {EUR.format(p.totalOwed)}
-            </p>
-            <p className="text-[10px] text-sp-admin-muted mt-0.5">
-              de {EUR.format(p.totalMargin)} margen
-            </p>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-}
-
 // ── Component ─────────────────────────────────────────────────────────────────
 
 /**
@@ -157,7 +108,7 @@ function PartnerOwedBlock({ partnersOwed }: { readonly partnersOwed: readonly Pa
  * @route /admin/campanas
  */
 export function CampaignsList({
-  campaigns, isManager, brands, talents, staffUsers, contactsByBrand, splitsMap, partnersOwed,
+  campaigns, isManager, brands, talents, staffUsers, contactsByBrand,
   rate = USD_EUR_RATE, rateDate = '', rateIsEstimated = true,
 }: Props): React.ReactElement {
   const [filters, setFilters]       = useState<CampaignFilterState>(EMPTY_FILTERS);
@@ -265,9 +216,6 @@ export function CampaignsList({
           sub={fmtCurrencyBreakdown(kpis.pendienteTalentEUR, kpis.pendienteTalentUSD, rate) ?? 'Importe a transferir a los creadores'}
         />
       </div>
-
-      {/* ── Reparto socios ────────────────────────────────────────── */}
-      <PartnerOwedBlock partnersOwed={partnersOwed} />
 
       {/* ── Filtros ───────────────────────────────────────────────── */}
       <CampaignFilters
@@ -461,8 +409,6 @@ export function CampaignsList({
         staffUsers={staffUsers}
         contactsByBrand={contactsByBrand}
         isManager={isManager}
-        splits={selected !== null ? (splitsMap[selected.id] ?? []) : []}
-        rate={rate}
       />
     </div>
   );


### PR DESCRIPTION
## Summary

- Elimina la sección **Reparto de socios** de los tratos del CRM
- Afecta: drawer de edición, lista de campañas y página de detalle (tab Pagos)
- Limpia la cascada completa de props/queries asociados (splits, partnersOwed, splitsMap, rate)
- Los datos en la tabla `campaign_splits` de la DB no se modifican

## Test plan

- [ ] CI verde
- [ ] /admin/campanas → sin bloque "Reparto socios" en la página
- [ ] Abrir un trato para editar → drawer sin sección "Reparto socios"
- [ ] /admin/campanas/[id] → tab Pagos solo muestra facturas, sin panel de reparto

🤖 Generated with [Claude Code](https://claude.com/claude-code)