### PR TITLE
fix(payroll-ocr): parser de periodo tolerante (marzo + variantes)

### DIFF
--- a/src/__tests__/server/parsePayrollOcrText.test.ts
+++ b/src/__tests__/server/parsePayrollOcrText.test.ts
@@ -56,7 +56,7 @@ const PDF_MAR = 'NOMINA ELEVATEX MARZO 2026.pdf';
 
 describe('parsePayrollOcrPage — muestras reales ELEVATEX', () => {
   it('[3] Pablo febrero — extrae todos los campos correctamente', () => {
-    const row = parsePayrollOcrPage(FEB_PABLO, 1, PDF_FEB);
+    const { row } = parsePayrollOcrPage(FEB_PABLO, 1, PDF_FEB);
     expect(row.counterpartyName).toBe('CAMACHO CARRION PABLO');
     expect(row.yearMonth).toBe('2026-02');
     expect(row.netAmount).toBe('1696.55');
@@ -69,7 +69,7 @@ describe('parsePayrollOcrPage — muestras reales ELEVATEX', () => {
   });
 
   it('[4] Alfonso febrero — extrae todos los campos correctamente', () => {
-    const row = parsePayrollOcrPage(FEB_ALFONSO, 2, PDF_FEB);
+    const { row } = parsePayrollOcrPage(FEB_ALFONSO, 2, PDF_FEB);
     expect(row.counterpartyName).toBe('ARIAS EPIFANIO ALFONSO');
     expect(row.yearMonth).toBe('2026-02');
     expect(row.netAmount).toBe('1369.00');
@@ -81,7 +81,7 @@ describe('parsePayrollOcrPage — muestras reales ELEVATEX', () => {
   });
 
   it('[5] Pablo marzo — extrae todos los campos correctamente', () => {
-    const row = parsePayrollOcrPage(MAR_PABLO, 1, PDF_MAR);
+    const { row } = parsePayrollOcrPage(MAR_PABLO, 1, PDF_MAR);
     expect(row.counterpartyName).toBe('CAMACHO CARRION PABLO');
     expect(row.yearMonth).toBe('2026-03');
     expect(row.netAmount).toBe('1696.55');
@@ -92,7 +92,7 @@ describe('parsePayrollOcrPage — muestras reales ELEVATEX', () => {
   });
 
   it('[6] Alfonso marzo — extrae todos los campos correctamente', () => {
-    const row = parsePayrollOcrPage(MAR_ALFONSO, 2, PDF_MAR);
+    const { row } = parsePayrollOcrPage(MAR_ALFONSO, 2, PDF_MAR);
     expect(row.counterpartyName).toBe('ARIAS EPIFANIO ALFONSO');
     expect(row.yearMonth).toBe('2026-03');
     expect(row.netAmount).toBe('1369.00');
@@ -107,7 +107,7 @@ describe('parsePayrollOcrPage — muestras reales ELEVATEX', () => {
 describe('parsePayrollOcrPage — campos obligatorios faltantes', () => {
   it('[7] si falta coste empresa → fila marcada inválida (include=false, warning)', () => {
     const text = FEB_ALFONSO.replace(/COSTE EMPRESA: 1\.369,00\n?/, '');
-    const row = parsePayrollOcrPage(text, 2, PDF_FEB);
+    const { row } = parsePayrollOcrPage(text, 2, PDF_FEB);
     expect(row.include).toBe(false);
     expect(row.warning).toMatch(/coste empresa/i);
     expect(row.netAmount).toBe('0.00');
@@ -115,7 +115,7 @@ describe('parsePayrollOcrPage — campos obligatorios faltantes', () => {
 
   it('[8] si falta trabajador → fila marcada inválida', () => {
     const text = FEB_ALFONSO.replace(/^ARIAS.*\n/m, '');
-    const row = parsePayrollOcrPage(text, 2, PDF_FEB);
+    const { row } = parsePayrollOcrPage(text, 2, PDF_FEB);
     expect(row.include).toBe(false);
     expect(row.warning).toMatch(/trabajador/i);
     expect(row.counterpartyName).toBe('');
@@ -123,7 +123,7 @@ describe('parsePayrollOcrPage — campos obligatorios faltantes', () => {
 
   it('[9] si falta periodo → fila marcada inválida (yearMonth=desconocido)', () => {
     const text = FEB_ALFONSO.replace(/PERIODO.*\n/, '');
-    const row = parsePayrollOcrPage(text, 2, PDF_FEB);
+    const { row } = parsePayrollOcrPage(text, 2, PDF_FEB);
     expect(row.include).toBe(false);
     expect(row.yearMonth).toBe('desconocido');
     expect(row.warning).toMatch(/mes\/año/i);
@@ -134,27 +134,175 @@ describe('parsePayrollOcrPage — campos obligatorios faltantes', () => {
 
 describe('parsePayrollOcrPage — robustez con variantes', () => {
   it('acepta "IRPF" sin puntos y "I.R.P.F." con puntos', () => {
-    const row = parsePayrollOcrPage(FEB_PABLO, 1, PDF_FEB);
+    const { row } = parsePayrollOcrPage(FEB_PABLO, 1, PDF_FEB);
     // IRPF aparece en notas si se detectó algún valor — no es obligatorio
     expect(row.include).toBe(true);
   });
 
   it('acepta diferentes separadores en el periodo (-/ vs espacio)', () => {
     const text = FEB_ALFONSO.replace('01 FEB 26 a 28 FEB 26', '01-FEB-26 AL 28-FEB-26');
-    const row = parsePayrollOcrPage(text, 1, PDF_FEB);
+    const { row } = parsePayrollOcrPage(text, 1, PDF_FEB);
     expect(row.yearMonth).toBe('2026-02');
   });
 
   it('el txId es determinista por (slug, yearMonth) → bloquea duplicados', () => {
-    const a = parsePayrollOcrPage(FEB_PABLO, 1, PDF_FEB);
-    const b = parsePayrollOcrPage(FEB_PABLO, 1, PDF_FEB);
+    const { row: a } = parsePayrollOcrPage(FEB_PABLO, 1, PDF_FEB);
+    const { row: b } = parsePayrollOcrPage(FEB_PABLO, 1, PDF_FEB);
     expect(a.txId).toBe(b.txId);
   });
 
   it('rellena notes con los campos detectados (incluye fileName)', () => {
-    const row = parsePayrollOcrPage(FEB_PABLO, 1, PDF_FEB);
+    const { row } = parsePayrollOcrPage(FEB_PABLO, 1, PDF_FEB);
     expect(row.notes).toContain(PDF_FEB);
     expect(row.notes).toContain('Período: 2026-02');
     expect(row.notes).toContain('OCR navegador');
   });
 });
+
+// ── Tests del fix de marzo: 3 estrategias en cascada ────────────────────────
+
+describe('parsePeriodFromText — estrategias en cascada (fix marzo 2026)', () => {
+  const baseRow = (period: string) => `
+CAMACHO CARRION PABLO
+${period}
+LIQUIDO A PERCIBIR 1.000,00
+COSTE EMPRESA: 1.696,55
+`.trim();
+
+  it('[2] marzo full range "01 MAR 26 a 31 MAR 26" → 2026-03 (no regresión vs. febrero)', () => {
+    const { row, diagnostic } = parsePayrollOcrPage(
+      baseRow('PERIODO 01 MAR 26 a 31 MAR 26'), 1, 'm.pdf',
+    );
+    expect(row.yearMonth).toBe('2026-03');
+    expect(diagnostic.hasPeriod).toBe(true);
+    expect(diagnostic.monthTokenDetected).toBe('MAR');
+    expect(diagnostic.validationMissingFields).toEqual([]);
+  });
+
+  it('[3a] estrategia B: "MAR 26" en contexto PERIODO → 2026-03', () => {
+    const { row, diagnostic } = parsePayrollOcrPage(
+      baseRow('PERIODO MAR 26'), 1, 'm.pdf',
+    );
+    expect(row.yearMonth).toBe('2026-03');
+    expect(diagnostic.monthTokenDetected).toBe('MAR');
+  });
+
+  it('[3b] estrategia B: "MARZO 2026" → 2026-03', () => {
+    const { row, diagnostic } = parsePayrollOcrPage(
+      baseRow('PERIODO MARZO 2026'), 1, 'm.pdf',
+    );
+    expect(row.yearMonth).toBe('2026-03');
+    expect(diagnostic.monthTokenDetected).toBe('MARZO');
+  });
+
+  it('[4a] tolera punto final "MAR." → 2026-03', () => {
+    const { row } = parsePayrollOcrPage(baseRow('PERIODO MAR. 26'), 1, 'm.pdf');
+    expect(row.yearMonth).toBe('2026-03');
+  });
+
+  it('[4b] tolera punto final "MARZO." → 2026-03', () => {
+    const { row } = parsePayrollOcrPage(baseRow('PERIODO MARZO. 2026'), 1, 'm.pdf');
+    expect(row.yearMonth).toBe('2026-03');
+  });
+
+  it('[5] estrategia C: formato narrativo "01 DE MARZO DE 2026" → 2026-03', () => {
+    const { row, diagnostic } = parsePayrollOcrPage(
+      baseRow('FECHA 01 DE MARZO DE 2026'), 1, 'm.pdf',
+    );
+    expect(row.yearMonth).toBe('2026-03');
+    expect(diagnostic.monthTokenDetected).toBe('MARZO');
+  });
+
+  it('[8] todos los meses ENE-DIC se reconocen correctamente (abreviatura y nombre)', () => {
+    const cases: Array<[string, string]> = [
+      ['ENE 26', '2026-01'], ['ENERO 2026',     '2026-01'],
+      ['FEB 26', '2026-02'], ['FEBRERO 2026',   '2026-02'],
+      ['MAR 26', '2026-03'], ['MARZO 2026',     '2026-03'],
+      ['ABR 26', '2026-04'], ['ABRIL 2026',     '2026-04'],
+      ['MAY 26', '2026-05'], ['MAYO 2026',      '2026-05'],
+      ['JUN 26', '2026-06'], ['JUNIO 2026',     '2026-06'],
+      ['JUL 26', '2026-07'], ['JULIO 2026',     '2026-07'],
+      ['AGO 26', '2026-08'], ['AGOSTO 2026',    '2026-08'],
+      ['SEP 26', '2026-09'], ['SEPT 26',        '2026-09'], ['SEPTIEMBRE 2026', '2026-09'],
+      ['OCT 26', '2026-10'], ['OCTUBRE 2026',   '2026-10'],
+      ['NOV 26', '2026-11'], ['NOVIEMBRE 2026', '2026-11'],
+      ['DIC 26', '2026-12'], ['DICIEMBRE 2026', '2026-12'],
+    ];
+    for (const [token, expected] of cases) {
+      const { row } = parsePayrollOcrPage(baseRow(`PERIODO ${token}`), 1, 'p.pdf');
+      expect({ token, got: row.yearMonth }).toEqual({ token, got: expected });
+    }
+  });
+
+  it('[bonus] tolera salto de línea entre fecha inicial y final', () => {
+    const { row } = parsePayrollOcrPage(baseRow('PERIODO 01 MAR 26\na 31 MAR 26'), 1, 'm.pdf');
+    expect(row.yearMonth).toBe('2026-03');
+  });
+});
+
+// ── Tests del diagnostic ────────────────────────────────────────────────────
+
+describe('PayrollOcrRowDiagnostic — metadata segura para logging', () => {
+  it('[6] si falta periodo → diagnostic.validationMissingFields = ["period"]', () => {
+    const text = `
+CAMACHO CARRION PABLO
+LIQUIDO A PERCIBIR 1.000,00
+COSTE EMPRESA: 1.696,55
+`.trim();
+    const { row, diagnostic } = parsePayrollOcrPage(text, 1, 'p.pdf');
+    expect(diagnostic.hasPeriod).toBe(false);
+    expect(diagnostic.monthTokenDetected).toBeNull();
+    expect(diagnostic.validationMissingFields).toEqual(['period']);
+    expect(row.include).toBe(false);
+    expect(row.warning).toMatch(/mes\/año/i);
+  });
+
+  it('[7] si falta nombre → diagnostic.validationMissingFields = ["employee"]', () => {
+    const text = `
+PERIODO 01 MAR 26 a 31 MAR 26
+LIQUIDO A PERCIBIR 1.000,00
+COSTE EMPRESA: 1.696,55
+`.trim();
+    const { row, diagnostic } = parsePayrollOcrPage(text, 1, 'p.pdf');
+    expect(diagnostic.hasEmployeeName).toBe(false);
+    expect(diagnostic.validationMissingFields).toEqual(['employee']);
+    expect(row.include).toBe(false);
+  });
+
+  it('si faltan todos los campos críticos → 3 missingFields', () => {
+    const text = `algun texto OCR irrelevante`;
+    const { diagnostic } = parsePayrollOcrPage(text, 1, 'p.pdf');
+    expect(diagnostic.hasEmployeeName).toBe(false);
+    expect(diagnostic.hasPeriod).toBe(false);
+    expect(diagnostic.hasCostCompany).toBe(false);
+    expect([...diagnostic.validationMissingFields].sort()).toEqual(['costCompany', 'employee', 'period']);
+  });
+
+  it('diagnostic NO incluye texto OCR crudo ni nombres ni importes (solo flags + token)', () => {
+    const { diagnostic } = parsePayrollOcrPage(
+      baseTextFebPablo(), 1, 'p.pdf',
+    );
+    // Verificación defensiva: el shape del diagnostic es solo flags + token + array de strings cortos
+    const keys = Object.keys(diagnostic).sort();
+    expect(keys).toEqual([
+      'hasCostCompany',
+      'hasEmployeeName',
+      'hasPeriod',
+      'monthTokenDetected',
+      'validationMissingFields',
+    ]);
+    // No debe haber strings con nombres ni importes
+    const json = JSON.stringify(diagnostic);
+    expect(json).not.toMatch(/CAMACHO|PABLO|ARIAS|ALFONSO/);
+    expect(json).not.toMatch(/1\.000|1\.696|1\.369/);
+  });
+});
+
+function baseTextFebPablo(): string {
+  return `
+CAMACHO CARRION PABLO
+PERIODO 01 FEB 26 a 28 FEB 26
+LIQUIDO A PERCIBIR 1.000,00
+COSTE EMPRESA: 1.696,55
+`.trim();
+}

--- a/src/features/admin/finance-payroll/client-ocr/parseOcrText.ts
+++ b/src/features/admin/finance-payroll/client-ocr/parseOcrText.ts
@@ -1,31 +1,64 @@
 /**
  * Parser puro de texto OCR extraído de nóminas ELEVATEX.
  *
- * Recibe el texto crudo de UNA página (un trabajador) y devuelve una
- * `PayrollImportRow` lista para mostrar en el preview del wizard.
+ * Recibe el texto crudo de UNA página (un trabajador) y devuelve:
+ *   - `row`: PayrollImportRow lista para el preview del wizard
+ *   - `diagnostic`: metadatos seguros (sin PII) para logging y troubleshooting
  *
  * Importable desde cliente y servidor (sin side-effects, sin imports
  * de env/db/server-only).
  *
  * Mantenido en paralelo con `src/lib/parsers/payrollOcr.ts::ocrTextToPayrollRow`
- * (server) — misma lógica de extracción y misma estructura de retorno.
- *
- * Sin logs con PII: solo retorna estructuras.
+ * (server, hoy en kill-switch detrás de PAYROLL_OCR_ENABLED).
  */
 
 import { normalizeAmount } from '@/lib/finance/payroll/manualRow';
 import type { PayrollImportRow } from '@/lib/finance/payroll/types';
 
-// ── Constantes ──────────────────────────────────────────────────────────────
+// ── Tipos públicos ──────────────────────────────────────────────────────────
 
-const MONTH_MAP: Record<string, number> = {
-  ENE: 1, FEB: 2, MAR: 3, ABR: 4, MAY: 5, JUN: 6,
-  JUL: 7, AGO: 8, SEP: 9, OCT: 10, NOV: 11, DIC: 12,
+export type MissingField = 'employee' | 'period' | 'costCompany';
+
+export type PayrollOcrRowDiagnostic = {
+  readonly hasEmployeeName: boolean;
+  readonly hasPeriod: boolean;
+  readonly hasCostCompany: boolean;
+  /** Token de mes encontrado por el parser (MAR, MARZO, etc.) o null. */
+  readonly monthTokenDetected: string | null;
+  readonly validationMissingFields: readonly MissingField[];
 };
 
-// "01 MAR 26 al 31 MAR 26" o "01-MAR-26 AL 31-MAR-26"
-const PERIOD_RX =
-  /(\d{1,2})[\s\-/]+([A-ZÑ]{3,4})[\s\-/]+(\d{2,4})\s+(?:[Aa][Ll]?)\s+(\d{1,2})[\s\-/]+([A-ZÑ]{3,4})[\s\-/]+(\d{2,4})/;
+export type PayrollOcrParseResult = {
+  readonly row: PayrollImportRow;
+  readonly diagnostic: PayrollOcrRowDiagnostic;
+};
+
+// ── Constantes ──────────────────────────────────────────────────────────────
+
+/**
+ * Mapa de tokens de mes (uppercase) → número de mes (1-12).
+ * Acepta abreviaturas españolas estándar (3-4 chars) y nombres completos.
+ * El parser tolera además punto final ("MAR.") y mayúscula/minúscula.
+ */
+const MONTH_MAP_EXT: Record<string, number> = {
+  ENE: 1,  ENERO: 1,
+  FEB: 2,  FEBRERO: 2,
+  MAR: 3,  MARZO: 3,
+  ABR: 4,  ABRIL: 4,
+  MAY: 5,  MAYO: 5,
+  JUN: 6,  JUNIO: 6,
+  JUL: 7,  JULIO: 7,
+  AGO: 8,  AGOSTO: 8,
+  SEP: 9,  SEPT: 9, SEPTIEMBRE: 9,
+  OCT: 10, OCTUBRE: 10,
+  NOV: 11, NOVIEMBRE: 11,
+  DIC: 12, DICIEMBRE: 12,
+};
+
+// Ordenar tokens por longitud descendente para que el regex matchee
+// "MARZO" antes que "MAR", "SEPTIEMBRE" antes que "SEPT", etc.
+const MONTH_TOKENS_SORTED = Object.keys(MONTH_MAP_EXT).sort((a, b) => b.length - a.length);
+const MONTHS_ALT = MONTH_TOKENS_SORTED.join('|');
 
 const PAYROLL_LABEL_WORDS = new Set([
   'TOTAL', 'DEVENGADO', 'DEDUCCIONES', 'EMPRESA', 'LIQUIDO', 'LÍQUIDO',
@@ -49,15 +82,93 @@ function makePayrollTxId(slug: string, yearMonth: string): string {
   return `payroll:${slug}:${yearMonth}`;
 }
 
-function parsePeriodFromText(text: string): string | null {
-  const upper = text.toUpperCase();
-  const m = PERIOD_RX.exec(upper);
-  if (!m || !m[5] || !m[6]) return null;
-  const endMonth = MONTH_MAP[m[5]];
-  if (!endMonth) return null;
-  const n = parseInt(m[6], 10);
-  const endYear = n < 100 ? 2000 + n : n;
-  return `${endYear}-${String(endMonth).padStart(2, '0')}`;
+function yearFromToken(token: string): number {
+  const n = parseInt(token, 10);
+  return n < 100 ? 2000 + n : n;
+}
+
+/**
+ * Parsea el periodo de la nómina y devuelve { yearMonth, monthToken }.
+ *
+ * Tres estrategias en cascada:
+ *
+ *   A) Rango completo: "01 MAR 26 a 31 MAR 26", "01-MAR-26 AL 31-MAR-26"
+ *      Tolera saltos de línea entre las dos fechas (whitespace normalizado).
+ *
+ *   B) Mes + año: "MAR 26", "MAR. 26", "MARZO 2026", "MARZO.2026"
+ *
+ *   C) Formato narrativo: "01 DE MARZO DE 2026"
+ *
+ * Devuelve { yearMonth: null, monthToken: null } si ninguna estrategia matchea.
+ */
+function parsePeriodFromText(text: string): { yearMonth: string | null; monthToken: string | null } {
+  // Normalizar whitespace (incluye saltos de línea) a espacios simples.
+  // Permite que la estrategia A tolere saltos de línea entre fecha inicial y final.
+  const upper = text.toUpperCase().replace(/\s+/g, ' ');
+
+  // ── Estrategia A: rango completo ──────────────────────────────────────
+  const RANGE_RX = new RegExp(
+    `(\\d{1,2})[\\s\\-/]+(${MONTHS_ALT})\\.?[\\s\\-/]+(\\d{2,4})\\s+(?:[Aa][Ll]?)\\s+(\\d{1,2})[\\s\\-/]+(${MONTHS_ALT})\\.?[\\s\\-/]+(\\d{2,4})`,
+  );
+  const mRange = RANGE_RX.exec(upper);
+  if (mRange && mRange[5] && mRange[6]) {
+    const endMonth = MONTH_MAP_EXT[mRange[5]];
+    if (endMonth) {
+      const year = yearFromToken(mRange[6]);
+      return {
+        yearMonth: `${year}-${String(endMonth).padStart(2, '0')}`,
+        monthToken: mRange[5],
+      };
+    }
+  }
+
+  // ── Estrategia B: mes + año (con o sin punto, abreviatura o nombre) ──
+  // Buscar dentro del contexto "PERIODO ..." si existe para evitar matches falsos
+  // en otras partes del documento.
+  const PERIODO_CONTEXT_RX = new RegExp(
+    `PER[IÍ]ODO[^A-ZÑ\\d]{0,20}(${MONTHS_ALT})\\.?\\s+(?:DE\\s+)?(\\d{2,4})`,
+  );
+  const mPerCtx = PERIODO_CONTEXT_RX.exec(upper);
+  if (mPerCtx && mPerCtx[1] && mPerCtx[2]) {
+    const month = MONTH_MAP_EXT[mPerCtx[1]];
+    if (month) {
+      const year = yearFromToken(mPerCtx[2]);
+      return {
+        yearMonth: `${year}-${String(month).padStart(2, '0')}`,
+        monthToken: mPerCtx[1],
+      };
+    }
+  }
+
+  // También aceptamos "MES MARZO 2026" o equivalente sin "PERIODO" cerca.
+  const SINGLE_RX = new RegExp(`\\b(${MONTHS_ALT})\\.?\\s+(?:DE\\s+)?(\\d{2,4})\\b`);
+  const mSingle = SINGLE_RX.exec(upper);
+  if (mSingle && mSingle[1] && mSingle[2]) {
+    const month = MONTH_MAP_EXT[mSingle[1]];
+    if (month) {
+      const year = yearFromToken(mSingle[2]);
+      return {
+        yearMonth: `${year}-${String(month).padStart(2, '0')}`,
+        monthToken: mSingle[1],
+      };
+    }
+  }
+
+  // ── Estrategia C: formato narrativo "01 DE MARZO DE 2026" ────────────
+  const DE_RX = new RegExp(`\\d{1,2}\\s+DE\\s+(${MONTHS_ALT})\\.?\\s+DE\\s+(\\d{2,4})`);
+  const mDe = DE_RX.exec(upper);
+  if (mDe && mDe[1] && mDe[2]) {
+    const month = MONTH_MAP_EXT[mDe[1]];
+    if (month) {
+      const year = yearFromToken(mDe[2]);
+      return {
+        yearMonth: `${year}-${String(month).padStart(2, '0')}`,
+        monthToken: mDe[1],
+      };
+    }
+  }
+
+  return { yearMonth: null, monthToken: null };
 }
 
 function extractNameFromLines(text: string): string | null {
@@ -83,21 +194,19 @@ function extractNameFromLines(text: string): string | null {
 
 /**
  * Parsea texto OCR de UNA página de nómina ELEVATEX y devuelve una
- * `PayrollImportRow` lista para el preview.
- *
- * Si faltan datos obligatorios (trabajador, periodo, coste empresa)
- * la fila se devuelve igualmente con `include=false` y un `warning`,
- * para que el usuario pueda completarla manualmente en el preview.
+ * `PayrollImportRow` lista para el preview + un objeto `diagnostic` con
+ * metadatos seguros (sin PII) para logging.
  */
 export function parsePayrollOcrPage(
   pageText: string,
   pageNum: number,
   pdfFileName: string,
-): PayrollImportRow {
+): PayrollOcrParseResult {
   const upper = pageText.toUpperCase();
 
   const employeeName = extractNameFromLines(pageText) ?? '';
-  const yearMonth = parsePeriodFromText(upper) ?? 'desconocido';
+  const periodResult = parsePeriodFromText(pageText);
+  const yearMonth = periodResult.yearMonth ?? 'desconocido';
 
   const costoMatch = /COSTE EMPRESA[:\s]+([\d.,]+)/.exec(upper);
   const costoStr = costoMatch?.[1] ? normalizeAmount(costoMatch[1]) : '0.00';
@@ -132,11 +241,19 @@ export function parsePayrollOcrPage(
   noteParts.push('OCR navegador — revisar');
   noteParts.push(`PDF: ${pdfFileName}`);
 
-  const missingRequired = !employeeName || costoStr === '0.00' || yearMonth === 'desconocido';
+  // Validación: campos obligatorios para que la fila sea importable.
+  const hasEmployeeName  = employeeName.length > 0;
+  const hasPeriod        = yearMonth !== 'desconocido';
+  const hasCostCompany   = costoStr !== '0.00';
 
-  return {
+  const validationMissingFields: MissingField[] = [];
+  if (!hasEmployeeName) validationMissingFields.push('employee');
+  if (!hasPeriod)       validationMissingFields.push('period');
+  if (!hasCostCompany)  validationMissingFields.push('costCompany');
+
+  const row: PayrollImportRow = {
     page: pageNum,
-    include: !missingRequired,
+    include: validationMissingFields.length === 0,
     slug,
     yearMonth,
     txId,
@@ -151,6 +268,18 @@ export function parsePayrollOcrPage(
     expenseSubtype: 'nomina_socio',
     status: 'pagada',
     notes: noteParts.join(' | '),
-    warning: missingRequired ? 'OCR: revisar datos (trabajador, mes/año, coste empresa)' : null,
+    warning: validationMissingFields.length > 0
+      ? `OCR: revisar datos (${validationMissingFields.map((f) => f === 'employee' ? 'trabajador' : f === 'period' ? 'mes/año' : 'coste empresa').join(', ')})`
+      : null,
   };
+
+  const diagnostic: PayrollOcrRowDiagnostic = {
+    hasEmployeeName,
+    hasPeriod,
+    hasCostCompany,
+    monthTokenDetected: periodResult.monthToken,
+    validationMissingFields,
+  };
+
+  return { row, diagnostic };
 }

--- a/src/features/admin/finance-payroll/client-ocr/runClientOcr.ts
+++ b/src/features/admin/finance-payroll/client-ocr/runClientOcr.ts
@@ -22,7 +22,7 @@
  * para que el wizard pueda mostrar detalle técnico colapsable.
  */
 
-import { parsePayrollOcrPage } from './parseOcrText';
+import { parsePayrollOcrPage, type PayrollOcrRowDiagnostic } from './parseOcrText';
 import type { PayrollImportRow } from '@/lib/finance/payroll/types';
 
 // ── Paths self-hosted (vía /public/tessdata/) ───────────────────────────────
@@ -168,6 +168,7 @@ export async function runClientOcr({ file, onProgress }: RunClientOcrInput): Pro
     logStep(currentStep);
 
     const rows: PayrollImportRow[] = [];
+    const rowMeta: Array<{ rowIndex: number } & PayrollOcrRowDiagnostic> = [];
     try {
       for (let i = 0; i < canvases.length; i++) {
         const canvas = canvases[i];
@@ -178,11 +179,13 @@ export async function runClientOcr({ file, onProgress }: RunClientOcrInput): Pro
         const { data } = await worker.recognize(canvas);
         const textLength = data.text?.length ?? 0;
         logStep('recognize-ok', { page: i + 1, textLength });
-        const row = parsePayrollOcrPage(data.text, i + 1, file.name);
+        const { row, diagnostic } = parsePayrollOcrPage(data.text, i + 1, file.name);
         rows.push(row);
+        // Solo metadata segura (sin PII): flags booleanos + token de mes + missing fields.
+        rowMeta.push({ rowIndex: i + 1, ...diagnostic });
       }
       currentStep = 'parse-ok';
-      logStep(currentStep, { rows: rows.length });
+      logStep(currentStep, { rows: rows.length, rowMeta });
     } finally {
       await worker.terminate();
     }


### PR DESCRIPTION
## Causa exacta

`parsePeriodFromText()` en `src/features/admin/finance-payroll/client-ocr/parseOcrText.ts` requería el **rango completo** \`01 MAR 26 a 31 MAR 26\` en una sola pasada de regex. Si el OCR de marzo producía cualquier variación (línea cortada, mes incompleto, formato alternativo), retornaba \`null\` → \`yearMonth = 'desconocido'\` → UI mostraba "Filas inválidas" aunque empleado y coste empresa estaban OK (como confirmó el usuario en la captura).

## Por qué febrero funcionaba y marzo no

Tesseract reconoce muy bien tanto MAR como FEB. Pero variaciones de **layout o transición de línea** entre las dos fechas del rango podían romper el regex frágil. Las nóminas siguen el mismo template, pero el OCR puede salir con espaciado distinto entre meses diferentes.

## Fix — 3 estrategias en cascada

`parsePeriodFromText()` ahora prueba 3 estrategias y solo retorna null si las 3 fallan:

### Estrategia A — rango completo
\`01 MAR 26 a 31 MAR 26\` (whitespace normalizado → tolera salto de línea entre fecha inicial y final).

### Estrategia B — mes + año
\`MAR 26\`, \`MARZO 2026\`, \`MAR. 26\`, \`MARZO. 2026\` (con o sin punto, abreviatura o nombre).
Prioriza el contexto \"PERIODO\" si está presente; fallback al primer token de mes encontrado.

### Estrategia C — formato narrativo
\`01 DE MARZO DE 2026\`.

## Ejemplos de formatos soportados ahora

| Input | yearMonth resultante |
|---|---|
| \`01 MAR 26 a 31 MAR 26\` | \`2026-03\` |
| \`MAR 26\` | \`2026-03\` |
| \`MARZO 2026\` | \`2026-03\` |
| \`MAR. 26\` / \`MARZO. 2026\` | \`2026-03\` |
| \`01 DE MARZO DE 2026\` | \`2026-03\` |
| \`01 MAR 26\n a 31 MAR 26\` (salto de línea) | \`2026-03\` |
| Los 12 meses (ENE-DIC) en abreviatura O nombre completo | correcto cada uno |

## Diagnóstico seguro (logging sin PII)

Nuevo retorno de \`parsePayrollOcrPage\`: \`{ row, diagnostic }\`. El \`diagnostic\` contiene solo metadatos:

\`\`\`
{
  hasEmployeeName: boolean,
  hasPeriod: boolean,
  hasCostCompany: boolean,
  monthTokenDetected: \"MAR\" | \"MARZO\" | null,
  validationMissingFields: (\"employee\" | \"period\" | \"costCompany\")[]
}
\`\`\`

\`runClientOcr\` lo loggea en el step \`parse-ok\`:

\`\`\`
[ocr] step=parse-ok {
  rows: 2,
  rowMeta: [
    { rowIndex: 1, hasEmployeeName: true, hasPeriod: true, hasCostCompany: true, monthTokenDetected: \"MAR\", validationMissingFields: [] },
    { rowIndex: 2, hasEmployeeName: true, hasPeriod: true, hasCostCompany: true, monthTokenDetected: \"MAR\", validationMissingFields: [] }
  ]
}
\`\`\`

**Nunca** se loggea texto OCR crudo, nombres, importes ni DNI. Test estático defensivo verifica que el JSON del diagnostic no contiene ningún de esos tokens.

El \`warning\` del row ahora también detalla qué falta: \"OCR: revisar datos (mes/año)\" / \"(trabajador, mes/año)\".

## Archivos tocados (3)

| Path | Cambio |
|---|---|
| \`src/features/admin/finance-payroll/client-ocr/parseOcrText.ts\` | Reescribe \`parsePeriodFromText\` con 3 estrategias + MONTH_MAP_EXT extendido. Nuevo retorno \`{ row, diagnostic }\`. |
| \`src/features/admin/finance-payroll/client-ocr/runClientOcr.ts\` | Loggea \`rowMeta\` en \`parse-ok\` step. |
| \`src/__tests__/server/parsePayrollOcrText.test.ts\` | Adapta tests existentes al nuevo retorno + añade 12 tests nuevos. |

## Tests añadidos (12)

| # | Test | Cobertura |
|---|---|---|
| 2 | marzo full range (no regresión vs. febrero) | ✅ |
| 3a-b | estrategia B con MAR/MARZO | ✅ |
| 4a-b | tolera punto final (MAR./MARZO.) | ✅ |
| 5 | estrategia C: narrativo \"01 DE MARZO DE 2026\" | ✅ |
| 8 | 12 meses ENE-DIC con abreviatura y nombre completo + SEPT | ✅ |
| bonus | salto de línea entre fecha inicial y final | ✅ |
| 6 | diagnostic correcto cuando falta periodo | ✅ |
| 7 | diagnostic correcto cuando falta nombre | ✅ |
| extra | diagnostic con 3 campos faltantes simultáneos | ✅ |
| defensivo | diagnostic NO contiene texto OCR ni nombres ni importes | ✅ |

## Confirmaciones

- ✅ **Febrero NO rompe** (los 4 tests existentes de Pablo/Alfonso febrero pasan)
- ✅ **Marzo parsea \`2026-03\`** (los 2 tests existentes de Pablo/Alfonso marzo pasan)
- ✅ Sin tocar Tesseract, CSP, \`/tessdata\`, OCR server, Blob, RBAC, Finanzas general, Schema, DB, Facturas, Google Sheets cron.

## CI

- \`npx tsc --noEmit\` ✅
- \`npm run lint\` ✅
- \`npm test\` ✅ — 100 suites / **1664 tests**

🤖 Generated with [Claude Code](https://claude.com/claude-code)