### PR TITLE
fix(audit): quick wins P1-03, P2-06, P3-03 (sin tocar DB/schema)

### DIFF
--- a/src/__tests__/server/audit-quick-wins.test.ts
+++ b/src/__tests__/server/audit-quick-wins.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Tests estáticos para los quick wins aprobados de la auditoría 2026-06-30.
+ *
+ * Cubren:
+ *   - P1-03: JSON-LD logo de marca usa URL absoluta (no relativa al proxy)
+ *   - P2-06: campanas/page.tsx ya no usa array hardcoded de roles
+ *   - P3-03: OG image de giveaway muestra /codigos (no /giveaways legacy)
+ *
+ * P1-01 (redirects EN) NO se modifica porque las páginas EN se sirven en
+ * /talents, /services, /contact via route group (en)/ — los redirects
+ * /en/talents → /talents son correctos.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const PROJECT_ROOT = path.resolve(__dirname, '..', '..', '..');
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(PROJECT_ROOT, rel), 'utf-8');
+}
+
+describe('Quick wins auditoría — verificación estática', () => {
+  // ── P1-03 ────────────────────────────────────────────────────────────────
+
+  describe('[P1-03] marcas/[brandSlug] JSON-LD usa URL absoluta para logo', () => {
+    const src = read('src/app/marcas/[brandSlug]/page.tsx');
+
+    it('envuelve brand.logoUrl con absoluteUrl() o detecta http:// para preservar absolutas', () => {
+      // El bloque debe contener una expresión que normalice la URL antes de pasarla al schema.
+      // Patrón aceptado: brand.logoUrl.startsWith('http') ? brand.logoUrl : absoluteUrl(brand.logoUrl)
+      expect(src).toMatch(/brand\.logoUrl\.startsWith\(['"]http['"]\)\s*\?\s*brand\.logoUrl\s*:\s*absoluteUrl\(\s*brand\.logoUrl\s*\)/);
+    });
+
+    it('NO contiene el patrón legacy "url: brand.logoUrl" sin normalizar', () => {
+      // Match exacto del patrón antiguo: "url: brand.logoUrl }"
+      expect(src).not.toMatch(/url:\s*brand\.logoUrl\s*\}/);
+    });
+  });
+
+  // ── P2-06 ────────────────────────────────────────────────────────────────
+
+  describe('[P2-06] admin/campanas/page.tsx usa ASSIGNABLE_TEAM_ROLES', () => {
+    const src = read('src/app/admin/(dashboard)/campanas/page.tsx');
+
+    it('importa ASSIGNABLE_TEAM_ROLES desde @/lib/team-roles', () => {
+      expect(src).toMatch(/from\s+['"]@\/lib\/team-roles['"]/);
+      expect(src).toMatch(/\bASSIGNABLE_TEAM_ROLES\b/);
+    });
+
+    it('NO contiene el array hardcoded de roles', () => {
+      expect(src).not.toMatch(/\[\s*['"]admin['"]\s*,\s*['"]admin_limited_tasks['"]\s*,\s*['"]manager['"]\s*,\s*['"]staff['"]\s*\]/);
+    });
+  });
+
+  // ── P3-03 ────────────────────────────────────────────────────────────────
+
+  describe('[P3-03] OG image de giveaway usa /codigos (no /giveaways)', () => {
+    const src = read('src/app/api/og-image/giveaway/route.tsx');
+
+    it('el footer renderiza "socialpro.es/codigos"', () => {
+      expect(src).toMatch(/socialpro\.es\/codigos/);
+    });
+
+    it('NO contiene la URL legacy "socialpro.es/giveaways" en el footer del template visual', () => {
+      // El nombre "giveaways" puede aparecer en la consulta SQL (FROM giveaways g) y
+      // está permitido. Solo verificamos que NO esté en el template visual del footer.
+      const footerSection = /padding:\s*['"]0 72px 24px 80px['"][\s\S]{0,800}/.exec(src);
+      expect(footerSection).toBeTruthy();
+      const footerText = footerSection?.[0] ?? '';
+      expect(footerText).not.toMatch(/socialpro\.es\/giveaways/);
+    });
+  });
+});

--- a/src/app/admin/(dashboard)/campanas/page.tsx
+++ b/src/app/admin/(dashboard)/campanas/page.tsx
@@ -3,6 +3,7 @@ import { user as userTable } from '@/db/schema';
 import { inArray } from 'drizzle-orm';
 
 import { requirePermission } from '@/lib/permissions';
+import { ASSIGNABLE_TEAM_ROLES } from '@/lib/team-roles';
 import { listCampaigns } from '@/lib/queries/campaigns';
 import { listCrmBrands, getBrandContacts } from '@/lib/queries/crmBrands';
 import { getAllTalents } from '@/lib/queries/talents';
@@ -25,7 +26,7 @@ export default async function AdminCampanasPage(): Promise<React.ReactElement> {
     db
       .select({ id: userTable.id, name: userTable.name })
       .from(userTable)
-      .where(inArray(userTable.role, ['admin', 'admin_limited_tasks', 'manager', 'staff']))
+      .where(inArray(userTable.role, [...ASSIGNABLE_TEAM_ROLES]))
       .orderBy(userTable.name),
     getUsdEurRate(),
   ]);

--- a/src/app/api/og-image/giveaway/route.tsx
+++ b/src/app/api/og-image/giveaway/route.tsx
@@ -142,7 +142,7 @@ export async function GET(req: Request) {
           {/* Footer */}
           <div style={{ padding: '0 72px 24px 80px', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
             <div style={{ fontSize: 12, color: 'rgba(255,255,255,0.18)', letterSpacing: 2 }}>
-              {`socialpro.es/giveaways${talentSlug ? ` · ${talentSlug}` : ''}`}
+              {`socialpro.es/codigos${talentSlug ? ` · ${talentSlug}` : ''}`}
             </div>
             <div style={{ fontSize: 11, color: 'rgba(255,255,255,0.12)', letterSpacing: 3, fontWeight: 700, textTransform: 'uppercase' }}>
               SocialPro

--- a/src/app/marcas/[brandSlug]/page.tsx
+++ b/src/app/marcas/[brandSlug]/page.tsx
@@ -90,7 +90,11 @@ export default async function BrandPage({ params }: PageProps) {
     name: brand.name,
     url: brand.officialUrl,
     description: (brand.description.split('\n\n')[0] ?? '').slice(0, 300),
-    ...(brand.logoUrl ? { logo: { '@type': 'ImageObject', url: brand.logoUrl } } : {}),
+    // logoUrl puede ser absoluta (Blob legacy) o relativa al proxy /api/brand-logo/[id].
+    // Google necesita URL absoluta en JSON-LD para crawlear y mostrar el logo en SERP.
+    ...(brand.logoUrl
+      ? { logo: { '@type': 'ImageObject', url: brand.logoUrl.startsWith('http') ? brand.logoUrl : absoluteUrl(brand.logoUrl) } }
+      : {}),
     knowsAbout: categoryTopics[brand.category] ?? categoryTopics.otros,
     subjectOf: {
       '@type': 'WebPage',


### PR DESCRIPTION
## Resumen

3 quick wins aprobados de la auditoría del 2026-06-30. Cero DB/schema/migration. Tests estáticos de regresión añadidos.

**P1-01 (redirects EN) NO se aplica** — falso positivo del agent. Las páginas EN se sirven en \`/talents\`, \`/services\`, \`/contact\` via route group \`src/app/(en)/\` (los paréntesis no añaden segmento URL en Next.js). Los redirects \`/en/talents → /talents\` actuales son correctos. **No tocado.**

## Cambios

### P1-03 — JSON-LD logo de marca con URL absoluta
**Archivo:** \`src/app/marcas/[brandSlug]/page.tsx:93\`

\`brand.logoUrl\` puede ser absoluta a Blob (filas legacy pre-#131) o relativa al proxy \`/api/brand-logo/{id}\` (filas nuevas post-#131). Google requiere absoluta en JSON-LD para crawlear y mostrar el logo en SERP.

\`\`\`diff
- ...(brand.logoUrl ? { logo: { '@type': 'ImageObject', url: brand.logoUrl } } : {}),
+ ...(brand.logoUrl
+   ? { logo: { '@type': 'ImageObject', url: brand.logoUrl.startsWith('http') ? brand.logoUrl : absoluteUrl(brand.logoUrl) } }
+   : {}),
\`\`\`

### P2-06 — Hardcoded role array → ASSIGNABLE_TEAM_ROLES
**Archivo:** \`src/app/admin/(dashboard)/campanas/page.tsx:28\`

Alineado con el patrón centralizado en PR #129.

\`\`\`diff
+ import { ASSIGNABLE_TEAM_ROLES } from '@/lib/team-roles';
...
- .where(inArray(userTable.role, ['admin', 'admin_limited_tasks', 'manager', 'staff']))
+ .where(inArray(userTable.role, [...ASSIGNABLE_TEAM_ROLES]))
\`\`\`

### P3-03 — Footer OG image: /giveaways → /codigos
**Archivo:** \`src/app/api/og-image/giveaway/route.tsx:145\`

La ruta \`/giveaways\` fue renombrada a \`/codigos\` el 2026-06-04 con redirect 301. El template del OG image seguía mostrando la URL legacy en el footer.

\`\`\`diff
- {`socialpro.es/giveaways${talentSlug ? ` · ${talentSlug}` : ''}`}
+ {`socialpro.es/codigos${talentSlug ? ` · ${talentSlug}` : ''}`}
\`\`\`

## Archivos tocados (4)

| Path | Cambio |
|---|---|
| \`src/app/marcas/[brandSlug]/page.tsx\` | P1-03 (4 líneas) |
| \`src/app/admin/(dashboard)/campanas/page.tsx\` | P2-06 (2 líneas: import + array) |
| \`src/app/api/og-image/giveaway/route.tsx\` | P3-03 (1 línea) |
| \`src/__tests__/server/audit-quick-wins.test.ts\` | **nuevo** — 6 tests estáticos |

## Confirmaciones

- ✅ **No se tocó DB, schema ni migrations** (cero archivos drizzle en el diff).
- ✅ No tocado: proxy de PDFs de facturas, OCR, Blob (uploads), Google Sheets cron, CSP, RBAC, Finanzas, Facturación, talent form, error.tsx global, dedup de entregables, ni nada fuera del scope aprobado.

## Tests añadidos (6)

| # | Test |
|---|---|
| 1 | P1-03: JSON-LD usa patrón \`startsWith('http') ? ... : absoluteUrl(...)\` |
| 2 | P1-03: ya no contiene \`url: brand.logoUrl }\` legacy |
| 3 | P2-06: importa \`ASSIGNABLE_TEAM_ROLES\` |
| 4 | P2-06: no contiene array hardcoded de roles |
| 5 | P3-03: footer renderiza \`/codigos\` |
| 6 | P3-03: footer NO contiene \`/giveaways\` legacy (solo permite el match en SQL \`FROM giveaways g\`) |

## CI

- \`npx tsc --noEmit\` ✅
- \`npm run lint\` ✅
- \`npm test\` ✅ — 101 suites / 1670 tests

## Validación manual post-deploy

| Ruta | Qué verificar |
|---|---|
| \`/en/talents\`, \`/en/services\`, \`/en/contact\` | 308 → \`/talents\`, \`/services\`, \`/contact\` (sin cambios — comportamiento existente) |
| \`/marcas/[brandSlug]\` | View source, buscar \`<script type=\"application/ld+json\">\`. El \`logo.url\` debe ser absoluta (\`https://socialpro.es/...\` o \`https://*.vercel-storage.com/...\`). Validar con Google Rich Results Test si quieres. |
| OG image giveaway | Inspeccionar URL tipo \`/api/og-image/giveaway?...\` en navegador o vía \`debug.html\`. Footer debe decir \`socialpro.es/codigos\`. Las redes sociales pueden tardar en repurgar su caché OG. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)