### PR TITLE
fix(talentos): redirect /talentos/tiger → /talentos/tigerr

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -99,12 +99,12 @@ const nextConfig: NextConfig = {
         destination: '/codigos',
         permanent: true,
       },
-      // /talentos/tigerr → /talentos/tiger (301 permanent — slug con typo 2026-06-30)
-      // El talent TIGERR tiene slug "tiger" en DB (una r). La URL pública usa "tigerr".
-      // Redirige al slug real hasta que el slug en DB sea corregido.
+      // /talentos/tiger → /talentos/tigerr (301 permanent — slug corregido 2026-06-30)
+      // Slug en DB actualizado de "tiger" a "tigerr". Redirect preserva cualquier
+      // enlace externo o caché que apunte a la URL antigua de una r.
       {
-        source: '/talentos/tigerr',
-        destination: '/talentos/tiger',
+        source: '/talentos/tiger',
+        destination: '/talentos/tigerr',
         permanent: true,
       },
     ];


### PR DESCRIPTION
Slug de TIGERR corregido en admin de `tiger` → `tigerr`.

Este PR invierte el redirect temporal del PR #129. Ahora `/talentos/tigerr` es la URL canónica y `/talentos/tiger` redirige a ella.

**Cambio:** 1 bloque en `next.config.ts`, source/destination intercambiados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)