### PR TITLE
fix(blob): proxy server-side para logos de marca y fotos del equipo

### DIFF
--- a/src/__tests__/server/blob-access-audit.test.ts
+++ b/src/__tests__/server/blob-access-audit.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Auditoría estática + funcional de uso de Vercel Blob.
+ *
+ * Garantiza:
+ * 1. Documentos financieros (facturas, nóminas, contratos, campañas, finanzas)
+ *    NUNCA usan `access: 'public'`.
+ * 2. El único path con `access: 'public'` legítimo en src/ es news/images.ts
+ *    (usa un store público dedicado vía BLOB_READ_WRITE_TOKEN_NEWS).
+ * 3. Los nuevos proxies de imágenes (/api/brand-logo, /api/team-photo) sirven
+ *    blobs privados con Bearer token y caché.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+// ── 1) Tests estáticos sobre source ─────────────────────────────────────
+
+const PROJECT_ROOT = path.resolve(__dirname, '..', '..', '..');
+const SRC_ROOT = path.join(PROJECT_ROOT, 'src');
+
+function walk(dir: string, files: string[] = []): string[] {
+  if (!fs.existsSync(dir)) return files;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name === '.next') continue;
+      walk(full, files);
+    } else if (/\.(ts|tsx|mts)$/.test(entry.name)) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+const PUBLIC_ACCESS_PATTERN = /access\s*:\s*['"]public['"]/;
+
+describe('Blob access audit — static source scan', () => {
+  it('documentos financieros NUNCA usan access: "public"', () => {
+    const FINANCIAL_PATHS = [
+      path.join(SRC_ROOT, 'app', 'admin', '(dashboard)', 'facturacion'),
+      path.join(SRC_ROOT, 'app', 'admin', '(dashboard)', 'contratos'),
+      path.join(SRC_ROOT, 'app', 'admin', '(dashboard)', 'campanas'),
+      path.join(SRC_ROOT, 'app', 'admin', '(dashboard)', 'finanzas'),
+      path.join(SRC_ROOT, 'lib', 'storage.ts'),
+    ];
+
+    const offenders: string[] = [];
+    for (const target of FINANCIAL_PATHS) {
+      const stat = fs.existsSync(target) ? fs.statSync(target) : null;
+      if (!stat) continue;
+      const files = stat.isDirectory() ? walk(target) : [target];
+      for (const file of files) {
+        const content = fs.readFileSync(file, 'utf-8');
+        if (PUBLIC_ACCESS_PATTERN.test(content)) {
+          offenders.push(path.relative(PROJECT_ROOT, file));
+        }
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('el único path con access: "public" en src/ es news/images.ts', () => {
+    // Lista blanca: archivos donde access:'public' está justificado
+    // (store público dedicado vía BLOB_READ_WRITE_TOKEN_NEWS)
+    const ALLOWED = new Set([
+      path.join('src', 'lib', 'news', 'images.ts'),
+    ].map((p) => p.replace(/\\/g, '/')));
+
+    const offenders: string[] = [];
+    const allFiles = walk(SRC_ROOT);
+    for (const file of allFiles) {
+      // Excluir tests
+      if (file.includes('__tests__')) continue;
+      const content = fs.readFileSync(file, 'utf-8');
+      if (!PUBLIC_ACCESS_PATTERN.test(content)) continue;
+      const rel = path.relative(PROJECT_ROOT, file).replace(/\\/g, '/');
+      if (!ALLOWED.has(rel)) {
+        offenders.push(rel);
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});
+
+// ── 2) Tests funcionales de los proxies nuevos ───────────────────────────
+
+const mockList = jest.fn();
+
+jest.mock('@vercel/blob', () => ({
+  list: (...args: unknown[]) => mockList(...args),
+}));
+
+jest.mock('@/lib/env', () => ({
+  env: {
+    get BLOB_READ_WRITE_TOKEN() {
+      return process.env.BLOB_READ_WRITE_TOKEN ?? '';
+    },
+  },
+}));
+
+import { NextRequest } from 'next/server';
+import { GET as brandLogoGET } from '@/app/api/brand-logo/[id]/route';
+import { GET as teamPhotoGET } from '@/app/api/team-photo/[id]/route';
+
+const BLOB_TOKEN = 'test-blob-token-xyz';
+
+const makeReq = (url: string) => new NextRequest(url);
+const makeParams = (id: string) => ({ params: Promise.resolve({ id }) });
+
+const mockBlobFetchOk = (contentType = 'image/png') => {
+  (global.fetch as jest.Mock).mockResolvedValue({
+    ok: true,
+    status: 200,
+    headers: { get: (k: string) => (k === 'content-type' ? contentType : null) },
+    arrayBuffer: () => Promise.resolve(new ArrayBuffer(16)),
+  });
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  global.fetch = jest.fn();
+  process.env.BLOB_READ_WRITE_TOKEN = BLOB_TOKEN;
+});
+
+afterEach(() => {
+  delete process.env.BLOB_READ_WRITE_TOKEN;
+});
+
+describe('/api/brand-logo/[id]', () => {
+  it('devuelve 200 con el blob más reciente', async () => {
+    mockList.mockResolvedValue({
+      blobs: [
+        { url: 'https://store/brands/5-100.png', uploadedAt: '2026-06-29T00:00:00Z' },
+        { url: 'https://store/brands/5-200.png', uploadedAt: '2026-06-30T00:00:00Z' },
+      ],
+    });
+    mockBlobFetchOk('image/png');
+
+    const res = await brandLogoGET(makeReq('http://localhost/api/brand-logo/5'), makeParams('5'));
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toBe('image/png');
+    // Fetched the most recent blob
+    expect((global.fetch as jest.Mock).mock.calls[0]?.[0]).toBe('https://store/brands/5-200.png');
+    // Bearer token used server-side
+    const headers = (global.fetch as jest.Mock).mock.calls[0]?.[1]?.headers;
+    expect(headers.Authorization).toBe(`Bearer ${BLOB_TOKEN}`);
+  });
+
+  it('devuelve 404 cuando no existen blobs para ese id', async () => {
+    mockList.mockResolvedValue({ blobs: [] });
+
+    const res = await brandLogoGET(makeReq('http://localhost/api/brand-logo/99'), makeParams('99'));
+
+    expect(res.status).toBe(404);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('devuelve 404 con id no numérico', async () => {
+    const res = await brandLogoGET(makeReq('http://localhost/api/brand-logo/abc'), makeParams('abc'));
+
+    expect(res.status).toBe(404);
+    expect(mockList).not.toHaveBeenCalled();
+  });
+
+  it('aplica Cache-Control público con SWR', async () => {
+    mockList.mockResolvedValue({
+      blobs: [{ url: 'https://store/brands/1-1.png', uploadedAt: '2026-06-30T00:00:00Z' }],
+    });
+    mockBlobFetchOk();
+
+    const res = await brandLogoGET(makeReq('http://localhost/api/brand-logo/1'), makeParams('1'));
+
+    expect(res.headers.get('cache-control')).toMatch(/public/);
+    expect(res.headers.get('cache-control')).toMatch(/stale-while-revalidate/);
+  });
+
+  it('lista por el prefijo correcto brands/{id}-', async () => {
+    mockList.mockResolvedValue({
+      blobs: [{ url: 'https://store/brands/42-x.png', uploadedAt: '2026-06-30T00:00:00Z' }],
+    });
+    mockBlobFetchOk();
+
+    await brandLogoGET(makeReq('http://localhost/api/brand-logo/42'), makeParams('42'));
+
+    expect(mockList).toHaveBeenCalledWith({ prefix: 'brands/42-' });
+  });
+});
+
+describe('/api/team-photo/[id]', () => {
+  it('devuelve 200 con el blob más reciente', async () => {
+    mockList.mockResolvedValue({
+      blobs: [
+        { url: 'https://store/team/3-100.jpg', uploadedAt: '2026-06-30T00:00:00Z' },
+        { url: 'https://store/team/3-50.jpg', uploadedAt: '2026-06-29T00:00:00Z' },
+      ],
+    });
+    mockBlobFetchOk('image/jpeg');
+
+    const res = await teamPhotoGET(makeReq('http://localhost/api/team-photo/3'), makeParams('3'));
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toBe('image/jpeg');
+    expect((global.fetch as jest.Mock).mock.calls[0]?.[0]).toBe('https://store/team/3-100.jpg');
+  });
+
+  it('devuelve 404 cuando no existen blobs para ese id', async () => {
+    mockList.mockResolvedValue({ blobs: [] });
+
+    const res = await teamPhotoGET(makeReq('http://localhost/api/team-photo/99'), makeParams('99'));
+
+    expect(res.status).toBe(404);
+  });
+
+  it('lista por el prefijo correcto team/{id}-', async () => {
+    mockList.mockResolvedValue({
+      blobs: [{ url: 'https://store/team/7-x.jpg', uploadedAt: '2026-06-30T00:00:00Z' }],
+    });
+    mockBlobFetchOk();
+
+    await teamPhotoGET(makeReq('http://localhost/api/team-photo/7'), makeParams('7'));
+
+    expect(mockList).toHaveBeenCalledWith({ prefix: 'team/7-' });
+  });
+});

--- a/src/app/admin/(dashboard)/brands/logo-action.ts
+++ b/src/app/admin/(dashboard)/brands/logo-action.ts
@@ -64,17 +64,20 @@ export async function uploadBrandLogoAction(
   try {
     const lastDot = fileEntry.name.lastIndexOf('.');
     const ext = lastDot >= 0 ? fileEntry.name.slice(lastDot + 1).toLowerCase() : 'png';
+    // Store is private-only — proxy /api/brand-logo/[id] serves it publicly.
     const blob = await put(`brands/${id}-${Date.now()}.${ext}`, fileEntry, {
-      access: 'public',
+      access: 'private',
       contentType: fileEntry.type,
     });
+    void blob;
 
-    await db.update(crmBrands).set({ logoUrl: blob.url, updatedAt: new Date() }).where(eq(crmBrands.id, id));
+    const proxyLogoUrl = `/api/brand-logo/${id}`;
+    await db.update(crmBrands).set({ logoUrl: proxyLogoUrl, updatedAt: new Date() }).where(eq(crmBrands.id, id));
 
     revalidatePath('/admin/brands');
     revalidatePath(`/admin/brands/${id}`);
 
-    return { success: true, logoUrl: blob.url };
+    return { success: true, logoUrl: proxyLogoUrl };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     logRedacted('error', '[admin] uploadBrandLogo error:', msg);

--- a/src/app/admin/(dashboard)/equipo/fotos/actions.ts
+++ b/src/app/admin/(dashboard)/equipo/fotos/actions.ts
@@ -43,8 +43,11 @@ export async function uploadTeamPhotoAction(
   const ext = lastDot >= 0 ? fileEntry.name.slice(lastDot + 1).toLowerCase() : 'jpg';
 
   try {
-    const blob = await put(`team/${id}-${Date.now()}.${ext}`, fileEntry, { access: 'public' });
-    await db.update(teamMembers).set({ photoUrl: blob.url }).where(eq(teamMembers.id, id));
+    // Store is private-only — proxy /api/team-photo/[id] serves it publicly.
+    const blob = await put(`team/${id}-${Date.now()}.${ext}`, fileEntry, { access: 'private' });
+    void blob;
+    const proxyPhotoUrl = `/api/team-photo/${id}`;
+    await db.update(teamMembers).set({ photoUrl: proxyPhotoUrl }).where(eq(teamMembers.id, id));
   } catch (err) {
     logRedacted('error', '[admin] Team photo upload error:', err);
     return { error: 'No se pudo subir la imagen' };

--- a/src/app/api/brand-logo/[id]/route.ts
+++ b/src/app/api/brand-logo/[id]/route.ts
@@ -1,0 +1,62 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { list } from '@vercel/blob';
+import { env } from '@/lib/env';
+
+/**
+ * Proxy público para logos de marca almacenados en Vercel Blob privado.
+ *
+ * - El Blob store está configurado como private-only (access: 'private').
+ * - Este endpoint usa el BLOB_READ_WRITE_TOKEN server-side para autenticar
+ *   la descarga y re-servir la imagen públicamente con cache.
+ * - logoUrl en DB = '/api/brand-logo/{id}' (esta ruta).
+ *   Lista los blobs del brand por prefijo brands/{id}- y sirve el más reciente.
+ *
+ * Sin auth: los logos de marca son contenido público (carrusel home, /marcas/[slug]).
+ */
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id: rawId } = await params;
+  const brandId = parseInt(rawId, 10);
+  if (!brandId || isNaN(brandId)) {
+    return new NextResponse('Not found', { status: 404 });
+  }
+
+  const { blobs } = await list({ prefix: `brands/${brandId}-` });
+
+  if (blobs.length === 0) {
+    return new NextResponse('No logo', { status: 404 });
+  }
+
+  const sorted = [...blobs].sort((a, b) =>
+    new Date(b.uploadedAt).getTime() - new Date(a.uploadedAt).getTime()
+  );
+  const blob = sorted[0];
+  if (!blob) return new NextResponse('No logo', { status: 404 });
+
+  const token = env.BLOB_READ_WRITE_TOKEN;
+  if (!token) {
+    return NextResponse.redirect(blob.url, 302);
+  }
+
+  const blobRes = await fetch(blob.url, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (!blobRes.ok) {
+    return new NextResponse(`Blob fetch error: ${blobRes.status}`, { status: blobRes.status });
+  }
+
+  const contentType = blobRes.headers.get('content-type') ?? 'image/png';
+  const buffer = await blobRes.arrayBuffer();
+
+  return new NextResponse(buffer, {
+    status: 200,
+    headers: {
+      'Content-Type': contentType,
+      'Cache-Control': 'public, max-age=86400, stale-while-revalidate=604800',
+    },
+  });
+}

--- a/src/app/api/team-photo/[id]/route.ts
+++ b/src/app/api/team-photo/[id]/route.ts
@@ -1,0 +1,62 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { list } from '@vercel/blob';
+import { env } from '@/lib/env';
+
+/**
+ * Proxy público para fotos del equipo almacenadas en Vercel Blob privado.
+ *
+ * - El Blob store está configurado como private-only (access: 'private').
+ * - Este endpoint usa el BLOB_READ_WRITE_TOKEN server-side para autenticar
+ *   la descarga y re-servir la imagen públicamente con cache.
+ * - photoUrl en DB = '/api/team-photo/{id}' (esta ruta).
+ *   Lista los blobs del miembro por prefijo team/{id}- y sirve el más reciente.
+ *
+ * Sin auth: las fotos del equipo son contenido público (/nosotros, home).
+ */
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id: rawId } = await params;
+  const memberId = parseInt(rawId, 10);
+  if (!memberId || isNaN(memberId)) {
+    return new NextResponse('Not found', { status: 404 });
+  }
+
+  const { blobs } = await list({ prefix: `team/${memberId}-` });
+
+  if (blobs.length === 0) {
+    return new NextResponse('No photo', { status: 404 });
+  }
+
+  const sorted = [...blobs].sort((a, b) =>
+    new Date(b.uploadedAt).getTime() - new Date(a.uploadedAt).getTime()
+  );
+  const blob = sorted[0];
+  if (!blob) return new NextResponse('No photo', { status: 404 });
+
+  const token = env.BLOB_READ_WRITE_TOKEN;
+  if (!token) {
+    return NextResponse.redirect(blob.url, 302);
+  }
+
+  const blobRes = await fetch(blob.url, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (!blobRes.ok) {
+    return new NextResponse(`Blob fetch error: ${blobRes.status}`, { status: blobRes.status });
+  }
+
+  const contentType = blobRes.headers.get('content-type') ?? 'image/jpeg';
+  const buffer = await blobRes.arrayBuffer();
+
+  return new NextResponse(buffer, {
+    status: 200,
+    headers: {
+      'Content-Type': contentType,
+      'Cache-Control': 'public, max-age=86400, stale-while-revalidate=604800',
+    },
+  });
+}


### PR DESCRIPTION
## Causa raíz

El Blob store de Vercel es **private-only**. Dos uploads seguían usando \`access: 'public'\` y rompían en producción:

| Archivo | Línea | Problema |
|---------|-------|----------|
| \`src/app/admin/(dashboard)/brands/logo-action.ts\` | 67 | \`put(..., { access: 'public' })\` → 500 |
| \`src/app/admin/(dashboard)/equipo/fotos/actions.ts\` | 46 | \`put(..., { access: 'public' })\` → 500 |

Error en runtime: \`Vercel Blob: Cannot use public access on a private store\`.

## Auditoría completa

### ✅ Ya correctos (no se tocan)

| Path | Display |
|------|---------|
| \`src/lib/storage.ts\` | absoluta en DB (deuda) |
| \`talents/fotos/actions.ts\` | \`/api/talent-photo/[id]\` |
| \`contratos/actions.ts\` | \`/api/admin/contratos/[id]/pdf\` (auth) |
| \`facturacion/invoices-actions.ts\` | absoluta en DB (deuda) |
| \`facturacion/import/import-actions.ts\` | absoluta en DB (deuda) |
| \`brands/brief-actions.ts\` | absoluta en DB (deuda) |
| \`campanas/contract-actions.ts\` | absoluta en DB (deuda) |
| \`campanas/generate-contract-action.ts\` | absoluta en DB (deuda) |

### ✅ Públicos legítimos (no se tocan)

- \`src/lib/news/images.ts\` — usa store separado público vía \`BLOB_READ_WRITE_TOKEN_NEWS\` con fallback documentado.
- \`scripts/migrate-imgur-*.ts\` — scripts puntuales, mismo token público.

### ❌ Rotos (este PR los arregla)

- \`brands/logo-action.ts\` — logos de marca
- \`equipo/fotos/actions.ts\` — fotos del equipo

## Fix (mismo patrón que /api/talent-photo/[id])

1. **Subir como \`private\`** con prefijo predecible: \`brands/{id}-\`, \`team/{id}-\`.
2. **Guardar URL del proxy** en DB: \`/api/brand-logo/{id}\`, \`/api/team-photo/{id}\` (relativa).
3. **Nuevos route handlers** listan blobs por prefijo y sirven el más reciente con Bearer token server-side + Cache-Control 1d/SWR 7d.

Los proxies **NO requieren auth** — las imágenes son contenido público (carrusel home, /marcas/[slug], /casos/[slug], /nosotros). PDFs financieros siguen tras auth via su proxy admin existente.

### Sin migración de DB

Filas viejas con URL absoluta a Blob siguen como están:
- Si la URL antigua resuelve (uploads pre-private-only): se sigue mostrando.
- Si no: en cuanto se suba un logo/foto nuevo, la fila se sobrescribe con la URL del proxy.
- \`<Image>\` y \`<img>\` aceptan ambos formatos — cero regresión visual.

## Confirmaciones

- ✅ Nóminas/facturas/contratos siguen privados (verificado por test estático).
- ✅ Ningún PDF sensible queda público.
- ✅ No se tocó OCR, UI de finanzas, RBAC ni se borraron archivos.
- ✅ Sin migración de DB.

## Archivos

- **Modify (2):** \`brands/logo-action.ts\`, \`equipo/fotos/actions.ts\`
- **Create (2):** \`api/brand-logo/[id]/route.ts\`, \`api/team-photo/[id]/route.ts\`
- **Create (1):** \`__tests__/server/blob-access-audit.test.ts\` — 10 tests

## Tests añadidos (10)

**Estáticos (2):**
1. Documentos financieros nunca usan \`access: 'public'\` (escanea facturacion/contratos/campanas/finanzas + storage.ts).
2. La única excepción legítima de \`access: 'public'\` en \`src/\` es \`lib/news/images.ts\`.

**Funcionales (8):**
3-7. \`/api/brand-logo/[id]\` — 200 con blob reciente, 404 sin blobs, 404 con id inválido, Cache-Control SWR, prefijo correcto.
8-10. \`/api/team-photo/[id]\` — 200, 404 sin blobs, prefijo correcto.

## CI

- \`npx tsc --noEmit\` ✅
- \`npm run lint\` ✅ (0 warnings 0 errors)
- \`npm test\` ✅ — 89 suites / 1574 tests verde

## Smoke en preview

1. Subir logo en \`/admin/brands/{id}\` → 200, no 500.
2. Subir foto del equipo en \`/admin/equipo/fotos\` → 200, aparece en \`/nosotros\`.
3. \`/api/brand-logo/99999\` y \`/api/team-photo/99999\` → 404 limpio.
4. Finanzas y nóminas intactos (no se tocaron).

🤖 Generated with [Claude Code](https://claude.com/claude-code)