### PR TITLE
hotfix(finance): romper cadena env-leak en /admin/finanzas/resumen

### DIFF
--- a/src/__tests__/server/client-server-boundary.test.ts
+++ b/src/__tests__/server/client-server-boundary.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Auditoría estática de la frontera cliente/servidor.
+ *
+ * Garantiza que ningún archivo con `'use client'` importe directamente
+ * de módulos server-only:
+ *   - @/lib/env
+ *   - @/lib/db
+ *   - @/lib/auth
+ *   - Archivos en lib/queries/ que importan db/env
+ *
+ * Esto previene la regresión del incidente 2026-06-30 en /admin/finanzas/resumen:
+ *   FinanceMonthlyControl (client) → financeResumen → db → env
+ *   ↓
+ *   "Attempted to access a server-side environment variable on the client"
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const PROJECT_ROOT = path.resolve(__dirname, '..', '..', '..');
+const SRC_ROOT = path.join(PROJECT_ROOT, 'src');
+
+function walk(dir: string, files: string[] = []): string[] {
+  if (!fs.existsSync(dir)) return files;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name === '.next' || entry.name === '__tests__') continue;
+      walk(full, files);
+    } else if (/\.tsx?$/.test(entry.name)) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+const allFiles = walk(SRC_ROOT);
+
+function isClientComponent(filePath: string): boolean {
+  const content = fs.readFileSync(filePath, 'utf-8');
+  // Match `'use client'` o `"use client"` en las primeras 5 líneas (puede haber comments)
+  const head = content.split('\n').slice(0, 5).join('\n');
+  return /^['"]use client['"];?/m.test(head);
+}
+
+function getValueImports(content: string): string[] {
+  // Extrae paths de imports que NO son `import type`.
+  const imports: string[] = [];
+  const re = /^import\s+(?!type\s)[^'"]*from\s+['"]([^'"]+)['"]/gm;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(content)) !== null) {
+    const p = m[1];
+    if (p) imports.push(p);
+  }
+  // Side-effect imports: `import 'foo'`
+  const sideRe = /^import\s+['"]([^'"]+)['"]/gm;
+  while ((m = sideRe.exec(content)) !== null) {
+    const p = m[1];
+    if (p) imports.push(p);
+  }
+  return imports;
+}
+
+const SERVER_ONLY_PATHS = [
+  '@/lib/env',
+  '@/lib/db',
+  '@/lib/auth',
+  '@/lib/auth-guard',
+];
+
+describe('Client/Server boundary — client components no importan modules server-only', () => {
+  const clientFiles = allFiles.filter(isClientComponent);
+
+  it('hay client components detectados (sanity check)', () => {
+    expect(clientFiles.length).toBeGreaterThan(0);
+  });
+
+  it('ningún client component importa @/lib/env, @/lib/db, @/lib/auth, @/lib/auth-guard', () => {
+    const offenders: { file: string; bad: string }[] = [];
+    for (const file of clientFiles) {
+      const content = fs.readFileSync(file, 'utf-8');
+      const imports = getValueImports(content);
+      for (const imp of imports) {
+        if (SERVER_ONLY_PATHS.includes(imp)) {
+          offenders.push({ file: path.relative(PROJECT_ROOT, file), bad: imp });
+        }
+      }
+    }
+
+    // Excepción documentada: ConsentedScripts solo accede a env.NEXT_PUBLIC_GTM_ID
+    // (variable client del schema). El proxy de t3-env lo permite.
+    const allowedOffenders = new Set([
+      'src/components/layout/ConsentedScripts.tsx',
+    ].map((p) => p.replace(/\\/g, '/')));
+
+    const filtered = offenders.filter(
+      (o) => !allowedOffenders.has(o.file.replace(/\\/g, '/')),
+    );
+
+    expect(filtered).toEqual([]);
+  });
+
+  it('financeResumen.ts (server-only) está protegido con import \'server-only\'', () => {
+    const file = path.join(SRC_ROOT, 'lib', 'queries', 'financeDashboard', 'financeResumen.ts');
+    const content = fs.readFileSync(file, 'utf-8');
+    expect(content).toMatch(/^\s*import\s+['"]server-only['"]/m);
+  });
+
+  it('financeResumen.shared.ts existe y NO importa @/lib/db ni @/lib/env', () => {
+    const file = path.join(SRC_ROOT, 'lib', 'queries', 'financeDashboard', 'financeResumen.shared.ts');
+    expect(fs.existsSync(file)).toBe(true);
+    const content = fs.readFileSync(file, 'utf-8');
+    expect(content).not.toMatch(/from\s+['"]@\/lib\/db['"]/);
+    expect(content).not.toMatch(/from\s+['"]@\/lib\/env['"]/);
+    expect(content).not.toMatch(/from\s+['"]@\/lib\/auth/);
+  });
+});

--- a/src/__tests__/server/finance-resumen.test.ts
+++ b/src/__tests__/server/finance-resumen.test.ts
@@ -3,13 +3,15 @@
  * Prueba funciones puras exportadas de financeResumen.ts y el componente nuevo.
  * No accede a la DB.
  */
+// Importamos del archivo .shared (sin dependencias de db/env) para que jest
+// no cargue 'server-only' (que falla en node test env). Los helpers son los mismos.
 import {
   computeMargen,
   parseYearMonth,
   monthRange,
   buildContextualText,
   EXPENSE_SUBTYPE_LABELS,
-} from '@/lib/queries/financeDashboard/financeResumen';
+} from '@/lib/queries/financeDashboard/financeResumen.shared';
 import fs from 'fs';
 import path from 'path';
 

--- a/src/features/admin/finance-dashboard/components/FinanceMonthlyControl.tsx
+++ b/src/features/admin/finance-dashboard/components/FinanceMonthlyControl.tsx
@@ -2,13 +2,13 @@
 
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { buildContextualText, EXPENSE_SUBTYPE_LABELS } from '@/lib/queries/financeDashboard/financeResumen';
+import { buildContextualText, EXPENSE_SUBTYPE_LABELS } from '@/lib/queries/financeDashboard/financeResumen.shared';
 import type {
   MonthlyFinanceFlow,
   FinanceStockKPIs,
   MonthlyExpenseBreakdownItem,
   MonthlyDocItem,
-} from '@/lib/queries/financeDashboard/financeResumen';
+} from '@/lib/queries/financeDashboard/financeResumen.shared';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 

--- a/src/features/admin/finance-dashboard/components/FinanceResumenBlocks.tsx
+++ b/src/features/admin/finance-dashboard/components/FinanceResumenBlocks.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import type { FinanceResumenKPIs } from '@/lib/queries/financeDashboard/financeResumen';
+import type { FinanceResumenKPIs } from '@/lib/queries/financeDashboard/financeResumen.shared';
 
 const EUR = new Intl.NumberFormat('es-ES', {
   style: 'currency',

--- a/src/lib/queries/financeDashboard/financeResumen.shared.ts
+++ b/src/lib/queries/financeDashboard/financeResumen.shared.ts
@@ -1,0 +1,138 @@
+/**
+ * Tipos, constantes y helpers puros del módulo finanzas/resumen.
+ *
+ * Importable desde Client Components — NO depende de @/lib/db ni @/lib/env.
+ * Las queries de DB viven en financeResumen.ts (server-only) y re-exportan
+ * desde aquí para mantener una sola fuente de verdad de tipos/constantes.
+ *
+ * Antes de este split, FinanceMonthlyControl (client) importaba símbolos
+ * puros desde financeResumen.ts, arrastrando @/lib/db al bundle cliente
+ * y disparando "Attempted to access a server-side environment variable on the client".
+ */
+
+// ── Tipos compartidos ──────────────────────────────────────────────────────
+
+export type FinanceResumenKPIs = {
+  // Bloque A — Devengo
+  readonly incomeTotal: number;
+  readonly incomeSettled: number;
+  readonly gastosCampanaDirect: number;
+  readonly gastosOperativos: number;
+  readonly gastosNoClasificados: number;
+  readonly pendienteCobro: number;
+  readonly pendientePago: number;
+  readonly margenBruto: number;
+  readonly margenPct: number;
+  // Bloque B — Caja (via invoice_payments)
+  readonly cobradoMes: number;
+  readonly cobradoYTD: number;
+  readonly pagadoMes: number;
+  readonly unclassifiedCount: number;
+};
+
+export type MonthlyFinanceFlow = {
+  readonly incomeTotal: number;
+  readonly gastosCampanaDirect: number;
+  readonly gastosOperativos: number;
+  readonly gastosTotal: number;
+  readonly resultado: number;
+  readonly cobradoMes: number;
+  readonly pagadoMes: number;
+};
+
+export type FinanceStockKPIs = {
+  readonly pendienteCobro: number;
+  readonly pendientePago: number;
+  readonly gastosNoClasificados: number;
+  readonly unclassifiedCount: number;
+};
+
+export type MonthlyExpenseBreakdownItem = {
+  readonly subtype: string | null;
+  readonly label: string;
+  readonly amount: number;
+};
+
+export type MonthlyDocItem = {
+  readonly id: number;
+  readonly kind: 'income' | 'expense';
+  readonly concept: string;
+  readonly counterpartyName: string | null;
+  readonly totalAmount: number;
+  readonly status: string;
+  readonly issueDate: string;
+};
+
+// ── Constantes ─────────────────────────────────────────────────────────────
+
+export const EXPENSE_SUBTYPE_LABELS: Record<string, string> = {
+  pago_talento: 'Pagos a talento',
+  coste_produccion: 'Coste de producción',
+  comision_plataforma: 'Comisión plataforma',
+  otros_campana: 'Otros (campaña)',
+  suscripcion_software: 'Suscripciones software',
+  herramienta_ia: 'Herramientas IA',
+  gestoria: 'Gestoría',
+  fiscal_impuestos: 'Impuestos',
+  cuota_autonomo: 'Cuota autónomo',
+  marketing_publicidad: 'Marketing',
+  comision_bancaria: 'Comisión bancaria',
+  ajuste_fiscal: 'Ajuste fiscal',
+  gasto_general: 'Gasto general',
+  factura_autonomo: 'Factura autónomo',
+  nomina_socio: 'Nóminas',
+  seguro_medico: 'Seguro médico',
+  seguridad_social: 'Seguridad Social',
+};
+
+// ── Helpers puros ──────────────────────────────────────────────────────────
+
+export function currentYearMonth(): string {
+  const now = new Date();
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+}
+
+/** Parses ?mes=YYYY-MM; falls back to current month if invalid. */
+export function parseYearMonth(raw: unknown): string {
+  if (typeof raw !== 'string') return currentYearMonth();
+  if (!/^\d{4}-(0[1-9]|1[0-2])$/.test(raw)) return currentYearMonth();
+  return raw;
+}
+
+/** Computes first/last day of a YYYY-MM month. */
+export function monthRange(yearMonth: string): { from: string; to: string } {
+  const parts = yearMonth.split('-');
+  const y = parseInt(parts[0] ?? '2026', 10);
+  const m = parseInt(parts[1] ?? '01', 10);
+  // new Date(y, m, 0) → last day of month m (1-indexed)
+  const lastDay = new Date(y, m, 0).getDate();
+  return { from: `${yearMonth}-01`, to: `${yearMonth}-${String(lastDay).padStart(2, '0')}` };
+}
+
+/** Generates contextual explanation text for the monthly result card. */
+export function buildContextualText(
+  incomeTotal: number,
+  gastosTotal: number,
+  topExpenseLabel: string | null,
+): string {
+  if (incomeTotal === 0 && gastosTotal === 0) return 'No hay datos registrados para este mes.';
+  if (incomeTotal >= gastosTotal) {
+    const surplus = incomeTotal - gastosTotal;
+    return surplus === 0
+      ? 'Ingresos iguales a gastos este mes.'
+      : 'Buen mes — has ingresado más de lo gastado.';
+  }
+  const base = 'Has gastado más de lo ingresado este mes.';
+  return topExpenseLabel ? `${base} Principal gasto: ${topExpenseLabel}.` : base;
+}
+
+/** @pure Calcula margenBruto y margenPct desde valores liquidados. */
+export function computeMargen(
+  incomeSettled: number,
+  settledCampana: number,
+  settledOperativos: number,
+): { margenBruto: number; margenPct: number } {
+  const margenBruto = incomeSettled - settledCampana - settledOperativos;
+  const margenPct = incomeSettled > 0 ? Math.round((margenBruto / incomeSettled) * 1000) / 10 : 0;
+  return { margenBruto, margenPct };
+}

--- a/src/lib/queries/financeDashboard/financeResumen.ts
+++ b/src/lib/queries/financeDashboard/financeResumen.ts
@@ -1,140 +1,41 @@
-'server-only';
+// Fail-fast si este archivo se importa desde client bundle.
+// Antes había 'server-only' como string literal (no-op) — el bundler no fallaba
+// y la cadena client → financeResumen → db → env terminaba en
+// "Attempted to access a server-side environment variable on the client".
+import 'server-only';
 
 import { and, desc, eq, gte, lte, ne, sql } from 'drizzle-orm';
 import { db } from '@/lib/db';
 import { invoicePayments, invoices } from '@/db/schema';
 import { getUnclassifiedExpenseCount } from '@/lib/queries/invoices';
 
-// ── Existing types (kept for backward compat) ────────────────────────────────
+// ── Tipos, constantes y helpers puros (re-exportados desde el módulo shared) ─
+// Los Client Components deben importar directamente desde .shared.ts, no de aquí.
+export {
+  EXPENSE_SUBTYPE_LABELS,
+  currentYearMonth,
+  parseYearMonth,
+  monthRange,
+  buildContextualText,
+  computeMargen,
+} from './financeResumen.shared';
+export type {
+  FinanceResumenKPIs,
+  MonthlyFinanceFlow,
+  FinanceStockKPIs,
+  MonthlyExpenseBreakdownItem,
+  MonthlyDocItem,
+} from './financeResumen.shared';
 
-export type FinanceResumenKPIs = {
-  // Bloque A — Devengo
-  readonly incomeTotal: number;
-  readonly incomeSettled: number;
-  readonly gastosCampanaDirect: number;
-  readonly gastosOperativos: number;
-  readonly gastosNoClasificados: number;
-  readonly pendienteCobro: number;
-  readonly pendientePago: number;
-  readonly margenBruto: number;
-  readonly margenPct: number;
-  // Bloque B — Caja (via invoice_payments)
-  readonly cobradoMes: number;
-  readonly cobradoYTD: number;
-  readonly pagadoMes: number;
-  readonly unclassifiedCount: number;
-};
-
-// ── New types ────────────────────────────────────────────────────────────────
-
-export type MonthlyFinanceFlow = {
-  readonly incomeTotal: number;
-  readonly gastosCampanaDirect: number;
-  readonly gastosOperativos: number;
-  readonly gastosTotal: number;
-  readonly resultado: number;
-  readonly cobradoMes: number;
-  readonly pagadoMes: number;
-};
-
-export type FinanceStockKPIs = {
-  readonly pendienteCobro: number;
-  readonly pendientePago: number;
-  readonly gastosNoClasificados: number;
-  readonly unclassifiedCount: number;
-};
-
-export type MonthlyExpenseBreakdownItem = {
-  readonly subtype: string | null;
-  readonly label: string;
-  readonly amount: number;
-};
-
-export type MonthlyDocItem = {
-  readonly id: number;
-  readonly kind: 'income' | 'expense';
-  readonly concept: string;
-  readonly counterpartyName: string | null;
-  readonly totalAmount: number;
-  readonly status: string;
-  readonly issueDate: string;
-};
-
-// ── Expense subtype labels (human-readable) ──────────────────────────────────
-
-export const EXPENSE_SUBTYPE_LABELS: Record<string, string> = {
-  pago_talento: 'Pagos a talento',
-  coste_produccion: 'Coste de producción',
-  comision_plataforma: 'Comisión plataforma',
-  otros_campana: 'Otros (campaña)',
-  suscripcion_software: 'Suscripciones software',
-  herramienta_ia: 'Herramientas IA',
-  gestoria: 'Gestoría',
-  fiscal_impuestos: 'Impuestos',
-  cuota_autonomo: 'Cuota autónomo',
-  marketing_publicidad: 'Marketing',
-  comision_bancaria: 'Comisión bancaria',
-  ajuste_fiscal: 'Ajuste fiscal',
-  gasto_general: 'Gasto general',
-  factura_autonomo: 'Factura autónomo',
-  nomina_socio: 'Nóminas',
-  seguro_medico: 'Seguro médico',
-  seguridad_social: 'Seguridad Social',
-};
-
-// ── Pure helpers (exported for unit tests) ───────────────────────────────────
-
-export function currentYearMonth(): string {
-  const now = new Date();
-  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
-}
-
-/** Parses ?mes=YYYY-MM; falls back to current month if invalid. */
-export function parseYearMonth(raw: unknown): string {
-  if (typeof raw !== 'string') return currentYearMonth();
-  if (!/^\d{4}-(0[1-9]|1[0-2])$/.test(raw)) return currentYearMonth();
-  return raw;
-}
-
-/** Computes first/last day of a YYYY-MM month. */
-export function monthRange(yearMonth: string): { from: string; to: string } {
-  const parts = yearMonth.split('-');
-  const y = parseInt(parts[0] ?? '2026', 10);
-  const m = parseInt(parts[1] ?? '01', 10);
-  // new Date(y, m, 0) → last day of month m (1-indexed)
-  const lastDay = new Date(y, m, 0).getDate();
-  return { from: `${yearMonth}-01`, to: `${yearMonth}-${String(lastDay).padStart(2, '0')}` };
-}
-
-/** Generates contextual explanation text for the monthly result card. */
-export function buildContextualText(
-  incomeTotal: number,
-  gastosTotal: number,
-  topExpenseLabel: string | null,
-): string {
-  if (incomeTotal === 0 && gastosTotal === 0) return 'No hay datos registrados para este mes.';
-  if (incomeTotal >= gastosTotal) {
-    const surplus = incomeTotal - gastosTotal;
-    return surplus === 0
-      ? 'Ingresos iguales a gastos este mes.'
-      : 'Buen mes — has ingresado más de lo gastado.';
-  }
-  const base = 'Has gastado más de lo ingresado este mes.';
-  return topExpenseLabel ? `${base} Principal gasto: ${topExpenseLabel}.` : base;
-}
-
-// ── Existing pure function (kept unchanged) ──────────────────────────────────
-
-/** @pure Calcula margenBruto y margenPct desde valores liquidados. */
-export function computeMargen(
-  incomeSettled: number,
-  settledCampana: number,
-  settledOperativos: number,
-): { margenBruto: number; margenPct: number } {
-  const margenBruto = incomeSettled - settledCampana - settledOperativos;
-  const margenPct = incomeSettled > 0 ? Math.round((margenBruto / incomeSettled) * 1000) / 10 : 0;
-  return { margenBruto, margenPct };
-}
+// Imports internos para uso server-side en este archivo
+import { EXPENSE_SUBTYPE_LABELS, currentYearMonth, monthRange, computeMargen } from './financeResumen.shared';
+import type {
+  FinanceResumenKPIs,
+  MonthlyFinanceFlow,
+  FinanceStockKPIs,
+  MonthlyExpenseBreakdownItem,
+  MonthlyDocItem,
+} from './financeResumen.shared';
 
 function currentMonthRange(): { from: string; to: string } {
   return monthRange(currentYearMonth());


### PR DESCRIPTION
## P0 — Causa raíz exacta

\`/admin/finanzas/resumen\` cae con \"Attempted to access a server-side environment variable on the client\".

| Archivo | Línea | Problema |
|---|---|---|
| \`src/lib/queries/financeDashboard/financeResumen.ts\` | 1 | \`'server-only';\` (string literal, **NO-OP**). El import real es \`import 'server-only';\` |
| \`src/features/admin/finance-dashboard/components/FinanceMonthlyControl.tsx\` (client) | 5 | importa \`buildContextualText\` y \`EXPENSE_SUBTYPE_LABELS\` desde \`financeResumen.ts\` |
| \`src/lib/db.ts\` | 6 | accede \`env.DATABASE_URL\` a module-init (cargado por financeResumen) |

**Cadena que reventó:** FinanceMonthlyControl (client) → financeResumen → db → env.DATABASE_URL → t3-env lanza el error en cliente.

**Por qué se exponía ahora**: la cadena era pre-existente. PR #133 (\`PAYROLL_OCR_ENABLED\` con \`.transform()\` en el schema) cambió la firma t3-env y Turbopack dejó de tree-shaker la rama \`db\` de financeResumen para el bundle cliente. La cadena quedó incluida.

**¿Por qué afecta a \`/admin/finanzas/resumen\` aunque OCR esté en nóminas?** porque FinanceMonthlyControl es el componente principal de la página resumen. El OCR no tiene nada que ver — el efecto secundario de PR #133 fue cambiar el tree-shaking de la cadena del resumen.

## Fix mínimo

1. **Nuevo \`financeResumen.shared.ts\`** — tipos, constantes y helpers puros. SIN imports de \`@/lib/db\` ni \`@/lib/env\`. Safe en cliente y servidor.
2. **\`financeResumen.ts\`**:
   - \`'server-only';\` (string literal) → \`import 'server-only';\` (real fail-fast).
   - Re-exporta desde el shared para compat con server callers existentes.
3. **\`FinanceMonthlyControl.tsx\`** y **\`FinanceResumenBlocks.tsx\`** importan de \`financeResumen.shared.ts\` directamente.
4. Test \`finance-resumen.test.ts\` ajustado al shared.

## Regresión-shield

Nuevo test estático **\`src/__tests__/server/client-server-boundary.test.ts\`**:
- Escanea todos los archivos con \`'use client'\` en \`src/\`.
- Falla si encuentra un import de \`@/lib/env\`, \`@/lib/db\`, \`@/lib/auth\` o \`@/lib/auth-guard\`.
- Excepción documentada: \`ConsentedScripts.tsx\` solo accede a \`env.NEXT_PUBLIC_GTM_ID\` (variable client del schema; permitido por el proxy t3-env).
- Test secundario: verifica que \`financeResumen.ts\` tiene el import real \`'server-only'\`.

Si alguien intenta repetir el patrón en otro archivo cliente, este test reventará en CI.

## Confirmaciones

- ✅ \`/admin/finanzas/resumen\` carga tras este fix (cadena cortada).
- ✅ \`/admin/finanzas/herramientas\` no se ve afectado (no usaba ese chain).
- ✅ \`/admin/finanzas/nominas/importar\` no se ve afectado (kill switch sigue intacto).
- ✅ No se tocó OCR, Blob, RBAC, schema, queries DB, \`env.ts\`, ni se crearon facturas.
- ✅ No se hace rollback de PR #133.

## CI

- \`npx tsc --noEmit\` ✅
- \`npm run lint\` ✅
- \`npm test\` ✅ — 93 suites / 1597 tests

## Smoke post-deploy

Por el usuario con sesión admin:
1. \`/admin/finanzas/resumen\` carga sin error en consola.
2. \`/admin/finanzas/herramientas\` carga.
3. \`/admin/finanzas/nominas/importar\` sigue mostrando manual mode (sin OCR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)