### PR TITLE
hotfix(csp): allow 'wasm-unsafe-eval' para que tesseract.js WASM compile

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -11,7 +11,12 @@ const securityHeaders = [
     key: 'Content-Security-Policy',
     value: [
       "default-src 'self'",
-      "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://va.vercel-scripts.com",
+      // 'wasm-unsafe-eval' permite WebAssembly.instantiate() — necesario para el OCR cliente
+      // de nóminas (tesseract.js core). Es el sub-permiso mínimo: NO habilita eval() ni
+      // dynamic code; solo compilación/instanciación de WASM. Ver CSP3 §6.1.
+      // Sin esto, el WASM de tesseract-core lanza:
+      //   "Compiling or instantiating WebAssembly module violates the following CSP directive"
+      "script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://www.googletagmanager.com https://va.vercel-scripts.com",
       "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
       "font-src 'self' https://fonts.gstatic.com",
       "img-src 'self' blob: data: https://*.vercel-storage.com https://www.googletagmanager.com https://*.twitch.tv https://*.jtvnw.net https://img.youtube.com https://*.ytimg.com https://i.imgur.com https:",

--- a/src/__tests__/server/csp-wasm-policy.test.ts
+++ b/src/__tests__/server/csp-wasm-policy.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Auditoría estática del CSP de next.config.ts respecto a WebAssembly + OCR.
+ *
+ * Garantiza que:
+ *   1. script-src incluye 'wasm-unsafe-eval' (necesario para WASM de tesseract.js).
+ *   2. NO se relaja a 'unsafe-eval' (que abriría también eval() de JS).
+ *   3. No se introducen dominios CDN externos para servir worker/core OCR
+ *      (cdn.jsdelivr.net, unpkg.com, tessdata.projectnaptha.com).
+ *
+ * Si alguien futuro añade 'unsafe-eval' o un CDN externo, este test reventará.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const NEXT_CONFIG = path.resolve(__dirname, '..', '..', '..', 'next.config.ts');
+const source = fs.readFileSync(NEXT_CONFIG, 'utf-8');
+
+// Extrae la value del header Content-Security-Policy
+function extractCsp(): string {
+  const match = source.match(/key:\s*['"]Content-Security-Policy['"],\s*value:\s*\[([\s\S]*?)\]\.join/);
+  if (!match || !match[1]) throw new Error('CSP directive not found in next.config.ts');
+  return match[1];
+}
+
+describe('CSP — WASM policy en next.config.ts', () => {
+  const csp = extractCsp();
+
+  it('[1] script-src incluye "wasm-unsafe-eval" (permite WASM.instantiate sin habilitar eval)', () => {
+    // Buscar la línea de script-src con wasm-unsafe-eval
+    const scriptSrcLine = csp.split('\n').find((l) => l.includes('script-src'));
+    expect(scriptSrcLine).toBeDefined();
+    expect(scriptSrcLine).toContain("'wasm-unsafe-eval'");
+  });
+
+  it('[2] script-src NO incluye "unsafe-eval" (sería demasiado permisivo — habilitaría eval/Function)', () => {
+    const scriptSrcLine = csp.split('\n').find((l) => l.includes('script-src')) ?? '';
+    // 'unsafe-eval' como token aislado. 'wasm-unsafe-eval' está OK y debe estar.
+    // Regex: 'unsafe-eval' precedido por espacio y seguido por espacio/comilla — sin 'wasm-' delante.
+    expect(scriptSrcLine).not.toMatch(/(?<!wasm-)'unsafe-eval'/);
+  });
+
+  it('[3] CSP NO permite cdn.jsdelivr.net (worker/core OCR son self-hosted)', () => {
+    expect(csp).not.toMatch(/cdn\.jsdelivr\.net/);
+  });
+
+  it('[3b] CSP NO permite unpkg.com', () => {
+    expect(csp).not.toMatch(/unpkg\.com/);
+  });
+
+  it('[3c] CSP NO permite tessdata.projectnaptha.com', () => {
+    expect(csp).not.toMatch(/tessdata\.projectnaptha\.com/);
+  });
+
+  it('[4] cambio justificado con comment explicativo encima de script-src', () => {
+    // El comentario debe mencionar wasm-unsafe-eval para que futuros mantenedores
+    // entiendan por qué está esa palabra extra en la directiva.
+    expect(source).toMatch(/wasm-unsafe-eval[\s\S]{0,200}WebAssembly|WebAssembly[\s\S]{0,200}wasm-unsafe-eval/);
+  });
+});


### PR DESCRIPTION
## Causa raíz exacta

Tras self-hostear los archivos OCR (PR #136), los assets se descargan correctamente desde \`/tessdata/*\`. Pero al inicializar el WASM core de tesseract.js, el browser lanza:

\`\`\`
WebAssembly.instantiate(): Compiling or instantiating WebAssembly module
violates the following Content Security Policy directive [...] script-src
'self' 'unsafe-inline' https://www.googletagmanager.com https://va.vercel-scripts.com
\`\`\`

El navegador requiere un permiso explícito de CSP para ejecutar WebAssembly. Por defecto, CSP `script-src 'self'` no lo permite.

## Cambio exacto en CSP

\`next.config.ts\` línea 14:

```diff
- "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://va.vercel-scripts.com",
+ "script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://www.googletagmanager.com https://va.vercel-scripts.com",
```

Con comentario explicativo arriba referenciando CSP3 §6.1 y el error que mitiga.

## Por qué `'wasm-unsafe-eval'` y NO `'unsafe-eval'`

| Directiva | Qué habilita | Superficie de ataque |
|---|---|---|
| **`'wasm-unsafe-eval'`** | SOLO `WebAssembly.compile()` / `WebAssembly.instantiate()` | Mínima — sandbox WASM |
| `'unsafe-eval'` | Lo anterior + `eval()`, `Function()`, `setTimeout(string)` | Amplia — XSS amplifier |

**Browser support de `'wasm-unsafe-eval'`** (CSP3):
- Chrome 99+ (abr 2022) ✅
- Edge 99+ (abr 2022) ✅
- Safari 15.4+ (mar 2022) ✅
- Firefox 119+ (oct 2023) ✅

Todos los browsers de los admins están cubiertos. Para el OCR cliente solo necesitamos compilar WASM, no ejecutar string-eval — usamos el permiso mínimo.

## Lo que NO se ha tocado

- ✅ Sin CDNs externos (jsdelivr/unpkg/projectnaptha siguen bloqueados).
- ✅ Sin `'unsafe-eval'` (broader).
- ✅ Sin cambios a `connect-src`, `style-src`, `img-src`, `frame-src`.
- ✅ Sin cambios a OCR server, Blob, RBAC, Finanzas general, DB, schema.

## Tests añadidos (6)

\`src/__tests__/server/csp-wasm-policy.test.ts\`:

| # | Test |
|---|---|
| 1 | script-src incluye `'wasm-unsafe-eval'` |
| 2 | script-src NO incluye `'unsafe-eval'` (regex con lookbehind para distinguirlo de wasm-unsafe-eval) |
| 3a | CSP no contiene `cdn.jsdelivr.net` |
| 3b | CSP no contiene `unpkg.com` |
| 3c | CSP no contiene `tessdata.projectnaptha.com` |
| 4 | El cambio está acompañado de comentario que justifica WebAssembly |

Si alguien futuro añade `'unsafe-eval'` o un CDN externo, el test reventará en CI.

## CI

- \`npx tsc --noEmit\` ✅
- \`npm run lint\` ✅
- \`npm test\` ✅ — 97 suites / 1632 tests

## Smoke esperado post-deploy

1. Subir `NOMINA ELEVATEX FEBRERO 2026.pdf`
2. Pulsar "Autocompletar con OCR"
3. En Console DevTools: cascada completa
   ```
   [ocr] step=tesseract-create-worker
   [ocr] step=tesseract-worker-ready       ← antes fallaba aquí
   [ocr] step=recognize-start { page: 1 }
   [ocr] step=recognize-ok { page: 1, textLength: ... }
   [ocr] step=recognize-start { page: 2 }
   [ocr] step=recognize-ok { page: 2, textLength: ... }
   [ocr] step=parse-ok { rows: 2 }
   [ocr] step=done
   ```
4. Preview con Pablo (1696.55) y Alfonso (1369.00), periodo 2026-02
5. Si falla por otra razón, el bloque "Detalles técnicos para soporte" muestra step+error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)