### PR TITLE
feat(audit/finanzas-1B): AR Aging sin dunning — vista /admin/finanzas/cobros

### DIFF
--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -119,6 +119,14 @@ Los 76 warnings del linter son todos `no-unused-vars`. Los más repetidos:
 ### TD-13 · `import Link from 'next/link'` sin usar en AboutSection
 **Archivo:** `src/features/marketing-site/components/AboutSection.tsx` (ya limpiado hoy — ✅)
 
+### TD-14 · `receivables.ts` widget resumen usa `invoices.paidAmount` deprecated
+**Archivo:** `src/lib/queries/financeDashboard/receivables.ts:53`
+**Contexto:** El schema marca `invoices.paidAmount` como `@deprecated` — la fuente canónica de pagos es `invoice_payments`. La query nueva `arAging.ts` (Fase 1B, 2026-07-01) ya usa `invoice_payments` como fuente única para ambas fuentes (issued + internal). La query legacy `receivables.ts` sigue leyendo `invoices.paidAmount` column solo para el path `internal`.
+**Consecuencia:** El widget "Cobros pendientes" del resumen puede mostrar un `pendingAmount` distinto al de la nueva vista `/admin/finanzas/cobros` si `paidAmount` column ha divergido de `invoice_payments`. En la práctica solo afecta facturas internas antiguas creadas antes de la migración a `invoice_payments` — para las nuevas, la column se mantiene sincronizada por las Server Actions.
+**Acción:** En un PR próximo (fuera de Fase 1B) migrar el internal branch de `receivables.ts` a `COALESCE(SUM(invoice_payments.amount), 0)` para uniformizar. Requiere revisar el impacto en la home CEO (Fase 1A.1) y las AI tools que consumen `getFinanceDashboard()`.
+**Riesgo:** Bajo mientras coexistan. Medio si hay incoherencia entre las dos vistas visibles al mismo tiempo.
+**Esfuerzo:** 30 min + tests.
+
 ---
 
 ## Rutas que necesitan clarificación de propósito

--- a/src/__tests__/server/audit-finanzas-1b-ar-aging.test.ts
+++ b/src/__tests__/server/audit-finanzas-1b-ar-aging.test.ts
@@ -1,0 +1,453 @@
+/**
+ * Tests para Fase 1B — AR Aging sin dunning automático.
+ *
+ * Cubre:
+ *   - Lógica pura del clasificador (buckets, pending, fallback dueDate, KPIs).
+ *   - Chequeos estáticos de la nueva ruta, navegación y query.
+ *   - Anti-scope-creep: sin Resend, cron, invoice_reminders, migraciones, schema changes.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  applyArAgingFilters,
+  calcPending,
+  classifyBucket,
+  computeKpis,
+  diffDaysIso,
+  humanStatusLabel,
+  resolveEffectiveDueDate,
+  sortByAgingPriority,
+  summarizeBuckets,
+} from '@/lib/queries/financeDashboard/arAging.shared';
+import type { ArAgingRow } from '@/types/arAging';
+
+const PROJECT_ROOT = path.resolve(__dirname, '..', '..', '..');
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(PROJECT_ROOT, rel), 'utf-8');
+}
+
+function exists(rel: string): boolean {
+  return fs.existsSync(path.join(PROJECT_ROOT, rel));
+}
+
+// ── Helper para construir rows sintéticos ──────────────────────────────────
+
+function makeRow(overrides: Partial<ArAgingRow>): ArAgingRow {
+  const base: ArAgingRow = {
+    id: 1,
+    source: 'issued',
+    invoiceNumber: 'A-001',
+    brandName: null,
+    clientName: null,
+    entity: null,
+    totalAmount: 1000,
+    paidAmount: 0,
+    pendingAmount: 1000,
+    currency: 'EUR',
+    status: 'emitida',
+    issueDate: '2026-06-01',
+    dueDate: '2026-06-30',
+    effectiveDueDate: '2026-06-30',
+    isEstimatedDueDate: false,
+    daysOverdue: 1,
+    bucket: '0-30',
+    pdfUrl: null,
+  };
+  return { ...base, ...overrides };
+}
+
+describe('[Fase 1B] AR Aging — lógica pura', () => {
+  // ── Bucket classification ────────────────────────────────────────────────
+
+  describe('classifyBucket()', () => {
+    it('daysOverdue < 0 → por_vencer', () => {
+      expect(classifyBucket(-1)).toBe('por_vencer');
+      expect(classifyBucket(-30)).toBe('por_vencer');
+      expect(classifyBucket(-365)).toBe('por_vencer');
+    });
+
+    it('daysOverdue 0..30 → 0-30', () => {
+      expect(classifyBucket(0)).toBe('0-30');
+      expect(classifyBucket(1)).toBe('0-30');
+      expect(classifyBucket(30)).toBe('0-30');
+    });
+
+    it('daysOverdue 31..60 → 31-60', () => {
+      expect(classifyBucket(31)).toBe('31-60');
+      expect(classifyBucket(60)).toBe('31-60');
+    });
+
+    it('daysOverdue 61..90 → 61-90', () => {
+      expect(classifyBucket(61)).toBe('61-90');
+      expect(classifyBucket(90)).toBe('61-90');
+    });
+
+    it('daysOverdue > 90 → +90', () => {
+      expect(classifyBucket(91)).toBe('+90');
+      expect(classifyBucket(500)).toBe('+90');
+    });
+  });
+
+  // ── Pending calc ────────────────────────────────────────────────────────
+
+  describe('calcPending()', () => {
+    it('pending = total - paid', () => {
+      expect(calcPending(1000, 400)).toBe(600);
+      expect(calcPending(50, 0)).toBe(50);
+    });
+
+    it('nunca devuelve negativo (protege sobrepagos)', () => {
+      expect(calcPending(100, 200)).toBe(0);
+      expect(calcPending(0, 5)).toBe(0);
+    });
+
+    it('trunca ruido por debajo de medio céntimo a 0', () => {
+      expect(calcPending(100.004, 100)).toBe(0);
+      expect(calcPending(100.01, 100)).toBe(0.01);
+    });
+  });
+
+  // ── Fallback dueDate ────────────────────────────────────────────────────
+
+  describe('resolveEffectiveDueDate()', () => {
+    it('usa dueDate cuando existe', () => {
+      const r = resolveEffectiveDueDate('2026-01-01', '2026-02-15');
+      expect(r.effectiveDueDate).toBe('2026-02-15');
+      expect(r.isEstimatedDueDate).toBe(false);
+    });
+
+    it('fallback issueDate + 30 días cuando dueDate es null', () => {
+      const r = resolveEffectiveDueDate('2026-01-01', null);
+      expect(r.effectiveDueDate).toBe('2026-01-31');
+      expect(r.isEstimatedDueDate).toBe(true);
+    });
+
+    it('fallback cruza el cambio de mes correctamente', () => {
+      const r = resolveEffectiveDueDate('2026-06-15', null);
+      expect(r.effectiveDueDate).toBe('2026-07-15');
+      expect(r.isEstimatedDueDate).toBe(true);
+    });
+  });
+
+  describe('diffDaysIso()', () => {
+    it('devuelve diferencia positiva cuando from > to', () => {
+      expect(diffDaysIso('2026-07-10', '2026-07-01')).toBe(9);
+    });
+
+    it('devuelve negativo cuando from < to', () => {
+      expect(diffDaysIso('2026-07-01', '2026-07-10')).toBe(-9);
+    });
+
+    it('devuelve 0 en la misma fecha', () => {
+      expect(diffDaysIso('2026-07-01', '2026-07-01')).toBe(0);
+    });
+  });
+
+  // ── Human labels ────────────────────────────────────────────────────────
+
+  describe('humanStatusLabel()', () => {
+    it('siempre "Vencida" cuando el bucket no es por_vencer', () => {
+      expect(humanStatusLabel('emitida', '0-30')).toBe('Vencida');
+      expect(humanStatusLabel('parcial', '31-60')).toBe('Vencida');
+      expect(humanStatusLabel('vencida', '+90')).toBe('Vencida');
+    });
+
+    it('mapea status a labels humanos cuando bucket=por_vencer', () => {
+      expect(humanStatusLabel('emitida', 'por_vencer')).toBe('Pendiente');
+      expect(humanStatusLabel('no_cobrada', 'por_vencer')).toBe('Pendiente');
+      expect(humanStatusLabel('pendiente', 'por_vencer')).toBe('Pendiente');
+      expect(humanStatusLabel('parcial', 'por_vencer')).toBe('Pagada parcial');
+      expect(humanStatusLabel('vencida', 'por_vencer')).toBe('Vencida');
+    });
+  });
+
+  // ── Filtros ─────────────────────────────────────────────────────────────
+
+  describe('applyArAgingFilters()', () => {
+    const rows: ArAgingRow[] = [
+      makeRow({ id: 1, bucket: '0-30', brandName: 'Acme', entity: 'España', source: 'issued' }),
+      makeRow({ id: 2, bucket: '31-60', brandName: 'Beta', entity: 'Andorra', source: 'issued' }),
+      makeRow({ id: 3, bucket: 'por_vencer', brandName: 'Acme', entity: 'España', source: 'internal' }),
+    ];
+
+    it('sin filtros devuelve todo', () => {
+      expect(applyArAgingFilters(rows, {}).length).toBe(3);
+    });
+
+    it('filtra por bucket', () => {
+      const out = applyArAgingFilters(rows, { bucket: '0-30' });
+      expect(out.map((r) => r.id)).toEqual([1]);
+    });
+
+    it('filtra por entity', () => {
+      const out = applyArAgingFilters(rows, { entity: 'España' });
+      expect(out.map((r) => r.id)).toEqual([1, 3]);
+    });
+
+    it('filtra por source', () => {
+      const out = applyArAgingFilters(rows, { source: 'internal' });
+      expect(out.map((r) => r.id)).toEqual([3]);
+    });
+
+    it('combina múltiples filtros con AND', () => {
+      const out = applyArAgingFilters(rows, { brand: 'Acme', source: 'issued' });
+      expect(out.map((r) => r.id)).toEqual([1]);
+    });
+  });
+
+  // ── KPIs y agregaciones ─────────────────────────────────────────────────
+
+  describe('computeKpis()', () => {
+    it('sin filas devuelve totales a 0 y avg/topBrand null', () => {
+      const kpis = computeKpis([]);
+      expect(kpis.totalPending).toBe(0);
+      expect(kpis.totalOverdue).toBe(0);
+      expect(kpis.overdueCount).toBe(0);
+      expect(kpis.pendingNotYetDue).toBe(0);
+      expect(kpis.avgDaysOverdue).toBeNull();
+      expect(kpis.topDebtorBrand).toBeNull();
+    });
+
+    it('totalVencido excluye por_vencer', () => {
+      const kpis = computeKpis([
+        makeRow({ id: 1, pendingAmount: 100, bucket: 'por_vencer', daysOverdue: -5 }),
+        makeRow({ id: 2, pendingAmount: 200, bucket: '0-30', daysOverdue: 10 }),
+        makeRow({ id: 3, pendingAmount: 300, bucket: '31-60', daysOverdue: 45 }),
+      ]);
+      expect(kpis.totalPending).toBe(600);
+      expect(kpis.totalOverdue).toBe(500);
+      expect(kpis.overdueCount).toBe(2);
+      expect(kpis.pendingNotYetDue).toBe(100);
+    });
+
+    it('avgDaysOverdue excluye por_vencer y devuelve entero', () => {
+      const kpis = computeKpis([
+        makeRow({ id: 1, bucket: 'por_vencer', daysOverdue: -10 }),
+        makeRow({ id: 2, bucket: '0-30', daysOverdue: 10 }),
+        makeRow({ id: 3, bucket: '31-60', daysOverdue: 40 }),
+      ]);
+      expect(kpis.avgDaysOverdue).toBe(25); // (10 + 40) / 2
+    });
+
+    it('avgDaysOverdue null si no hay vencidas', () => {
+      const kpis = computeKpis([
+        makeRow({ id: 1, bucket: 'por_vencer', daysOverdue: -10 }),
+        makeRow({ id: 2, bucket: 'por_vencer', daysOverdue: -20 }),
+      ]);
+      expect(kpis.avgDaysOverdue).toBeNull();
+    });
+
+    it('topDebtorBrand suma por marca y devuelve la mayor', () => {
+      // Acme suma 100 + 400 = 500. Beta suma 300. Acme gana.
+      const kpis = computeKpis([
+        makeRow({ id: 1, brandName: 'Acme', pendingAmount: 100 }),
+        makeRow({ id: 2, brandName: 'Beta', pendingAmount: 300 }),
+        makeRow({ id: 3, brandName: 'Acme', pendingAmount: 400 }),
+      ]);
+      expect(kpis.topDebtorBrand).toEqual({ name: 'Acme', amount: 500 });
+    });
+
+    it('topDebtorBrand ignora filas sin marca', () => {
+      const kpis = computeKpis([
+        makeRow({ id: 1, brandName: null, pendingAmount: 999 }),
+        makeRow({ id: 2, brandName: 'Solo', pendingAmount: 50 }),
+      ]);
+      expect(kpis.topDebtorBrand).toEqual({ name: 'Solo', amount: 50 });
+    });
+  });
+
+  describe('summarizeBuckets()', () => {
+    it('siempre devuelve los 5 buckets en orden canónico', () => {
+      const buckets = summarizeBuckets([]);
+      expect(buckets.map((b) => b.key)).toEqual([
+        'por_vencer', '0-30', '31-60', '61-90', '+90',
+      ]);
+      expect(buckets.every((b) => b.amount === 0 && b.count === 0)).toBe(true);
+    });
+
+    it('suma correctamente por bucket y calcula %', () => {
+      const buckets = summarizeBuckets([
+        makeRow({ id: 1, bucket: '0-30', pendingAmount: 100 }),
+        makeRow({ id: 2, bucket: '0-30', pendingAmount: 200 }),
+        makeRow({ id: 3, bucket: '31-60', pendingAmount: 700 }),
+      ]);
+      const total = 1000;
+      const b030 = buckets.find((b) => b.key === '0-30');
+      const b3160 = buckets.find((b) => b.key === '31-60');
+      expect(b030).toEqual({ key: '0-30', amount: 300, count: 2, pct: (300 / total) * 100 });
+      expect(b3160).toEqual({ key: '31-60', amount: 700, count: 1, pct: 70 });
+    });
+  });
+
+  describe('sortByAgingPriority()', () => {
+    it('ordena por effectiveDueDate ASC, luego pending DESC', () => {
+      const rows = sortByAgingPriority([
+        makeRow({ id: 1, effectiveDueDate: '2026-05-01', pendingAmount: 100 }),
+        makeRow({ id: 2, effectiveDueDate: '2026-04-01', pendingAmount: 500 }),
+        makeRow({ id: 3, effectiveDueDate: '2026-05-01', pendingAmount: 800 }),
+      ]);
+      expect(rows.map((r) => r.id)).toEqual([2, 3, 1]);
+    });
+  });
+});
+
+// ── Chequeos estáticos ─────────────────────────────────────────────────────
+
+describe('[Fase 1B] AR Aging — chequeos estáticos', () => {
+  describe('Ruta /admin/finanzas/cobros', () => {
+    const src = read('src/app/admin/(dashboard)/finanzas/cobros/page.tsx');
+
+    it('existe la página', () => {
+      expect(exists('src/app/admin/(dashboard)/finanzas/cobros/page.tsx')).toBe(true);
+    });
+
+    it('llama a requirePermission("facturacion", "read")', () => {
+      expect(src).toMatch(
+        /requirePermission\(\s*['"]facturacion['"]\s*,\s*['"]read['"]\s*\)/,
+      );
+    });
+
+    it('importa getArAging', () => {
+      expect(src).toMatch(/from\s+['"]@\/lib\/queries\/financeDashboard\/arAging['"]/);
+      expect(src).toMatch(/\bgetArAging\b/);
+    });
+
+    it('renderiza los 4 sub-componentes de la vista', () => {
+      expect(src).toMatch(/ArAgingKPIs/);
+      expect(src).toMatch(/ArAgingBuckets/);
+      expect(src).toMatch(/ArAgingTable/);
+      expect(src).toMatch(/ArAgingFiltersBar/);
+    });
+
+    it('renderiza banner multi-divisa cuando hasMultipleCurrencies', () => {
+      expect(src).toMatch(/hasMultipleCurrencies/);
+      expect(src).toMatch(/distintas divisas/);
+    });
+  });
+
+  describe('FinanzasNav', () => {
+    const src = read('src/app/admin/(dashboard)/finanzas/FinanzasNav.tsx');
+
+    it('incluye tab /admin/finanzas/cobros', () => {
+      expect(src).toMatch(/\/admin\/finanzas\/cobros/);
+    });
+
+    it('label humano "Cobros pendientes"', () => {
+      expect(src).toMatch(/Cobros pendientes/);
+    });
+  });
+
+  describe('Query getArAging', () => {
+    const src = read('src/lib/queries/financeDashboard/arAging.ts');
+
+    it('usa invoicePayments como fuente de paid (no invoices.paidAmount column)', () => {
+      expect(src).toMatch(/COALESCE\(SUM\(\$\{invoicePayments\.amount\}\)/);
+      expect(src).not.toMatch(/paidAmount:\s*invoices\.paidAmount/);
+    });
+
+    it('marca el archivo como server-only', () => {
+      expect(src).toMatch(/^['"]server-only['"];/m);
+    });
+
+    it('índice de queries re-exporta getArAging', () => {
+      const idx = read('src/lib/queries/financeDashboard/index.ts');
+      expect(idx).toMatch(/export\s+\{\s*getArAging\s*\}/);
+    });
+  });
+
+  describe('Componentes AR Aging', () => {
+    const files = [
+      'src/features/admin/finance-dashboard/components/ArAgingKPIs.tsx',
+      'src/features/admin/finance-dashboard/components/ArAgingBuckets.tsx',
+      'src/features/admin/finance-dashboard/components/ArAgingTable.tsx',
+      'src/features/admin/finance-dashboard/components/ArAgingFilters.tsx',
+    ];
+
+    it.each(files)('%s existe', (rel) => {
+      expect(exists(rel)).toBe(true);
+    });
+
+    it('la tabla no muestra strings técnicos ni status raw', () => {
+      const tbl = read('src/features/admin/finance-dashboard/components/ArAgingTable.tsx');
+      // No renderiza `row.status` crudo — usa humanStatusLabel
+      expect(tbl).toMatch(/humanStatusLabel/);
+      expect(tbl).not.toMatch(/\{row\.status\}/);
+    });
+
+    it('los KPIs y buckets no muestran labels técnicos como "paidAmount" o "invoice_payments"', () => {
+      const kpis = read('src/features/admin/finance-dashboard/components/ArAgingKPIs.tsx');
+      const buckets = read('src/features/admin/finance-dashboard/components/ArAgingBuckets.tsx');
+      for (const src of [kpis, buckets]) {
+        expect(src).not.toMatch(/>\s*paidAmount\s*</);
+        expect(src).not.toMatch(/>\s*invoice_payments\s*</);
+        expect(src).not.toMatch(/>\s*status\s*raw\s*</);
+      }
+    });
+  });
+
+  describe('Tipos', () => {
+    it('existe src/types/arAging.ts con los tipos esperados', () => {
+      expect(exists('src/types/arAging.ts')).toBe(true);
+      const src = read('src/types/arAging.ts');
+      expect(src).toMatch(/ArAgingRow/);
+      expect(src).toMatch(/ArAgingBucket/);
+      expect(src).toMatch(/ArAgingKpis/);
+      expect(src).toMatch(/ArAgingFilters/);
+    });
+  });
+});
+
+// ── Anti-scope-creep ───────────────────────────────────────────────────────
+
+describe('[Fase 1B] Anti-scope-creep', () => {
+  const filesToScan = [
+    'src/lib/queries/financeDashboard/arAging.ts',
+    'src/lib/queries/financeDashboard/arAging.shared.ts',
+    'src/app/admin/(dashboard)/finanzas/cobros/page.tsx',
+    'src/features/admin/finance-dashboard/components/ArAgingKPIs.tsx',
+    'src/features/admin/finance-dashboard/components/ArAgingBuckets.tsx',
+    'src/features/admin/finance-dashboard/components/ArAgingTable.tsx',
+    'src/features/admin/finance-dashboard/components/ArAgingFilters.tsx',
+  ];
+
+  it.each(filesToScan)('%s no importa Resend ni utilidades de email', (rel) => {
+    const src = read(rel);
+    expect(src).not.toMatch(/from\s+['"]resend['"]/);
+    expect(src).not.toMatch(/@\/lib\/email/);
+    expect(src).not.toMatch(/sendEmail/);
+  });
+
+  it.each(filesToScan)('%s no referencia invoice_reminders ni tablas nuevas', (rel) => {
+    const src = read(rel);
+    expect(src).not.toMatch(/invoice_reminders/);
+    expect(src).not.toMatch(/invoiceReminders/);
+  });
+
+  it('no se ha creado ninguna migration nueva para esta feature', () => {
+    // Los migration snapshots de la Fase 1B no deben aparecer. Si aparecen,
+    // significa que alguien tocó schema.
+    const src = read('src/lib/queries/financeDashboard/arAging.ts');
+    expect(src).not.toMatch(/pgTable\s*\(/);
+    expect(src).not.toMatch(/alterTable/);
+  });
+
+  it('no hay cron nuevo apuntando a AR aging', () => {
+    // Rutas típicas de cron en el proyecto.
+    const cronDir = 'src/app/api/cron';
+    if (!exists(cronDir)) return;
+    const entries = fs.readdirSync(path.join(PROJECT_ROOT, cronDir), { withFileTypes: true });
+    const names = entries.map((e) => e.name);
+    for (const name of names) {
+      expect(name).not.toMatch(/ar-aging|receivables?-remind|invoice-remind|dunning/);
+    }
+  });
+
+  it('el índice de queries no exporta helpers de dunning ni reminders', () => {
+    const idx = read('src/lib/queries/financeDashboard/index.ts');
+    expect(idx).not.toMatch(/dunning/i);
+    expect(idx).not.toMatch(/reminders?/i);
+    expect(idx).not.toMatch(/sendReminder/);
+  });
+});

--- a/src/app/admin/(dashboard)/finanzas/FinanzasNav.tsx
+++ b/src/app/admin/(dashboard)/finanzas/FinanzasNav.tsx
@@ -11,6 +11,7 @@ type Tab = {
 
 const TABS: readonly Tab[] = [
   { href: '/admin/finanzas/resumen', label: 'Control mensual' },
+  { href: '/admin/finanzas/cobros', label: 'Cobros pendientes' },
   { href: '/admin/finanzas/pl', label: 'Histórico mensual' },
   {
     href: '/admin/finanzas/gastos',

--- a/src/app/admin/(dashboard)/finanzas/cobros/page.tsx
+++ b/src/app/admin/(dashboard)/finanzas/cobros/page.tsx
@@ -1,0 +1,85 @@
+import { requirePermission } from '@/lib/permissions';
+import { getArAging } from '@/lib/queries/financeDashboard/arAging';
+import { AR_AGING_BUCKET_ORDER, type ArAgingBucketKey, type ArAgingFilters, type ArAgingSource } from '@/types/arAging';
+import { ArAgingKPIs } from '@/features/admin/finance-dashboard/components/ArAgingKPIs';
+import { ArAgingBuckets } from '@/features/admin/finance-dashboard/components/ArAgingBuckets';
+import { ArAgingTable } from '@/features/admin/finance-dashboard/components/ArAgingTable';
+import { ArAgingFiltersBar } from '@/features/admin/finance-dashboard/components/ArAgingFilters';
+
+export const metadata = { title: 'Cobros pendientes · Finanzas' };
+
+const BUCKET_SET = new Set<ArAgingBucketKey>(AR_AGING_BUCKET_ORDER);
+const SOURCE_SET = new Set<ArAgingSource>(['issued', 'internal']);
+
+type PageProps = {
+  readonly searchParams?: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export default async function FinanzasCobrosPage({ searchParams }: PageProps): Promise<React.ReactElement> {
+  await requirePermission('facturacion', 'read');
+
+  const sp = (await searchParams) ?? {};
+  const filters = parseFilters(sp);
+  const data = await getArAging(filters);
+
+  return (
+    <div className="space-y-5 pt-2">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-bold text-sp-admin-fg">Cobros pendientes</h1>
+          <p className="text-sm text-sp-admin-muted">
+            Facturas emitidas e internas con saldo pendiente. Ordenadas por vencimiento.
+          </p>
+        </div>
+      </div>
+
+      {data.hasMultipleCurrencies && (
+        <div className="rounded-lg border border-amber-500/30 bg-amber-500/5 px-4 py-3 text-sm text-amber-300">
+          Los totales agregan importes en distintas divisas sin conversión. Revisa las filas para el detalle.
+        </div>
+      )}
+
+      <ArAgingKPIs kpis={data.kpis} />
+
+      <ArAgingBuckets buckets={data.buckets} />
+
+      <ArAgingFiltersBar
+        applied={data.appliedFilters}
+        availableEntities={data.availableEntities}
+        availableBrands={data.availableBrands}
+        hasResults={data.rows.length > 0}
+      />
+
+      <ArAgingTable rows={data.rows} />
+    </div>
+  );
+}
+
+function firstParam(v: string | string[] | undefined): string | undefined {
+  if (v === undefined) return undefined;
+  return Array.isArray(v) ? v[0] : v;
+}
+
+function parseFilters(sp: Record<string, string | string[] | undefined>): ArAgingFilters {
+  const bucket = firstParam(sp.bucket);
+  const entity = firstParam(sp.entity);
+  const brand = firstParam(sp.brand);
+  const source = firstParam(sp.source);
+
+  const out: {
+    bucket?: ArAgingBucketKey;
+    entity?: string;
+    brand?: string;
+    source?: ArAgingSource;
+  } = {};
+
+  if (bucket && BUCKET_SET.has(bucket as ArAgingBucketKey)) {
+    out.bucket = bucket as ArAgingBucketKey;
+  }
+  if (entity) out.entity = entity;
+  if (brand) out.brand = brand;
+  if (source && SOURCE_SET.has(source as ArAgingSource)) {
+    out.source = source as ArAgingSource;
+  }
+  return out;
+}

--- a/src/features/admin/finance-dashboard/components/ArAgingBuckets.tsx
+++ b/src/features/admin/finance-dashboard/components/ArAgingBuckets.tsx
@@ -1,0 +1,76 @@
+import { AR_AGING_BUCKET_LABELS, type ArAgingBucket } from '@/types/arAging';
+
+const EUR = new Intl.NumberFormat('es-ES', {
+  style: 'currency',
+  currency: 'EUR',
+  maximumFractionDigits: 0,
+});
+
+function bucketColor(key: ArAgingBucket['key']): string {
+  switch (key) {
+    case 'por_vencer': return 'bg-emerald-500/60';
+    case '0-30':      return 'bg-amber-500/70';
+    case '31-60':     return 'bg-orange-500/70';
+    case '61-90':     return 'bg-red-500/70';
+    case '+90':       return 'bg-red-600/80';
+  }
+}
+
+function bucketTextColor(key: ArAgingBucket['key']): string {
+  switch (key) {
+    case 'por_vencer': return 'text-emerald-400';
+    case '0-30':      return 'text-amber-400';
+    case '31-60':     return 'text-orange-400';
+    case '61-90':     return 'text-red-400';
+    case '+90':       return 'text-red-400';
+  }
+}
+
+type Props = {
+  readonly buckets: readonly ArAgingBucket[];
+};
+
+export function ArAgingBuckets({ buckets }: Props): React.ReactElement {
+  const total = buckets.reduce((s, b) => s + b.count, 0);
+  if (total === 0) {
+    return (
+      <div className="rounded-2xl border border-sp-admin-border bg-sp-admin-card px-5 py-8 text-center text-sm text-sp-admin-muted">
+        No hay cobros pendientes con los filtros aplicados
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-2xl border border-sp-admin-border bg-sp-admin-card p-5">
+      <p className="mb-4 text-[11px] font-semibold uppercase tracking-widest text-sp-admin-muted">
+        Antigüedad del pendiente
+      </p>
+      <div className="space-y-3">
+        {buckets.map((b) => {
+          const label = AR_AGING_BUCKET_LABELS[b.key];
+          const pctLabel = `${b.pct.toFixed(0)}%`;
+          const countLabel = b.count === 1 ? '1 factura' : `${b.count} facturas`;
+          return (
+            <div key={b.key}>
+              <div className="mb-1 flex items-baseline justify-between gap-3">
+                <span className="text-sm text-sp-admin-fg">
+                  {label}
+                  <span className="ml-2 text-xs text-sp-admin-muted">· {countLabel}</span>
+                </span>
+                <span className={`tabular-nums text-sm ${bucketTextColor(b.key)}`}>
+                  {EUR.format(b.amount)} <span className="text-sp-admin-muted">· {pctLabel}</span>
+                </span>
+              </div>
+              <div className="h-1.5 w-full overflow-hidden rounded-full bg-sp-admin-border">
+                <div
+                  className={`h-full rounded-full ${bucketColor(b.key)}`}
+                  style={{ width: `${Math.min(b.pct, 100).toFixed(1)}%` }}
+                />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/features/admin/finance-dashboard/components/ArAgingFilters.tsx
+++ b/src/features/admin/finance-dashboard/components/ArAgingFilters.tsx
@@ -1,0 +1,165 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useCallback, useTransition } from 'react';
+import {
+  AR_AGING_BUCKET_LABELS,
+  AR_AGING_BUCKET_ORDER,
+  type ArAgingBucketKey,
+  type ArAgingFilters,
+  type ArAgingSource,
+} from '@/types/arAging';
+
+const SOURCE_LABELS: Readonly<Record<ArAgingSource, string>> = {
+  issued: 'Emitidas (Veri*factu)',
+  internal: 'Internas',
+};
+
+type Props = {
+  readonly applied: ArAgingFilters;
+  readonly availableEntities: readonly string[];
+  readonly availableBrands: readonly string[];
+  readonly hasResults: boolean;
+};
+
+export function ArAgingFiltersBar({
+  applied,
+  availableEntities,
+  availableBrands,
+  hasResults,
+}: Props): React.ReactElement {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [pending, startTransition] = useTransition();
+
+  const update = useCallback(
+    (key: keyof ArAgingFilters, value: string | undefined) => {
+      const params = new URLSearchParams(searchParams?.toString() ?? '');
+      if (value) {
+        params.set(key, value);
+      } else {
+        params.delete(key);
+      }
+      const qs = params.toString();
+      startTransition(() => {
+        router.push(qs ? `/admin/finanzas/cobros?${qs}` : '/admin/finanzas/cobros');
+      });
+    },
+    [router, searchParams],
+  );
+
+  const clearAll = useCallback(() => {
+    startTransition(() => {
+      router.push('/admin/finanzas/cobros');
+    });
+  }, [router]);
+
+  const hasAnyFilter =
+    Boolean(applied.bucket) ||
+    Boolean(applied.entity) ||
+    Boolean(applied.brand) ||
+    Boolean(applied.source);
+
+  return (
+    <div
+      className={`flex flex-wrap items-end gap-3 rounded-xl border border-sp-admin-border bg-sp-admin-card p-4 ${pending ? 'opacity-70' : ''}`}
+      aria-busy={pending}
+    >
+      <FilterSelect
+        label="Antigüedad"
+        value={applied.bucket ?? ''}
+        onChange={(v) => update('bucket', v || undefined)}
+        options={[
+          { value: '', label: 'Todas' },
+          ...AR_AGING_BUCKET_ORDER.map((k: ArAgingBucketKey) => ({
+            value: k,
+            label: AR_AGING_BUCKET_LABELS[k],
+          })),
+        ]}
+      />
+
+      <FilterSelect
+        label="Entidad"
+        value={applied.entity ?? ''}
+        onChange={(v) => update('entity', v || undefined)}
+        options={[
+          { value: '', label: 'Todas' },
+          ...availableEntities.map((e) => ({ value: e, label: e })),
+        ]}
+        disabled={availableEntities.length === 0}
+      />
+
+      <FilterSelect
+        label="Marca"
+        value={applied.brand ?? ''}
+        onChange={(v) => update('brand', v || undefined)}
+        options={[
+          { value: '', label: 'Todas' },
+          ...availableBrands.map((b) => ({ value: b, label: b })),
+        ]}
+        disabled={availableBrands.length === 0}
+      />
+
+      <FilterSelect
+        label="Origen"
+        value={applied.source ?? ''}
+        onChange={(v) => update('source', v || undefined)}
+        options={[
+          { value: '', label: 'Todos' },
+          { value: 'issued', label: SOURCE_LABELS.issued },
+          { value: 'internal', label: SOURCE_LABELS.internal },
+        ]}
+      />
+
+      {hasAnyFilter && (
+        <button
+          type="button"
+          onClick={clearAll}
+          className="ml-auto rounded-lg border border-sp-admin-border px-3 py-1.5 text-xs font-medium text-sp-admin-muted hover:border-sp-orange hover:text-sp-admin-fg"
+        >
+          Limpiar filtros
+        </button>
+      )}
+
+      {!hasResults && hasAnyFilter && (
+        <p className="ml-auto text-xs text-sp-admin-muted">
+          Sin resultados con estos filtros
+        </p>
+      )}
+    </div>
+  );
+}
+
+// ── Sub ──────────────────────────────────────────────────────────────────────
+
+type Option = { readonly value: string; readonly label: string };
+
+type FilterSelectProps = {
+  readonly label: string;
+  readonly value: string;
+  readonly onChange: (v: string) => void;
+  readonly options: readonly Option[];
+  readonly disabled?: boolean;
+};
+
+function FilterSelect({ label, value, onChange, options, disabled }: FilterSelectProps): React.ReactElement {
+  return (
+    <label className="flex flex-col gap-1">
+      <span className="text-[10px] font-semibold uppercase tracking-[0.16em] text-sp-admin-muted">
+        {label}
+      </span>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
+        className="rounded-lg border border-sp-admin-border bg-sp-admin-card px-3 py-1.5 text-sm font-medium text-sp-admin-fg focus:outline-none focus:ring-1 focus:ring-sp-orange disabled:opacity-50"
+      >
+        {options.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/src/features/admin/finance-dashboard/components/ArAgingKPIs.tsx
+++ b/src/features/admin/finance-dashboard/components/ArAgingKPIs.tsx
@@ -1,0 +1,108 @@
+import type { ArAgingKpis } from '@/types/arAging';
+
+const EUR = new Intl.NumberFormat('es-ES', {
+  style: 'currency',
+  currency: 'EUR',
+  maximumFractionDigits: 0,
+});
+
+type Accent = 'income' | 'warn' | 'neutral' | 'expense';
+
+type KpiCardProps = {
+  readonly label: string;
+  readonly value: string;
+  readonly hint?: string;
+  readonly accent: Accent;
+};
+
+function KpiCard({ label, value, hint, accent }: KpiCardProps): React.ReactElement {
+  const border =
+    accent === 'income' ? 'border-emerald-500/40'
+    : accent === 'warn' ? 'border-amber-500/40'
+    : accent === 'expense' ? 'border-red-500/40'
+    : 'border-sp-admin-border';
+  const dot =
+    accent === 'income' ? 'bg-emerald-500'
+    : accent === 'warn' ? 'bg-amber-500'
+    : accent === 'expense' ? 'bg-red-500'
+    : 'bg-sp-admin-muted';
+  const valueColor =
+    accent === 'income' ? 'text-emerald-400'
+    : accent === 'warn' ? 'text-amber-400'
+    : accent === 'expense' ? 'text-red-400'
+    : 'text-sp-admin-fg';
+
+  return (
+    <div className={`flex flex-col gap-2 rounded-xl border ${border} bg-sp-admin-card p-5`}>
+      <div className="flex items-center gap-2">
+        <span className={`h-2 w-2 rounded-full ${dot}`} />
+        <span className="text-[11px] font-semibold uppercase tracking-[0.16em] text-sp-admin-muted">
+          {label}
+        </span>
+      </div>
+      <span className={`text-3xl font-black tabular-nums ${valueColor}`}>{value}</span>
+      {hint && <span className="text-[11px] text-sp-admin-muted">{hint}</span>}
+    </div>
+  );
+}
+
+type Props = {
+  readonly kpis: ArAgingKpis;
+};
+
+export function ArAgingKPIs({ kpis }: Props): React.ReactElement {
+  const topBrandValue = kpis.topDebtorBrand
+    ? EUR.format(kpis.topDebtorBrand.amount)
+    : '—';
+  const topBrandHint = kpis.topDebtorBrand?.name ?? 'Sin marca principal';
+
+  const avgLabel =
+    kpis.avgDaysOverdue !== null
+      ? `${kpis.avgDaysOverdue} d`
+      : '—';
+
+  return (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+      <KpiCard
+        label="Total pendiente de cobrar"
+        value={EUR.format(kpis.totalPending)}
+        hint="Saldo vivo total"
+        accent="income"
+      />
+      <KpiCard
+        label="Total vencido"
+        value={kpis.totalOverdue > 0 ? EUR.format(kpis.totalOverdue) : 'Al día'}
+        hint="Facturas con fecha vencida"
+        accent={kpis.totalOverdue > 0 ? 'expense' : 'neutral'}
+      />
+      <KpiCard
+        label="Facturas vencidas"
+        value={String(kpis.overdueCount)}
+        hint="Número de facturas fuera de plazo"
+        accent={kpis.overdueCount > 0 ? 'expense' : 'neutral'}
+      />
+      <KpiCard
+        label="Pendiente por vencer"
+        value={EUR.format(kpis.pendingNotYetDue)}
+        hint="Aún dentro del plazo"
+        accent={kpis.pendingNotYetDue > 0 ? 'warn' : 'neutral'}
+      />
+      <KpiCard
+        label="Mayor deuda por marca"
+        value={topBrandValue}
+        hint={topBrandHint}
+        accent={kpis.topDebtorBrand ? 'warn' : 'neutral'}
+      />
+      <KpiCard
+        label="Promedio días de retraso"
+        value={avgLabel}
+        hint="Solo entre facturas vencidas"
+        accent={
+          kpis.avgDaysOverdue !== null && kpis.avgDaysOverdue > 30 ? 'expense'
+          : kpis.avgDaysOverdue !== null && kpis.avgDaysOverdue > 0 ? 'warn'
+          : 'neutral'
+        }
+      />
+    </div>
+  );
+}

--- a/src/features/admin/finance-dashboard/components/ArAgingTable.tsx
+++ b/src/features/admin/finance-dashboard/components/ArAgingTable.tsx
@@ -1,0 +1,190 @@
+import { AR_AGING_BUCKET_LABELS, type ArAgingRow } from '@/types/arAging';
+import { humanStatusLabel } from '@/lib/queries/financeDashboard/arAging.shared';
+
+const EUR = new Intl.NumberFormat('es-ES', {
+  style: 'currency',
+  currency: 'EUR',
+  maximumFractionDigits: 2,
+});
+
+const DATE_FMT = new Intl.DateTimeFormat('es-ES', {
+  day: '2-digit',
+  month: 'short',
+  year: '2-digit',
+});
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '—';
+  const [y, m, d] = iso.split('-').map(Number);
+  if (!y || !m || !d) return iso;
+  return DATE_FMT.format(new Date(y, m - 1, d));
+}
+
+function formatMoney(amount: number, currency: string): string {
+  if (currency === 'EUR') return EUR.format(amount);
+  try {
+    return new Intl.NumberFormat('es-ES', {
+      style: 'currency',
+      currency,
+      maximumFractionDigits: 2,
+    }).format(amount);
+  } catch {
+    return `${amount.toFixed(2)} ${currency}`;
+  }
+}
+
+function daysLabel(daysOverdue: number): string {
+  if (daysOverdue < 0) return `en ${-daysOverdue} d`;
+  if (daysOverdue === 0) return 'hoy';
+  return `${daysOverdue} d`;
+}
+
+function bucketBadgeClass(bucket: ArAgingRow['bucket']): string {
+  switch (bucket) {
+    case 'por_vencer': return 'border-emerald-500/40 text-emerald-400';
+    case '0-30':      return 'border-amber-500/40 text-amber-400';
+    case '31-60':     return 'border-orange-500/40 text-orange-400';
+    case '61-90':     return 'border-red-500/40 text-red-400';
+    case '+90':       return 'border-red-600/60 text-red-400';
+  }
+}
+
+function statusBadgeClass(label: string): string {
+  if (label === 'Vencida') return 'border-red-500/40 text-red-400';
+  if (label === 'Pagada parcial') return 'border-amber-500/40 text-amber-400';
+  return 'border-sp-admin-border text-sp-admin-muted';
+}
+
+type Props = {
+  readonly rows: readonly ArAgingRow[];
+};
+
+export function ArAgingTable({ rows }: Props): React.ReactElement {
+  if (rows.length === 0) {
+    return (
+      <div className="rounded-2xl border border-sp-admin-border bg-sp-admin-card px-5 py-8 text-center text-sm text-sp-admin-muted">
+        No hay cobros pendientes con los filtros aplicados
+      </div>
+    );
+  }
+
+  const headers = [
+    'Marca / Cliente',
+    'Factura',
+    'Entidad',
+    'Importe',
+    'Pagado',
+    'Pendiente',
+    'Emisión',
+    'Vencimiento',
+    'Días de retraso',
+    'Bucket',
+    'Estado',
+    'PDF',
+  ];
+
+  return (
+    <div className="rounded-2xl border border-sp-admin-border bg-sp-admin-card">
+      <div className="border-b border-sp-admin-border px-5 py-3">
+        <h3 className="text-[11px] font-semibold uppercase tracking-[0.2em] text-sp-admin-muted">
+          Facturas pendientes
+        </h3>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-sp-admin-border">
+              {headers.map((h) => (
+                <th
+                  key={h}
+                  className="px-3 py-2 text-left text-[10px] font-semibold uppercase tracking-[0.15em] text-sp-admin-muted whitespace-nowrap"
+                >
+                  {h}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => {
+              const primary = row.brandName ?? row.clientName ?? '—';
+              const secondary = row.brandName && row.clientName && row.brandName !== row.clientName
+                ? row.clientName
+                : null;
+              const statusLabel = humanStatusLabel(row.status, row.bucket);
+
+              return (
+                <tr
+                  key={`${row.source}-${row.id}`}
+                  className="border-b border-sp-admin-border/50 last:border-0 hover:bg-white/[0.02]"
+                >
+                  <td className="px-3 py-2 text-sp-admin-fg">
+                    <div className="font-medium">{primary}</div>
+                    {secondary && (
+                      <div className="text-xs text-sp-admin-muted">{secondary}</div>
+                    )}
+                  </td>
+                  <td className="px-3 py-2 font-mono text-xs text-sp-admin-fg whitespace-nowrap">
+                    {row.invoiceNumber}
+                    {row.source === 'issued' && (
+                      <span className="ml-1 text-[9px] text-sp-admin-muted">EMI</span>
+                    )}
+                  </td>
+                  <td className="px-3 py-2 text-sp-admin-muted whitespace-nowrap">
+                    {row.entity ?? '—'}
+                  </td>
+                  <td className="px-3 py-2 text-right text-sp-admin-fg whitespace-nowrap">
+                    {formatMoney(row.totalAmount, row.currency)}
+                  </td>
+                  <td className="px-3 py-2 text-right text-emerald-400 whitespace-nowrap">
+                    {row.paidAmount > 0 ? formatMoney(row.paidAmount, row.currency) : <span className="text-sp-admin-muted">—</span>}
+                  </td>
+                  <td className="px-3 py-2 text-right font-semibold text-amber-400 whitespace-nowrap">
+                    {formatMoney(row.pendingAmount, row.currency)}
+                  </td>
+                  <td className="px-3 py-2 text-sp-admin-muted whitespace-nowrap">
+                    {formatDate(row.issueDate)}
+                  </td>
+                  <td className={`px-3 py-2 whitespace-nowrap ${row.bucket !== 'por_vencer' ? 'text-red-400' : 'text-sp-admin-muted'}`}>
+                    <div>{formatDate(row.effectiveDueDate)}</div>
+                    {row.isEstimatedDueDate && (
+                      <div className="text-[10px] italic text-sp-admin-muted">
+                        Vencimiento estimado
+                      </div>
+                    )}
+                  </td>
+                  <td className={`px-3 py-2 whitespace-nowrap tabular-nums ${row.bucket !== 'por_vencer' ? 'text-red-400' : 'text-sp-admin-muted'}`}>
+                    {daysLabel(row.daysOverdue)}
+                  </td>
+                  <td className="px-3 py-2 whitespace-nowrap">
+                    <span className={`rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-wider ${bucketBadgeClass(row.bucket)}`}>
+                      {AR_AGING_BUCKET_LABELS[row.bucket]}
+                    </span>
+                  </td>
+                  <td className="px-3 py-2 whitespace-nowrap">
+                    <span className={`rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-wider ${statusBadgeClass(statusLabel)}`}>
+                      {statusLabel}
+                    </span>
+                  </td>
+                  <td className="px-3 py-2 whitespace-nowrap">
+                    {row.pdfUrl ? (
+                      <a
+                        href={row.pdfUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-xs text-sp-blue underline-offset-2 hover:underline"
+                      >
+                        Ver PDF
+                      </a>
+                    ) : (
+                      <span className="text-xs text-sp-admin-muted">—</span>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/queries/financeDashboard/arAging.shared.ts
+++ b/src/lib/queries/financeDashboard/arAging.shared.ts
@@ -1,0 +1,244 @@
+/**
+ * Lógica pura del AR Aging — clasificación de cobros pendientes por antigüedad.
+ *
+ * Sin dependencias de @/lib/db ni de 'server-only' para permitir tests unitarios
+ * y consumo desde Client Components si hiciera falta.
+ *
+ * La query con DB vive en `arAging.ts` (server-only) y usa estas funciones.
+ */
+
+import {
+  AR_AGING_BUCKET_ORDER,
+  type ArAgingBucket,
+  type ArAgingBucketKey,
+  type ArAgingFilters,
+  type ArAgingKpis,
+  type ArAgingRow,
+} from '@/types/arAging';
+
+// ── Zona horaria canónica ───────────────────────────────────────────────────
+
+/**
+ * Fecha actual en formato ISO YYYY-MM-DD en Europe/Madrid.
+ * Aislado como función para poder mockear en tests inyectando un `today` fijo.
+ */
+export function todayInMadrid(now: Date = new Date()): string {
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Europe/Madrid',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(now);
+  return parts;
+}
+
+// ── Fechas: fallback dueDate y diff de días ─────────────────────────────────
+
+/**
+ * Suma `days` días a un ISO date `YYYY-MM-DD` y devuelve otro ISO date.
+ * Usa Date UTC para evitar drift por horario de verano.
+ */
+export function addDaysIso(iso: string, days: number): string {
+  const [y, m, d] = iso.split('-').map(Number);
+  if (!y || !m || !d) return iso;
+  const utc = Date.UTC(y, m - 1, d) + days * 86_400_000;
+  const dt = new Date(utc);
+  const yy = dt.getUTCFullYear();
+  const mm = String(dt.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(dt.getUTCDate()).padStart(2, '0');
+  return `${yy}-${mm}-${dd}`;
+}
+
+/**
+ * Diferencia en días enteros entre dos ISO dates (`today - dueDate`).
+ * Positivo = vencida hace N días; 0 = vence hoy; negativo = vence en N días.
+ */
+export function diffDaysIso(from: string, to: string): number {
+  const [ya, ma, da] = from.split('-').map(Number);
+  const [yb, mb, db] = to.split('-').map(Number);
+  if (!ya || !ma || !da || !yb || !mb || !db) return 0;
+  const a = Date.UTC(ya, ma - 1, da);
+  const b = Date.UTC(yb, mb - 1, db);
+  return Math.round((a - b) / 86_400_000);
+}
+
+/**
+ * Devuelve `effectiveDueDate` e `isEstimatedDueDate` aplicando fallback
+ * `issueDate + 30 días` cuando no hay dueDate real.
+ */
+export function resolveEffectiveDueDate(
+  issueDate: string,
+  dueDate: string | null,
+): { effectiveDueDate: string; isEstimatedDueDate: boolean } {
+  if (dueDate) {
+    return { effectiveDueDate: dueDate, isEstimatedDueDate: false };
+  }
+  return { effectiveDueDate: addDaysIso(issueDate, 30), isEstimatedDueDate: true };
+}
+
+// ── Clasificación por bucket ────────────────────────────────────────────────
+
+/**
+ * Devuelve el bucket de aging para un `daysOverdue` dado.
+ *
+ * daysOverdue < 0        → 'por_vencer'
+ * daysOverdue 0..30      → '0-30'
+ * daysOverdue 31..60     → '31-60'
+ * daysOverdue 61..90     → '61-90'
+ * daysOverdue > 90       → '+90'
+ */
+export function classifyBucket(daysOverdue: number): ArAgingBucketKey {
+  if (daysOverdue < 0) return 'por_vencer';
+  if (daysOverdue <= 30) return '0-30';
+  if (daysOverdue <= 60) return '31-60';
+  if (daysOverdue <= 90) return '61-90';
+  return '+90';
+}
+
+// ── Cálculo de pendiente ────────────────────────────────────────────────────
+
+const CENT = 0.005;
+
+/**
+ * `pending = MAX(0, total - paid)` con corte de ruido por debajo de medio céntimo.
+ * Nunca devuelve negativo (protege contra sobrepagos en DB).
+ */
+export function calcPending(total: number, paid: number): number {
+  const raw = Math.round((total - paid) * 100) / 100;
+  if (raw < CENT) return 0;
+  return raw;
+}
+
+// ── Estado visible en UI (label humano, no status raw) ──────────────────────
+
+/**
+ * Devuelve el label visible que la UI debe pintar para un status crudo.
+ * Nunca debe mostrarse el status raw en la vista de cobros.
+ */
+export function humanStatusLabel(status: string, bucket: ArAgingBucketKey): string {
+  if (bucket !== 'por_vencer') return 'Vencida';
+  switch (status) {
+    case 'parcial':
+      return 'Pagada parcial';
+    case 'vencida':
+      return 'Vencida';
+    case 'emitida':
+    case 'no_cobrada':
+    case 'pendiente':
+    default:
+      return 'Pendiente';
+  }
+}
+
+// ── Filtrado en memoria ─────────────────────────────────────────────────────
+
+/**
+ * Aplica filtros al array de rows. Cada filtro es opcional; si no está
+ * definido, no restringe. La combinación es AND.
+ */
+export function applyArAgingFilters(
+  rows: readonly ArAgingRow[],
+  filters: ArAgingFilters,
+): readonly ArAgingRow[] {
+  return rows.filter((r) => {
+    if (filters.bucket && r.bucket !== filters.bucket) return false;
+    if (filters.entity && r.entity !== filters.entity) return false;
+    if (filters.brand && r.brandName !== filters.brand) return false;
+    if (filters.source && r.source !== filters.source) return false;
+    return true;
+  });
+}
+
+// ── Agregaciones: buckets + KPIs ────────────────────────────────────────────
+
+/**
+ * Suma importes y cuentas por bucket. El % se calcula sobre el total pendiente.
+ * Devuelve los 5 buckets siempre en orden canónico (aunque estén a 0).
+ */
+export function summarizeBuckets(rows: readonly ArAgingRow[]): readonly ArAgingBucket[] {
+  const totalPending = rows.reduce((s, r) => s + r.pendingAmount, 0);
+  const map = new Map<ArAgingBucketKey, { amount: number; count: number }>();
+  for (const k of AR_AGING_BUCKET_ORDER) map.set(k, { amount: 0, count: 0 });
+  for (const r of rows) {
+    const b = map.get(r.bucket);
+    if (!b) continue;
+    b.amount += r.pendingAmount;
+    b.count += 1;
+  }
+  return AR_AGING_BUCKET_ORDER.map((key) => {
+    const b = map.get(key) ?? { amount: 0, count: 0 };
+    const pct = totalPending > 0 ? (b.amount / totalPending) * 100 : 0;
+    return { key, amount: b.amount, count: b.count, pct };
+  });
+}
+
+/**
+ * KPIs para las tarjetas superiores. Todos los importes son suma de `pendingAmount`.
+ *
+ * - `totalPending`      = sum de todos los rows filtrados
+ * - `totalOverdue`      = sum donde bucket != por_vencer
+ * - `overdueCount`      = count donde bucket != por_vencer
+ * - `pendingNotYetDue`  = sum donde bucket = por_vencer
+ * - `avgDaysOverdue`    = promedio de daysOverdue solo entre vencidas; null si no hay
+ * - `topDebtorBrand`    = marca con mayor pending sumado; null si no hay marcas
+ */
+export function computeKpis(rows: readonly ArAgingRow[]): ArAgingKpis {
+  let totalPending = 0;
+  let totalOverdue = 0;
+  let overdueCount = 0;
+  let pendingNotYetDue = 0;
+  let overdueDaysSum = 0;
+
+  const brandTotals = new Map<string, number>();
+
+  for (const r of rows) {
+    totalPending += r.pendingAmount;
+    if (r.bucket === 'por_vencer') {
+      pendingNotYetDue += r.pendingAmount;
+    } else {
+      totalOverdue += r.pendingAmount;
+      overdueCount += 1;
+      overdueDaysSum += r.daysOverdue;
+    }
+    if (r.brandName) {
+      brandTotals.set(r.brandName, (brandTotals.get(r.brandName) ?? 0) + r.pendingAmount);
+    }
+  }
+
+  let topDebtorBrand: ArAgingKpis['topDebtorBrand'] = null;
+  for (const [name, amount] of brandTotals) {
+    if (!topDebtorBrand || amount > topDebtorBrand.amount) {
+      topDebtorBrand = { name, amount };
+    }
+  }
+
+  return {
+    totalPending: round2(totalPending),
+    totalOverdue: round2(totalOverdue),
+    overdueCount,
+    pendingNotYetDue: round2(pendingNotYetDue),
+    avgDaysOverdue: overdueCount > 0 ? Math.round(overdueDaysSum / overdueCount) : null,
+    topDebtorBrand: topDebtorBrand
+      ? { name: topDebtorBrand.name, amount: round2(topDebtorBrand.amount) }
+      : null,
+  };
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+// ── Orden final ─────────────────────────────────────────────────────────────
+
+/**
+ * Orden por defecto: más vencidas primero (effectiveDueDate ASC),
+ * y a igualdad de fecha, mayor importe arriba.
+ */
+export function sortByAgingPriority(rows: readonly ArAgingRow[]): readonly ArAgingRow[] {
+  return [...rows].sort((a, b) => {
+    if (a.effectiveDueDate !== b.effectiveDueDate) {
+      return a.effectiveDueDate < b.effectiveDueDate ? -1 : 1;
+    }
+    return b.pendingAmount - a.pendingAmount;
+  });
+}

--- a/src/lib/queries/financeDashboard/arAging.ts
+++ b/src/lib/queries/financeDashboard/arAging.ts
@@ -1,0 +1,239 @@
+'server-only';
+
+import { and, asc, eq, inArray, sql } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import {
+  billingClients,
+  crmBrands,
+  invoicePayments,
+  invoices,
+  issuedInvoices,
+  issuerCompanies,
+} from '@/db/schema';
+import { INVOICE_COMPANY_LABELS } from '@/lib/schemas/invoice';
+import { PENDING_INCOME_FILTER } from '@/lib/utils/invoice-status';
+import type { InvoiceStatus } from '@/types';
+import type { ArAgingData, ArAgingFilters, ArAgingRow } from '@/types/arAging';
+import {
+  applyArAgingFilters,
+  calcPending,
+  classifyBucket,
+  computeKpis,
+  diffDaysIso,
+  resolveEffectiveDueDate,
+  sortByAgingPriority,
+  summarizeBuckets,
+  todayInMadrid,
+} from './arAging.shared';
+
+// Facturas emitidas: status es varchar libre pero convención observada.
+const ISSUED_PENDING_STATUSES = ['emitida', 'vencida', 'parcial'] as const;
+
+/**
+ * Fetch AR aging: cobros pendientes de `issued_invoices` + `invoices kind=income`.
+ *
+ * `paidAmount` viene SIEMPRE de `invoice_payments` (fuente canónica). No leemos
+ * `invoices.paidAmount` porque el schema lo marca como @deprecated.
+ *
+ * Filtros se aplican en memoria tras derivar bucket y daysOverdue.
+ */
+export async function getArAging(
+  filters: ArAgingFilters = {},
+): Promise<ArAgingData> {
+  const today = todayInMadrid();
+
+  const [issuedRows, internalRows] = await Promise.all([
+    db
+      .select({
+        id: issuedInvoices.id,
+        invoiceNumber: issuedInvoices.invoiceNumber,
+        totalAmount: issuedInvoices.totalAmount,
+        paidAmount: sql<string>`COALESCE(SUM(${invoicePayments.amount}), 0)::text`,
+        currency: issuedInvoices.currency,
+        status: issuedInvoices.status,
+        issueDate: issuedInvoices.issueDate,
+        dueDate: issuedInvoices.dueDate,
+        brandName: crmBrands.name,
+        clientName: billingClients.name,
+        issuerName: issuerCompanies.name,
+        pdfUrl: issuedInvoices.pdfUrl,
+      })
+      .from(issuedInvoices)
+      .leftJoin(billingClients, eq(billingClients.id, issuedInvoices.billingClientId))
+      .leftJoin(crmBrands, eq(crmBrands.id, issuedInvoices.relatedBrandId))
+      .leftJoin(issuerCompanies, eq(issuerCompanies.id, issuedInvoices.issuerCompanyId))
+      .leftJoin(invoicePayments, eq(invoicePayments.issuedInvoiceId, issuedInvoices.id))
+      .where(inArray(issuedInvoices.status, [...ISSUED_PENDING_STATUSES]))
+      .groupBy(
+        issuedInvoices.id,
+        issuedInvoices.invoiceNumber,
+        issuedInvoices.totalAmount,
+        issuedInvoices.currency,
+        issuedInvoices.status,
+        issuedInvoices.issueDate,
+        issuedInvoices.dueDate,
+        crmBrands.name,
+        billingClients.name,
+        issuerCompanies.name,
+        issuedInvoices.pdfUrl,
+      )
+      .orderBy(asc(issuedInvoices.issueDate)),
+
+    db
+      .select({
+        id: invoices.id,
+        number: invoices.number,
+        totalAmount: invoices.totalAmount,
+        paidAmount: sql<string>`COALESCE(SUM(${invoicePayments.amount}), 0)::text`,
+        currency: invoices.currency,
+        status: invoices.status,
+        issueDate: invoices.issueDate,
+        dueDate: invoices.dueDate,
+        brandName: crmBrands.name,
+        counterpartyName: invoices.counterpartyName,
+        company: invoices.company,
+        fileUrl: invoices.fileUrl,
+        invoiceFileId: invoices.invoiceFileId,
+      })
+      .from(invoices)
+      .leftJoin(crmBrands, eq(crmBrands.id, invoices.brandId))
+      .leftJoin(invoicePayments, eq(invoicePayments.invoiceId, invoices.id))
+      .where(
+        and(
+          eq(invoices.kind, 'income'),
+          inArray(invoices.status, PENDING_INCOME_FILTER as InvoiceStatus[]),
+        ),
+      )
+      .groupBy(
+        invoices.id,
+        invoices.number,
+        invoices.totalAmount,
+        invoices.currency,
+        invoices.status,
+        invoices.issueDate,
+        invoices.dueDate,
+        crmBrands.name,
+        invoices.counterpartyName,
+        invoices.company,
+        invoices.fileUrl,
+        invoices.invoiceFileId,
+      )
+      .orderBy(asc(invoices.issueDate)),
+  ]);
+
+  const issued: ArAgingRow[] = issuedRows
+    .map((r) => buildRow({
+      id: r.id,
+      source: 'issued',
+      invoiceNumber: r.invoiceNumber,
+      brandName: r.brandName,
+      clientName: r.clientName,
+      entity: r.issuerName,
+      totalAmount: Number(r.totalAmount),
+      paidAmount: Number(r.paidAmount),
+      currency: r.currency ?? 'EUR',
+      status: r.status,
+      issueDate: r.issueDate,
+      dueDate: r.dueDate,
+      pdfUrl: r.pdfUrl ?? null,
+      today,
+    }))
+    .filter((r) => r.pendingAmount > 0);
+
+  const internal: ArAgingRow[] = internalRows
+    .map((r) => buildRow({
+      id: r.id,
+      source: 'internal',
+      invoiceNumber: r.number ?? `INT-${r.id}`,
+      brandName: r.brandName,
+      clientName: r.counterpartyName,
+      entity: r.company ? (INVOICE_COMPANY_LABELS[r.company] ?? null) : null,
+      totalAmount: Number(r.totalAmount),
+      paidAmount: Number(r.paidAmount),
+      currency: r.currency ?? 'EUR',
+      status: r.status,
+      issueDate: r.issueDate,
+      dueDate: r.dueDate,
+      pdfUrl: r.invoiceFileId ? `/api/admin/facturas/${r.id}/pdf` : (r.fileUrl ?? null),
+      today,
+    }))
+    .filter((r) => r.pendingAmount > 0);
+
+  const unfilteredRows: readonly ArAgingRow[] = [...issued, ...internal];
+
+  const availableEntities = uniqueSortedNonEmpty(unfilteredRows.map((r) => r.entity));
+  const availableBrands = uniqueSortedNonEmpty(unfilteredRows.map((r) => r.brandName));
+
+  const filtered = applyArAgingFilters(unfilteredRows, filters);
+  const rows = sortByAgingPriority(filtered);
+  const kpis = computeKpis(rows);
+  const buckets = summarizeBuckets(rows);
+
+  const currencies = new Set(rows.map((r) => r.currency));
+  const hasMultipleCurrencies = currencies.size > 1;
+
+  return {
+    rows,
+    kpis,
+    buckets,
+    hasMultipleCurrencies,
+    totalUnfilteredRows: unfilteredRows.length,
+    availableEntities,
+    availableBrands,
+    appliedFilters: filters,
+  };
+}
+
+// ── Helpers privados ─────────────────────────────────────────────────────────
+
+type BuildRowInput = {
+  readonly id: number;
+  readonly source: 'issued' | 'internal';
+  readonly invoiceNumber: string;
+  readonly brandName: string | null;
+  readonly clientName: string | null;
+  readonly entity: string | null;
+  readonly totalAmount: number;
+  readonly paidAmount: number;
+  readonly currency: string;
+  readonly status: string;
+  readonly issueDate: string;
+  readonly dueDate: string | null;
+  readonly pdfUrl: string | null;
+  readonly today: string;
+};
+
+function buildRow(input: BuildRowInput): ArAgingRow {
+  const { effectiveDueDate, isEstimatedDueDate } = resolveEffectiveDueDate(
+    input.issueDate,
+    input.dueDate,
+  );
+  const daysOverdue = diffDaysIso(input.today, effectiveDueDate);
+  const bucket = classifyBucket(daysOverdue);
+  const pendingAmount = calcPending(input.totalAmount, input.paidAmount);
+
+  return {
+    id: input.id,
+    source: input.source,
+    invoiceNumber: input.invoiceNumber,
+    brandName: input.brandName,
+    clientName: input.clientName,
+    entity: input.entity,
+    totalAmount: input.totalAmount,
+    paidAmount: input.paidAmount,
+    pendingAmount,
+    currency: input.currency,
+    status: input.status,
+    issueDate: input.issueDate,
+    dueDate: input.dueDate,
+    effectiveDueDate,
+    isEstimatedDueDate,
+    daysOverdue,
+    bucket,
+    pdfUrl: input.pdfUrl,
+  };
+}
+
+function uniqueSortedNonEmpty(values: ReadonlyArray<string | null>): readonly string[] {
+  return Array.from(new Set(values.filter((v): v is string => Boolean(v)))).sort();
+}

--- a/src/lib/queries/financeDashboard/index.ts
+++ b/src/lib/queries/financeDashboard/index.ts
@@ -49,3 +49,4 @@ export type {
 } from './financeResumen';
 export { getFinancePnL } from './pnlDetail';
 export type { FinancePnLResult } from './pnlDetail';
+export { getArAging } from './arAging';

--- a/src/types/arAging.ts
+++ b/src/types/arAging.ts
@@ -1,0 +1,80 @@
+export type ArAgingBucketKey = 'por_vencer' | '0-30' | '31-60' | '61-90' | '+90';
+
+export const AR_AGING_BUCKET_ORDER: readonly ArAgingBucketKey[] = [
+  'por_vencer',
+  '0-30',
+  '31-60',
+  '61-90',
+  '+90',
+] as const;
+
+export const AR_AGING_BUCKET_LABELS: Readonly<Record<ArAgingBucketKey, string>> = {
+  por_vencer: 'Por vencer',
+  '0-30': '0-30 días',
+  '31-60': '31-60 días',
+  '61-90': '61-90 días',
+  '+90': '+90 días',
+} as const;
+
+export type ArAgingSource = 'issued' | 'internal';
+
+export type ArAgingRow = {
+  readonly id: number;
+  readonly source: ArAgingSource;
+
+  readonly invoiceNumber: string;
+  readonly brandName: string | null;
+  readonly clientName: string | null;
+  readonly entity: string | null;
+
+  readonly totalAmount: number;
+  readonly paidAmount: number;
+  readonly pendingAmount: number;
+  readonly currency: string;
+
+  readonly status: string;
+
+  readonly issueDate: string;
+  readonly dueDate: string | null;
+  readonly effectiveDueDate: string;
+  readonly isEstimatedDueDate: boolean;
+
+  readonly daysOverdue: number;
+  readonly bucket: ArAgingBucketKey;
+
+  readonly pdfUrl: string | null;
+};
+
+export type ArAgingBucket = {
+  readonly key: ArAgingBucketKey;
+  readonly amount: number;
+  readonly count: number;
+  readonly pct: number;
+};
+
+export type ArAgingKpis = {
+  readonly totalPending: number;
+  readonly totalOverdue: number;
+  readonly overdueCount: number;
+  readonly pendingNotYetDue: number;
+  readonly avgDaysOverdue: number | null;
+  readonly topDebtorBrand: { readonly name: string; readonly amount: number } | null;
+};
+
+export type ArAgingFilters = {
+  readonly bucket?: ArAgingBucketKey;
+  readonly entity?: string;
+  readonly brand?: string;
+  readonly source?: ArAgingSource;
+};
+
+export type ArAgingData = {
+  readonly rows: readonly ArAgingRow[];
+  readonly kpis: ArAgingKpis;
+  readonly buckets: readonly ArAgingBucket[];
+  readonly hasMultipleCurrencies: boolean;
+  readonly totalUnfilteredRows: number;
+  readonly availableEntities: readonly string[];
+  readonly availableBrands: readonly string[];
+  readonly appliedFilters: ArAgingFilters;
+};


### PR DESCRIPTION
## Resumen

Vista nueva **`/admin/finanzas/cobros`** con buckets de antigüedad, 6 KPIs CEO-friendly y filtros por URL. Sin dunning automático — Fase 1C.

Nav en Finanzas queda: **Control mensual · Cobros pendientes · Histórico mensual · Gastos · Herramientas**.

Cero DB / schema / migrations / crons / emails / Resend / invoice_reminders.

## Cómo calcula pagos

`paidAmount` **SIEMPRE** vía `COALESCE(SUM(invoice_payments.amount), 0)` — fuente canónica. No leemos `invoices.paidAmount` (deprecated en el schema).

Para **ambas** fuentes:
- `issued_invoices` → `LEFT JOIN invoice_payments ON invoice_payments.issued_invoice_id = issued_invoices.id`
- `invoices kind=income` → `LEFT JOIN invoice_payments ON invoice_payments.invoice_id = invoices.id`

## Cómo calcula pendiente

\`\`\`ts
paidAmount        = COALESCE(SUM(invoice_payments.amount), 0)
pendingAmount     = MAX(0, totalAmount - paidAmount)   // nunca negativo
effectiveDueDate  = dueDate ?? issueDate + 30 días     // fallback
isEstimatedDueDate= (dueDate === null)
daysOverdue       = todayMadrid - effectiveDueDate     // días enteros
\`\`\`

Filas con `pendingAmount <= 0.005` se descartan (ruido de céntimos).

## Buckets

| Rango | Bucket |
|---|---|
| < 0 días | Por vencer |
| 0..30 | 0-30 días |
| 31..60 | 31-60 días |
| 61..90 | 61-90 días |
| > 90 | +90 días |

## KPIs (6 CEO-friendly)

1. **Total pendiente de cobrar** — saldo vivo total
2. **Total vencido** — `SUM(pending) WHERE bucket != 'por_vencer'`
3. **Facturas vencidas** — count donde bucket != por_vencer
4. **Pendiente por vencer** — `SUM(pending) WHERE bucket = 'por_vencer'`
5. **Mayor deuda por marca** — top 1 GROUP BY brandName (nombre + importe)
6. **Promedio días de retraso** — `AVG(daysOverdue) WHERE bucket != 'por_vencer'`; \"—\" si no hay vencidas

## Filtros (URL searchParams, deep-linkables)

- **bucket** — por_vencer | 0-30 | 31-60 | 61-90 | +90
- **entity** — nombre del emisor (`issuer_companies.name` para issued; `INVOICE_COMPANY_LABELS` para internal)
- **brand** — `crmBrands.name` (JOIN via `relatedBrandId` / `brandId`)
- **source** — issued | internal

Cliente ('use client') actualiza la URL con `router.push` + `useTransition`.

## dueDate null → fallback

`effectiveDueDate = issueDate + 30 días` y bandera `isEstimatedDueDate=true`. En la tabla se pinta con etiqueta *"Vencimiento estimado"* en cursiva.

## Multi-divisa

- Importe original en tabla con símbolo apropiado por `currency`.
- **Sin conversión nueva.**
- Si detecto mezcla → banner amber: *"Los totales agregan importes en distintas divisas sin conversión. Revisa las filas para el detalle."*

## Orden por defecto

\`effectiveDueDate ASC, pendingAmount DESC\` — más vencidas primero; a igualdad, mayor deuda arriba.

## Archivos tocados (12)

**Nuevos (9):**
- \`src/types/arAging.ts\` — tipos + BUCKETS constants
- \`src/lib/queries/financeDashboard/arAging.shared.ts\` — lógica pura testeable
- \`src/lib/queries/financeDashboard/arAging.ts\` — query server-only
- \`src/app/admin/(dashboard)/finanzas/cobros/page.tsx\` — RSC
- \`src/features/admin/finance-dashboard/components/ArAgingKPIs.tsx\`
- \`src/features/admin/finance-dashboard/components/ArAgingBuckets.tsx\`
- \`src/features/admin/finance-dashboard/components/ArAgingTable.tsx\`
- \`src/features/admin/finance-dashboard/components/ArAgingFilters.tsx\` ('use client')
- \`src/__tests__/server/audit-finanzas-1b-ar-aging.test.ts\` — 64 tests

**Modificados (3):**
- \`src/app/admin/(dashboard)/finanzas/FinanzasNav.tsx\` — +1 tab
- \`src/lib/queries/financeDashboard/index.ts\` — re-export getArAging
- \`docs/tech-debt.md\` — TD-14 nota sobre receivables.ts vs invoice_payments

## Divergencia conocida (documentada)

El widget \`ReceivablesTable\` que sigue embebido en \`/admin/finanzas/resumen\` usa la query legacy \`receivables.ts\`, que para el path **internal** lee \`invoices.paidAmount\` column (deprecated). AR aging usa \`invoice_payments\` para ambas fuentes.

Puede haber divergencia solo si hay facturas internas antiguas donde \`paidAmount\` column ya no coincide con \`invoice_payments\`. Registrado como **TD-14** en \`docs/tech-debt.md\`. Fuera de scope 1B por acuerdo — no ampliar alcance.

## Confirmaciones

- ✅ **DB / schema / migrations**: intactos. Cero cambios en \`src/db/schema/\`, cero en \`drizzle/\`.
- ✅ **Crons / emails / Resend / invoice_reminders**: cero. Confirmado por tests anti-scope-creep.
- ✅ **RBAC / OCR / Blob / Sheets / Tratos / facturación legal**: sin tocar.
- ✅ **Labels humanos**: la tabla usa \`humanStatusLabel()\` y nunca renderiza \`{row.status}\` crudo. Tests estáticos lo verifican.
- ✅ **Fuente única de pagos**: la query usa \`COALESCE(SUM(invoice_payments.amount), 0)\` para ambas fuentes. Test estático verifica que **no** aparece \`paidAmount: invoices.paidAmount\` en el select.

## CI local

- ✅ \`npx tsc --noEmit\` — clean
- ✅ \`npm run lint\` — 0/0
- ✅ \`npm test\` — 110 suites · **1871 tests** verdes (64 nuevos)
- ⚠️ \`npm run build\` local requiere \`.env.local\` con \`DATABASE_URL / RESEND_API_KEY / BETTER_AUTH_SECRET / NEXT_PUBLIC_SITE_URL\`. Vercel las tiene y correrá el build en el deploy.

## Test plan post-merge

- [ ] Preview: \`/admin/finanzas/cobros\` carga con KPIs + buckets + tabla + filtros (con o sin datos).
- [ ] Preview: \`FinanzasNav\` muestra tab \"Cobros pendientes\" activa cuando estás en la ruta.
- [ ] Preview: cambiar filtros actualiza URL (\`?bucket=0-30\`, \`?entity=...\`) y refresca resultados sin recargar página.
- [ ] Preview: cambiar de mes en \`/admin/finanzas/resumen\` no rompe.
- [ ] Preview: factura con \`dueDate=null\` aparece con \"Vencimiento estimado\" en cursiva.
- [ ] Comparar totales de \"Cobros pendientes\" de \`/resumen\` vs KPI \"Total pendiente de cobrar\" de \`/cobros\` — si divergen, el motivo es TD-14 (documentado).

🤖 Generated with [Claude Code](https://claude.com/claude-code)