### PR TITLE
fix(payroll): kill switch OCR + blindaje total para evitar caer la página

### DIFF
--- a/src/__tests__/client/PayrollStepNeedsOcr.test.tsx
+++ b/src/__tests__/client/PayrollStepNeedsOcr.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * UI: el wizard de nóminas oculta el botón OCR cuando ocrEnabled=false.
+ * Garantiza que en producción (con kill switch on) el usuario solo ve
+ * el camino manual y no aparece ningún término técnico.
+ */
+
+// Mock de actions para evitar cargar la cadena server (auth → better-auth, etc.)
+jest.mock('@/app/admin/(dashboard)/finanzas/nominas/importar/actions', () => ({
+  parsePayrollPdfAction: jest.fn(),
+  ocrPayrollPdfAction: jest.fn(),
+  applyPayrollImportAction: jest.fn(),
+}));
+
+import { render, screen } from '@testing-library/react';
+import { StepNeedsOcr } from '@/features/admin/finance-payroll/PayrollImportWizard';
+
+const baseProps = {
+  file: new File(['x'], 'nomina.pdf'),
+  fileName: 'nomina.pdf',
+  pageCount: 2,
+  onBack: jest.fn(),
+  onOcr: jest.fn(),
+  onManual: jest.fn(),
+  isOcrPending: false,
+  error: null,
+};
+
+describe('StepNeedsOcr — kill switch UI', () => {
+  it('[5] ocrEnabled=false → NO renderiza botón OCR; muestra solo "Introducir manualmente"', () => {
+    render(<StepNeedsOcr {...baseProps} ocrEnabled={false} />);
+    expect(screen.queryByText(/Autocompletar con OCR/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/Introducir manualmente/i)).toBeInTheDocument();
+  });
+
+  it('ocrEnabled=false → muestra copy explicativo de OCR deshabilitado', () => {
+    render(<StepNeedsOcr {...baseProps} ocrEnabled={false} />);
+    expect(
+      screen.getByText(/OCR automático deshabilitado temporalmente/i),
+    ).toBeInTheDocument();
+  });
+
+  it('ocrEnabled=true → renderiza ambos botones (OCR + Manual)', () => {
+    render(<StepNeedsOcr {...baseProps} ocrEnabled={true} />);
+    expect(screen.getByText(/Autocompletar con OCR/i)).toBeInTheDocument();
+    expect(screen.getByText(/Introducir manualmente/i)).toBeInTheDocument();
+  });
+
+  it('[8] copy de UI no contiene términos técnicos (DOMMatrix, tesseract, pdf.worker, timeout)', () => {
+    const { container } = render(<StepNeedsOcr {...baseProps} ocrEnabled={false} />);
+    const text = (container.textContent ?? '').toLowerCase();
+    for (const kw of ['dommatrix', 'tesseract', 'pdf.worker', 'cannot find module']) {
+      expect(text).not.toContain(kw);
+    }
+  });
+
+  it('error pasado por prop se renderiza pero sin filtrar términos técnicos', () => {
+    render(
+      <StepNeedsOcr
+        {...baseProps}
+        ocrEnabled={false}
+        error="No se pudo leer el PDF automáticamente. Puedes introducir los datos manualmente."
+      />,
+    );
+    expect(screen.getByText(/No se pudo leer el PDF automáticamente/i)).toBeInTheDocument();
+    expect(screen.queryByText(/tesseract/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/DOMMatrix/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/__tests__/server/payroll-actions-killswitch.test.ts
+++ b/src/__tests__/server/payroll-actions-killswitch.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Kill switch + blindaje de las server actions de importación de nóminas.
+ *
+ * Garantiza que /admin/finanzas/nominas/importar nunca tire la página:
+ *  - OCR deshabilitado (default prod): nunca invoca tesseract
+ *  - OCR habilitado: invoca tesseract por el camino normal
+ *  - Cualquier excepción en parse/OCR/apply → { ok: false, error } controlado
+ *  - Mensajes al usuario son genéricos (sin DOMMatrix/tesseract/pdf.worker)
+ */
+
+// ── Mocks (hoisted) ─────────────────────────────────────────────────────────
+
+jest.mock('@/lib/auth', () => ({ auth: {} }));
+jest.mock('@/lib/db', () => ({ db: {} }));
+
+const mockRequirePermission = jest.fn();
+jest.mock('@/lib/permissions', () => ({
+  requirePermission: (...args: unknown[]) => mockRequirePermission(...args),
+  PERMISSIONS: {},
+}));
+
+const mockParsePayrollPdfBuffer = jest.fn();
+const mockDetectMonthFromFilename = jest.fn();
+jest.mock('@/lib/parsers/payrollPdf', () => ({
+  parsePayrollPdfBuffer: (...args: unknown[]) => mockParsePayrollPdfBuffer(...args),
+  detectMonthFromFilename: (...args: unknown[]) => mockDetectMonthFromFilename(...args),
+}));
+
+const mockOcrPayrollPdf = jest.fn();
+jest.mock('@/lib/parsers/payrollOcr', () => ({
+  ocrPayrollPdf: (...args: unknown[]) => mockOcrPayrollPdf(...args),
+}));
+
+const mockGetExistingPayrollTxIds = jest.fn();
+const mockApplyPayrollImport = jest.fn();
+jest.mock('@/lib/queries/payrollImport', () => ({
+  getExistingPayrollTxIds: (...args: unknown[]) => mockGetExistingPayrollTxIds(...args),
+  applyPayrollImport: (...args: unknown[]) => mockApplyPayrollImport(...args),
+}));
+
+let MOCK_OCR_ENABLED = false;
+jest.mock('@/lib/env', () => ({
+  env: {
+    get PAYROLL_OCR_ENABLED() { return MOCK_OCR_ENABLED; },
+  },
+}));
+
+// Silenciar logs en consola durante tests
+jest.mock('@/lib/log', () => ({
+  logRedacted: jest.fn(),
+}));
+
+// ── Imports tras mocks ──────────────────────────────────────────────────────
+
+import {
+  parsePayrollPdfAction,
+  ocrPayrollPdfAction,
+  applyPayrollImportAction,
+} from '@/app/admin/(dashboard)/finanzas/nominas/importar/actions';
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function makePdfFormData(filename = 'nomina.pdf', size = 1024): FormData {
+  const fd = new FormData();
+  const file = new File(['%PDF-1.4 fake'], filename, { type: 'application/pdf' });
+  Object.defineProperty(file, 'size', { value: size });
+  fd.append('pdf', file);
+  return fd;
+}
+
+const TECH_KEYWORDS = ['DOMMatrix', 'tesseract', 'pdf.worker', 'Cannot find module', 'timeout', 'fake worker', 'GlobalWorkerOptions'];
+
+function expectNoTechnicalLeak(error: string | undefined): void {
+  for (const kw of TECH_KEYWORDS) {
+    expect(error?.toLowerCase() ?? '').not.toContain(kw.toLowerCase());
+  }
+}
+
+// ── Setup ───────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  MOCK_OCR_ENABLED = false;
+  mockRequirePermission.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+});
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('ocrPayrollPdfAction — kill switch PAYROLL_OCR_ENABLED', () => {
+  it('[1] flag off → devuelve error controlado y NO invoca tesseract', async () => {
+    MOCK_OCR_ENABLED = false;
+    const res = await ocrPayrollPdfAction(makePdfFormData());
+    expect(res.ok).toBe(false);
+    expect(mockOcrPayrollPdf).not.toHaveBeenCalled();
+    if (!res.ok) {
+      expect(res.error).toContain('deshabilitado');
+      expectNoTechnicalLeak(res.error);
+    }
+  });
+
+  it('[2] flag on → invoca ocrPayrollPdf por el camino normal', async () => {
+    MOCK_OCR_ENABLED = true;
+    mockOcrPayrollPdf.mockResolvedValue({
+      rows: [{ counterpartyName: 'Test', yearMonth: '2026-06', netAmount: 1000 }],
+      pageCount: 1,
+    });
+
+    const res = await ocrPayrollPdfAction(makePdfFormData());
+    expect(mockOcrPayrollPdf).toHaveBeenCalledTimes(1);
+    expect(res.ok).toBe(true);
+  });
+
+  it('[6] flag default es false cuando env var no se define (verificado al nivel de env.ts)', async () => {
+    // Garantizado por el schema en env.ts: PAYROLL_OCR_ENABLED.default('false').
+    // Aquí solo verificamos que la action respeta MOCK_OCR_ENABLED=false sin tirar.
+    MOCK_OCR_ENABLED = false;
+    const res = await ocrPayrollPdfAction(makePdfFormData());
+    expect(res.ok).toBe(false);
+    expect(mockOcrPayrollPdf).not.toHaveBeenCalled();
+  });
+});
+
+describe('parsePayrollPdfAction — blindaje de excepciones', () => {
+  it('[3] excepción inesperada en parsePayrollPdfBuffer → ok:false controlado', async () => {
+    mockParsePayrollPdfBuffer.mockRejectedValue(
+      new Error('DOMMatrix is not defined — fake worker failed setting up tesseract'),
+    );
+
+    const res = await parsePayrollPdfAction(makePdfFormData());
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.error).toBeTruthy();
+      expectNoTechnicalLeak(res.error);
+    }
+  });
+
+  it('[8] mensaje al usuario es genérico y guía hacia manual', async () => {
+    mockParsePayrollPdfBuffer.mockRejectedValue(new Error('Cannot find module ..'));
+
+    const res = await parsePayrollPdfAction(makePdfFormData());
+    if (!res.ok) {
+      expect(res.error).toMatch(/manualmente/i);
+      expectNoTechnicalLeak(res.error);
+    }
+  });
+});
+
+describe('ocrPayrollPdfAction — blindaje de excepciones (flag on)', () => {
+  beforeEach(() => { MOCK_OCR_ENABLED = true; });
+
+  it('[4a] excepción dentro de ocrPayrollPdf → ok:false controlado', async () => {
+    mockOcrPayrollPdf.mockRejectedValue(new Error('Cannot find module ..'));
+
+    const res = await ocrPayrollPdfAction(makePdfFormData());
+    expect(res.ok).toBe(false);
+    if (!res.ok) expectNoTechnicalLeak(res.error);
+  });
+
+  it('[4b] excepción fuera del race (p.ej. requirePermission) → ok:false controlado', async () => {
+    mockRequirePermission.mockRejectedValue(new Error('boom'));
+
+    const res = await ocrPayrollPdfAction(makePdfFormData());
+    expect(res.ok).toBe(false);
+    if (!res.ok) expectNoTechnicalLeak(res.error);
+  });
+
+  it('[4c] timeout interno → ok:false controlado', async () => {
+    mockOcrPayrollPdf.mockRejectedValue(new Error('ocr_timeout'));
+
+    const res = await ocrPayrollPdfAction(makePdfFormData());
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.error).toMatch(/manualmente/i);
+      expectNoTechnicalLeak(res.error);
+    }
+  });
+});
+
+describe('applyPayrollImportAction — no inserta nada si OCR falla', () => {
+  it('[7a] no llama applyPayrollImport si las rows están vacías o inválidas', async () => {
+    const fd = new FormData();
+    const file = new File(['fake'], 'n.pdf', { type: 'application/pdf' });
+    fd.append('pdf', file);
+    fd.append('rows', 'not-json');
+
+    const res = await applyPayrollImportAction(fd);
+    expect(res.ok).toBe(false);
+    expect(mockApplyPayrollImport).not.toHaveBeenCalled();
+  });
+
+  it('[7b] excepción en applyPayrollImport → ok:false controlado, no propaga', async () => {
+    mockGetExistingPayrollTxIds.mockResolvedValue([]);
+    mockApplyPayrollImport.mockRejectedValue(new Error('DB connection lost'));
+
+    const fd = new FormData();
+    const file = new File(['fake'], 'n.pdf', { type: 'application/pdf' });
+    fd.append('pdf', file);
+    fd.append('rows', JSON.stringify([{
+      counterpartyName: 'Test Worker',
+      yearMonth: '2026-06',
+      grossAmount: '1500',
+      netAmount: '1000',
+      employerCost: '2000',
+      deductions: '500',
+      irpfPct: '15',
+      txId: 'test-tx-1',
+    }]));
+
+    const res = await applyPayrollImportAction(fd);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expectNoTechnicalLeak(res.error);
+  });
+});

--- a/src/__tests__/server/payroll-ocr-action.test.ts
+++ b/src/__tests__/server/payroll-ocr-action.test.ts
@@ -1,7 +1,15 @@
 /**
- * Tests para ocrPayrollPdfAction — error handling controlado.
+ * Tests para ocrPayrollPdfAction — error handling controlado (camino OCR habilitado).
+ * Para el kill switch (PAYROLL_OCR_ENABLED=false) ver payroll-actions-killswitch.test.ts.
  * Verifica que la action NUNCA lanza excepción al caller y NUNCA loggea PII.
  */
+
+// Forzar flag OCR ON en este test — verificamos el camino completo OCR.
+jest.mock('@/lib/env', () => ({
+  env: { PAYROLL_OCR_ENABLED: true },
+}));
+jest.mock('@/lib/auth', () => ({ auth: {} }));
+jest.mock('@/lib/db', () => ({ db: {} }));
 
 import { ocrPayrollPdfAction } from '@/app/admin/(dashboard)/finanzas/nominas/importar/actions';
 
@@ -76,16 +84,19 @@ describe('ocrPayrollPdfAction — captura excepción y devuelve { ok: false }', 
 // ── 2. Timeout ────────────────────────────────────────────────────────────────
 
 describe('ocrPayrollPdfAction — timeout interno', () => {
-  it('timeout de 55 s → retorna { ok: false } con mensaje "tardó demasiado"', async () => {
+  it('timeout de 55 s → retorna { ok: false } con mensaje genérico', async () => {
     // El internal timeout lanza `new Error('ocr_timeout')` tras 55 s.
-    // Simulamos ese escenario haciendo que ocrPayrollPdf rechace con ese error.
+    // Mensaje unificado (no expone "tardó demasiado") y guía hacia manual.
     const mock = await getOcrMock();
     mock.mockRejectedValue(new Error('ocr_timeout'));
 
     const res = await ocrPayrollPdfAction(makePdfFormData());
 
     expect(res.ok).toBe(false);
-    if (!res.ok) expect(res.error).toMatch(/tardó demasiado/i);
+    if (!res.ok) {
+      expect(res.error).toMatch(/no se pudo completar/i);
+      expect(res.error).toMatch(/manualmente/i);
+    }
   });
 });
 

--- a/src/app/admin/(dashboard)/finanzas/nominas/importar/actions.ts
+++ b/src/app/admin/(dashboard)/finanzas/nominas/importar/actions.ts
@@ -7,6 +7,8 @@ import type { OcrPayrollResult } from '@/lib/parsers/payrollOcr';
 import { getExistingPayrollTxIds, applyPayrollImport } from '@/lib/queries/payrollImport';
 import { PayrollImportRowsSchema } from '@/lib/schemas/payroll';
 import type { PayrollImportRow, PayrollApplyResult, FilenameWarning } from '@/lib/finance/payroll/types';
+import { env } from '@/lib/env';
+import { logRedacted } from '@/lib/log';
 
 // Timeout interno: deja 5 s de margen antes de que Vercel mate la función a los 60 s.
 // Devuelve una promesa que nunca resuelve — solo rechaza con 'ocr_timeout' al cumplirse el delay.
@@ -30,122 +32,159 @@ type OcrResult =
   | { ok: false; error: string };
 
 export async function parsePayrollPdfAction(formData: FormData): Promise<ParseResult> {
-  await requirePermission('facturacion', 'write');
+  // Blindaje total: cualquier excepción (incluida la inicialización de pdfjs-dist
+  // que ha fallado en producción con DOMMatrix/worker errors) cae en el catch
+  // y devuelve un mensaje genérico al usuario, sin tirar el RSC fetch.
+  try {
+    await requirePermission('facturacion', 'write');
 
-  const file = formData.get('pdf');
-  if (!(file instanceof File)) return { ok: false, error: 'No se recibió ningún archivo PDF.' };
-  if (!file.name.toLowerCase().endsWith('.pdf'))
-    return { ok: false, error: 'El archivo debe ser un PDF.' };
-  if (file.size > 20 * 1024 * 1024)
-    return { ok: false, error: 'El archivo supera 20 MB.' };
+    const file = formData.get('pdf');
+    if (!(file instanceof File)) return { ok: false, error: 'No se recibió ningún archivo PDF.' };
+    if (!file.name.toLowerCase().endsWith('.pdf'))
+      return { ok: false, error: 'El archivo debe ser un PDF.' };
+    if (file.size > 20 * 1024 * 1024)
+      return { ok: false, error: 'El archivo supera 20 MB.' };
 
-  const buffer = await file.arrayBuffer();
-  const { rows, pageCount, itemCount, filenameWarning } = await parsePayrollPdfBuffer(buffer, file.name);
+    const buffer = await file.arrayBuffer();
+    const { rows, pageCount, itemCount, filenameWarning } = await parsePayrollPdfBuffer(buffer, file.name);
 
-  if (pageCount === 0) {
-    return { ok: false, error: 'El PDF está vacío o no es un documento válido.' };
-  }
+    if (pageCount === 0) {
+      return { ok: false, error: 'El PDF está vacío o no es un documento válido.' };
+    }
 
-  // A row is only valid when it has ALL THREE: real employee name, known period, coste empresa > 0.
-  // Missing ANY ONE makes the row useless. Vectorized PDFs may extract stray amounts without labels
-  // (netAmount non-zero but yearMonth='desconocido') — the old AND condition missed those cases.
-  function isRowUseless(r: PayrollImportRow): boolean {
-    return !r.counterpartyName.trim() || r.yearMonth === 'desconocido' || Number(r.netAmount) <= 0;
-  }
-  const allRowsUseless = rows.length > 0 && rows.every(isRowUseless);
+    // A row is only valid when it has ALL THREE: real employee name, known period, coste empresa > 0.
+    // Missing ANY ONE makes the row useless. Vectorized PDFs may extract stray amounts without labels
+    // (netAmount non-zero but yearMonth='desconocido') — the old AND condition missed those cases.
+    function isRowUseless(r: PayrollImportRow): boolean {
+      return !r.counterpartyName.trim() || r.yearMonth === 'desconocido' || Number(r.netAmount) <= 0;
+    }
+    const allRowsUseless = rows.length > 0 && rows.every(isRowUseless);
 
-  if (itemCount === 0 || allRowsUseless) {
-    const dateFromFilename = detectMonthFromFilename(file.name);
-    const suggestedYearMonth = dateFromFilename
-      ? `${dateFromFilename.year}-${String(dateFromFilename.month).padStart(2, '0')}`
-      : undefined;
+    if (itemCount === 0 || allRowsUseless) {
+      const dateFromFilename = detectMonthFromFilename(file.name);
+      const suggestedYearMonth = dateFromFilename
+        ? `${dateFromFilename.year}-${String(dateFromFilename.month).padStart(2, '0')}`
+        : undefined;
+      return {
+        ok: true,
+        mode: 'needs-ocr',
+        pageCount,
+        fileName: file.name,
+        ...(suggestedYearMonth !== undefined ? { suggestedYearMonth } : {}),
+      };
+    }
+
+    if (rows.length === 0) return { ok: false, error: 'El PDF no contiene páginas reconocibles.' };
+
     return {
       ok: true,
-      mode: 'needs-ocr',
-      pageCount,
+      mode: 'parsed',
+      rows,
       fileName: file.name,
-      ...(suggestedYearMonth !== undefined ? { suggestedYearMonth } : {}),
+      ...(filenameWarning ? { filenameWarning } : {}),
+    };
+  } catch (err) {
+    logRedacted('error', '[payroll-parse] step=failed', err);
+    return {
+      ok: false,
+      error: 'No se pudo leer el PDF automáticamente. Puedes introducir los datos manualmente.',
     };
   }
-
-  if (rows.length === 0) return { ok: false, error: 'El PDF no contiene páginas reconocibles.' };
-
-  return {
-    ok: true,
-    mode: 'parsed',
-    rows,
-    fileName: file.name,
-    ...(filenameWarning ? { filenameWarning } : {}),
-  };
 }
 
 export async function ocrPayrollPdfAction(formData: FormData): Promise<OcrResult> {
-  await requirePermission('facturacion', 'write');
-
-  const file = formData.get('pdf');
-  if (!(file instanceof File)) return { ok: false, error: 'No se recibió ningún archivo PDF.' };
-  if (!file.name.toLowerCase().endsWith('.pdf'))
-    return { ok: false, error: 'El archivo debe ser un PDF.' };
-  if (file.size > 20 * 1024 * 1024)
-    return { ok: false, error: 'El archivo supera 20 MB.' };
-
-  const buffer = await file.arrayBuffer();
-  const startMs = Date.now();
-  console.log('[ocr-payroll] step=start');
-
-  let result: OcrPayrollResult;
+  // Blindaje total: nunca debe burbujear excepción al cliente (rompería el RSC).
   try {
-    result = await Promise.race([ocrPayrollPdf(buffer, file.name), ocrTimeoutRace()]);
-  } catch (err) {
+    await requirePermission('facturacion', 'write');
+
+    // Kill switch: si PAYROLL_OCR_ENABLED no es 'true' (default en prod),
+    // no se carga tesseract.js — devolvemos error controlado para que el wizard
+    // muestre el modo manual sin tirar la página.
+    if (!env.PAYROLL_OCR_ENABLED) {
+      logRedacted('info', '[ocr-payroll] step=disabled');
+      return {
+        ok: false,
+        error: 'OCR automático deshabilitado temporalmente. Puedes introducir los datos manualmente.',
+      };
+    }
+
+    const file = formData.get('pdf');
+    if (!(file instanceof File)) return { ok: false, error: 'No se recibió ningún archivo PDF.' };
+    if (!file.name.toLowerCase().endsWith('.pdf'))
+      return { ok: false, error: 'El archivo debe ser un PDF.' };
+    if (file.size > 20 * 1024 * 1024)
+      return { ok: false, error: 'El archivo supera 20 MB.' };
+
+    const buffer = await file.arrayBuffer();
+    const startMs = Date.now();
+    console.log('[ocr-payroll] step=start');
+
+    let result: OcrPayrollResult;
+    try {
+      result = await Promise.race([ocrPayrollPdf(buffer, file.name), ocrTimeoutRace()]);
+    } catch (err) {
+      const elapsed = Date.now() - startMs;
+      const isTimeout = err instanceof Error && err.message === 'ocr_timeout';
+      logRedacted('error', '[ocr-payroll] step=failed', {
+        step: isTimeout ? 'timeout' : 'error',
+        elapsedMs: elapsed,
+      });
+      return {
+        ok: false,
+        error: 'No se pudo completar el OCR. Puedes introducir los datos manualmente.',
+      };
+    }
+
     const elapsed = Date.now() - startMs;
-    const isTimeout = err instanceof Error && err.message === 'ocr_timeout';
-    console.error('[ocr-payroll] step=failed', {
-      step: isTimeout ? 'timeout' : 'error',
-      elapsedMs: elapsed,
-      ...(err instanceof Error && !isTimeout ? { errorMessage: err.message } : {}),
-    });
+    const { rows, pageCount } = result;
+    console.log('[ocr-payroll] step=done', { elapsedMs: elapsed, pageCount, rowCount: rows.length });
+
+    if (pageCount === 0) return { ok: false, error: 'El PDF está vacío o no es un documento válido.' };
+    if (rows.length === 0) return { ok: false, error: 'OCR no pudo reconocer páginas en el PDF.' };
+
+    return { ok: true, rows, fileName: file.name };
+  } catch (err) {
+    logRedacted('error', '[ocr-payroll] step=failed-outer', err);
     return {
       ok: false,
-      error: isTimeout
-        ? 'El OCR tardó demasiado. Puedes introducir los datos manualmente.'
-        : 'No se pudo completar el OCR. Puedes introducir los datos manualmente.',
+      error: 'No se pudo completar el OCR. Puedes introducir los datos manualmente.',
     };
   }
-
-  const elapsed = Date.now() - startMs;
-  const { rows, pageCount } = result;
-  console.log('[ocr-payroll] step=done', { elapsedMs: elapsed, pageCount, rowCount: rows.length });
-
-  if (pageCount === 0) return { ok: false, error: 'El PDF está vacío o no es un documento válido.' };
-  if (rows.length === 0) return { ok: false, error: 'OCR no pudo reconocer páginas en el PDF.' };
-
-  return { ok: true, rows, fileName: file.name };
 }
 
 export async function applyPayrollImportAction(formData: FormData): Promise<ApplyResult> {
-  const session = await requirePermission('facturacion', 'write');
-
-  const pdfFile = formData.get('pdf');
-  if (!(pdfFile instanceof File)) return { ok: false, error: 'Falta el archivo PDF.' };
-
-  const rowsJson = formData.get('rows');
-  if (typeof rowsJson !== 'string') return { ok: false, error: 'Faltan las filas a insertar.' };
-
-  let parsed: unknown;
+  // Blindaje total: blob/DB errors quedan controlados.
   try {
-    parsed = JSON.parse(rowsJson);
-  } catch {
-    return { ok: false, error: 'Formato de filas inválido.' };
+    const session = await requirePermission('facturacion', 'write');
+
+    const pdfFile = formData.get('pdf');
+    if (!(pdfFile instanceof File)) return { ok: false, error: 'Falta el archivo PDF.' };
+
+    const rowsJson = formData.get('rows');
+    if (typeof rowsJson !== 'string') return { ok: false, error: 'Faltan las filas a insertar.' };
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(rowsJson);
+    } catch {
+      return { ok: false, error: 'Formato de filas inválido.' };
+    }
+
+    const validation = PayrollImportRowsSchema.safeParse(parsed);
+    if (!validation.success) {
+      return { ok: false, error: `Filas inválidas: ${validation.error.issues[0]?.message ?? 'error de validación'}` };
+    }
+
+    const rows: PayrollImportRow[] = validation.data;
+    const existingTxIds = await getExistingPayrollTxIds();
+    const result = await applyPayrollImport(rows, existingTxIds, pdfFile, session.user.id);
+
+    return { ok: true, result };
+  } catch (err) {
+    logRedacted('error', '[payroll-apply] step=failed', err);
+    return {
+      ok: false,
+      error: 'No se pudo guardar la importación. Revisa los datos e inténtalo de nuevo.',
+    };
   }
-
-  const validation = PayrollImportRowsSchema.safeParse(parsed);
-  if (!validation.success) {
-    return { ok: false, error: `Filas inválidas: ${validation.error.issues[0]?.message ?? 'error de validación'}` };
-  }
-
-  const rows: PayrollImportRow[] = validation.data;
-  const existingTxIds = await getExistingPayrollTxIds();
-  const result = await applyPayrollImport(rows, existingTxIds, pdfFile, session.user.id);
-
-  return { ok: true, result };
 }

--- a/src/app/admin/(dashboard)/finanzas/nominas/importar/page.tsx
+++ b/src/app/admin/(dashboard)/finanzas/nominas/importar/page.tsx
@@ -1,6 +1,7 @@
 import { requirePermission } from '@/lib/permissions';
 import { getExistingPayrollTxIds } from '@/lib/queries/payrollImport';
 import { PayrollImportWizard } from '@/features/admin/finance-payroll/PayrollImportWizard';
+import { env } from '@/lib/env';
 
 export const metadata = { title: 'Importar nóminas | Admin' };
 
@@ -21,7 +22,7 @@ export default async function PayrollImportPage(): Promise<React.ReactElement> {
           Ningún dato se inserta hasta confirmar explícitamente.
         </p>
       </div>
-      <PayrollImportWizard existingTxIds={[...existingTxIds]} />
+      <PayrollImportWizard existingTxIds={[...existingTxIds]} ocrEnabled={env.PAYROLL_OCR_ENABLED} />
     </div>
   );
 }

--- a/src/features/admin/finance-payroll/PayrollImportWizard.tsx
+++ b/src/features/admin/finance-payroll/PayrollImportWizard.tsx
@@ -22,9 +22,9 @@ type Step =
   | { id: 2; rows: PayrollImportRow[]; file: File; sourceMode: 'parsed' | 'ocr-preview' | 'manual'; pageCount?: number; suggestedYearMonth?: string; filenameWarning?: FilenameWarning }
   | { id: 3; result: PayrollApplyResult };
 
-type Props = { existingTxIds: string[] };
+type Props = { existingTxIds: string[]; ocrEnabled: boolean };
 
-export function PayrollImportWizard({ existingTxIds }: Props): React.ReactElement {
+export function PayrollImportWizard({ existingTxIds, ocrEnabled }: Props): React.ReactElement {
   const [step, setStep] = useState<Step>({ id: 0 });
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
@@ -157,6 +157,7 @@ export function PayrollImportWizard({ existingTxIds }: Props): React.ReactElemen
         onManual={handleGoManual}
         isOcrPending={isPending}
         error={error}
+        ocrEnabled={ocrEnabled}
       />
     );
   }
@@ -280,55 +281,72 @@ type NeedsOcrProps = {
   onManual: () => void;
   isOcrPending: boolean;
   error: string | null;
+  ocrEnabled: boolean;
 };
 
-function StepNeedsOcr({ fileName, pageCount, onBack, onOcr, onManual, isOcrPending, error }: NeedsOcrProps): React.ReactElement {
+export function StepNeedsOcr({ fileName, pageCount, onBack, onOcr, onManual, isOcrPending, error, ocrEnabled }: NeedsOcrProps): React.ReactElement {
   return (
     <div className="space-y-4 max-w-lg">
       <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-xs text-amber-800 space-y-1.5">
-        <p className="font-semibold">PDF sin texto seleccionable</p>
+        <p className="font-semibold">No se pudo leer el texto del PDF automáticamente</p>
         <p>
           <strong>{fileName}</strong>
           {pageCount > 0 ? ` (${pageCount} página${pageCount !== 1 ? 's' : ''})` : ''} es un PDF
-          vectorizado o escaneado. No se pudo extraer texto directamente.
+          vectorizado o escaneado.
         </p>
-        <p>Elige cómo continuar:</p>
+        {ocrEnabled
+          ? <p>Elige cómo continuar:</p>
+          : <p>Introduce los datos manualmente revisando la nómina.</p>}
       </div>
 
-      <div className="grid grid-cols-2 gap-3">
-        <button
-          type="button"
-          disabled={isOcrPending}
-          onClick={onOcr}
-          className="flex flex-col items-start gap-1.5 rounded-lg border border-sp-border bg-sp-admin-surface p-4 text-left hover:border-sp-orange/60 disabled:opacity-50 transition-colors"
-        >
-          <span className="text-sm font-medium text-sp-admin-fg">
-            {isOcrPending ? 'Analizando con OCR…' : 'Autocompletar con OCR'}
-          </span>
-          <span className="text-xs text-sp-admin-muted">
-            {isOcrPending
-              ? 'Esto puede tardar hasta 30 segundos. No cierres esta página.'
-              : 'Reconocimiento óptico automático. Puede tardar 20–40 s. Revisa los datos antes de confirmar.'}
-          </span>
-        </button>
-        <button
-          type="button"
-          disabled={isOcrPending}
-          onClick={onManual}
-          className="flex flex-col items-start gap-1.5 rounded-lg border border-sp-border bg-sp-admin-surface p-4 text-left hover:border-sp-orange/60 disabled:opacity-50 transition-colors"
-        >
-          <span className="text-sm font-medium text-sp-admin-fg">Introducir manualmente</span>
-          <span className="text-xs text-sp-admin-muted">
-            Escribe los importes directamente desde el PDF. Sin errores de OCR.
-          </span>
-        </button>
-      </div>
+      {ocrEnabled ? (
+        <div className="grid grid-cols-2 gap-3">
+          <button
+            type="button"
+            disabled={isOcrPending}
+            onClick={onOcr}
+            className="flex flex-col items-start gap-1.5 rounded-lg border border-sp-border bg-sp-admin-surface p-4 text-left hover:border-sp-orange/60 disabled:opacity-50 transition-colors"
+          >
+            <span className="text-sm font-medium text-sp-admin-fg">
+              {isOcrPending ? 'Analizando con OCR…' : 'Autocompletar con OCR'}
+            </span>
+            <span className="text-xs text-sp-admin-muted">
+              {isOcrPending
+                ? 'Esto puede tardar hasta 30 segundos. No cierres esta página.'
+                : 'Reconocimiento óptico automático. Puede tardar 20–40 s. Revisa los datos antes de confirmar.'}
+            </span>
+          </button>
+          <button
+            type="button"
+            disabled={isOcrPending}
+            onClick={onManual}
+            className="flex flex-col items-start gap-1.5 rounded-lg border border-sp-border bg-sp-admin-surface p-4 text-left hover:border-sp-orange/60 disabled:opacity-50 transition-colors"
+          >
+            <span className="text-sm font-medium text-sp-admin-fg">Introducir manualmente</span>
+            <span className="text-xs text-sp-admin-muted">
+              Escribe los importes directamente desde el PDF. Sin errores de OCR.
+            </span>
+          </button>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          <div className="rounded-lg border border-sp-border bg-sp-admin-surface px-4 py-3 text-xs text-sp-admin-muted">
+            OCR automático deshabilitado temporalmente. Puedes introducir los datos manualmente.
+          </div>
+          <button
+            type="button"
+            onClick={onManual}
+            className="flex w-full items-center justify-center rounded-lg border border-sp-orange/60 bg-sp-orange/10 px-4 py-3 text-sm font-medium text-sp-orange hover:bg-sp-orange/20 transition-colors"
+          >
+            Introducir manualmente
+          </button>
+        </div>
+      )}
 
       {error && (
         <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-xs text-red-800 space-y-1">
-          <p className="font-semibold">No se pudo completar el OCR</p>
           <p>{error}</p>
-          <p>Puedes usar <strong>Introducir manualmente</strong> para continuar sin OCR.</p>
+          <p>Puedes usar <strong>Introducir manualmente</strong> para continuar.</p>
         </div>
       )}
 

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -32,6 +32,11 @@ export const env = createEnv({
     BLOB_READ_WRITE_TOKEN_NEWS: z.string().min(1).optional(),
     // Google Sheets API key for reading public spreadsheets (no OAuth needed).
     GOOGLE_SHEETS_API_KEY: z.string().min(1).optional(),
+    // Kill switch del OCR de nóminas. Default false en producción (tesseract.js
+    // está roto en Vercel — Cannot find module '..' + timeouts). Solo se invoca
+    // tesseract si la variable es exactamente 'true'. Developers pueden setear
+    // PAYROLL_OCR_ENABLED=true en .env.local para probar el flujo OCR en local.
+    PAYROLL_OCR_ENABLED: z.enum(['true', 'false']).optional().default('false').transform((v) => v === 'true'),
   },
   client: {
     NEXT_PUBLIC_SITE_URL: z.string().url(),
@@ -57,6 +62,7 @@ export const env = createEnv({
     BLOB_READ_WRITE_TOKEN: process.env.BLOB_READ_WRITE_TOKEN,
     BLOB_READ_WRITE_TOKEN_NEWS: process.env.BLOB_READ_WRITE_TOKEN_NEWS,
     GOOGLE_SHEETS_API_KEY: process.env.GOOGLE_SHEETS_API_KEY,
+    PAYROLL_OCR_ENABLED: process.env.PAYROLL_OCR_ENABLED,
 
     NEXT_PUBLIC_SITE_URL: process.env.NEXT_PUBLIC_SITE_URL,
     NEXT_PUBLIC_GTM_ID: process.env.NEXT_PUBLIC_GTM_ID,


### PR DESCRIPTION
## Causa raíz

\`/admin/finanzas/nominas/importar\` tira la página cuando:

| Error | Origen | Estado |
|---|---|---|
| \`Cannot find module '..'\` | tesseract.js spawn worker — NFT no tracea el require relativo | persiste tras PR #127 |
| \`DOMMatrix is not defined\` | pdfjs-dist al cargar | persiste |
| \`Setting up fake worker failed\` | pdf.worker.mjs path resolution | persiste |
| Runtime timeout 60s | OCR LSTM tarda 40-55s, picos > 55s | persiste |
| \`Cannot use public access on a private store\` | Blob privado | ✅ resuelto en PR #131 |

Todos burbujan como excepciones del Server Action y rompen el RSC fetch → pantalla en blanco / error de cliente. **El usuario nunca debería ver eso.**

## Solución — Opción C aprobada

### 1. Env \`PAYROLL_OCR_ENABLED\` (default \`false\` en producción)

\`src/lib/env.ts\`:
\`\`\`ts
PAYROLL_OCR_ENABLED: z.enum(['true', 'false']).optional().default('false').transform((v) => v === 'true'),
\`\`\`

- En producción: tesseract no se carga nunca.
- En \`.env.local\` developers pueden poner \`PAYROLL_OCR_ENABLED=true\` para probar OCR localmente.

### 2. Blindaje try/catch en los 3 server actions

- \`parsePayrollPdfAction\` → cualquier excepción (incluido pdfjs-dist roto) → \`{ ok: false, error: 'No se pudo leer el PDF automáticamente. Puedes introducir los datos manualmente.' }\`
- \`ocrPayrollPdfAction\` → early-return si flag off; try/catch envolvente para timeouts/MODULE_NOT_FOUND; mensaje unificado genérico.
- \`applyPayrollImportAction\` → try/catch envolvente para errores de Blob/DB.

### 3. UX \`StepNeedsOcr\` adaptado al flag

**Con flag off** (producción ahora):
- Botón OCR oculto.
- Único botón "Introducir manualmente" como acción principal.
- Copy: "OCR automático deshabilitado temporalmente. Puedes introducir los datos manualmente."

**Con flag on** (futuro / desarrollo):
- Comportamiento actual (dos botones lado a lado).

### Mensajes al usuario (siempre genéricos)

- ✅ \"No se pudo leer el texto del PDF automáticamente\"
- ✅ \"OCR automático deshabilitado temporalmente. Puedes introducir los datos manualmente.\"
- ✅ \"No se pudo completar el OCR. Puedes introducir los datos manualmente.\"
- ❌ Nunca: \`DOMMatrix\`, \`tesseract\`, \`pdf.worker\`, \`Cannot find module\`, \`timeout\` — solo en logs server.

## Archivos modificados

| Archivo | Cambio |
|---|---|
| \`src/lib/env.ts\` | + \`PAYROLL_OCR_ENABLED\` |
| \`src/app/admin/(dashboard)/finanzas/nominas/importar/actions.ts\` | try/catch envolvente en 3 actions + kill switch |
| \`src/app/admin/(dashboard)/finanzas/nominas/importar/page.tsx\` | lee env y pasa a wizard |
| \`src/features/admin/finance-payroll/PayrollImportWizard.tsx\` | prop \`ocrEnabled\`, render condicional, export de \`StepNeedsOcr\` |
| \`src/__tests__/server/payroll-actions-killswitch.test.ts\` | **nuevo** — 10 tests |
| \`src/__tests__/client/PayrollStepNeedsOcr.test.tsx\` | **nuevo** — 5 tests RTL |
| \`src/__tests__/server/payroll-ocr-action.test.ts\` | actualizado al mensaje unificado |

## Confirmaciones explícitas

- ✅ OCR **deshabilitado en producción** por default — tesseract.js nunca se invoca con el flag off.
- ✅ El wizard **no cae nunca** — todas las excepciones son capturadas y devueltas como \`{ ok: false, error }\`.
- ✅ No se crean facturas si OCR falla (el flujo se corta en step 2 antes de confirmar).
- ✅ Mensajes técnicos solo en logs server, nunca en UI.
- ✅ Modo manual queda como camino principal y mantiene su comportamiento (campos vacíos, mes/año desde filename si se detecta).

## No tocado

Blob · RBAC · Finanzas UI (salvo wizard) · queries contables · schema · invoices · no OCR externo · no push directo a master.

## CI

- \`npx tsc --noEmit\` ✅
- \`npm run lint\` ✅
- \`npm test\` ✅ — 92 suites / 1593 tests

## Follow-up futuro (no en este PR)

Si el equipo quiere OCR funcional → reconsiderar (D1) external OCR (Google Vision con DPA GDPR), (B) queue separado, o esperar a que Vercel mejore soporte tesseract.js.

🤖 Generated with [Claude Code](https://claude.com/claude-code)