### PR TITLE
feat(audit/finanzas): desglose visual anual de gastos en /admin/finanzas/pl

### DIFF
--- a/src/__tests__/server/audit-finanzas-expense-breakdown.test.ts
+++ b/src/__tests__/server/audit-finanzas-expense-breakdown.test.ts
@@ -1,0 +1,349 @@
+/**
+ * Tests para el desglose visual anual de gastos.
+ *
+ * Cubre:
+ *   - Clasificador puro (`classifyExpenseSubgroup`): 17 subgrupos + guardarraíles.
+ *   - Agregación (`summarizeExpenseSubgroups`): pct, orden DESC, edge cases.
+ *   - Estáticos: page.tsx renderiza el bloque; getFinancePnL expone `expenseBySubgroup`.
+ *   - Anti-scope-creep: sin schema/migrations/cron/Resend/emails.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  classifyExpenseSubgroup,
+  detectPartner,
+  summarizeExpenseSubgroups,
+  EXPENSE_SUBGROUP_LABELS,
+  type ExpenseClassifierInput,
+  type ExpenseSubgroupKey,
+} from '@/lib/queries/financeDashboard/expenseSubgroups';
+
+const PROJECT_ROOT = path.resolve(__dirname, '..', '..', '..');
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(PROJECT_ROOT, rel), 'utf-8');
+}
+
+function makeInput(overrides: Partial<ExpenseClassifierInput>): ExpenseClassifierInput {
+  return {
+    expenseGroup: null,
+    expenseSubtype: null,
+    concept: null,
+    counterpartyName: null,
+    ...overrides,
+  };
+}
+
+// ── Detección de socio ─────────────────────────────────────────────────────
+
+describe('detectPartner()', () => {
+  it('reconoce Pablo por nombre', () => {
+    expect(detectPartner('Nómina Pablo julio')).toBe('pablo');
+    expect(detectPartner('CAMACHO CARRION PABLO')).toBe('pablo');
+    expect(detectPartner('RETA Pablo García')).toBe('pablo');
+    expect(detectPartner('Cuota autónomo Keko')).toBe('pablo');
+  });
+
+  it('reconoce Alfonso por nombre', () => {
+    expect(detectPartner('Nómina Alfonso agosto')).toBe('alfonso');
+    expect(detectPartner('ARIAS EPIFANIO ALFONSO')).toBe('alfonso');
+    expect(detectPartner('RETA Alfonso')).toBe('alfonso');
+  });
+
+  it('devuelve null si no hay señal', () => {
+    expect(detectPartner('Cuota autónomo')).toBeNull();
+    expect(detectPartner('')).toBeNull();
+    expect(detectPartner('Gestoría trimestre')).toBeNull();
+  });
+
+  it('devuelve null si aparecen ambos (ambiguo, conservador)', () => {
+    expect(detectPartner('Pago Pablo y Alfonso conjunto')).toBeNull();
+  });
+});
+
+// ── Clasificador por subtipo ───────────────────────────────────────────────
+
+describe('classifyExpenseSubgroup()', () => {
+  describe('Nóminas (partner-aware)', () => {
+    it('nomina_socio + Pablo → nomina_pablo', () => {
+      expect(classifyExpenseSubgroup(makeInput({
+        expenseSubtype: 'nomina_socio',
+        concept: 'Nómina julio 2026',
+        counterpartyName: 'CAMACHO CARRION PABLO',
+      }))).toBe('nomina_pablo');
+    });
+
+    it('nomina_socio + Camacho en concept → nomina_pablo', () => {
+      expect(classifyExpenseSubgroup(makeInput({
+        expenseSubtype: 'nomina_socio',
+        concept: 'Nómina Camacho jul',
+      }))).toBe('nomina_pablo');
+    });
+
+    it('nomina_socio + Keko → nomina_pablo', () => {
+      expect(classifyExpenseSubgroup(makeInput({
+        expenseSubtype: 'nomina_socio',
+        counterpartyName: 'Nómina Keko',
+      }))).toBe('nomina_pablo');
+    });
+
+    it('nomina_socio + Alfonso → nomina_alfonso', () => {
+      expect(classifyExpenseSubgroup(makeInput({
+        expenseSubtype: 'nomina_socio',
+        counterpartyName: 'ARIAS EPIFANIO ALFONSO',
+      }))).toBe('nomina_alfonso');
+    });
+
+    it('nomina_socio sin persona → nomina_otros', () => {
+      expect(classifyExpenseSubgroup(makeInput({
+        expenseSubtype: 'nomina_socio',
+        concept: 'Nómina genérica',
+      }))).toBe('nomina_otros');
+    });
+
+    it('nomina_socio con ambigüedad Pablo + Alfonso → nomina_otros', () => {
+      expect(classifyExpenseSubgroup(makeInput({
+        expenseSubtype: 'nomina_socio',
+        concept: 'Reparto nóminas Pablo y Alfonso',
+      }))).toBe('nomina_otros');
+    });
+  });
+
+  describe('Cuota autónomo (partner-aware)', () => {
+    it('cuota_autonomo + Pablo → cuota_pablo', () => {
+      expect(classifyExpenseSubgroup(makeInput({
+        expenseSubtype: 'cuota_autonomo',
+        concept: 'Cuota de autónomo — Pablo',
+      }))).toBe('cuota_pablo');
+    });
+
+    it('cuota_autonomo + Alfonso → cuota_alfonso', () => {
+      expect(classifyExpenseSubgroup(makeInput({
+        expenseSubtype: 'cuota_autonomo',
+        concept: 'Cuota de autónomo — Alfonso',
+      }))).toBe('cuota_alfonso');
+    });
+
+    it('factura_autonomo + Pablo → cuota_pablo (agrupado)', () => {
+      expect(classifyExpenseSubgroup(makeInput({
+        expenseSubtype: 'factura_autonomo',
+        counterpartyName: 'RETA Pablo García',
+      }))).toBe('cuota_pablo');
+    });
+
+    it('cuota_autonomo sin persona → cuota_otros', () => {
+      expect(classifyExpenseSubgroup(makeInput({
+        expenseSubtype: 'cuota_autonomo',
+        concept: 'Cuota autónomo',
+      }))).toBe('cuota_otros');
+    });
+  });
+
+  describe('Seguridad Social (siempre agregado)', () => {
+    it('seguridad_social → seguridad_social', () => {
+      expect(classifyExpenseSubgroup(makeInput({
+        expenseSubtype: 'seguridad_social',
+        concept: 'SS junio',
+      }))).toBe('seguridad_social');
+    });
+  });
+
+  describe('Mapeo directo por subtipo', () => {
+    const cases: Array<[string, ExpenseSubgroupKey]> = [
+      ['suscripcion_software', 'software_ia'],
+      ['herramienta_ia',       'software_ia'],
+      ['gestoria',             'gestoria'],
+      ['fiscal_impuestos',     'fiscal'],
+      ['ajuste_fiscal',        'fiscal'],
+      ['marketing_publicidad', 'marketing'],
+      ['comision_bancaria',    'comisiones'],
+      ['comision_plataforma',  'comisiones'],
+      ['pago_talento',         'pagos_talentos'],
+      ['coste_produccion',     'campana_otros'],
+      ['otros_campana',        'campana_otros'],
+      ['seguro_medico',        'seguro_medico'],
+      ['gasto_general',        'gasto_general'],
+    ];
+
+    it.each(cases)('subtype=%s → %s', (subtype, expected) => {
+      expect(classifyExpenseSubgroup(makeInput({ expenseSubtype: subtype })))
+        .toBe(expected);
+    });
+  });
+
+  describe('Guardarraíl anti falso positivo', () => {
+    it('pago_talento con "Pablo" en concepto → pagos_talentos (no nomina_pablo)', () => {
+      expect(classifyExpenseSubgroup(makeInput({
+        expenseSubtype: 'pago_talento',
+        concept: 'Pago talento Pablo Streamer',
+      }))).toBe('pagos_talentos');
+    });
+
+    it('marketing_publicidad con "Alfonso" en concepto → marketing (no nomina)', () => {
+      expect(classifyExpenseSubgroup(makeInput({
+        expenseSubtype: 'marketing_publicidad',
+        concept: 'Sponsor Alfonso Torneo',
+      }))).toBe('marketing');
+    });
+  });
+
+  describe('Sin subtipo', () => {
+    it('subtype=null + group=null → sin_clasificar', () => {
+      expect(classifyExpenseSubgroup(makeInput({}))).toBe('sin_clasificar');
+    });
+
+    it('subtype=null + group=campaign_direct → campana_otros', () => {
+      expect(classifyExpenseSubgroup(makeInput({
+        expenseGroup: 'campaign_direct',
+      }))).toBe('campana_otros');
+    });
+
+    it('subtype=null + group=operational → sin_clasificar', () => {
+      expect(classifyExpenseSubgroup(makeInput({
+        expenseGroup: 'operational',
+      }))).toBe('sin_clasificar');
+    });
+  });
+});
+
+// ── Agregación ─────────────────────────────────────────────────────────────
+
+describe('summarizeExpenseSubgroups()', () => {
+  it('devuelve orden DESC por importe', () => {
+    const map = new Map<ExpenseSubgroupKey, { amount: number; count: number }>();
+    map.set('nomina_pablo',   { amount: 5090, count: 4 });
+    map.set('software_ia',    { amount:  420, count: 5 });
+    map.set('nomina_alfonso', { amount: 4107, count: 3 });
+    const out = summarizeExpenseSubgroups(map, 10_000);
+    expect(out.map((r) => r.key)).toEqual(['nomina_pablo', 'nomina_alfonso', 'software_ia']);
+  });
+
+  it('calcula pct = amount / total * 100', () => {
+    const map = new Map<ExpenseSubgroupKey, { amount: number; count: number }>();
+    map.set('nomina_pablo', { amount: 500, count: 1 });
+    const out = summarizeExpenseSubgroups(map, 2000);
+    expect(out[0]?.pct).toBe(25);
+  });
+
+  it('pct = 0 cuando totalExpense es 0 (no NaN)', () => {
+    const map = new Map<ExpenseSubgroupKey, { amount: number; count: number }>();
+    map.set('sin_clasificar', { amount: 0, count: 1 });
+    const out = summarizeExpenseSubgroups(map, 0);
+    expect(out[0]?.pct).toBe(0);
+    expect(Number.isNaN(out[0]?.pct ?? NaN)).toBe(false);
+  });
+
+  it('excluye subgrupos con count = 0', () => {
+    const map = new Map<ExpenseSubgroupKey, { amount: number; count: number }>();
+    map.set('nomina_pablo',   { amount: 100, count: 1 });
+    map.set('nomina_alfonso', { amount:   0, count: 0 });
+    const out = summarizeExpenseSubgroups(map, 100);
+    expect(out.map((r) => r.key)).toEqual(['nomina_pablo']);
+  });
+
+  it('label sale del EXPENSE_SUBGROUP_LABELS', () => {
+    const map = new Map<ExpenseSubgroupKey, { amount: number; count: number }>();
+    map.set('cuota_alfonso', { amount: 1890, count: 6 });
+    const out = summarizeExpenseSubgroups(map, 1890);
+    expect(out[0]?.label).toBe('Cuota autónomo Alfonso');
+    expect(out[0]?.label).toBe(EXPENSE_SUBGROUP_LABELS.cuota_alfonso);
+  });
+
+  it('suma de subgrupos = total (tolerancia < 0.01)', () => {
+    // Emula la ruta feliz: acumulador tiene lo mismo que sumaría el loop de gastos.
+    const parts: Array<[ExpenseSubgroupKey, number, number]> = [
+      ['nomina_pablo',   5090.00, 4],
+      ['nomina_alfonso', 4107.00, 3],
+      ['cuota_pablo',    1890.00, 6],
+      ['cuota_alfonso',  1890.00, 6],
+      ['software_ia',     420.00, 5],
+    ];
+    const map = new Map<ExpenseSubgroupKey, { amount: number; count: number }>();
+    for (const [key, amount, count] of parts) map.set(key, { amount, count });
+    const total = parts.reduce((s, [, amt]) => s + amt, 0);
+    const out = summarizeExpenseSubgroups(map, total);
+    const sum = out.reduce((s, r) => s + r.amount, 0);
+    expect(Math.abs(sum - total)).toBeLessThan(0.01);
+  });
+});
+
+// ── Chequeos estáticos ─────────────────────────────────────────────────────
+
+describe('Integración /admin/finanzas/pl', () => {
+  const pageSrc = read('src/app/admin/(dashboard)/finanzas/pl/page.tsx');
+  const querySrc = read('src/lib/queries/financeDashboard/pnlDetail.ts');
+  const componentSrc = read('src/features/admin/pnl/components/AnnualExpenseBreakdown.tsx');
+
+  it('page.tsx importa y renderiza AnnualExpenseBreakdown', () => {
+    expect(pageSrc).toMatch(/from\s+['"]@\/features\/admin\/pnl\/components\/AnnualExpenseBreakdown['"]/);
+    expect(pageSrc).toMatch(/<AnnualExpenseBreakdown\b/);
+    expect(pageSrc).toMatch(/rows=\{pnl\.expenseBySubgroup\}/);
+    expect(pageSrc).toMatch(/totalExpense=\{pnl\.gastos\}/);
+  });
+
+  it('getFinancePnL declara expenseBySubgroup en el resultado', () => {
+    expect(querySrc).toMatch(/expenseBySubgroup:\s*readonly ExpenseSubgroupRow\[\]/);
+  });
+
+  it('getFinancePnL añade expenseSubtype, concept y counterpartyName al SELECT', () => {
+    expect(querySrc).toMatch(/expenseSubtype:\s*invoices\.expenseSubtype/);
+    expect(querySrc).toMatch(/concept:\s*invoices\.concept/);
+    expect(querySrc).toMatch(/counterpartyName:\s*invoices\.counterpartyName/);
+  });
+
+  it('getFinancePnL usa el clasificador en el loop', () => {
+    expect(querySrc).toMatch(/classifyExpenseSubgroup\(/);
+    expect(querySrc).toMatch(/summarizeExpenseSubgroups\(/);
+  });
+
+  it('componente evita NaN% cuando total = 0', () => {
+    // Rama que devuelve el "empty state" ANTES de dividir → sin cálculo de pct.
+    expect(componentSrc).toMatch(/totalExpense <= 0/);
+    expect(componentSrc).not.toMatch(/NaN/);
+  });
+
+  it('componente respeta los filtros pasando from/to al título', () => {
+    // Título dinámico se computa en función del rango recibido.
+    expect(componentSrc).toMatch(/isYearToDateRange\(from,\s*to\)/);
+    expect(componentSrc).toMatch(/Dónde se ha ido el dinero este año/);
+    expect(componentSrc).toMatch(/Dónde se ha ido el dinero en este periodo/);
+  });
+});
+
+// ── Anti-scope-creep ───────────────────────────────────────────────────────
+
+describe('Anti-scope-creep', () => {
+  const filesToScan = [
+    'src/lib/queries/financeDashboard/expenseSubgroups.ts',
+    'src/lib/queries/financeDashboard/pnlDetail.ts',
+    'src/features/admin/pnl/components/AnnualExpenseBreakdown.tsx',
+    'src/app/admin/(dashboard)/finanzas/pl/page.tsx',
+  ];
+
+  it.each(filesToScan)('%s no importa Resend ni utilidades de email', (rel) => {
+    const src = read(rel);
+    expect(src).not.toMatch(/from\s+['"]resend['"]/);
+    expect(src).not.toMatch(/@\/lib\/email/);
+    expect(src).not.toMatch(/sendEmail/);
+  });
+
+  it.each(filesToScan)('%s no referencia invoice_reminders ni dunning', (rel) => {
+    const src = read(rel);
+    expect(src).not.toMatch(/invoice_reminders/);
+    expect(src).not.toMatch(/dunning/i);
+  });
+
+  it('expenseSubgroups.ts no accede a la DB ni a server-only', () => {
+    const src = read('src/lib/queries/financeDashboard/expenseSubgroups.ts');
+    expect(src).not.toMatch(/^['"]server-only['"];/m);
+    expect(src).not.toMatch(/from\s+['"]@\/lib\/db['"]/);
+    expect(src).not.toMatch(/from\s+['"]@\/db\/schema['"]/);
+  });
+
+  it('cambios NO incluyen definiciones de tabla nuevas', () => {
+    const src = read('src/lib/queries/financeDashboard/pnlDetail.ts');
+    expect(src).not.toMatch(/pgTable\s*\(/);
+    expect(src).not.toMatch(/alterTable/);
+  });
+});

--- a/src/app/admin/(dashboard)/finanzas/pl/page.tsx
+++ b/src/app/admin/(dashboard)/finanzas/pl/page.tsx
@@ -8,6 +8,7 @@ import { PnLOverviewCards } from '@/features/admin/pnl/components/PnLOverviewCar
 import { PnLBreakdownTable } from '@/features/admin/pnl/components/PnLBreakdownTable';
 import { PnLCategoryList } from '@/features/admin/pnl/components/PnLCategoryList';
 import { PnLFilters } from '@/features/admin/pnl/components/PnLFilters';
+import { AnnualExpenseBreakdown } from '@/features/admin/pnl/components/AnnualExpenseBreakdown';
 import type { InvoiceCompany } from '@/types';
 import type { PnLFilters as PnLFiltersType } from '@/lib/queries/pnl';
 
@@ -93,6 +94,14 @@ export default async function FinanzasPnLPage({ searchParams }: PageProps): Prom
           </div>
         )}
       </div>
+
+      {/* Dónde se ha ido el dinero — desglose visual por subgrupo */}
+      <AnnualExpenseBreakdown
+        rows={pnl.expenseBySubgroup}
+        totalExpense={pnl.gastos}
+        from={from}
+        to={to}
+      />
 
       {/* Caja YTD */}
       <div className="grid grid-cols-2 gap-3">

--- a/src/features/admin/pnl/components/AnnualExpenseBreakdown.tsx
+++ b/src/features/admin/pnl/components/AnnualExpenseBreakdown.tsx
@@ -1,0 +1,122 @@
+import type { ExpenseSubgroupKey, ExpenseSubgroupRow } from '@/lib/queries/financeDashboard/expenseSubgroups';
+
+const EUR = new Intl.NumberFormat('es-ES', {
+  style: 'currency',
+  currency: 'EUR',
+  maximumFractionDigits: 0,
+});
+
+/**
+ * Detecta si el rango corresponde al año en curso (desde 1-ene hasta hoy).
+ * Se usa solo para elegir el título: "este año" vs "este periodo".
+ */
+function isYearToDateRange(from: string, to: string): boolean {
+  const now = new Date();
+  const y = now.getFullYear();
+  const yearStart = `${y}-01-01`;
+  const mm = String(now.getMonth() + 1).padStart(2, '0');
+  const dd = String(now.getDate()).padStart(2, '0');
+  const today = `${y}-${mm}-${dd}`;
+  return from === yearStart && to === today;
+}
+
+function barColor(key: ExpenseSubgroupKey): string {
+  switch (key) {
+    case 'nomina_pablo':
+    case 'nomina_alfonso':
+    case 'nomina_otros':
+      return 'bg-red-500/70';
+    case 'cuota_pablo':
+    case 'cuota_alfonso':
+    case 'cuota_otros':
+    case 'seguridad_social':
+      return 'bg-orange-500/70';
+    case 'pagos_talentos':
+    case 'campana_otros':
+      return 'bg-red-400/60';
+    case 'sin_clasificar':
+      return 'bg-amber-500/70';
+    default:
+      return 'bg-red-500/50';
+  }
+}
+
+function amountColor(key: ExpenseSubgroupKey): string {
+  return key === 'sin_clasificar' ? 'text-amber-400' : 'text-red-400';
+}
+
+function facturasLabel(count: number): string {
+  return count === 1 ? '1 factura' : `${count} facturas`;
+}
+
+type Props = {
+  readonly rows: readonly ExpenseSubgroupRow[];
+  readonly totalExpense: number;
+  readonly from: string;
+  readonly to: string;
+};
+
+/**
+ * Desglose visual de gastos por subgrupo humano (Nóminas Pablo, Software / IA,
+ * Cuota autónomo Alfonso, …). Ordenado DESC por importe.
+ *
+ * @kind server
+ * @feature admin/pnl
+ * @route /admin/finanzas/pl
+ */
+export function AnnualExpenseBreakdown({ rows, totalExpense, from, to }: Props): React.ReactElement {
+  const title = isYearToDateRange(from, to)
+    ? 'Dónde se ha ido el dinero este año'
+    : 'Dónde se ha ido el dinero en este periodo';
+
+  if (rows.length === 0 || totalExpense <= 0) {
+    return (
+      <div className="rounded-2xl border border-sp-admin-border bg-sp-admin-card p-5">
+        <p className="mb-2 text-[11px] font-semibold uppercase tracking-widest text-sp-admin-muted">
+          {title}
+        </p>
+        <p className="py-4 text-center text-sm text-sp-admin-muted">
+          No hay gastos registrados en este rango.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-2xl border border-sp-admin-border bg-sp-admin-card p-5">
+      <div className="mb-4 flex items-baseline justify-between gap-3">
+        <p className="text-[11px] font-semibold uppercase tracking-widest text-sp-admin-muted">
+          {title}
+        </p>
+        <p className="text-xs text-sp-admin-muted">
+          Total gastos: <span className="tabular-nums text-sp-admin-fg">{EUR.format(totalExpense)}</span>
+        </p>
+      </div>
+      <ul className="space-y-3">
+        {rows.map((r) => {
+          const pctLabel = totalExpense > 0 ? `${r.pct.toFixed(0)}%` : '—';
+          return (
+            <li key={r.key}>
+              <div className="mb-1 flex items-baseline justify-between gap-3">
+                <span className="text-sm text-sp-admin-fg">
+                  {r.label}
+                  <span className="ml-2 text-xs text-sp-admin-muted">· {facturasLabel(r.count)}</span>
+                </span>
+                <span className={`tabular-nums text-sm ${amountColor(r.key)}`}>
+                  {EUR.format(r.amount)}
+                  <span className="text-sp-admin-muted"> · {pctLabel}</span>
+                </span>
+              </div>
+              <div className="h-1.5 w-full overflow-hidden rounded-full bg-sp-admin-border">
+                <div
+                  className={`h-full rounded-full ${barColor(r.key)}`}
+                  style={{ width: `${Math.min(r.pct, 100).toFixed(1)}%` }}
+                />
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/src/lib/queries/financeDashboard/expenseSubgroups.ts
+++ b/src/lib/queries/financeDashboard/expenseSubgroups.ts
@@ -1,0 +1,184 @@
+/**
+ * Clasificador puro de gastos en subgrupos visuales para dirección.
+ *
+ * Convierte cada fila de `invoices kind=expense` en un `ExpenseSubgroupKey`
+ * con label humano listo para pintar. No accede a DB ni depende de server-only.
+ *
+ * Se consume desde `pnlDetail.ts` (server) durante la agregación y desde
+ * `AnnualExpenseBreakdown.tsx` (RSC) para mostrar los labels.
+ */
+
+// ── Tipos y constantes públicas ─────────────────────────────────────────────
+
+export type ExpenseSubgroupKey =
+  | 'nomina_pablo'
+  | 'nomina_alfonso'
+  | 'nomina_otros'
+  | 'cuota_pablo'
+  | 'cuota_alfonso'
+  | 'cuota_otros'
+  | 'seguridad_social'
+  | 'software_ia'
+  | 'gestoria'
+  | 'fiscal'
+  | 'marketing'
+  | 'comisiones'
+  | 'pagos_talentos'
+  | 'campana_otros'
+  | 'seguro_medico'
+  | 'gasto_general'
+  | 'sin_clasificar';
+
+export const EXPENSE_SUBGROUP_LABELS: Readonly<Record<ExpenseSubgroupKey, string>> = {
+  nomina_pablo:      'Nóminas Pablo',
+  nomina_alfonso:    'Nóminas Alfonso',
+  nomina_otros:      'Nóminas (sin identificar)',
+  cuota_pablo:       'Cuota autónomo Pablo',
+  cuota_alfonso:     'Cuota autónomo Alfonso',
+  cuota_otros:       'Cuota autónomo (sin identificar)',
+  seguridad_social:  'Seguridad Social',
+  software_ia:       'Software / IA',
+  gestoria:          'Gestoría',
+  fiscal:            'Fiscal / impuestos',
+  marketing:         'Marketing',
+  comisiones:        'Comisiones bancarias',
+  pagos_talentos:    'Pagos a talentos',
+  campana_otros:     'Costes campaña',
+  seguro_medico:     'Seguro médico',
+  gasto_general:     'Gasto general',
+  sin_clasificar:    'Sin clasificar',
+} as const;
+
+export type ExpenseClassifierInput = {
+  readonly expenseGroup: string | null;
+  readonly expenseSubtype: string | null;
+  readonly concept: string | null;
+  readonly counterpartyName: string | null;
+};
+
+// ── Detección de socio ──────────────────────────────────────────────────────
+
+const PABLO_RE   = /\b(pablo|camacho|keko)\b/i;
+const ALFONSO_RE = /\b(alfonso|arias)\b/i;
+
+/**
+ * Detecta a Pablo o Alfonso en un texto libre combinado (concept + counterparty).
+ * Devuelve `null` si:
+ *   - no hay señal;
+ *   - hay señal de ambos (ambiguo) → conservador, cae a "sin identificar".
+ */
+export function detectPartner(text: string): 'pablo' | 'alfonso' | null {
+  const p = PABLO_RE.test(text);
+  const a = ALFONSO_RE.test(text);
+  if (p && !a) return 'pablo';
+  if (a && !p) return 'alfonso';
+  return null;
+}
+
+/**
+ * Subtipos donde SÍ tiene sentido separar por socio (nómina + cuota autónomo).
+ * NO incluye `pago_talento`: los pagos a talentos externos nunca deben
+ * clasificarse como nómina propia aunque coincida un nombre.
+ */
+const PARTNER_AWARE_SUBTYPES: ReadonlySet<string> = new Set([
+  'nomina_socio',
+  'cuota_autonomo',
+  'factura_autonomo',
+]);
+
+// ── Clasificador ────────────────────────────────────────────────────────────
+
+/**
+ * Clasifica una fila de gasto en su subgrupo visual.
+ *
+ * Reglas (aplicadas en orden):
+ *   1. Si es nómina o cuota autónomo → detecta socio en `concept + counterparty`.
+ *   2. `expenseSubtype` mapea al subgrupo canónico.
+ *   3. Fallback: `expenseGroup` decide entre `campana_otros` (campaign_direct)
+ *      y `sin_clasificar` (operational o null).
+ */
+export function classifyExpenseSubgroup(input: ExpenseClassifierInput): ExpenseSubgroupKey {
+  const subtype = input.expenseSubtype;
+  const group = input.expenseGroup;
+
+  // Detección de socio SOLO en subtipos donde tiene sentido.
+  if (subtype && PARTNER_AWARE_SUBTYPES.has(subtype)) {
+    const text = [input.concept ?? '', input.counterpartyName ?? '']
+      .filter((s) => s.length > 0)
+      .join(' ');
+    const partner = detectPartner(text);
+    if (subtype === 'nomina_socio') {
+      if (partner === 'pablo') return 'nomina_pablo';
+      if (partner === 'alfonso') return 'nomina_alfonso';
+      return 'nomina_otros';
+    }
+    // cuota_autonomo + factura_autonomo se agrupan como "Cuota autónomo"
+    if (partner === 'pablo') return 'cuota_pablo';
+    if (partner === 'alfonso') return 'cuota_alfonso';
+    return 'cuota_otros';
+  }
+
+  // Mapeo directo por subtipo.
+  switch (subtype) {
+    case 'seguridad_social':      return 'seguridad_social';
+    case 'suscripcion_software':  return 'software_ia';
+    case 'herramienta_ia':        return 'software_ia';
+    case 'gestoria':              return 'gestoria';
+    case 'fiscal_impuestos':      return 'fiscal';
+    case 'ajuste_fiscal':         return 'fiscal';
+    case 'marketing_publicidad':  return 'marketing';
+    case 'comision_bancaria':     return 'comisiones';
+    case 'comision_plataforma':   return 'comisiones';
+    case 'pago_talento':          return 'pagos_talentos';
+    case 'coste_produccion':      return 'campana_otros';
+    case 'otros_campana':         return 'campana_otros';
+    case 'seguro_medico':         return 'seguro_medico';
+    case 'gasto_general':         return 'gasto_general';
+  }
+
+  // Sin subtipo → decide el grupo.
+  if (group === 'campaign_direct') return 'campana_otros';
+  return 'sin_clasificar';
+}
+
+// ── Agregación ──────────────────────────────────────────────────────────────
+
+export type ExpenseSubgroupRow = {
+  readonly key: ExpenseSubgroupKey;
+  readonly label: string;
+  readonly amount: number;
+  readonly count: number;
+  readonly pct: number;
+};
+
+/**
+ * Convierte un mapa acumulado de subgrupos en un array ordenado DESC por importe.
+ * `pct` se calcula sobre el total pasado como parámetro; si total <= 0, pct = 0
+ * (evita `NaN%` en la UI).
+ */
+export function summarizeExpenseSubgroups(
+  aggregate: ReadonlyMap<ExpenseSubgroupKey, { amount: number; count: number }>,
+  totalExpense: number,
+): readonly ExpenseSubgroupRow[] {
+  const rows: ExpenseSubgroupRow[] = [];
+  for (const [key, v] of aggregate) {
+    if (v.count === 0) continue;
+    const pct = totalExpense > 0 ? (v.amount / totalExpense) * 100 : 0;
+    rows.push({
+      key,
+      label: EXPENSE_SUBGROUP_LABELS[key],
+      amount: round2(v.amount),
+      count: v.count,
+      pct: round1(pct),
+    });
+  }
+  rows.sort((a, b) => b.amount - a.amount);
+  return rows;
+}
+
+function round1(n: number): number {
+  return Math.round(n * 10) / 10;
+}
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}

--- a/src/lib/queries/financeDashboard/pnlDetail.ts
+++ b/src/lib/queries/financeDashboard/pnlDetail.ts
@@ -10,6 +10,12 @@ import {
   PENDING_INCOME_STATUSES,
   PENDING_EXPENSE_STATUSES,
 } from '@/lib/utils/invoice-status';
+import {
+  classifyExpenseSubgroup,
+  summarizeExpenseSubgroups,
+  type ExpenseSubgroupKey,
+  type ExpenseSubgroupRow,
+} from './expenseSubgroups';
 
 export type FinancePnLResult = PnLResult & {
   readonly gastosCampanaDirect: number;
@@ -17,6 +23,7 @@ export type FinancePnLResult = PnLResult & {
   readonly gastosNoClasificados: number;
   readonly cobradoYTD: number;
   readonly pagadoYTD: number;
+  readonly expenseBySubgroup: readonly ExpenseSubgroupRow[];
 };
 
 /** @pure Clasifica un gasto en su bucket de expenseGroup. */
@@ -45,6 +52,7 @@ const ZERO: FinancePnLResult = {
   gastosNoClasificados: 0,
   cobradoYTD: 0,
   pagadoYTD: 0,
+  expenseBySubgroup: [],
 };
 
 /**
@@ -76,7 +84,10 @@ export async function getFinancePnL(filters: PnLFilters = {}): Promise<FinancePn
         campaignId: invoices.campaignId,
         talentId: invoices.talentId,
         expenseGroup: invoices.expenseGroup,
+        expenseSubtype: invoices.expenseSubtype,
         category: invoices.category,
+        concept: invoices.concept,
+        counterpartyName: invoices.counterpartyName,
         issueDate: invoices.issueDate,
       })
       .from(invoices)
@@ -135,6 +146,7 @@ export async function getFinancePnL(filters: PnLFilters = {}): Promise<FinancePn
 
   const monthMap = new Map<string, { ingresos: number; gastos: number }>();
   const categoryMap = new Map<string, { total: number; count: number }>();
+  const subgroupMap = new Map<ExpenseSubgroupKey, { amount: number; count: number }>();
 
   for (const row of rows) {
     const amount = Number(row.totalAmount ?? 0);
@@ -165,6 +177,18 @@ export async function getFinancePnL(filters: PnLFilters = {}): Promise<FinancePn
       if (bucket === 'campaign_direct') gastosCampanaDirect += amount;
       else if (bucket === 'operational') gastosOperativos += amount;
       else gastosNoClasificados += amount;
+
+      // Desglose visual por subgrupo (Nóminas Pablo / Alfonso, Software / IA, ...)
+      const subgroupKey = classifyExpenseSubgroup({
+        expenseGroup: row.expenseGroup,
+        expenseSubtype: row.expenseSubtype,
+        concept: row.concept,
+        counterpartyName: row.counterpartyName,
+      });
+      const subEntry = subgroupMap.get(subgroupKey) ?? { amount: 0, count: 0 };
+      subEntry.amount += amount;
+      subEntry.count += 1;
+      subgroupMap.set(subgroupKey, subEntry);
     }
 
     monthMap.set(month, monthEntry);
@@ -183,6 +207,8 @@ export async function getFinancePnL(filters: PnLFilters = {}): Promise<FinancePn
     .sort(([, a], [, b]) => b.total - a.total)
     .map(([category, v]) => ({ category, total: v.total, count: v.count }));
 
+  const expenseBySubgroup = summarizeExpenseSubgroups(subgroupMap, gastos);
+
   return {
     ingresos,
     gastos,
@@ -199,5 +225,6 @@ export async function getFinancePnL(filters: PnLFilters = {}): Promise<FinancePn
     gastosNoClasificados,
     cobradoYTD: Number(cobradoYTDRows[0]?.total ?? 0),
     pagadoYTD: Number(pagadoYTDRows[0]?.total ?? 0),
+    expenseBySubgroup,
   };
 }


### PR DESCRIPTION
## Resumen

Nuevo bloque **"Dónde se ha ido el dinero"** en `/admin/finanzas/pl` con líneas separadas por socio (**Nóminas Pablo**, **Cuota autónomo Alfonso**), categoría de negocio (**Software / IA**, **Gestoría**, **Fiscal / impuestos**, **Comisiones bancarias**, **Pagos a talentos**, **Seguro médico**, …) y bandeja **Sin clasificar** con alerta visual.

Puramente presentacional. Cero DB / schema / migrations / crons / emails / Resend / invoice_reminders / dunning / OCR / Blob / Sheets / RBAC / AR aging / seed scripts / payroll parser / setup2026 / Tratos / facturación legal.

## Ejemplo visual del bloque

Ubicado entre el desglose por `expenseGroup` y Caja YTD:

```
DÓNDE SE HA IDO EL DINERO ESTE AÑO          Total gastos: 13.397 €

Nóminas Pablo              · 4 facturas   5.090 € · 38%
█████████████████████████████████████████░░░░░░░░░░░░

Nóminas Alfonso            · 3 facturas   4.107 € · 31%
██████████████████████████████░░░░░░░░░░░░░░░░░░░░░░░

Cuota autónomo Pablo       · 6 facturas   1.890 € · 14%
█████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░

Cuota autónomo Alfonso     · 6 facturas   1.890 € · 14%
█████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░

Software / IA              · 5 facturas     420 € · 3%
███░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
```

Si hay algo en **Sin clasificar** aparece con badge/color amber para que salte a la vista.

Título dinámico:
- Rango = 1-ene → hoy → **"Dónde se ha ido el dinero este año"**
- Rango custom → **"Dónde se ha ido el dinero en este periodo"**

## Labels finales (17 subgrupos)

| Key | Label visible |
|---|---|
| `nomina_pablo` | Nóminas Pablo |
| `nomina_alfonso` | Nóminas Alfonso |
| `nomina_otros` | Nóminas (sin identificar) |
| `cuota_pablo` | Cuota autónomo Pablo |
| `cuota_alfonso` | Cuota autónomo Alfonso |
| `cuota_otros` | Cuota autónomo (sin identificar) |
| `seguridad_social` | Seguridad Social |
| `software_ia` | Software / IA |
| `gestoria` | Gestoría |
| `fiscal` | Fiscal / impuestos |
| `marketing` | Marketing |
| `comisiones` | Comisiones bancarias |
| `pagos_talentos` | Pagos a talentos |
| `campana_otros` | Costes campaña |
| `seguro_medico` | Seguro médico |
| `gasto_general` | Gasto general |
| `sin_clasificar` | Sin clasificar |

## Reglas de clasificación

```
nomina_socio                            → nomina_pablo | alfonso | otros
cuota_autonomo | factura_autonomo       → cuota_pablo  | alfonso | otros
seguridad_social                        → seguridad_social
suscripcion_software | herramienta_ia   → software_ia
gestoria                                → gestoria
fiscal_impuestos | ajuste_fiscal        → fiscal
marketing_publicidad                    → marketing
comision_bancaria | comision_plataforma → comisiones
pago_talento                            → pagos_talentos
coste_produccion | otros_campana        → campana_otros
seguro_medico                           → seguro_medico
gasto_general                           → gasto_general
subtype null + expenseGroup=campaign_direct → campana_otros
subtype null + otros / null             → sin_clasificar
```

## Cómo detecto Pablo / Alfonso

Regex sobre `concept + " " + counterpartyName`:

- Pablo: `\b(pablo|camacho|keko)\b` (case-insensitive)
- Alfonso: `\b(alfonso|arias)\b` (case-insensitive)

**Guardarraíl importante**: la detección de persona **solo se aplica** cuando `expenseSubtype ∈ {nomina_socio, cuota_autonomo, factura_autonomo}`. Un `pago_talento` con "Pablo" en el concepto va siempre a **Pagos a talentos**, nunca a Nóminas.

Ambigüedad (ambos regex matchean) → cae al bucket "(sin identificar)" — conservador, señalable para reclasificar manualmente.

## Filtros

El bloque **respeta automáticamente** los filtros existentes de `/pl`:
- `from` (default `startOfLocalYearIso()`)
- `to` (default `todayLocalIso()`)
- `company`
- `brandId`
- `talentId`

La agregación se hace **sobre las mismas rows** que ya trae `getFinancePnL` con los filtros aplicados. No hay una segunda query.

## Suma con el total de gastos

`expenseBySubgroup` se acumula en el **mismo loop** de gastos donde `gastos += amount`. Por invariante:

```
SUM(expenseBySubgroup[*].amount) === gastos   (± 0.01 por redondeo)
```

Cubierto por test explícito. Nada de gastos queda fuera del desglose: todo cae en algún subgrupo (peor caso: "Sin clasificar", visible en la UI con badge amber).

## Archivos tocados (5)

**Nuevos (3):**
- `src/lib/queries/financeDashboard/expenseSubgroups.ts` (~184 LOC) — clasificador puro + agregación + labels
- `src/features/admin/pnl/components/AnnualExpenseBreakdown.tsx` (~122 LOC) — RSC del bloque visual
- `src/__tests__/server/audit-finanzas-expense-breakdown.test.ts` (~349 LOC) — 55 tests

**Modificados (2):**
- `src/lib/queries/financeDashboard/pnlDetail.ts` — SELECT +3 columnas, loop añade acumulador de subgrupos, tipo `FinancePnLResult` añade `expenseBySubgroup`
- `src/app/admin/(dashboard)/finanzas/pl/page.tsx` — import + `<AnnualExpenseBreakdown …>` entre `expenseGroup` grid y "Caja YTD"

**No toco:**
- `PnLCategoryList` legacy (queda intacta como referencia operativa).
- DB / schema / `src/db/schema/` / `drizzle/` / migrations / crons / emails / Resend / invoice_reminders / OCR / Blob / Sheets / RBAC / seed scripts / payroll parser / setup2026 / Tratos / facturación legal.
- `EXPENSE_SUBTYPE_LABELS` (lo consumo, no lo modifico).

## Confirmaciones

- ✅ **Cero DB / schema / migrations / drizzle**
- ✅ **Cero crons / emails / Resend / invoice_reminders / dunning**
- ✅ Cálculos contables previos intactos — solo añado un acumulador nuevo al mismo loop
- ✅ **Filtros de `/pl` respetados** — la agregación usa las mismas rows filtradas
- ✅ **Suma cuadra con `pnl.gastos`** (test explícito, tolerancia < 0.01)
- ✅ **Sin `NaN%`** cuando el total es 0 (rama de empty state + test)
- ✅ **Guardarraíl anti falso positivo**: `pago_talento` con "Pablo" en concept → `pagos_talentos`, no `nomina_pablo` (test explícito)
- ✅ **Clasificador puro** — sin `'server-only'`, sin `@/lib/db`, sin `@/db/schema` (test estático)

## Tests

55 tests nuevos:

1. **Detección de socio** (Pablo/Alfonso/Camacho/Arias/Keko + ambigüedad + vacío)
2. **Nóminas partner-aware** (Pablo, Alfonso, sin persona, ambiguo)
3. **Cuota autónomo partner-aware** (Pablo, Alfonso, factura_autonomo agrupado)
4. **Seguridad Social** (siempre agregada)
5. **Mapeo directo** por subtipo (13 casos)
6. **Guardarraíles**: `pago_talento` con "Pablo" → pagos_talentos; `marketing_publicidad` con "Alfonso" → marketing
7. **Sin subtipo** (null → sin_clasificar; campaign_direct → campana_otros; operational → sin_clasificar)
8. **Agregación**: orden DESC, pct sin NaN, exclusión count=0, label desde constante, suma = total
9. **Estáticos**: page.tsx renderiza el bloque, getFinancePnL expone campo, SELECT añade 3 columnas, clasificador usado en loop
10. **Anti-scope-creep**: sin Resend/email/dunning/invoice_reminders, sin `pgTable`/`alterTable`, clasificador puro sin server-only

## CI local

- ✅ `npx tsc --noEmit` — clean
- ✅ `npm run lint` — 0/0
- ✅ `npm test` — 111 suites · **1926 tests** verdes (55 nuevos)
- ⚠️ `npm run build` local requiere `.env.local` con `DATABASE_URL / RESEND_API_KEY / BETTER_AUTH_SECRET / NEXT_PUBLIC_SITE_URL`. Vercel las tiene y correrá el build en el deploy.

## Test plan post-merge

- [ ] `/admin/finanzas/pl` carga con el bloque nuevo entre el desglose por `expenseGroup` y Caja YTD.
- [ ] Rango YTD → título "Dónde se ha ido el dinero este año".
- [ ] Cambiar el rango (ej. solo Q1) → título "…en este periodo" y datos refiltrados.
- [ ] Verificar que **Nóminas Pablo** y **Nóminas Alfonso** aparecen separados con importes creíbles.
- [ ] Verificar que **Cuota autónomo Pablo** y **Cuota autónomo Alfonso** aparecen separados.
- [ ] Si aparece **Cuota autónomo (sin identificar)**, es señal para revisar/completar el `counterpartyName` de esas filas.
- [ ] Total del bloque coincide con la card "Gastos" del PnL Overview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
