### PR TITLE
fix(talentos): corregir slug de TIGERR en DB (tiger → tigerr)

### DIFF
--- a/scripts/fix-tigerr-slug.ts
+++ b/scripts/fix-tigerr-slug.ts
@@ -1,0 +1,82 @@
+/**
+ * One-off fix: corrige el slug de TIGERR de "tiger" a "tigerr".
+ *
+ * El admin form no permite editar el slug (solo se setea via slugify(name)
+ * en createTalentAction), así que este script aplica el cambio directamente
+ * en DB de forma controlada y gateada.
+ *
+ * Uso: npx tsx --env-file=.env.local scripts/fix-tigerr-slug.ts
+ *
+ * Salvaguardas:
+ *  - UPDATE gateado por id=224 AND slug='tiger' (idempotente)
+ *  - Si el slug ya es 'tigerr', no hace nada (re-run safe)
+ *  - Verifica que no exista colisión con un slug 'tigerr' previo
+ */
+import { neon } from '@neondatabase/serverless';
+
+const DATABASE_URL = process.env.DATABASE_URL;
+if (!DATABASE_URL) {
+  console.error('❌ DATABASE_URL no definida. Ejecuta con: npx tsx --env-file=.env.local scripts/fix-tigerr-slug.ts');
+  process.exit(1);
+}
+
+const sql = neon(DATABASE_URL);
+const TIGERR_ID = 224;
+
+async function main() {
+  console.log('--- Pre-check ---');
+  const before = await sql`
+    SELECT id, name, slug, is_published, show_in_roster, visibility, archived_at
+    FROM talents
+    WHERE slug IN ('tiger', 'tigerr') OR name ILIKE '%tigerr%'
+    ORDER BY id
+  `;
+  for (const row of before) {
+    console.log(`id=${row.id} | slug="${row.slug}" | name="${row.name}" | is_published=${row.is_published} | show_in_roster=${row.show_in_roster} | archived_at=${row.archived_at}`);
+  }
+
+  const tiger    = before.find((r) => r.id === TIGERR_ID && r.slug === 'tiger');
+  const tigerr   = before.find((r) => r.slug === 'tigerr');
+
+  if (tigerr && tigerr.id !== TIGERR_ID) {
+    console.error(`❌ ABORT: ya existe otro talent con slug "tigerr" (id=${tigerr.id}). Resolver colisión manualmente.`);
+    process.exit(1);
+  }
+
+  if (!tiger && tigerr?.id === TIGERR_ID) {
+    console.log('✅ El slug ya es "tigerr" — no hay nada que hacer.');
+    return;
+  }
+
+  if (!tiger) {
+    console.error(`❌ ABORT: no se encontró talent con id=${TIGERR_ID} y slug="tiger". Estado inesperado.`);
+    process.exit(1);
+  }
+
+  console.log('\n--- UPDATE ---');
+  const result = await sql`
+    UPDATE talents
+    SET slug = 'tigerr', updated_at = NOW()
+    WHERE id = ${TIGERR_ID} AND slug = 'tiger'
+    RETURNING id, name, slug
+  `;
+  console.log(`Filas actualizadas: ${result.length}`);
+  for (const row of result) {
+    console.log(`  → id=${row.id} | slug="${row.slug}" | name="${row.name}"`);
+  }
+
+  console.log('\n--- Post-check ---');
+  const after = await sql`SELECT id, name, slug FROM talents WHERE id = ${TIGERR_ID}`;
+  for (const row of after) {
+    console.log(`id=${row.id} | slug="${row.slug}" | name="${row.name}"`);
+  }
+
+  if (after[0]?.slug === 'tigerr') {
+    console.log('\n✅ OK — slug actualizado correctamente.');
+  } else {
+    console.error('\n❌ ERROR — el slug no quedó como "tigerr".');
+    process.exit(1);
+  }
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/src/__tests__/server/next-config-redirects.test.ts
+++ b/src/__tests__/server/next-config-redirects.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Auditoría estática de redirects en next.config.ts.
+ *
+ * Garantiza que el redirect canónico de TIGERR no se invierta accidentalmente:
+ *   ✅ /talentos/tiger  → /talentos/tigerr
+ *   ❌ /talentos/tigerr → /talentos/tiger  (rompería el perfil)
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const PROJECT_ROOT = path.resolve(__dirname, '..', '..', '..');
+const NEXT_CONFIG = path.join(PROJECT_ROOT, 'next.config.ts');
+
+describe('next.config.ts — redirects de talentos', () => {
+  const content = fs.readFileSync(NEXT_CONFIG, 'utf-8');
+
+  it('contiene redirect /talentos/tiger → /talentos/tigerr', () => {
+    // Tolerante a whitespace y comillas simples/dobles entre source/destination
+    const pattern = /source:\s*['"]\/talentos\/tiger['"][\s\S]{0,200}?destination:\s*['"]\/talentos\/tigerr['"]/;
+    expect(content).toMatch(pattern);
+  });
+
+  it('NO contiene redirect inverso /talentos/tigerr → /talentos/tiger', () => {
+    const pattern = /source:\s*['"]\/talentos\/tigerr['"][\s\S]{0,200}?destination:\s*['"]\/talentos\/tiger['"]/;
+    expect(content).not.toMatch(pattern);
+  });
+
+  it('el redirect canónico es permanente (301/308)', () => {
+    const block = /source:\s*['"]\/talentos\/tiger['"][\s\S]{0,300}?permanent:\s*true/;
+    expect(content).toMatch(block);
+  });
+});

--- a/src/__tests__/server/queries-talents.test.ts
+++ b/src/__tests__/server/queries-talents.test.ts
@@ -254,24 +254,24 @@ describe('talent queries', () => {
     });
 
     // ── Tigerr visibility conditions ──────────────────────────────────────────
-    // Slug real en DB: "tiger". URL pública: /talentos/tigerr → redirects a /talentos/tiger.
-    // Estos tests documentan las condiciones exactas que controlan el acceso público.
+    // Slug canónico en DB: "tigerr" (corregido 2026-06-30 via fix-tigerr-slug.ts).
+    // El slug antiguo "tiger" redirige a "tigerr" en next.config.ts.
 
-    it('[tigerr] slug "tiger" con isPublished=true y archivedAt=null → devuelve talent', async () => {
-      const talent = makeTalentRow({ slug: 'tiger', isPublished: true, archivedAt: null });
+    it('[tigerr] slug "tigerr" con isPublished=true y archivedAt=null → devuelve talent', async () => {
+      const talent = makeTalentRow({ slug: 'tigerr', isPublished: true, archivedAt: null });
       mockFindFirst.mockResolvedValue(talent);
 
-      const result = await getTalentBySlug('tiger');
+      const result = await getTalentBySlug('tigerr');
 
       expect(result).toBeDefined();
-      expect(result?.slug).toBe('tiger');
+      expect(result?.slug).toBe('tigerr');
     });
 
     it('[tigerr] isPublished=false → DB filtra y devuelve undefined → página 404', async () => {
       // La query incluye eq(talents.isPublished, true) — DB no devuelve la fila
       mockFindFirst.mockResolvedValue(undefined);
 
-      const result = await getTalentBySlug('tiger');
+      const result = await getTalentBySlug('tigerr');
 
       expect(result).toBeUndefined();
     });
@@ -280,24 +280,43 @@ describe('talent queries', () => {
       // La query incluye isNull(talents.archivedAt) — DB no devuelve la fila si hay fecha
       mockFindFirst.mockResolvedValue(undefined);
 
-      const result = await getTalentBySlug('tiger');
+      const result = await getTalentBySlug('tigerr');
 
       expect(result).toBeUndefined();
     });
 
-    it('[tigerr] slug "tigerr" (dos r) → devuelve undefined — el slug real es "tiger"', async () => {
-      // La query usa eq exacto; "tigerr" no coincide con "tiger" en DB.
-      // El redirect /talentos/tigerr → /talentos/tiger en next.config.ts resuelve esto.
-      mockFindFirst.mockResolvedValue(undefined);
+    it('[tigerr] showInRoster=false pero isPublished=true → carga por URL directa', async () => {
+      // showInRoster solo afecta a la lista pública /talentos. El acceso directo
+      // por /talentos/[slug] depende exclusivamente de isPublished + !archivedAt.
+      // Es exactamente la configuración de TIGERR en producción.
+      const talent = makeTalentRow({
+        slug: 'tigerr',
+        isPublished: true,
+        showInRoster: false,
+        archivedAt: null,
+      });
+      mockFindFirst.mockResolvedValue(talent);
 
       const result = await getTalentBySlug('tigerr');
+
+      expect(result).toBeDefined();
+      expect(result?.showInRoster).toBe(false);
+      expect(result?.isPublished).toBe(true);
+    });
+
+    it('[tigerr] slug antiguo "tiger" → devuelve undefined (slug corregido a "tigerr"; next.config.ts redirige)', async () => {
+      // La query usa eq exacto. El slug en DB ahora es "tigerr".
+      // /talentos/tiger redirige 301 a /talentos/tigerr en next.config.ts.
+      mockFindFirst.mockResolvedValue(undefined);
+
+      const result = await getTalentBySlug('tiger');
 
       expect(result).toBeUndefined();
     });
 
     it('[tigerr] campos opcionales vacíos (tags/stats/socials=[]) → no lanza excepción', async () => {
       const talent = makeTalentRow({
-        slug: 'tiger',
+        slug: 'tigerr',
         isPublished: true,
         archivedAt: null,
         tags: [],
@@ -306,7 +325,7 @@ describe('talent queries', () => {
       });
       mockFindFirst.mockResolvedValue(talent);
 
-      const result = await getTalentBySlug('tiger');
+      const result = await getTalentBySlug('tigerr');
 
       expect(result).toBeDefined();
       expect(result?.tags).toEqual([]);
@@ -314,12 +333,12 @@ describe('talent queries', () => {
       expect(result?.socials).toEqual([]);
     });
 
-    it('[tigerr] slug en mayúsculas "TIGER" → devuelve undefined (query usa eq exacto, slugs siempre lowercase)', async () => {
+    it('[tigerr] slug en mayúsculas "TIGERR" → devuelve undefined (query usa eq exacto, slugs siempre lowercase)', async () => {
       // slugify() siempre lowercase — los slugs en DB son siempre minúsculas.
       // El route param llega siempre lowercase desde Next.js dynamic routing.
       mockFindFirst.mockResolvedValue(undefined);
 
-      const result = await getTalentBySlug('TIGER');
+      const result = await getTalentBySlug('TIGERR');
 
       expect(result).toBeUndefined();
     });


### PR DESCRIPTION
## Causa raíz

El formulario admin de talentos **NO expone el slug como campo editable**, y `updateTalentProfileAction` **no toca el campo `slug`**. El slug solo se setea al crear el talento via `slugify(name)`. Cuando intentaste cambiar el slug desde admin, los demás campos se guardaban pero el slug quedaba intacto en su valor original.

Estado encontrado en DB (vía \`scripts/diagnose-tigerr.ts\`):

| campo | valor |
|-------|-------|
| id | 224 |
| **slug** | **tiger** (una r) ← bug |
| name | TIGERR |
| is_published | true |
| show_in_roster | false |
| archived_at | null |

## Fix aplicado (data, no schema)

Script \`scripts/fix-tigerr-slug.ts\` ejecutado en producción, gateado por \`id = 224 AND slug = 'tiger'\`:

\`\`\`
--- Pre-check ---
id=224 | slug="tiger" | name="TIGERR" | ...

--- UPDATE ---
Filas actualizadas: 1
  → id=224 | slug="tigerr" | name="TIGERR"

--- Post-check ---
id=224 | slug="tigerr" | name="TIGERR"

✅ OK — slug actualizado correctamente.
\`\`\`

Script idempotente y safe re-run (no hace nada si el slug ya es \`tigerr\`).

## Redirects finales

| URL | Resultado |
|-----|-----------|
| \`/talentos/tigerr\` | 200 (canonical) |
| \`/talentos/tiger\` | 308 → \`/talentos/tigerr\` (ya activo desde PR #130) |

## ISR / cache

\`/talentos/tigerr\` actualmente devuelve 404 cacheado por ISR (\`revalidate = 3600\`). **El merge de este PR dispara redeploy de Vercel, que regenera el cache automáticamente** — \`generateStaticParams\` incluirá \`tigerr\` esta vez (porque la DB ya tiene ese slug).

## Tests añadidos / actualizados (+4)

- **queries-talents.test.ts** — 6 tests Tigerr actualizados al nuevo slug canónico. Nuevo: \"showInRoster=false + isPublished=true carga por URL directa\" (cubre el bug de aislar acceso vs. listado público).
- **next-config-redirects.test.ts** (nuevo) — 3 tests estáticos:
  - Existe \`/talentos/tiger\` → \`/talentos/tigerr\`
  - **NO** existe el redirect inverso
  - El redirect es permanente

## CI

- \`npx tsc --noEmit\` ✅
- \`npm run lint\` ✅
- \`npm test\` ✅ — 90 suites / 1578 tests

## Verificación post-merge esperada

1. Deploy READY en producción
2. \`curl https://socialpro.es/talentos/tigerr\` → 200
3. \`curl https://socialpro.es/talentos/tiger\` → 308 → tigerr

## Out of scope (follow-up, no en este PR)

- Hacer el slug editable en el admin form para evitar recurrencia. Requiere: nuevo input + validación regex + check de unicidad + opcional redirect old→new al guardar.

## No tocado

OCR · Blob · Finanzas · RBAC · ningún otro talento.

🤖 Generated with [Claude Code](https://claude.com/claude-code)