### PR TITLE
fix(audit): UX Finanzas — labels humanos + claridad visual

### DIFF
--- a/src/__tests__/server/audit-finanzas-ux.test.ts
+++ b/src/__tests__/server/audit-finanzas-ux.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests defensivos para la mejora de UX de Finanzas (2026-06-30).
+ *
+ * Cubren:
+ *   1-4. /pl/page.tsx + PnLOverviewCards no contienen strings técnicos.
+ *   5.   EXPENSE_SUBTYPE_LABELS traduce los 17 subtipos sin tokens snake_case.
+ *   6.   nomina_socio → "Nóminas socios".
+ *   7.   FinanceMonthlyControl calcula y muestra % por categoría.
+ *   8.   GastosPageClient calcula importe total por tab.
+ *   9.   NaN%/Infinity% no se renderiza si total = 0.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { EXPENSE_SUBTYPE_LABELS } from '@/lib/queries/financeDashboard/financeResumen.shared';
+
+const PROJECT_ROOT = path.resolve(__dirname, '..', '..', '..');
+const read = (rel: string): string => fs.readFileSync(path.join(PROJECT_ROOT, rel), 'utf-8');
+
+// ── 1-4. Strings técnicos eliminados ────────────────────────────────────────
+
+describe('Finanzas UX — strings técnicos eliminados', () => {
+  const TECH_STRINGS = [
+    'campaign_direct',
+    'operational + legacy',
+    'invoice_payments',
+    'base devengado',
+  ];
+
+  it('[1] /admin/finanzas/pl/page.tsx no contiene strings técnicos en JSX', () => {
+    const src = read('src/app/admin/(dashboard)/finanzas/pl/page.tsx');
+    for (const s of TECH_STRINGS) {
+      expect(src).not.toContain(s);
+    }
+  });
+
+  it('[2] PnLOverviewCards.tsx usa labels humanos', () => {
+    const src = read('src/features/admin/pnl/components/PnLOverviewCards.tsx');
+    // Label modernizado: "Ingresos del periodo" (era "Ingresos devengados")
+    expect(src).toContain('Ingresos del periodo');
+    expect(src).not.toContain('Ingresos devengados');
+    // Hint humanizado
+    expect(src).toContain('Por fecha de factura');
+    expect(src).toContain('Incluido en gastos');
+    expect(src).toContain('Ingresos − pagos a creadores');
+    expect(src).toContain('Ingresos menos gastos');
+    // Labels técnicos antiguos eliminados
+    expect(src).not.toContain('Subset de gastos');
+    expect(src).not.toContain('Sobre campañas');
+    expect(src).not.toContain('Resultado operativo');
+  });
+
+  it('[3] /pl/page.tsx contiene subtítulos humanos en sus 4 cards', () => {
+    const src = read('src/app/admin/(dashboard)/finanzas/pl/page.tsx');
+    expect(src).toContain('Gastos directos de campaña');
+    expect(src).toContain('Software, gestoría, impuestos, nóminas y marketing');
+    expect(src).toContain('Cobros conciliados del año');
+    expect(src).toContain('Pagos conciliados del año');
+  });
+
+  it('[4] header del /pl es humanizado', () => {
+    const src = read('src/app/admin/(dashboard)/finanzas/pl/page.tsx');
+    expect(src).toContain('Resultado del periodo');
+    expect(src).toContain('cobros y pagos conciliados');
+  });
+});
+
+// ── 5-6. EXPENSE_SUBTYPE_LABELS ──────────────────────────────────────────────
+
+describe('EXPENSE_SUBTYPE_LABELS — labels humanos sin snake_case', () => {
+  it('[5] ningún valor del mapa contiene snake_case visible (token_underscore)', () => {
+    for (const [key, label] of Object.entries(EXPENSE_SUBTYPE_LABELS)) {
+      // un label humano no debe contener guion-bajo ni el propio key
+      expect({ key, label }).toEqual({ key, label });
+      expect(label).not.toMatch(/[a-z]_[a-z]/);
+    }
+  });
+
+  it('[6] nomina_socio → "Nóminas socios"', () => {
+    expect(EXPENSE_SUBTYPE_LABELS.nomina_socio).toBe('Nóminas socios');
+  });
+
+  it('cubre los 17 subtipos del enum de DB', () => {
+    const EXPECTED_KEYS = [
+      'pago_talento', 'coste_produccion', 'comision_plataforma', 'otros_campana',
+      'suscripcion_software', 'herramienta_ia', 'gestoria', 'fiscal_impuestos',
+      'cuota_autonomo', 'marketing_publicidad', 'comision_bancaria', 'ajuste_fiscal',
+      'gasto_general', 'factura_autonomo', 'nomina_socio', 'seguro_medico',
+      'seguridad_social',
+    ];
+    for (const k of EXPECTED_KEYS) {
+      expect(EXPENSE_SUBTYPE_LABELS[k]).toBeDefined();
+      expect(EXPENSE_SUBTYPE_LABELS[k]?.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ── 7. % por categoría en Control mensual ───────────────────────────────────
+
+describe('FinanceMonthlyControl — % por categoría', () => {
+  const src = read('src/features/admin/finance-dashboard/components/FinanceMonthlyControl.tsx');
+
+  it('[7] calcula porcentaje por categoría y lo renderiza junto al importe', () => {
+    // Debe haber un cálculo del tipo (item.amount / breakdownTotal) * 100
+    expect(src).toMatch(/item\.amount\s*\/\s*breakdownTotal\s*\)\s*\*\s*100/);
+    // Y debe renderizarse en el JSX (pctLabel + tabla)
+    expect(src).toMatch(/pctLabel/);
+    // Y el carácter "·" separador en la línea de importe (junto a pctLabel)
+    expect(src).toMatch(/EUR\.format\(item\.amount\)[\s\S]{0,200}·\s*\{pctLabel\}/);
+  });
+
+  it('[9] guard contra NaN/Infinity: si breakdownTotal = 0 → "0%"', () => {
+    expect(src).toMatch(/breakdownTotal\s*>\s*0\s*\?\s*\(item\.amount/);
+    expect(src).toMatch(/Number\.isFinite\(pct\)/);
+  });
+});
+
+// ── 8. Total por tab en Gastos ──────────────────────────────────────────────
+
+describe('GastosPageClient — importe total por tab', () => {
+  const src = read('src/app/admin/(dashboard)/finanzas/gastos/GastosPageClient.tsx');
+
+  it('[8] calcula la suma de totalAmount por cada tab', () => {
+    expect(src).toMatch(/function\s+sumTotalAmount\(/);
+    expect(src).toMatch(/Number\(r\.totalAmount\)/);
+    // El cálculo debe aplicarse a los tres arrays
+    expect(src).toMatch(/totalDirectos\s*=\s*sumTotalAmount\(directos\)/);
+    expect(src).toMatch(/totalOperativos\s*=\s*sumTotalAmount\(operativos\)/);
+    expect(src).toMatch(/totalSinClasif\s*=\s*sumTotalAmount\(sinClasificar\)/);
+  });
+
+  it('el importe se renderiza junto al contador (no debajo, no como tooltip)', () => {
+    // Debe aparecer el separador "·" + EUR0.format(total) en el JSX del botón
+    expect(src).toMatch(/EUR0\.format\(total\)/);
+    expect(src).toMatch(/·\s+\{EUR0\.format/);
+  });
+});

--- a/src/app/admin/(dashboard)/finanzas/gastos/GastosPageClient.tsx
+++ b/src/app/admin/(dashboard)/finanzas/gastos/GastosPageClient.tsx
@@ -13,8 +13,24 @@ type Props = {
 const TABS = ['Directos', 'Operativos', 'Sin clasificar'] as const;
 type TabName = (typeof TABS)[number];
 
+// Formateador local — sin importar nada nuevo.
+const EUR0 = new Intl.NumberFormat('es-ES', { style: 'currency', currency: 'EUR', maximumFractionDigits: 0 });
+
+function sumTotalAmount(rows: readonly InvoiceWithRelations[]): number {
+  let s = 0;
+  for (const r of rows) {
+    const n = Number(r.totalAmount);
+    if (Number.isFinite(n)) s += n;
+  }
+  return s;
+}
+
 export function GastosPageClient({ directos, operativos, sinClasificar }: Props): React.ReactElement {
   const [active, setActive] = useState<TabName>('Directos');
+
+  const totalDirectos     = sumTotalAmount(directos);
+  const totalOperativos   = sumTotalAmount(operativos);
+  const totalSinClasif    = sumTotalAmount(sinClasificar);
 
   return (
     <div className="space-y-4">
@@ -24,6 +40,10 @@ export function GastosPageClient({ directos, operativos, sinClasificar }: Props)
             tab === 'Directos' ? directos.length
             : tab === 'Operativos' ? operativos.length
             : sinClasificar.length;
+          const total =
+            tab === 'Directos' ? totalDirectos
+            : tab === 'Operativos' ? totalOperativos
+            : totalSinClasif;
           const isActive = active === tab;
           return (
             <button
@@ -38,15 +58,20 @@ export function GastosPageClient({ directos, operativos, sinClasificar }: Props)
             >
               {tab}
               {count > 0 && (
-                <span
-                  className={`ml-1.5 rounded px-1 py-0.5 text-[10px] font-semibold ${
-                    tab === 'Sin clasificar'
-                      ? 'bg-amber-500/15 text-amber-400'
-                      : 'bg-sp-admin-border text-sp-admin-muted'
-                  }`}
-                >
-                  {count}
-                </span>
+                <>
+                  <span
+                    className={`ml-1.5 rounded px-1 py-0.5 text-[10px] font-semibold ${
+                      tab === 'Sin clasificar'
+                        ? 'bg-amber-500/15 text-amber-400'
+                        : 'bg-sp-admin-border text-sp-admin-muted'
+                    }`}
+                  >
+                    {count}
+                  </span>
+                  <span className="ml-1.5 tabular-nums text-[10px] text-sp-admin-muted">
+                    · {EUR0.format(total)}
+                  </span>
+                </>
               )}
             </button>
           );

--- a/src/app/admin/(dashboard)/finanzas/pl/page.tsx
+++ b/src/app/admin/(dashboard)/finanzas/pl/page.tsx
@@ -57,7 +57,7 @@ export default async function FinanzasPnLPage({ searchParams }: PageProps): Prom
       <div className="flex flex-wrap items-end justify-between gap-4">
         <div>
           <h1 className="font-display text-4xl font-black uppercase text-sp-admin-text">Resultados</h1>
-          <p className="text-sm text-sp-admin-muted">Resultado financiero — base devengado. Caja YTD vía invoice_payments.</p>
+          <p className="text-sm text-sp-admin-muted">Resultado del periodo. Importes por fecha de factura/gasto. Caja muestra cobros y pagos conciliados.</p>
         </div>
       </div>
 
@@ -78,12 +78,12 @@ export default async function FinanzasPnLPage({ searchParams }: PageProps): Prom
         <div className="rounded-xl border border-sp-admin-border bg-sp-admin-card p-4">
           <p className="text-[10px] font-semibold uppercase tracking-widest text-sp-admin-muted">Costes directos</p>
           <p className="mt-2 text-xl font-bold text-red-400">{EUR.format(pnl.gastosCampanaDirect)}</p>
-          <p className="text-[10px] text-sp-admin-muted mt-0.5">campaign_direct</p>
+          <p className="text-[10px] text-sp-admin-muted mt-0.5">Gastos directos de campaña</p>
         </div>
         <div className="rounded-xl border border-sp-admin-border bg-sp-admin-card p-4">
           <p className="text-[10px] font-semibold uppercase tracking-widest text-sp-admin-muted">Gastos operativos</p>
           <p className="mt-2 text-xl font-bold text-amber-400">{EUR.format(pnl.gastosOperativos)}</p>
-          <p className="text-[10px] text-sp-admin-muted mt-0.5">operational + legacy</p>
+          <p className="text-[10px] text-sp-admin-muted mt-0.5">Software, gestoría, impuestos, nóminas y marketing</p>
         </div>
         {pnl.gastosNoClasificados > 0 && (
           <div className="rounded-xl border border-amber-500/30 bg-amber-500/5 p-4">
@@ -99,12 +99,12 @@ export default async function FinanzasPnLPage({ searchParams }: PageProps): Prom
         <div className="rounded-xl border border-sp-admin-border bg-sp-admin-card p-4">
           <p className="text-[10px] font-semibold uppercase tracking-widest text-sp-admin-muted">Cobrado YTD (caja)</p>
           <p className="mt-2 text-xl font-bold text-emerald-400">{EUR.format(pnl.cobradoYTD)}</p>
-          <p className="text-[10px] text-sp-admin-muted mt-0.5">invoice_payments — ingresos</p>
+          <p className="text-[10px] text-sp-admin-muted mt-0.5">Cobros conciliados del año</p>
         </div>
         <div className="rounded-xl border border-sp-admin-border bg-sp-admin-card p-4">
           <p className="text-[10px] font-semibold uppercase tracking-widest text-sp-admin-muted">Pagado YTD (caja)</p>
           <p className="mt-2 text-xl font-bold text-red-400">{EUR.format(pnl.pagadoYTD)}</p>
-          <p className="text-[10px] text-sp-admin-muted mt-0.5">invoice_payments — gastos</p>
+          <p className="text-[10px] text-sp-admin-muted mt-0.5">Pagos conciliados del año</p>
         </div>
       </div>
 

--- a/src/features/admin/finance-dashboard/components/FinanceMonthlyControl.tsx
+++ b/src/features/admin/finance-dashboard/components/FinanceMonthlyControl.tsx
@@ -187,11 +187,14 @@ export function FinanceMonthlyControl({ mes, flow, stock, breakdown, docs }: Pro
           <div className="space-y-3">
             {breakdown.map((item) => {
               const pct = breakdownTotal > 0 ? (item.amount / breakdownTotal) * 100 : 0;
+              const pctLabel = Number.isFinite(pct) ? `${pct.toFixed(0)}%` : '0%';
               return (
                 <div key={item.subtype ?? 'null'}>
                   <div className="mb-1 flex items-baseline justify-between gap-3">
                     <span className="text-sm text-sp-admin-fg">{item.label}</span>
-                    <span className="tabular-nums text-sm text-red-400">{EUR.format(item.amount)}</span>
+                    <span className="tabular-nums text-sm text-red-400">
+                      {EUR.format(item.amount)} <span className="text-sp-admin-muted">· {pctLabel}</span>
+                    </span>
                   </div>
                   <div className="h-1.5 w-full overflow-hidden rounded-full bg-sp-admin-border">
                     <div

--- a/src/features/admin/pnl/components/PnLOverviewCards.tsx
+++ b/src/features/admin/pnl/components/PnLOverviewCards.tsx
@@ -42,11 +42,11 @@ export function PnLOverviewCards({ pnl }: Props): React.ReactElement {
   const margenTone = pnl.margenBruto >= 0 ? 'positive' : 'danger';
   return (
     <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
-      <Card label="Ingresos devengados" value={pnl.ingresos} tone="positive" />
-      <Card label="Gastos totales" value={pnl.gastos} tone="warning" />
-      <Card label="Pagos a creadores" value={pnl.pagosCreadores} tone="warning" hint="Subset de gastos" />
-      <Card label="Margen campañas" value={pnl.comisionAgencia} tone={pnl.comisionAgencia >= 0 ? 'positive' : 'danger'} hint="Sobre campañas" />
-      <Card label="Resultado operativo" value={pnl.margenBruto} tone={margenTone} hint="Ingresos − gastos" />
+      <Card label="Ingresos del periodo" value={pnl.ingresos} tone="positive" hint="Por fecha de factura" />
+      <Card label="Gastos totales" value={pnl.gastos} tone="warning" hint="Por fecha de factura/gasto" />
+      <Card label="Pagos a creadores" value={pnl.pagosCreadores} tone="warning" hint="Incluido en gastos" />
+      <Card label="Margen sobre campañas" value={pnl.comisionAgencia} tone={pnl.comisionAgencia >= 0 ? 'positive' : 'danger'} hint="Ingresos − pagos a creadores" />
+      <Card label="Resultado del periodo" value={pnl.margenBruto} tone={margenTone} hint="Ingresos menos gastos" />
       <Card label="Margen %" value={pnl.margenPct} tone={margenTone} hint="Sobre ingresos totales" formatAs="percent" />
       <Card label="Pendiente cobro" value={pnl.pendienteCobro} tone={pnl.pendienteCobro > 0 ? 'warning' : 'neutral'} />
       <Card label="Pendiente pago" value={pnl.pendientePago} tone={pnl.pendientePago > 0 ? 'warning' : 'neutral'} />

--- a/src/lib/queries/financeDashboard/financeResumen.shared.ts
+++ b/src/lib/queries/financeDashboard/financeResumen.shared.ts
@@ -80,7 +80,7 @@ export const EXPENSE_SUBTYPE_LABELS: Record<string, string> = {
   ajuste_fiscal: 'Ajuste fiscal',
   gasto_general: 'Gasto general',
   factura_autonomo: 'Factura autónomo',
-  nomina_socio: 'Nóminas',
+  nomina_socio: 'Nóminas socios',
   seguro_medico: 'Seguro médico',
   seguridad_social: 'Seguridad Social',
 };


### PR DESCRIPTION
## Scope

Solo cambios de presentación. **Sin tocar queries, DB, schema, ni cálculos contables.** Las queries devuelven los datos correctos; el problema era strings técnicos hardcoded en JSX y labels poco humanos.

## Textos técnicos eliminados

| Antes (técnico) | Después (humano) | Archivo |
|---|---|---|
| `Resultado financiero — base devengado. Caja YTD vía invoice_payments.` | `Resultado del periodo. Importes por fecha de factura/gasto. Caja muestra cobros y pagos conciliados.` | \`pl/page.tsx\` header |
| `campaign_direct` | \`Gastos directos de campaña\` | \`pl/page.tsx\` card hint |
| `operational + legacy` | \`Software, gestoría, impuestos, nóminas y marketing\` | \`pl/page.tsx\` card hint |
| `invoice_payments — ingresos` | \`Cobros conciliados del año\` | \`pl/page.tsx\` card hint |
| `invoice_payments — gastos` | \`Pagos conciliados del año\` | \`pl/page.tsx\` card hint |
| \`Ingresos devengados\` | \`Ingresos del periodo\` + hint \`Por fecha de factura\` | PnLOverviewCards |
| \`Pagos a creadores\` hint \`Subset de gastos\` | hint \`Incluido en gastos\` | PnLOverviewCards |
| \`Margen campañas\` hint \`Sobre campañas\` | \`Margen sobre campañas\` + hint \`Ingresos − pagos a creadores\` | PnLOverviewCards |
| \`Resultado operativo\` hint \`Ingresos − gastos\` | \`Resultado del periodo\` + hint \`Ingresos menos gastos\` | PnLOverviewCards |
| \`nomina_socio: 'Nóminas'\` | \`nomina_socio: 'Nóminas socios'\` | EXPENSE_SUBTYPE_LABELS |

## Cómo queda "Dónde se ha gastado el dinero"

Antes:
\`\`\`
Nóminas socios     3.066 €  [barra ───────]
Cuota autónomo     630 €    [barra ──]
Software           220 €    [barra ─]
\`\`\`

Después:
\`\`\`
Nóminas socios     3.066 € · 48%  [barra ───────]
Cuota autónomo       630 € · 10%  [barra ──]
Software             220 €  · 3%  [barra ─]
\`\`\`

Cálculo: \`(item.amount / breakdownTotal) * 100\`, redondeado a entero. Guard: si \`breakdownTotal = 0\` → \`"0%"\`, sin NaN ni Infinity.

## Cómo quedan los tabs de Gastos

Antes:
\`\`\`
[ Directos  12 ]  [ Operativos  20 ]  [ Sin clasificar  6 ]
\`\`\`

Después:
\`\`\`
[ Directos · 12 · 4.560 € ]  [ Operativos · 20 · 14.673 € ]  [ Sin clasificar · 6 · 1.664 € ]
\`\`\`

Cálculo client-side con \`sumTotalAmount\` que parsea \`Number(r.totalAmount)\` con \`isFinite\` guard. Sin nuevas queries ni props server.

## Archivos tocados (6)

| Path | Cambio |
|---|---|
| \`src/app/admin/(dashboard)/finanzas/pl/page.tsx\` | header + 4 hints |
| \`src/features/admin/pnl/components/PnLOverviewCards.tsx\` | 5 labels/hints humanizados |
| \`src/lib/queries/financeDashboard/financeResumen.shared.ts\` | \`nomina_socio\` label |
| \`src/features/admin/finance-dashboard/components/FinanceMonthlyControl.tsx\` | renderiza \`% + EUR\` por barra |
| \`src/app/admin/(dashboard)/finanzas/gastos/GastosPageClient.tsx\` | \`sumTotalAmount\` + render del total por tab |
| \`src/__tests__/server/audit-finanzas-ux.test.ts\` | **nuevo** — 11 tests defensivos |

## Confirmaciones

- ✅ **No se tocaron queries** (lib/queries/* sin cambios excepto el label de subtipo)
- ✅ **No se tocó DB, schema, ni migrations**
- ✅ **No se tocaron cálculos contables** (ingresos/gastos/margen siguen llegando desde las queries existentes)
- ✅ **Cero nuevas dependencias** (sin librerías de charts)
- ✅ No tocado: OCR, Blob, Sheets cron, RBAC, Facturación PDFs (cerrado en PR #141), creación de facturas, pagos/conciliación, CSP

## Tests añadidos (11)

| # | Test |
|---|---|
| 1 | \`/pl/page.tsx\` no contiene \`campaign_direct\`, \`operational + legacy\`, \`invoice_payments\`, \`base devengado\` |
| 2 | PnLOverviewCards usa labels nuevos y NO los antiguos |
| 3 | \`/pl/page.tsx\` tiene los 4 subtítulos humanos |
| 4 | Header \`/pl\` humanizado |
| 5 | EXPENSE_SUBTYPE_LABELS no contiene snake_case en values |
| 6 | \`nomina_socio === 'Nóminas socios'\` |
| 7 | Los 17 subtipos del enum están cubiertos en el mapa |
| 8 | FinanceMonthlyControl calcula \`(amount/total)*100\` y renderiza junto a EUR |
| 9 | Guard contra NaN/Infinity presente (\`Number.isFinite(pct)\`) |
| 10 | GastosPageClient usa \`sumTotalAmount\` para los 3 arrays |
| 11 | Total se renderiza junto al contador con separador \`·\` |

## CI

- \`npx tsc --noEmit\` ✅
- \`npm run lint\` ✅
- \`npm test\` ✅ — **104 suites / 1702 tests**

## Validación manual post-deploy

| Ruta | Qué verificar |
|---|---|
| \`/admin/finanzas/resumen\` | barras de "Dónde se ha gastado el dinero" muestran \`importe · %\` |
| \`/admin/finanzas/pl\` | header y 4 cards de KPIs sin strings técnicos |
| \`/admin/finanzas/pl\` | PnLOverviewCards muestra "Ingresos del periodo" / "Margen sobre campañas" / "Resultado del periodo" |
| \`/admin/finanzas/gastos\` | tabs muestran \`Directos · 12 · 4.560 €\` |
| Categoría "Nóminas socios" | aparece así en Control mensual y donde se use el helper |

🤖 Generated with [Claude Code](https://claude.com/claude-code)