### PR TITLE
fix(audit/P2-08): error.tsx global + admin + root layout

### DIFF
--- a/src/__tests__/client/error-boundaries-render.test.tsx
+++ b/src/__tests__/client/error-boundaries-render.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * Tests de render con RTL para los error boundaries.
+ *
+ * Garantiza el comportamiento runtime:
+ *   - El mensaje al usuario es amigable y NO contiene `error.message` ni stack.
+ *   - El `error.digest` se muestra como Ref si está presente.
+ *   - El botón Reintentar dispara `reset()`.
+ *   - Console.error solo loggea metadata segura.
+ *
+ * NO se testea global-error.tsx en RTL porque renderiza <html>/<body>
+ * (su comportamiento clave queda cubierto por el test estático).
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import AppError from '@/app/error';
+import AdminError from '@/app/admin/(dashboard)/error';
+
+type ErrorBoundary = typeof AppError;
+
+const errorWithDigest = (digest = 'abc123def') => {
+  const e = new Error('TEXTO SECRETO QUE NUNCA DEBE APARECER EN UI');
+  // @ts-expect-error -- digest es un campo no estándar del tipo Error añadido por Next.js
+  e.digest = digest;
+  return e as Error & { digest?: string };
+};
+
+const errorWithoutDigest = () => {
+  return new Error('OTRO SECRETO QUE NUNCA DEBE APARECER') as Error & { digest?: string };
+};
+
+describe.each([
+  ['app/error.tsx', AppError as ErrorBoundary],
+  ['admin/(dashboard)/error.tsx', AdminError as ErrorBoundary],
+])('Error boundary %s — render', (_label, Boundary) => {
+  let consoleSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it('NUNCA renderiza error.message en la UI', () => {
+    const { container } = render(<Boundary error={errorWithDigest()} reset={jest.fn()} />);
+    expect(container.textContent).not.toContain('TEXTO SECRETO');
+  });
+
+  it('NUNCA renderiza error.stack en la UI', () => {
+    const err = errorWithDigest();
+    err.stack = 'at SECRET_STACK_FRAME (./file.ts:42:13)';
+    const { container } = render(<Boundary error={err} reset={jest.fn()} />);
+    expect(container.textContent).not.toContain('SECRET_STACK_FRAME');
+    expect(container.textContent).not.toContain('./file.ts');
+  });
+
+  it('muestra `Ref: <digest>` cuando el digest está presente', () => {
+    render(<Boundary error={errorWithDigest('digest-test-xyz')} reset={jest.fn()} />);
+    expect(screen.getByText(/Ref:\s*digest-test-xyz/)).toBeInTheDocument();
+  });
+
+  it('NO muestra el bloque Ref cuando el digest es undefined', () => {
+    const { container } = render(<Boundary error={errorWithoutDigest()} reset={jest.fn()} />);
+    expect(container.textContent).not.toMatch(/Ref:/);
+  });
+
+  it('el botón Reintentar dispara reset()', async () => {
+    const user = userEvent.setup();
+    const reset = jest.fn();
+    render(<Boundary error={errorWithDigest()} reset={reset} />);
+    await user.click(screen.getByRole('button', { name: /reintentar/i }));
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+
+  it('console.error solo recibe metadata segura (no error.message ni stack completos)', () => {
+    const err = errorWithDigest('safe-digest');
+    err.stack = 'at SECRET (./x.ts:1:1)';
+    render(<Boundary error={err} reset={jest.fn()} />);
+    // El primer arg es el tag, el segundo es un objeto con name + digest.
+    for (const call of consoleSpy.mock.calls) {
+      const argsStr = (call as unknown[]).map((a) => typeof a === 'string' ? a : JSON.stringify(a)).join(' ');
+      expect(argsStr).not.toContain('TEXTO SECRETO');
+      expect(argsStr).not.toContain('SECRET');
+      expect(argsStr).not.toContain('./x.ts');
+    }
+  });
+});

--- a/src/__tests__/server/error-boundaries-static.test.ts
+++ b/src/__tests__/server/error-boundaries-static.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tests estáticos para los error boundaries (P2-08).
+ *
+ * Garantiza:
+ *   1. Los 3 archivos existen: app/error.tsx, app/global-error.tsx,
+ *      app/admin/(dashboard)/error.tsx
+ *   2. Son client components ('use client').
+ *   3. NUNCA renderizan `error.message` ni `error.stack` (solo `error.digest`).
+ *   4. Console.error solo loggea metadata segura (digest, name), no message/stack.
+ *   5. Exportan un componente default que acepta { error, reset }.
+ *   6. global-error.tsx incluye <html> y <body> (requisito Next.js).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const PROJECT_ROOT = path.resolve(__dirname, '..', '..', '..');
+const read = (rel: string): string => fs.readFileSync(path.join(PROJECT_ROOT, rel), 'utf-8');
+const exists = (rel: string): boolean => fs.existsSync(path.join(PROJECT_ROOT, rel));
+
+const FILES = [
+  'src/app/error.tsx',
+  'src/app/global-error.tsx',
+  'src/app/admin/(dashboard)/error.tsx',
+] as const;
+
+describe('Error boundaries — los 3 archivos existen', () => {
+  for (const f of FILES) {
+    it(`${f} existe`, () => {
+      expect(exists(f)).toBe(true);
+    });
+  }
+});
+
+describe('Error boundaries — son client components', () => {
+  for (const f of FILES) {
+    it(`${f} declara 'use client' al inicio`, () => {
+      const src = read(f);
+      expect(src).toMatch(/^['"]use client['"];/);
+    });
+  }
+});
+
+describe('Error boundaries — NUNCA renderizan error.message ni error.stack', () => {
+  for (const f of FILES) {
+    it(`${f} NO contiene {error.message} en JSX`, () => {
+      const src = read(f);
+      expect(src).not.toMatch(/\{\s*error\.message\s*\}/);
+      expect(src).not.toMatch(/\{\s*error\?\.message\s*\}/);
+    });
+
+    it(`${f} NO contiene {error.stack} en JSX`, () => {
+      const src = read(f);
+      expect(src).not.toMatch(/\{\s*error\.stack\s*\}/);
+      expect(src).not.toMatch(/\{\s*error\?\.stack\s*\}/);
+    });
+
+    it(`${f} expone error.digest (única forma segura de mostrar)`, () => {
+      const src = read(f);
+      expect(src).toMatch(/error\.digest/);
+    });
+  }
+});
+
+describe('Error boundaries — console.error solo loggea metadata segura', () => {
+  for (const f of FILES) {
+    it(`${f} no loggea error.message ni error.stack a console`, () => {
+      const src = read(f);
+      // console.error('...', error) sería peligroso porque imprime todo el objeto.
+      // El patrón seguro es console.error('tag', { name: error.name, digest: error.digest })
+      expect(src).not.toMatch(/console\.error\(\s*['"][^'"]*['"]\s*,\s*error\s*\)/);
+      expect(src).not.toMatch(/console\.error\(\s*error\s*\)/);
+      expect(src).not.toMatch(/console\.error\([^)]{0,100}error\.message/);
+      expect(src).not.toMatch(/console\.error\([^)]{0,100}error\.stack/);
+    });
+  }
+});
+
+describe('Error boundaries — firma del componente', () => {
+  for (const f of FILES) {
+    it(`${f} default export es una function/componente con prop { error, reset }`, () => {
+      const src = read(f);
+      expect(src).toMatch(/export\s+default\s+function/);
+      // Acepta tanto { error, reset } como destructuring tipado
+      expect(src).toMatch(/error\s*[:,]/);
+      expect(src).toMatch(/reset\s*[:)]/);
+    });
+  }
+});
+
+describe('global-error.tsx — requisitos especiales de Next.js', () => {
+  const src = read('src/app/global-error.tsx');
+
+  it('incluye <html> en el render (reemplaza el root layout)', () => {
+    expect(src).toMatch(/<html\b/);
+  });
+
+  it('incluye <body> en el render', () => {
+    expect(src).toMatch(/<body\b/);
+  });
+
+  it('lang="es" en el <html> tag', () => {
+    expect(src).toMatch(/lang=['"]es['"]/);
+  });
+});

--- a/src/app/admin/(dashboard)/error.tsx
+++ b/src/app/admin/(dashboard)/error.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+
+/**
+ * Error boundary del contexto admin `/admin/(dashboard)/**`.
+ *
+ * Captura excepciones no manejadas en cualquier ruta admin (talents,
+ * brands, campanas, finanzas, etc.) y muestra una UI consistente con
+ * el tema oscuro del CRM.
+ *
+ * Reglas de seguridad (idénticas a `app/error.tsx`):
+ *   - NUNCA renderiza `error.message` ni stack trace.
+ *   - Solo expone `error.digest` para que soporte localice el error.
+ *   - Loggea solo metadata segura por consola.
+ *
+ * @kind client (requerido por Next.js)
+ */
+export default function AdminError({
+  error,
+  reset,
+}: {
+  readonly error: Error & { digest?: string };
+  readonly reset: () => void;
+}): React.JSX.Element {
+  useEffect(() => {
+    // safe: solo metadata; nunca error.message ni stack
+    console.error('[admin/error]', { name: error.name, digest: error.digest ?? null });
+  }, [error.name, error.digest]);
+
+  return (
+    <div className="rounded-2xl border border-red-500/30 bg-red-500/5 px-6 py-12 text-center">
+      <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-red-400 mb-3">
+        Error en esta página
+      </p>
+      <h1 className="text-xl font-bold text-sp-admin-fg mb-2">
+        No se pudo cargar el contenido
+      </h1>
+      <p className="text-sm text-sp-admin-muted max-w-md mx-auto mb-6">
+        Ha ocurrido un error inesperado al cargar esta sección del panel.
+        Puedes reintentar; si persiste, comparte la referencia con soporte.
+      </p>
+
+      {error.digest && (
+        <p className="text-[11px] font-mono text-sp-admin-muted/70 mb-6">
+          Ref: {error.digest}
+        </p>
+      )}
+
+      <div className="flex flex-wrap justify-center gap-3">
+        <button
+          type="button"
+          onClick={reset}
+          className="rounded-lg border border-sp-admin-border bg-sp-admin-card px-4 py-2 text-sm font-semibold text-sp-admin-fg hover:border-sp-orange/60 hover:text-sp-orange transition-colors"
+        >
+          Reintentar
+        </button>
+        <Link
+          href="/admin"
+          className="rounded-lg bg-sp-orange px-4 py-2 text-sm font-semibold text-white hover:opacity-90 transition-opacity"
+        >
+          Ir al inicio del panel
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+
+/**
+ * Error boundary global para Server Components y rutas no admin.
+ *
+ * Captura cualquier excepción no manejada en la jerarquía de rutas
+ * (excluido el root layout en sí — para eso ver `global-error.tsx`).
+ *
+ * Reglas de seguridad:
+ *   - NUNCA renderiza `error.message` ni stack trace al usuario.
+ *   - Solo expone `error.digest` (ID server-generado, seguro de mostrar
+ *     y útil para que soporte localice el error en logs).
+ *   - Loggea solo `digest` y `name` por consola — nunca message ni stack.
+ *
+ * @kind client (requerido por Next.js para error boundaries)
+ */
+export default function GlobalAppError({
+  error,
+  reset,
+}: {
+  readonly error: Error & { digest?: string };
+  readonly reset: () => void;
+}): React.JSX.Element {
+  useEffect(() => {
+    // safe: solo metadata; nunca error.message ni stack (pueden contener PII)
+    console.error('[app/error]', { name: error.name, digest: error.digest ?? null });
+  }, [error.name, error.digest]);
+
+  return (
+    <div className="min-h-[60vh] flex flex-col items-center justify-center px-6 py-24 text-center">
+      <p className="text-[11px] font-black uppercase tracking-[0.25em] text-sp-orange mb-4">
+        Algo no fue bien
+      </p>
+      <h1 className="font-display text-4xl sm:text-5xl font-black uppercase tracking-tight text-sp-dark leading-none mb-4">
+        Página no disponible
+      </h1>
+      <p className="text-sp-muted text-base max-w-md mb-6">
+        Ha ocurrido un error inesperado al cargar esta página. Puedes reintentar o volver al inicio.
+      </p>
+
+      {error.digest && (
+        <p className="text-[11px] font-mono text-sp-muted/70 mb-8">
+          Ref: {error.digest}
+        </p>
+      )}
+
+      <div className="flex flex-wrap justify-center gap-3">
+        <button
+          type="button"
+          onClick={reset}
+          className="px-6 py-2.5 rounded-full border border-sp-border text-sm font-semibold text-sp-dark hover:border-sp-orange hover:text-sp-orange transition-colors"
+        >
+          Reintentar
+        </button>
+        <Link
+          href="/"
+          className="inline-block bg-sp-grad text-white font-display font-bold uppercase tracking-wider text-sm px-8 py-3 rounded-full hover:opacity-90 transition-opacity"
+        >
+          Volver al inicio
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { useEffect } from 'react';
+
+/**
+ * Error boundary del root layout. Se activa SOLO cuando falla algo dentro
+ * del propio `app/layout.tsx` (fuente, providers, etc.) — el catch normal
+ * `app/error.tsx` NO captura errores del root layout en sí.
+ *
+ * Debe incluir `<html>` y `<body>` propios porque reemplaza al root layout
+ * cuando este ha fallado (Next.js docs).
+ *
+ * Reglas de seguridad:
+ *   - NUNCA renderiza `error.message` ni stack trace.
+ *   - Solo expone `error.digest` para que soporte localice el error en logs.
+ *   - Sin chrome del sitio (puede ser que el chrome sea exactamente lo roto).
+ *   - HTML mínimo, sin dependencias externas, sin fuentes custom.
+ *
+ * @kind client (requerido por Next.js)
+ */
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  readonly error: Error & { digest?: string };
+  readonly reset: () => void;
+}): React.JSX.Element {
+  useEffect(() => {
+    // safe: solo metadata; nunca error.message ni stack
+    console.error('[global-error]', { name: error.name, digest: error.digest ?? null });
+  }, [error.name, error.digest]);
+
+  return (
+    <html lang="es">
+      <body
+        style={{
+          margin: 0,
+          minHeight: '100vh',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: '32px',
+          fontFamily:
+            '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
+          background: '#0f0f0f',
+          color: '#e8e8e8',
+          textAlign: 'center',
+        }}
+      >
+        <p
+          style={{
+            fontSize: 11,
+            fontWeight: 900,
+            letterSpacing: '0.25em',
+            textTransform: 'uppercase',
+            color: '#f5632a',
+            marginBottom: 16,
+          }}
+        >
+          Algo no fue bien
+        </p>
+        <h1
+          style={{
+            fontSize: 36,
+            fontWeight: 900,
+            textTransform: 'uppercase',
+            margin: '0 0 12px',
+            letterSpacing: '-0.02em',
+          }}
+        >
+          Página no disponible
+        </h1>
+        <p style={{ maxWidth: 480, opacity: 0.7, marginBottom: 24 }}>
+          Ha ocurrido un error inesperado. Puedes reintentar o recargar.
+        </p>
+        {error.digest && (
+          <p
+            style={{
+              fontFamily:
+                'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Monaco, Consolas, monospace',
+              fontSize: 11,
+              opacity: 0.55,
+              marginBottom: 24,
+            }}
+          >
+            Ref: {error.digest}
+          </p>
+        )}
+        <button
+          type="button"
+          onClick={reset}
+          style={{
+            padding: '12px 32px',
+            borderRadius: 9999,
+            border: 0,
+            background: 'linear-gradient(135deg,#f5632a 0%,#e03070 35%,#c42880 62%,#8b3aad 100%)',
+            color: '#fff',
+            fontWeight: 700,
+            textTransform: 'uppercase',
+            letterSpacing: '0.05em',
+            fontSize: 13,
+            cursor: 'pointer',
+          }}
+        >
+          Reintentar
+        </button>
+      </body>
+    </html>
+  );
+}


### PR DESCRIPTION
## Causa raíz

No existían error boundaries en \`src/app/\`. Cualquier excepción no manejada en Server Components o en el root layout podía mostrar pantalla en blanco al usuario (y con stack/mensaje técnico expuesto si Next.js no encontraba boundary).

## Fix — 3 archivos nuevos, aditivo puro

### 1. \`src/app/error.tsx\` — boundary para rutas no admin

\`'use client'\`; recibe \`{ error, reset }\` y muestra:
- Mensaje amigable con tipografía/brand del sitio
- Botones "Reintentar" (\`reset()\`) y "Volver al inicio"
- \`error.digest\` como "Ref: xxxx" si está presente

**Nunca expone** \`error.message\` ni \`error.stack\`.

### 2. \`src/app/global-error.tsx\` — boundary del root layout

Se activa SOLO cuando falla algo dentro del propio \`app/layout.tsx\` (fuentes, providers, etc.). Reemplaza al root layout — por eso incluye \`<html lang="es">\` y \`<body>\` propios, con **estilos inline y cero dependencias externas** (la app puede estar parcialmente cargada).

Mismo contrato de privacidad: solo digest, nunca message/stack.

### 3. \`src/app/admin/(dashboard)/error.tsx\` — boundary del CRM

UI consistente con el tema oscuro del panel. Card roja con "Reintentar" + "Ir al inicio del panel". Mismo contrato.

## Contrato de privacidad (estricto en los 3)

| Aspecto | Regla |
|---|---|
| \`error.message\` en UI | ❌ Nunca |
| \`error.stack\` en UI | ❌ Nunca |
| \`error.digest\` en UI | ✅ Como "Ref:" (es un ID server-generado seguro) |
| Logger consola | Solo \`{ name, digest }\` — nunca \`error\` completo |

Razón: \`error.message\` puede contener URLs con tokens, IDs de sesión, datos de usuario.

## Archivos tocados (5)

| Path | Cambio |
|---|---|
| \`src/app/error.tsx\` | **nuevo** |
| \`src/app/global-error.tsx\` | **nuevo** |
| \`src/app/admin/(dashboard)/error.tsx\` | **nuevo** |
| \`src/__tests__/server/error-boundaries-static.test.ts\` | **nuevo** (24 tests) |
| \`src/__tests__/client/error-boundaries-render.test.tsx\` | **nuevo** (12 tests, parametrizados x2 boundaries) |

## Tests añadidos (36)

### Estáticos (24)
- Los 3 archivos existen
- Los 3 son \`'use client'\`
- Los 3 NO contienen \`{error.message}\` ni \`{error.stack}\` en JSX (4 patrones cubiertos cada uno)
- Los 3 exponen \`error.digest\`
- Los 3 no loggean \`error.message\` ni \`stack\` a consola
- Los 3 exportan default function con prop \`{ error, reset }\`
- \`global-error.tsx\` incluye \`<html>\`, \`<body>\`, \`lang="es"\`

### Render (12, parametrizado x2 boundaries con RTL)
- NUNCA renderiza \`error.message\` en UI (string "TEXTO_SECRETO" inyectado para verificar)
- NUNCA renderiza \`error.stack\` (string "SECRET_STACK_FRAME" inyectado)
- Muestra "Ref: \<digest\>" si digest presente
- NO muestra bloque Ref si digest undefined
- Botón "Reintentar" dispara \`reset()\`
- \`console.error\` solo recibe metadata segura (verificación contra strings secretos)

## Confirmaciones

- ✅ **No tocadas queries, DB, schema, migrations**
- ✅ No tocados: OCR, Blob, Sheets, RBAC, Facturación PDFs, CSP, queries, cálculos contables
- ✅ **Aditivo puro**: 3 archivos nuevos, ningún componente existente modificado
- ✅ **NUNCA expone error.message/stack ni PII en runtime** (verificado por test)

## CI

- \`npx tsc --noEmit\` ✅
- \`npm run lint\` ✅
- \`npm test\` ✅ — **106 suites / 1738 tests**

## Validación manual post-deploy

Difícil reproducir sin forzar un error. Una opción es añadir temporalmente un \`throw new Error('test')\` en alguna Server Action o page y verificar:
- Web pública: aparece "Página no disponible — Reintentar / Volver al inicio" con brand
- Admin: aparece card roja "No se pudo cargar el contenido" en el dashboard sin perder la sidebar
- Si el error tiene digest, aparece "Ref: xxxx"
- En DevTools Console: solo \`[app/error] { name: '...', digest: '...' }\`, sin stack

Si no quieres provocar errores, déjalo como defensivo silencioso — entrará en acción cuando lo necesitemos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)