### PR TITLE
fix(audit/P2-04): slug editable en form de talentos

### DIFF
--- a/src/__tests__/server/talent-slug-editable.test.ts
+++ b/src/__tests__/server/talent-slug-editable.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Tests del campo slug editable en TalentProfileForm + action (P2-04).
+ *
+ * Cubre:
+ *   - Schema Zod TalentProfileUpdate acepta/rechaza slugs según regla
+ *   - Form muestra input slug + preview + warning
+ *   - Form contiene link a la pestaña Redes
+ *   - Action no se ha modificado en nada peligroso (sin migración, sin schema)
+ *
+ * El test de uniqueness DB y de revalidate dual son verificación estática
+ * sobre el source code de la action (sin invocar DB real).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const PROJECT_ROOT = path.resolve(__dirname, '..', '..', '..');
+const read = (rel: string): string => fs.readFileSync(path.join(PROJECT_ROOT, rel), 'utf-8');
+
+// ── Tests del schema Zod (importamos solo el schema, sin tocar DB) ──────────
+
+// Re-construimos el regex del slug igual que en la action para validar inputs.
+// Mantenido en paralelo con TalentProfileUpdate.slug en talents/actions.ts:
+const SLUG_RX = /^[a-z0-9-]+$/;
+
+describe('TalentProfileUpdate — schema Zod del slug', () => {
+  it('[3] slug válido se acepta: "tigerr"', () => {
+    expect(SLUG_RX.test('tigerr')).toBe(true);
+  });
+
+  it('[3b] slug válido con guiones: "creator-cs2"', () => {
+    expect(SLUG_RX.test('creator-cs2')).toBe(true);
+  });
+
+  it('[4] slug con mayúsculas se rechaza con regex (la action aplica toLowerCase antes)', () => {
+    // El zod schema hace .toLowerCase() ANTES de validar, así que "Tigerr"
+    // llega como "tigerr" y pasa. Aquí verificamos que el regex base no
+    // acepta mayúsculas — es la última línea de defensa.
+    expect(SLUG_RX.test('Tigerr')).toBe(false);
+    expect(SLUG_RX.test('TIGER')).toBe(false);
+  });
+
+  it('[4b] slug con espacios se rechaza por regex', () => {
+    expect(SLUG_RX.test('tiger gg')).toBe(false);
+    expect(SLUG_RX.test(' tigerr')).toBe(false);
+  });
+
+  it('[5] slug con caracteres inválidos se rechaza: ñ, @, /, ., etc.', () => {
+    for (const s of ['tig@err', 'tig.err', 'tig/err', 'tig_err', 'tigéerr', 'tigñr', 'tigerr!']) {
+      expect({ s, ok: SLUG_RX.test(s) }).toEqual({ s, ok: false });
+    }
+  });
+
+  it('[5b] slug vacío se rechaza (regex requiere al menos un carácter)', () => {
+    expect(SLUG_RX.test('')).toBe(false);
+  });
+});
+
+// ── Tests estáticos sobre el form ───────────────────────────────────────────
+
+describe('TalentProfileForm.tsx — slug input y warning', () => {
+  const src = read('src/features/admin/talents/components/TalentProfileForm.tsx');
+
+  it('[1] el formulario tiene una sección "Slug público" con un input', () => {
+    expect(src).toMatch(/Slug público/);
+    expect(src).toMatch(/id=['"]pf-slug['"]/);
+    expect(src).toMatch(/name=['"]slug['"]/);
+  });
+
+  it('[2] el input tiene preview que muestra /talentos/<slug>', () => {
+    // Patrón: /talentos/{slug} dentro del JSX del preview
+    expect(src).toMatch(/\/talentos\/\{slug/);
+  });
+
+  it('input aplica pattern y maxLength en cliente', () => {
+    expect(src).toMatch(/pattern=['"]\^\[a-z0-9-\]\+\$['"]/);
+    expect(src).toMatch(/maxLength=\{100\}/);
+  });
+
+  it('input normaliza con toLowerCase + trim al teclear', () => {
+    expect(src).toMatch(/e\.target\.value\.toLowerCase\(\)\.trim\(\)/);
+  });
+
+  it('[9] muestra warning de que cambiar slug puede romper enlaces antiguos', () => {
+    expect(src).toMatch(/Cambiar el slug modifica la URL pública/);
+    expect(src).toMatch(/enlaces antiguos pueden dejar de funcionar/i);
+  });
+
+  it('muestra cambio detectado old → new cuando el slug cambia', () => {
+    expect(src).toMatch(/slugChanged/);
+    expect(src).toMatch(/Cambio detectado/);
+  });
+
+  it('[10] contiene link/card hacia la pestaña Redes del detalle', () => {
+    expect(src).toMatch(/Las redes sociales se editan desde la pestaña/);
+    expect(src).toMatch(/Ir a Redes/);
+    // Link a /admin/talents/{id}
+    expect(src).toMatch(/href=\{`\/admin\/talents\/\$\{talent\.id\}`\}/);
+  });
+
+  it('no duplica el editor de redes (no importa TalentSocialsEditor)', () => {
+    expect(src).not.toMatch(/TalentSocialsEditor/);
+    expect(src).not.toMatch(/upsertTalentSocialsAction/);
+  });
+});
+
+// ── Tests estáticos sobre la action ─────────────────────────────────────────
+
+describe('updateTalentProfileAction — slug + uniqueness + revalidate dual', () => {
+  const src = read('src/app/admin/(dashboard)/talents/actions.ts');
+
+  it('TalentProfileUpdate schema incluye slug con regex /^[a-z0-9-]+$/', () => {
+    expect(src).toMatch(/slug:[\s\S]{0,300}regex\(\/\^\[a-z0-9-\]\+\$\//);
+  });
+
+  it('schema aplica toLowerCase y trim antes de validar', () => {
+    expect(src).toMatch(/slug:[\s\S]{0,200}\.trim\(\)[\s\S]{0,100}\.toLowerCase\(\)/);
+  });
+
+  it('schema valida min(1, "Slug obligatorio") — si isPublished=true, slug vacío se rechaza al primer paso', () => {
+    expect(src).toMatch(/min\(1,\s*['"]Slug obligatorio['"]\)/);
+  });
+
+  it('[6] action hace uniqueness check con SELECT id WHERE slug = newSlug AND id != currentId', () => {
+    expect(src).toMatch(/and\(\s*eq\(talents\.slug,\s*newSlug\),\s*ne\(talents\.id,\s*id\)\s*\)/);
+  });
+
+  it('[6b] devuelve mensaje humano "Este slug ya está usado por otro talento."', () => {
+    expect(src).toMatch(/Este slug ya está usado por otro talento\./);
+  });
+
+  it('[7] el mismo talento puede guardar su slug actual: uniqueness check solo si oldSlug !== newSlug', () => {
+    expect(src).toMatch(/if\s*\(\s*oldSlug\s*!==\s*newSlug\s*\)/);
+  });
+
+  it('action setea el slug en db.update', () => {
+    expect(src).toMatch(/slug:\s+newSlug/);
+  });
+
+  it('action revalida SIEMPRE el path del nuevo slug', () => {
+    expect(src).toMatch(/revalidatePath\(`\/talentos\/\$\{newSlug\}`\)/);
+  });
+
+  it('action revalida el path del old slug solo si cambió', () => {
+    expect(src).toMatch(/if\s*\(oldSlug\s*&&\s*oldSlug\s*!==\s*newSlug\)/);
+    expect(src).toMatch(/revalidatePath\(`\/talentos\/\$\{oldSlug\}`\)/);
+  });
+
+  it('action revalida también /sitemap.xml', () => {
+    expect(src).toMatch(/revalidatePath\(['"]\/sitemap\.xml['"]\)/);
+  });
+
+  it('importa ne y and de drizzle-orm', () => {
+    expect(src).toMatch(/import\s+\{[^}]*\bne\b[^}]*\}\s+from\s+['"]drizzle-orm['"]/);
+    expect(src).toMatch(/import\s+\{[^}]*\band\b[^}]*\}\s+from\s+['"]drizzle-orm['"]/);
+  });
+});
+
+// ── [11] No hay migraciones ni schema changes ───────────────────────────────
+
+describe('Sin migraciones ni cambios de schema', () => {
+  it('[11] no se han modificado archivos drizzle en este branch', () => {
+    // Solo verificación negativa: el schema de talents no debe contener
+    // ningún campo nuevo añadido por este PR. talents.slug existía ya.
+    const schema = read('src/db/schema/talents.ts');
+    expect(schema).toMatch(/slug:\s*varchar\(['"]slug['"],\s*\{\s*length:\s*100\s*\}\)\.notNull\(\)\.unique\(\)/);
+    // Y no debe haber rastros de "TODO migration" o similar
+    expect(schema).not.toMatch(/TODO\s+migration|FIXME\s+migration/i);
+  });
+});

--- a/src/app/admin/(dashboard)/talents/actions.ts
+++ b/src/app/admin/(dashboard)/talents/actions.ts
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
-import { eq, sql, inArray } from 'drizzle-orm';
+import { eq, sql, inArray, and, ne } from 'drizzle-orm';
 import { z } from 'zod';
 
 import { requirePermission } from '@/lib/permissions';
@@ -362,6 +362,10 @@ export async function setTalentPublishedAction(talentId: number, publish: boolea
 
 const TalentProfileUpdate = z.object({
   id: IdSchema,
+  slug:          z.string().trim().toLowerCase()
+    .min(1, 'Slug obligatorio')
+    .max(100, 'Slug demasiado largo (máx 100)')
+    .regex(/^[a-z0-9-]+$/, 'Slug solo puede contener letras minúsculas, números y guiones'),
   name:          z.string().trim().min(1, 'Nombre obligatorio').max(120),
   role:          z.string().trim().min(1, 'Rol obligatorio').max(150),
   role2:         z.string().trim().max(150).optional().transform((v) => v === '' ? null : v ?? null),
@@ -400,11 +404,25 @@ export async function updateTalentProfileAction(
   }
 
   try {
-    // Obtener slug actual para revalidar la ruta pública individual
+    // Obtener slug actual para detectar cambio y revalidar el path correcto
     const current = await db.select({ slug: talents.slug }).from(talents).where(eq(talents.id, id)).limit(1);
-    const slug = current[0]?.slug;
+    const oldSlug = current[0]?.slug;
+    const newSlug = data.slug;
+
+    // Uniqueness check si el slug cambió: si existe otro talento con ese slug, error humano.
+    if (oldSlug !== newSlug) {
+      const collision = await db
+        .select({ id: talents.id })
+        .from(talents)
+        .where(and(eq(talents.slug, newSlug), ne(talents.id, id)))
+        .limit(1);
+      if (collision.length > 0) {
+        return { success: false, error: 'Este slug ya está usado por otro talento.' };
+      }
+    }
 
     await db.update(talents).set({
+      slug:          newSlug,
       name:          data.name,
       role:          data.role,
       role2:         data.role2,
@@ -427,10 +445,13 @@ export async function updateTalentProfileAction(
     revalidatePath('/admin/talents');
     revalidatePath(`/admin/talents/${id}`);
     revalidatePath('/talentos');
-    if (slug) {
-      revalidatePath(`/talentos/${slug}`);
-      revalidatePath('/sitemap.xml');
+    // Revalidar SIEMPRE el nuevo slug y, si cambió, también el antiguo
+    // para que la caché ISR no sirva contenido stale en ninguno de los dos.
+    revalidatePath(`/talentos/${newSlug}`);
+    if (oldSlug && oldSlug !== newSlug) {
+      revalidatePath(`/talentos/${oldSlug}`);
     }
+    revalidatePath('/sitemap.xml');
   } catch (err) {
     logRedacted('error', '[admin] updateTalentProfile error:', err);
     return { success: false, error: 'Error al guardar perfil' };

--- a/src/features/admin/talents/components/TalentProfileForm.tsx
+++ b/src/features/admin/talents/components/TalentProfileForm.tsx
@@ -4,6 +4,7 @@ import { useActionState, useState } from 'react';
 import { updateTalentProfileAction } from '@/app/admin/(dashboard)/talents/actions';
 import { COUNTRIES } from '@/lib/countries';
 import { countryFlagEmoji } from '@/lib/flag-images';
+import Link from 'next/link';
 
 const INPUT  = 'w-full rounded-lg border border-sp-admin-border bg-sp-admin-bg px-3 py-2 text-sm text-sp-admin-text outline-none focus:border-sp-admin-accent transition-colors';
 const SELECT = 'w-full rounded-lg border border-sp-admin-border bg-sp-admin-bg px-3 py-2 text-sm text-sp-admin-text outline-none focus:border-sp-admin-accent transition-colors cursor-pointer';
@@ -65,6 +66,8 @@ export function TalentProfileForm({ talent }: Props): React.JSX.Element {
   const [country, setCountry]           = useState(talent.creatorCountry ?? '');
   const [isPublished, setIsPublished]   = useState(talent.isPublished);
   const [showInRoster, setShowInRoster] = useState(talent.showInRoster);
+  const [slug, setSlug]                 = useState(talent.slug);
+  const slugChanged = slug !== talent.slug;
 
   const flagPreview = country.length === 2 ? countryFlagEmoji(country) : null;
   const knownCountry = COUNTRIES.find((c) => c.code === country);
@@ -106,6 +109,42 @@ export function TalentProfileForm({ talent }: Props): React.JSX.Element {
             <input id="pf-game" name="game" defaultValue={talent.game}
               maxLength={100} className={INPUT} placeholder="CS2, VALORANT, GTA…" />
           </div>
+        </div>
+      </section>
+
+      {/* Slug público */}
+      <section className="rounded-2xl bg-sp-admin-card border border-sp-admin-border p-5">
+        <h2 className="font-bold text-sp-admin-text text-sm mb-4">Slug público</h2>
+        <div className="space-y-2">
+          <label htmlFor="pf-slug" className={LABEL}>Slug *</label>
+          <input
+            id="pf-slug"
+            name="slug"
+            type="text"
+            required
+            maxLength={100}
+            value={slug}
+            onChange={(e) => setSlug(e.target.value.toLowerCase().trim())}
+            pattern="^[a-z0-9-]+$"
+            placeholder="ejemplo-creador"
+            className={INPUT + ' font-mono'}
+            aria-describedby="pf-slug-preview pf-slug-warning"
+          />
+          <p id="pf-slug-preview" className="text-[11px] text-sp-admin-muted">
+            URL pública: <span className="font-mono text-sp-admin-text">/talentos/{slug || '—'}</span>
+          </p>
+          <p id="pf-slug-warning" className={`text-[11px] rounded-lg px-3 py-2 ${
+            slugChanged ? 'border border-amber-500/30 bg-amber-500/5 text-amber-600' : 'text-sp-admin-muted'
+          }`}>
+            Solo letras minúsculas, números y guiones. Cambiar el slug modifica la URL pública
+            del talento. Los enlaces antiguos pueden dejar de funcionar si no se añade un redirect
+            manual.
+          </p>
+          {slugChanged && (
+            <p className="text-[11px] font-semibold text-amber-700">
+              Cambio detectado: <span className="font-mono">/talentos/{talent.slug}</span> → <span className="font-mono">/talentos/{slug || '(vacío)'}</span>
+            </p>
+          )}
         </div>
       </section>
 
@@ -299,6 +338,21 @@ export function TalentProfileForm({ talent }: Props): React.JSX.Element {
               defaultValue={talent.bioLong ?? ''} className={INPUT} />
           </div>
         </div>
+      </section>
+
+      {/* Redes sociales — link al detail (no duplicar editor) */}
+      <section className="rounded-2xl bg-sp-admin-card border border-sp-admin-border p-5">
+        <h2 className="font-bold text-sp-admin-text text-sm mb-2">Redes sociales</h2>
+        <p className="text-[11px] text-sp-admin-muted mb-3">
+          Las redes sociales se editan desde la pestaña <strong>Redes</strong> del perfil
+          (handles, followers, profile URL, colores).
+        </p>
+        <Link
+          href={`/admin/talents/${talent.id}`}
+          className="inline-flex items-center gap-1 rounded-lg border border-sp-admin-border bg-sp-admin-bg px-3 py-1.5 text-xs font-semibold text-sp-admin-text hover:border-sp-orange/60 hover:text-sp-orange transition-colors"
+        >
+          Ir a Redes →
+        </Link>
       </section>
 
       {/* Acciones */}


### PR DESCRIPTION
## Causa raíz (incidente Tigerr)

\`talents.slug\` existe en DB con constraint UNIQUE, pero \`TalentProfileForm\` no exponía el campo. \`updateTalentProfileAction\` no lo actualizaba. Para corregir \`tiger → tigerr\` tuvimos que recurrir a \`scripts/fix-tigerr-slug.ts\` + redirect manual en \`next.config.ts\`. Este PR evita repetirlo.

## Cómo queda el input de slug

\`\`\`
┌─ Slug público ──────────────────────────────────────────┐
│ Slug *                                                  │
│ ┌───────────────────────────────────────────────────┐   │
│ │ tigerr                                            │   │
│ └───────────────────────────────────────────────────┘   │
│                                                         │
│ URL pública: /talentos/tigerr                           │
│                                                         │
│ ⚠ Solo letras minúsculas, números y guiones. Cambiar   │
│   el slug modifica la URL pública del talento. Los     │
│   enlaces antiguos pueden dejar de funcionar si no se  │
│   añade un redirect manual.                            │
│                                                         │
│ Cambio detectado: /talentos/tiger → /talentos/tigerr   │
│ (aparece resaltado en ámbar cuando el slug cambia)     │
└─────────────────────────────────────────────────────────┘
\`\`\`

- \`useState({slug})\` se actualiza con \`.toLowerCase().trim()\` al teclear
- \`pattern=\"^[a-z0-9-]+$\"\` + \`maxLength=100\` + \`required\`
- Preview live de la URL pública
- Warning permanente + alerta visual cuando \`slugChanged\`

## Cómo se valida uniqueness

En \`updateTalentProfileAction\`:

\`\`\`ts
if (oldSlug !== newSlug) {
  const collision = await db
    .select({ id: talents.id })
    .from(talents)
    .where(and(eq(talents.slug, newSlug), ne(talents.id, id)))
    .limit(1);
  if (collision.length > 0) {
    return { success: false, error: 'Este slug ya está usado por otro talento.' };
  }
}
\`\`\`

- Solo se hace check si el slug cambió → el mismo talento puede guardar su slug actual sin error
- Constraint UNIQUE en DB sigue siendo la última defensa
- Mensaje humano explícito al usuario

## Cómo se revalidan old/new slug

\`\`\`ts
revalidatePath(`/talentos/${newSlug}`);           // SIEMPRE: caché ISR del nuevo path
if (oldSlug && oldSlug !== newSlug) {
  revalidatePath(`/talentos/${oldSlug}`);          // SOLO si cambió: purga el antiguo
}
revalidatePath('/sitemap.xml');                    // SIEMPRE: actualiza sitemap
\`\`\`

Si el usuario cambia el slug:
- \`/talentos/<newSlug>\` se regenera con los datos actualizados
- \`/talentos/<oldSlug>\` se purga → si alguien entra ahí ahora, la query \`getTalentBySlug\` no encuentra el talent → 404 limpio
- \`/sitemap.xml\` refleja el cambio

## Confirmación: no duplicé el editor de redes

- **No** se importa \`TalentSocialsEditor\` (sigue solo en \`TalentDetailTabs\`)
- **No** se llama \`upsertTalentSocialsAction\`
- Sí se añade una card al final del form con link "Ir a Redes →" a \`/admin/talents/{id}\` (donde está el TalentDetailTabs con la pestaña Redes)
- Tests verifican que el import no se introduce por error

## Confirmación: no toqué DB/schema/migrations

- Cero archivos drizzle en el diff
- Test \`[11]\` verifica que \`talents.slug\` sigue siendo el preexistente \`varchar(100).notNull().unique()\`
- Sin redirect automático old → new (decisión consciente: queda como acción manual del admin en \`next.config.ts\`, igual que se hizo para Tigerr)

## Archivos tocados (3)

| Path | Cambio |
|---|---|
| \`src/features/admin/talents/components/TalentProfileForm.tsx\` | + sección Slug, + card Redes, +Link import |
| \`src/app/admin/(dashboard)/talents/actions.ts\` | + slug en Zod, + uniqueness check, + revalidate dual, + and/ne import |
| \`src/__tests__/server/talent-slug-editable.test.ts\` | **nuevo** — 26 tests |

## Tests añadidos (26)

| Bloque | Tests |
|---|---|
| Schema Zod | 6 — acepta tigerr/creator-cs2; rechaza mayúsculas, espacios, chars especiales, vacío |
| Form static | 8 — input slug existe, preview, pattern, normalización, warning, cambio detectado, link Redes, NO duplica editor |
| Action static | 11 — schema slug, uniqueness check con \`and(eq, ne)\`, mensaje humano, condicional oldSlug !== newSlug, set slug, revalidate dual, imports |
| Schema sin cambios | 1 — talents.slug sigue preexistente |

## CI

- \`npx tsc --noEmit\` ✅
- \`npm run lint\` ✅
- \`npm test\` ✅ — **107 suites / 1764 tests**

## Validación manual post-deploy

1. Abrir \`/admin/talents/<id>/edit\` de cualquier talento.
2. Verificar que aparece sección "Slug público" con el slug actual + preview \`/talentos/<slug>\` + warning.
3. Cambiar el slug (probar mayúsculas → se normaliza; carácter inválido → input rechaza por pattern).
4. Probar slug duplicado: si tienes 2 talentos, pon el slug de otro → al guardar, error humano "Este slug ya está usado por otro talento."
5. Cambiar slug de un talento publicado → verificar:
   - \`/talentos/<newSlug>\` carga el perfil
   - \`/talentos/<oldSlug>\` ahora 404 (limpio, sin pantalla blanca gracias al error boundary del PR #143)
6. Al final del form, ver card "Redes sociales" con link "Ir a Redes →".

🤖 Generated with [Claude Code](https://claude.com/claude-code)