### PR TITLE
feat(audit/finanzas): desglose expandible con items en /admin/finanzas/pl

### DIFF
--- a/src/__tests__/server/audit-finanzas-expense-breakdown.test.ts
+++ b/src/__tests__/server/audit-finanzas-expense-breakdown.test.ts
@@ -1,21 +1,26 @@
 /**
- * Tests para el desglose visual anual de gastos.
+ * Tests para el desglose visual anual de gastos (con expandible por items).
  *
  * Cubre:
- *   - Clasificador puro (`classifyExpenseSubgroup`): 17 subgrupos + guardarraíles.
- *   - Agregación (`summarizeExpenseSubgroups`): pct, orden DESC, edge cases.
- *   - Estáticos: page.tsx renderiza el bloque; getFinancePnL expone `expenseBySubgroup`.
+ *   - Clasificador puro: 18 subgrupos + guardarraíles + hosting/dominio.
+ *   - Agregación con items ordenados por issueDate ASC.
+ *   - Construcción de pdfUrl vía proxy interno (nunca Blob directo).
+ *   - Estáticos: page.tsx renderiza el bloque; componente usa <details>;
+ *     Sin clasificar tiene CTA; GastosPageClient lee el hash.
  *   - Anti-scope-creep: sin schema/migrations/cron/Resend/emails.
  */
 
 import * as fs from 'fs';
 import * as path from 'path';
 import {
+  buildInvoicePdfUrl,
   classifyExpenseSubgroup,
   detectPartner,
   summarizeExpenseSubgroups,
   EXPENSE_SUBGROUP_LABELS,
   type ExpenseClassifierInput,
+  type ExpenseSubgroupAggregate,
+  type ExpenseSubgroupItem,
   type ExpenseSubgroupKey,
 } from '@/lib/queries/financeDashboard/expenseSubgroups';
 
@@ -33,6 +38,23 @@ function makeInput(overrides: Partial<ExpenseClassifierInput>): ExpenseClassifie
     counterpartyName: null,
     ...overrides,
   };
+}
+
+function makeItem(overrides: Partial<ExpenseSubgroupItem> = {}): ExpenseSubgroupItem {
+  return {
+    id: 1,
+    issueDate: '2026-01-01',
+    concept: 'x',
+    counterpartyName: null,
+    totalAmount: 0,
+    status: 'pagada',
+    pdfUrl: null,
+    ...overrides,
+  };
+}
+
+function makeAgg(amount: number, count: number, items: ExpenseSubgroupItem[] = []): ExpenseSubgroupAggregate {
+  return { amount, count, items };
 }
 
 // ── Detección de socio ─────────────────────────────────────────────────────
@@ -149,6 +171,64 @@ describe('classifyExpenseSubgroup()', () => {
     });
   });
 
+  describe('Hosting / dominio (frontend-only)', () => {
+    it('suscripcion_software + "Vercel Pro" → hosting_dominio', () => {
+      expect(classifyExpenseSubgroup(makeInput({
+        expenseSubtype: 'suscripcion_software',
+        concept: 'Vercel Pro',
+      }))).toBe('hosting_dominio');
+    });
+
+    it('herramienta_ia + counterparty "Cloudflare" → hosting_dominio', () => {
+      expect(classifyExpenseSubgroup(makeInput({
+        expenseSubtype: 'herramienta_ia',
+        counterpartyName: 'Cloudflare',
+      }))).toBe('hosting_dominio');
+    });
+
+    it('gasto_general + "Renovación dominio socialpro.es" → hosting_dominio', () => {
+      expect(classifyExpenseSubgroup(makeInput({
+        expenseSubtype: 'gasto_general',
+        concept: 'Renovación dominio socialpro.es',
+      }))).toBe('hosting_dominio');
+    });
+
+    it('null + "Namecheap DNS" → hosting_dominio', () => {
+      expect(classifyExpenseSubgroup(makeInput({
+        expenseSubtype: null,
+        concept: 'Namecheap DNS',
+      }))).toBe('hosting_dominio');
+    });
+
+    it('null + "GoDaddy renovación" → hosting_dominio', () => {
+      expect(classifyExpenseSubgroup(makeInput({
+        expenseSubtype: null,
+        counterpartyName: 'GoDaddy',
+      }))).toBe('hosting_dominio');
+    });
+
+    it('suscripcion_software + "ChatGPT" (sin señal hosting) → software_ia', () => {
+      expect(classifyExpenseSubgroup(makeInput({
+        expenseSubtype: 'suscripcion_software',
+        concept: 'ChatGPT plus',
+      }))).toBe('software_ia');
+    });
+
+    it('pago_talento con "Vercel" en concept → pagos_talentos (guardarraíl)', () => {
+      expect(classifyExpenseSubgroup(makeInput({
+        expenseSubtype: 'pago_talento',
+        concept: 'Sponsor Vercel al talento',
+      }))).toBe('pagos_talentos');
+    });
+
+    it('marketing_publicidad con "hosting" → marketing (guardarraíl)', () => {
+      expect(classifyExpenseSubgroup(makeInput({
+        expenseSubtype: 'marketing_publicidad',
+        concept: 'Campaña hosting jul',
+      }))).toBe('marketing');
+    });
+  });
+
   describe('Mapeo directo por subtipo', () => {
     const cases: Array<[string, ExpenseSubgroupKey]> = [
       ['suscripcion_software', 'software_ia'],
@@ -172,7 +252,7 @@ describe('classifyExpenseSubgroup()', () => {
     });
   });
 
-  describe('Guardarraíl anti falso positivo', () => {
+  describe('Guardarraíl anti falso positivo (nómina)', () => {
     it('pago_talento con "Pablo" en concepto → pagos_talentos (no nomina_pablo)', () => {
       expect(classifyExpenseSubgroup(makeInput({
         expenseSubtype: 'pago_talento',
@@ -207,51 +287,74 @@ describe('classifyExpenseSubgroup()', () => {
   });
 });
 
-// ── Agregación ─────────────────────────────────────────────────────────────
+// ── buildInvoicePdfUrl ─────────────────────────────────────────────────────
+
+describe('buildInvoicePdfUrl()', () => {
+  it('devuelve el proxy interno cuando invoiceFileId !== null', () => {
+    const url = buildInvoicePdfUrl({ id: 42, invoiceFileId: 7, fileUrl: null });
+    expect(url).toBe('/api/admin/facturacion/42/pdf');
+  });
+
+  it('devuelve el proxy interno cuando solo fileUrl existe (legacy)', () => {
+    const url = buildInvoicePdfUrl({ id: 99, invoiceFileId: null, fileUrl: 'https://blob.vercel-storage.com/private/xxx' });
+    expect(url).toBe('/api/admin/facturacion/99/pdf');
+  });
+
+  it('devuelve null si no hay ni invoiceFileId ni fileUrl', () => {
+    expect(buildInvoicePdfUrl({ id: 1, invoiceFileId: null, fileUrl: null })).toBeNull();
+  });
+
+  it('nunca expone la URL directa de Blob privado', () => {
+    const url = buildInvoicePdfUrl({ id: 5, invoiceFileId: 1, fileUrl: 'https://blob.vercel-storage.com/private/leak' });
+    expect(url).not.toMatch(/blob\.vercel-storage/);
+    expect(url).not.toMatch(/^https:\/\//);
+  });
+});
+
+// ── Agregación con items ────────────────────────────────────────────────────
 
 describe('summarizeExpenseSubgroups()', () => {
   it('devuelve orden DESC por importe', () => {
-    const map = new Map<ExpenseSubgroupKey, { amount: number; count: number }>();
-    map.set('nomina_pablo',   { amount: 5090, count: 4 });
-    map.set('software_ia',    { amount:  420, count: 5 });
-    map.set('nomina_alfonso', { amount: 4107, count: 3 });
+    const map = new Map<ExpenseSubgroupKey, ExpenseSubgroupAggregate>();
+    map.set('nomina_pablo',   makeAgg(5090, 4));
+    map.set('software_ia',    makeAgg( 420, 5));
+    map.set('nomina_alfonso', makeAgg(4107, 3));
     const out = summarizeExpenseSubgroups(map, 10_000);
     expect(out.map((r) => r.key)).toEqual(['nomina_pablo', 'nomina_alfonso', 'software_ia']);
   });
 
   it('calcula pct = amount / total * 100', () => {
-    const map = new Map<ExpenseSubgroupKey, { amount: number; count: number }>();
-    map.set('nomina_pablo', { amount: 500, count: 1 });
+    const map = new Map<ExpenseSubgroupKey, ExpenseSubgroupAggregate>();
+    map.set('nomina_pablo', makeAgg(500, 1));
     const out = summarizeExpenseSubgroups(map, 2000);
     expect(out[0]?.pct).toBe(25);
   });
 
   it('pct = 0 cuando totalExpense es 0 (no NaN)', () => {
-    const map = new Map<ExpenseSubgroupKey, { amount: number; count: number }>();
-    map.set('sin_clasificar', { amount: 0, count: 1 });
+    const map = new Map<ExpenseSubgroupKey, ExpenseSubgroupAggregate>();
+    map.set('sin_clasificar', makeAgg(0, 1));
     const out = summarizeExpenseSubgroups(map, 0);
     expect(out[0]?.pct).toBe(0);
     expect(Number.isNaN(out[0]?.pct ?? NaN)).toBe(false);
   });
 
   it('excluye subgrupos con count = 0', () => {
-    const map = new Map<ExpenseSubgroupKey, { amount: number; count: number }>();
-    map.set('nomina_pablo',   { amount: 100, count: 1 });
-    map.set('nomina_alfonso', { amount:   0, count: 0 });
+    const map = new Map<ExpenseSubgroupKey, ExpenseSubgroupAggregate>();
+    map.set('nomina_pablo',   makeAgg(100, 1));
+    map.set('nomina_alfonso', makeAgg(  0, 0));
     const out = summarizeExpenseSubgroups(map, 100);
     expect(out.map((r) => r.key)).toEqual(['nomina_pablo']);
   });
 
   it('label sale del EXPENSE_SUBGROUP_LABELS', () => {
-    const map = new Map<ExpenseSubgroupKey, { amount: number; count: number }>();
-    map.set('cuota_alfonso', { amount: 1890, count: 6 });
+    const map = new Map<ExpenseSubgroupKey, ExpenseSubgroupAggregate>();
+    map.set('cuota_alfonso', makeAgg(1890, 6));
     const out = summarizeExpenseSubgroups(map, 1890);
     expect(out[0]?.label).toBe('Cuota autónomo Alfonso');
     expect(out[0]?.label).toBe(EXPENSE_SUBGROUP_LABELS.cuota_alfonso);
   });
 
   it('suma de subgrupos = total (tolerancia < 0.01)', () => {
-    // Emula la ruta feliz: acumulador tiene lo mismo que sumaría el loop de gastos.
     const parts: Array<[ExpenseSubgroupKey, number, number]> = [
       ['nomina_pablo',   5090.00, 4],
       ['nomina_alfonso', 4107.00, 3],
@@ -259,12 +362,78 @@ describe('summarizeExpenseSubgroups()', () => {
       ['cuota_alfonso',  1890.00, 6],
       ['software_ia',     420.00, 5],
     ];
-    const map = new Map<ExpenseSubgroupKey, { amount: number; count: number }>();
-    for (const [key, amount, count] of parts) map.set(key, { amount, count });
+    const map = new Map<ExpenseSubgroupKey, ExpenseSubgroupAggregate>();
+    for (const [key, amount, count] of parts) map.set(key, makeAgg(amount, count));
     const total = parts.reduce((s, [, amt]) => s + amt, 0);
     const out = summarizeExpenseSubgroups(map, total);
     const sum = out.reduce((s, r) => s + r.amount, 0);
     expect(Math.abs(sum - total)).toBeLessThan(0.01);
+  });
+
+  describe('items dentro del subgrupo', () => {
+    it('cada subgrupo devuelto incluye su array de items', () => {
+      const items = [
+        makeItem({ id: 10, issueDate: '2026-01-01', totalAmount: 100 }),
+        makeItem({ id: 11, issueDate: '2026-02-01', totalAmount: 100 }),
+      ];
+      const map = new Map<ExpenseSubgroupKey, ExpenseSubgroupAggregate>();
+      map.set('nomina_pablo', makeAgg(200, 2, items));
+      const out = summarizeExpenseSubgroups(map, 200);
+      expect(out[0]?.items).toHaveLength(2);
+    });
+
+    it('items ordenados por issueDate ASC dentro de cada subgrupo', () => {
+      const items = [
+        makeItem({ id: 3, issueDate: '2026-03-01' }),
+        makeItem({ id: 1, issueDate: '2026-01-01' }),
+        makeItem({ id: 2, issueDate: '2026-02-01' }),
+      ];
+      const map = new Map<ExpenseSubgroupKey, ExpenseSubgroupAggregate>();
+      map.set('nomina_pablo', makeAgg(300, 3, items));
+      const out = summarizeExpenseSubgroups(map, 300);
+      expect(out[0]?.items.map((i) => i.id)).toEqual([1, 2, 3]);
+    });
+
+    it('subgroup.count === items.length', () => {
+      const items = [
+        makeItem({ id: 1 }),
+        makeItem({ id: 2 }),
+        makeItem({ id: 3 }),
+      ];
+      const map = new Map<ExpenseSubgroupKey, ExpenseSubgroupAggregate>();
+      map.set('software_ia', makeAgg(300, 3, items));
+      const out = summarizeExpenseSubgroups(map, 300);
+      expect(out[0]?.count).toBe(out[0]?.items.length);
+    });
+
+    it('SUM(items.totalAmount) === subgroup.amount (tolerancia < 0.01)', () => {
+      const items = [
+        makeItem({ id: 1, totalAmount: 1696.55 }),
+        makeItem({ id: 2, totalAmount: 1696.55 }),
+        makeItem({ id: 3, totalAmount: 1696.55 }),
+        makeItem({ id: 4, totalAmount: 1696.55 }),
+      ];
+      const total = 1696.55 * 4;
+      const map = new Map<ExpenseSubgroupKey, ExpenseSubgroupAggregate>();
+      map.set('nomina_pablo', makeAgg(total, 4, items));
+      const out = summarizeExpenseSubgroups(map, total);
+      const sum = out[0]?.items.reduce((s, i) => s + i.totalAmount, 0) ?? 0;
+      expect(Math.abs(sum - (out[0]?.amount ?? 0))).toBeLessThan(0.01);
+    });
+
+    it('ningún item filtra la URL directa de Blob', () => {
+      const items = [
+        makeItem({ id: 1, pdfUrl: '/api/admin/facturacion/1/pdf' }),
+        makeItem({ id: 2, pdfUrl: null }),
+      ];
+      const map = new Map<ExpenseSubgroupKey, ExpenseSubgroupAggregate>();
+      map.set('nomina_pablo', makeAgg(200, 2, items));
+      const out = summarizeExpenseSubgroups(map, 200);
+      for (const it of out[0]?.items ?? []) {
+        expect(it.pdfUrl ?? '').not.toMatch(/blob\.vercel-storage/);
+        expect(it.pdfUrl ?? '').not.toMatch(/^https?:\/\//);
+      }
+    });
   });
 });
 
@@ -274,6 +443,8 @@ describe('Integración /admin/finanzas/pl', () => {
   const pageSrc = read('src/app/admin/(dashboard)/finanzas/pl/page.tsx');
   const querySrc = read('src/lib/queries/financeDashboard/pnlDetail.ts');
   const componentSrc = read('src/features/admin/pnl/components/AnnualExpenseBreakdown.tsx');
+  const gastosClientSrc = read('src/app/admin/(dashboard)/finanzas/gastos/GastosPageClient.tsx');
+  const subgroupsSrc = read('src/lib/queries/financeDashboard/expenseSubgroups.ts');
 
   it('page.tsx importa y renderiza AnnualExpenseBreakdown', () => {
     expect(pageSrc).toMatch(/from\s+['"]@\/features\/admin\/pnl\/components\/AnnualExpenseBreakdown['"]/);
@@ -286,28 +457,70 @@ describe('Integración /admin/finanzas/pl', () => {
     expect(querySrc).toMatch(/expenseBySubgroup:\s*readonly ExpenseSubgroupRow\[\]/);
   });
 
-  it('getFinancePnL añade expenseSubtype, concept y counterpartyName al SELECT', () => {
+  it('getFinancePnL añade id, expenseSubtype, concept, counterpartyName, invoiceFileId y fileUrl al SELECT', () => {
+    expect(querySrc).toMatch(/\bid:\s*invoices\.id\b/);
     expect(querySrc).toMatch(/expenseSubtype:\s*invoices\.expenseSubtype/);
     expect(querySrc).toMatch(/concept:\s*invoices\.concept/);
     expect(querySrc).toMatch(/counterpartyName:\s*invoices\.counterpartyName/);
+    expect(querySrc).toMatch(/invoiceFileId:\s*invoices\.invoiceFileId/);
+    expect(querySrc).toMatch(/fileUrl:\s*invoices\.fileUrl/);
   });
 
-  it('getFinancePnL usa el clasificador en el loop', () => {
+  it('getFinancePnL usa el clasificador y buildInvoicePdfUrl en el loop', () => {
     expect(querySrc).toMatch(/classifyExpenseSubgroup\(/);
     expect(querySrc).toMatch(/summarizeExpenseSubgroups\(/);
+    expect(querySrc).toMatch(/buildInvoicePdfUrl\(/);
   });
 
   it('componente evita NaN% cuando total = 0', () => {
-    // Rama que devuelve el "empty state" ANTES de dividir → sin cálculo de pct.
     expect(componentSrc).toMatch(/totalExpense <= 0/);
     expect(componentSrc).not.toMatch(/NaN/);
   });
 
   it('componente respeta los filtros pasando from/to al título', () => {
-    // Título dinámico se computa en función del rango recibido.
     expect(componentSrc).toMatch(/isYearToDateRange\(from,\s*to\)/);
     expect(componentSrc).toMatch(/Dónde se ha ido el dinero este año/);
     expect(componentSrc).toMatch(/Dónde se ha ido el dinero en este periodo/);
+  });
+
+  it('componente usa <details> y <summary> HTML nativos', () => {
+    expect(componentSrc).toMatch(/<details\b/);
+    expect(componentSrc).toMatch(/<summary\b/);
+  });
+
+  it('componente NO usa useState ni useEffect (server component)', () => {
+    expect(componentSrc).not.toMatch(/useState\(/);
+    expect(componentSrc).not.toMatch(/useEffect\(/);
+  });
+
+  it("componente NO declara 'use client'", () => {
+    // Solo cuenta como directiva si es la primera línea "no-import".
+    expect(componentSrc.split('\n')[0]?.trim()).not.toBe("'use client';");
+    expect(componentSrc).not.toMatch(/^['"]use client['"];/m);
+  });
+
+  it('Sin clasificar renderiza CTA con enlace a /admin/finanzas/gastos#sin-clasificar', () => {
+    expect(componentSrc).toMatch(/\/admin\/finanzas\/gastos#sin-clasificar/);
+    expect(componentSrc).toMatch(/Clasificar/);
+  });
+
+  it('GastosPageClient activa la tab "Sin clasificar" al detectar el hash', () => {
+    // Puede ser vía useEffect + setActive, o vía initializer del useState
+    // (patrón preferido — sin efecto, sin warning de set-state-in-effect).
+    expect(gastosClientSrc).toMatch(/window\.location\.hash/);
+    expect(gastosClientSrc).toMatch(/['"]#sin-clasificar['"]/);
+    expect(gastosClientSrc).toMatch(/Sin clasificar/);
+  });
+
+  it('la tabla de items pasa por humanStatus() y no muestra status raw', () => {
+    expect(componentSrc).toMatch(/humanStatus\(/);
+    // Nunca renderiza {it.status} crudo dentro del JSX.
+    expect(componentSrc).not.toMatch(/\{it\.status\}/);
+  });
+
+  it('expenseSubgroups.ts expone el subgrupo hosting_dominio con su label', () => {
+    expect(subgroupsSrc).toMatch(/hosting_dominio/);
+    expect(subgroupsSrc).toMatch(/Hosting \/ dominio/);
   });
 });
 
@@ -319,6 +532,7 @@ describe('Anti-scope-creep', () => {
     'src/lib/queries/financeDashboard/pnlDetail.ts',
     'src/features/admin/pnl/components/AnnualExpenseBreakdown.tsx',
     'src/app/admin/(dashboard)/finanzas/pl/page.tsx',
+    'src/app/admin/(dashboard)/finanzas/gastos/GastosPageClient.tsx',
   ];
 
   it.each(filesToScan)('%s no importa Resend ni utilidades de email', (rel) => {

--- a/src/app/admin/(dashboard)/finanzas/gastos/GastosPageClient.tsx
+++ b/src/app/admin/(dashboard)/finanzas/gastos/GastosPageClient.tsx
@@ -25,8 +25,16 @@ function sumTotalAmount(rows: readonly InvoiceWithRelations[]): number {
   return s;
 }
 
+// Deep-link: /admin/finanzas/gastos#sin-clasificar activa la tab correcta.
+// WHY: el CTA del bloque "Sin clasificar" de /pl (AnnualExpenseBreakdown)
+// aterriza aquí; sin este initializer el usuario cae siempre en "Directos".
+function initialTabFromHash(): TabName {
+  if (typeof window === 'undefined') return 'Directos';
+  return window.location.hash === '#sin-clasificar' ? 'Sin clasificar' : 'Directos';
+}
+
 export function GastosPageClient({ directos, operativos, sinClasificar }: Props): React.ReactElement {
-  const [active, setActive] = useState<TabName>('Directos');
+  const [active, setActive] = useState<TabName>(initialTabFromHash);
 
   const totalDirectos     = sumTotalAmount(directos);
   const totalOperativos   = sumTotalAmount(operativos);

--- a/src/features/admin/pnl/components/AnnualExpenseBreakdown.tsx
+++ b/src/features/admin/pnl/components/AnnualExpenseBreakdown.tsx
@@ -1,10 +1,30 @@
-import type { ExpenseSubgroupKey, ExpenseSubgroupRow } from '@/lib/queries/financeDashboard/expenseSubgroups';
+import Link from 'next/link';
+import type { ExpenseSubgroupItem, ExpenseSubgroupKey, ExpenseSubgroupRow } from '@/lib/queries/financeDashboard/expenseSubgroups';
 
 const EUR = new Intl.NumberFormat('es-ES', {
   style: 'currency',
   currency: 'EUR',
   maximumFractionDigits: 0,
 });
+
+const EUR2 = new Intl.NumberFormat('es-ES', {
+  style: 'currency',
+  currency: 'EUR',
+  maximumFractionDigits: 2,
+});
+
+const DATE_FMT = new Intl.DateTimeFormat('es-ES', {
+  day: '2-digit',
+  month: 'short',
+  year: '2-digit',
+});
+
+function formatDate(iso: string): string {
+  if (!iso) return '—';
+  const [y, m, d] = iso.split('-').map(Number);
+  if (!y || !m || !d) return iso;
+  return DATE_FMT.format(new Date(y, m - 1, d));
+}
 
 /**
  * Detecta si el rango corresponde al año en curso (desde 1-ene hasta hoy).
@@ -49,6 +69,150 @@ function facturasLabel(count: number): string {
   return count === 1 ? '1 factura' : `${count} facturas`;
 }
 
+const STATUS_HUMAN: Readonly<Record<string, string>> = {
+  cobrada:     'Cobrada',
+  pagada:      'Pagada',
+  emitida:     'Emitida',
+  pendiente:   'Pendiente',
+  vencida:     'Vencida',
+  borrador:    'Borrador',
+  no_cobrada:  'Sin cobrar',
+  no_pagada:   'Sin pagar',
+  no_cobrado:  'Sin cobrar',
+  no_pagado:   'Sin pagar',
+  anulada:     'Anulada',
+  parcial:     'Parcial',
+};
+
+function humanStatus(status: string): string {
+  return STATUS_HUMAN[status] ?? status;
+}
+
+// ── Subcomponente por subgrupo ──────────────────────────────────────────────
+
+type RowProps = {
+  readonly row: ExpenseSubgroupRow;
+  readonly isFirst: boolean;
+};
+
+function SubgroupRow({ row, isFirst }: RowProps): React.ReactElement {
+  const pctLabel = `${row.pct.toFixed(0)}%`;
+  return (
+    <details
+      className="group border-b border-sp-admin-border/40 py-3 last:border-0 [&_.chev]:transition-transform [&[open]_.chev]:rotate-90"
+      open={isFirst}
+    >
+      <summary className="flex cursor-pointer list-none flex-col gap-1.5">
+        <div className="flex items-baseline justify-between gap-3">
+          <span className="flex items-center gap-2 text-sm text-sp-admin-fg">
+            <span className="chev text-sp-admin-muted">▸</span>
+            {row.label}
+            <span className="text-xs text-sp-admin-muted">· {facturasLabel(row.count)}</span>
+          </span>
+          <span className={`tabular-nums text-sm ${amountColor(row.key)}`}>
+            {EUR.format(row.amount)}
+            <span className="text-sp-admin-muted"> · {pctLabel}</span>
+          </span>
+        </div>
+        <div className="h-1.5 w-full overflow-hidden rounded-full bg-sp-admin-border">
+          <div
+            className={`h-full rounded-full ${barColor(row.key)}`}
+            style={{ width: `${Math.min(row.pct, 100).toFixed(1)}%` }}
+          />
+        </div>
+      </summary>
+
+      {row.key === 'sin_clasificar' && (
+        <div className="mt-3 flex items-center gap-2 rounded-lg border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-xs text-amber-300">
+          <span>Estos gastos aún no tienen categoría asignada.</span>
+          <Link
+            href="/admin/finanzas/gastos#sin-clasificar"
+            className="ml-auto font-semibold underline underline-offset-2 hover:text-amber-200"
+          >
+            Clasificar →
+          </Link>
+        </div>
+      )}
+
+      <ItemsTable items={row.items} highlightUnclassified={row.key === 'sin_clasificar'} />
+    </details>
+  );
+}
+
+// ── Tabla de items ─────────────────────────────────────────────────────────
+
+type ItemsTableProps = {
+  readonly items: readonly ExpenseSubgroupItem[];
+  readonly highlightUnclassified: boolean;
+};
+
+function ItemsTable({ items, highlightUnclassified }: ItemsTableProps): React.ReactElement {
+  if (items.length === 0) {
+    return (
+      <p className="mt-3 text-xs italic text-sp-admin-muted">
+        Sin facturas registradas.
+      </p>
+    );
+  }
+
+  return (
+    <div className="mt-3 overflow-x-auto">
+      <table className="w-full text-xs">
+        <thead>
+          <tr className="border-b border-sp-admin-border/40 text-left text-[10px] font-semibold uppercase tracking-[0.15em] text-sp-admin-muted">
+            <th className="py-1.5 pr-3 font-semibold">Fecha</th>
+            <th className="py-1.5 pr-3 font-semibold">Concepto</th>
+            <th className="py-1.5 pr-3 font-semibold">Contraparte</th>
+            <th className="py-1.5 pr-3 text-right font-semibold">Importe</th>
+            <th className="py-1.5 pr-3 font-semibold">Estado</th>
+            <th className="py-1.5 font-semibold">PDF</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((it) => (
+            <tr
+              key={it.id}
+              className="border-b border-sp-admin-border/20 last:border-0 hover:bg-white/[0.02]"
+            >
+              <td className="py-1.5 pr-3 whitespace-nowrap text-sp-admin-muted">
+                {formatDate(it.issueDate)}
+              </td>
+              <td className="py-1.5 pr-3 text-sp-admin-fg">
+                {it.concept || <span className="text-sp-admin-muted">—</span>}
+              </td>
+              <td className="py-1.5 pr-3 text-sp-admin-muted">
+                {it.counterpartyName ?? '—'}
+              </td>
+              <td className={`py-1.5 pr-3 whitespace-nowrap text-right tabular-nums ${highlightUnclassified ? 'text-amber-400' : 'text-red-400'}`}>
+                {EUR2.format(it.totalAmount)}
+              </td>
+              <td className="py-1.5 pr-3 whitespace-nowrap text-sp-admin-muted">
+                {humanStatus(it.status)}
+              </td>
+              <td className="py-1.5 whitespace-nowrap">
+                {it.pdfUrl ? (
+                  <a
+                    href={it.pdfUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sp-blue underline-offset-2 hover:underline"
+                  >
+                    Ver PDF
+                  </a>
+                ) : (
+                  <span className="text-sp-admin-muted">—</span>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ── Bloque principal ───────────────────────────────────────────────────────
+
 type Props = {
   readonly rows: readonly ExpenseSubgroupRow[];
   readonly totalExpense: number;
@@ -58,7 +222,8 @@ type Props = {
 
 /**
  * Desglose visual de gastos por subgrupo humano (Nóminas Pablo, Software / IA,
- * Cuota autónomo Alfonso, …). Ordenado DESC por importe.
+ * Cuota autónomo Alfonso, …). Cada línea es expandible con `<details>` HTML
+ * nativo — sin `'use client'` ni `useState`.
  *
  * @kind server
  * @feature admin/pnl
@@ -84,7 +249,7 @@ export function AnnualExpenseBreakdown({ rows, totalExpense, from, to }: Props):
 
   return (
     <div className="rounded-2xl border border-sp-admin-border bg-sp-admin-card p-5">
-      <div className="mb-4 flex items-baseline justify-between gap-3">
+      <div className="mb-3 flex items-baseline justify-between gap-3">
         <p className="text-[11px] font-semibold uppercase tracking-widest text-sp-admin-muted">
           {title}
         </p>
@@ -92,31 +257,14 @@ export function AnnualExpenseBreakdown({ rows, totalExpense, from, to }: Props):
           Total gastos: <span className="tabular-nums text-sp-admin-fg">{EUR.format(totalExpense)}</span>
         </p>
       </div>
-      <ul className="space-y-3">
-        {rows.map((r) => {
-          const pctLabel = totalExpense > 0 ? `${r.pct.toFixed(0)}%` : '—';
-          return (
-            <li key={r.key}>
-              <div className="mb-1 flex items-baseline justify-between gap-3">
-                <span className="text-sm text-sp-admin-fg">
-                  {r.label}
-                  <span className="ml-2 text-xs text-sp-admin-muted">· {facturasLabel(r.count)}</span>
-                </span>
-                <span className={`tabular-nums text-sm ${amountColor(r.key)}`}>
-                  {EUR.format(r.amount)}
-                  <span className="text-sp-admin-muted"> · {pctLabel}</span>
-                </span>
-              </div>
-              <div className="h-1.5 w-full overflow-hidden rounded-full bg-sp-admin-border">
-                <div
-                  className={`h-full rounded-full ${barColor(r.key)}`}
-                  style={{ width: `${Math.min(r.pct, 100).toFixed(1)}%` }}
-                />
-              </div>
-            </li>
-          );
-        })}
-      </ul>
+      <p className="mb-2 text-[10px] italic text-sp-admin-muted">
+        Haz clic en una categoría para ver los gastos concretos.
+      </p>
+      <div>
+        {rows.map((r, i) => (
+          <SubgroupRow key={r.key} row={r} isFirst={i === 0} />
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/lib/queries/financeDashboard/expenseSubgroups.ts
+++ b/src/lib/queries/financeDashboard/expenseSubgroups.ts
@@ -19,6 +19,7 @@ export type ExpenseSubgroupKey =
   | 'cuota_otros'
   | 'seguridad_social'
   | 'software_ia'
+  | 'hosting_dominio'
   | 'gestoria'
   | 'fiscal'
   | 'marketing'
@@ -38,6 +39,7 @@ export const EXPENSE_SUBGROUP_LABELS: Readonly<Record<ExpenseSubgroupKey, string
   cuota_otros:       'Cuota autónomo (sin identificar)',
   seguridad_social:  'Seguridad Social',
   software_ia:       'Software / IA',
+  hosting_dominio:   'Hosting / dominio',
   gestoria:          'Gestoría',
   fiscal:            'Fiscal / impuestos',
   marketing:         'Marketing',
@@ -86,6 +88,30 @@ const PARTNER_AWARE_SUBTYPES: ReadonlySet<string> = new Set([
   'factura_autonomo',
 ]);
 
+// ── Detección de hosting / dominio ──────────────────────────────────────────
+
+const HOSTING_RE = /\b(hosting|dominio|domain|vercel|cloudflare|namecheap|godaddy|dns|ssl)\b/i;
+
+/**
+ * Subtipos donde puede aparecer un gasto de hosting/dominio "escondido":
+ * software, herramienta IA, gasto general o filas sin subtipo asignado.
+ *
+ * NO incluye `pago_talento`, `marketing_publicidad` u otros — evita reclasificar
+ * pagos a talentos o campañas patrocinadas que casualmente mencionen a Vercel.
+ */
+const HOSTING_CANDIDATE_SUBTYPES: ReadonlySet<string | null> = new Set([
+  'suscripcion_software',
+  'herramienta_ia',
+  'gasto_general',
+  null,
+]);
+
+function looksLikeHosting(input: ExpenseClassifierInput): boolean {
+  if (!HOSTING_CANDIDATE_SUBTYPES.has(input.expenseSubtype)) return false;
+  const text = [input.concept ?? '', input.counterpartyName ?? ''].join(' ');
+  return HOSTING_RE.test(text);
+}
+
 // ── Clasificador ────────────────────────────────────────────────────────────
 
 /**
@@ -93,8 +119,9 @@ const PARTNER_AWARE_SUBTYPES: ReadonlySet<string> = new Set([
  *
  * Reglas (aplicadas en orden):
  *   1. Si es nómina o cuota autónomo → detecta socio en `concept + counterparty`.
- *   2. `expenseSubtype` mapea al subgrupo canónico.
- *   3. Fallback: `expenseGroup` decide entre `campana_otros` (campaign_direct)
+ *   2. Si es candidato a hosting/dominio → hosting_dominio.
+ *   3. `expenseSubtype` mapea al subgrupo canónico.
+ *   4. Fallback: `expenseGroup` decide entre `campana_otros` (campaign_direct)
  *      y `sin_clasificar` (operational o null).
  */
 export function classifyExpenseSubgroup(input: ExpenseClassifierInput): ExpenseSubgroupKey {
@@ -117,6 +144,9 @@ export function classifyExpenseSubgroup(input: ExpenseClassifierInput): ExpenseS
     if (partner === 'alfonso') return 'cuota_alfonso';
     return 'cuota_otros';
   }
+
+  // Hosting / dominio (solo dentro de subtipos candidatos).
+  if (looksLikeHosting(input)) return 'hosting_dominio';
 
   // Mapeo directo por subtipo.
   switch (subtype) {
@@ -141,6 +171,41 @@ export function classifyExpenseSubgroup(input: ExpenseClassifierInput): ExpenseS
   return 'sin_clasificar';
 }
 
+// ── Items dentro de cada subgrupo ───────────────────────────────────────────
+
+/**
+ * Item concreto (una factura de gasto) dentro de un subgrupo.
+ *
+ * `pdfUrl` es SIEMPRE una ruta interna al proxy admin, nunca una URL
+ * directa al Blob privado.
+ */
+export type ExpenseSubgroupItem = {
+  readonly id: number;
+  readonly issueDate: string;
+  readonly concept: string;
+  readonly counterpartyName: string | null;
+  readonly totalAmount: number;
+  readonly status: string;
+  readonly pdfUrl: string | null;
+};
+
+/**
+ * Construye la URL del proxy interno del PDF de una factura interna.
+ * Devuelve `null` si la factura no tiene ni `invoiceFileId` ni `fileUrl` legacy.
+ *
+ * IMPORTANTE: nunca se retorna la URL directa del Blob (privacidad).
+ */
+export function buildInvoicePdfUrl(input: {
+  readonly id: number;
+  readonly invoiceFileId: number | null;
+  readonly fileUrl: string | null;
+}): string | null {
+  if (input.invoiceFileId === null && (input.fileUrl === null || input.fileUrl.length === 0)) {
+    return null;
+  }
+  return `/api/admin/facturacion/${input.id}/pdf`;
+}
+
 // ── Agregación ──────────────────────────────────────────────────────────────
 
 export type ExpenseSubgroupRow = {
@@ -149,27 +214,41 @@ export type ExpenseSubgroupRow = {
   readonly amount: number;
   readonly count: number;
   readonly pct: number;
+  readonly items: readonly ExpenseSubgroupItem[];
+};
+
+export type ExpenseSubgroupAggregate = {
+  readonly amount: number;
+  readonly count: number;
+  readonly items: readonly ExpenseSubgroupItem[];
 };
 
 /**
  * Convierte un mapa acumulado de subgrupos en un array ordenado DESC por importe.
  * `pct` se calcula sobre el total pasado como parámetro; si total <= 0, pct = 0
  * (evita `NaN%` en la UI).
+ *
+ * Los items de cada subgrupo se ordenan por `issueDate ASC` (enero, feb, mar…).
  */
 export function summarizeExpenseSubgroups(
-  aggregate: ReadonlyMap<ExpenseSubgroupKey, { amount: number; count: number }>,
+  aggregate: ReadonlyMap<ExpenseSubgroupKey, ExpenseSubgroupAggregate>,
   totalExpense: number,
 ): readonly ExpenseSubgroupRow[] {
   const rows: ExpenseSubgroupRow[] = [];
   for (const [key, v] of aggregate) {
     if (v.count === 0) continue;
     const pct = totalExpense > 0 ? (v.amount / totalExpense) * 100 : 0;
+    const sortedItems = [...v.items].sort((a, b) => {
+      if (a.issueDate !== b.issueDate) return a.issueDate < b.issueDate ? -1 : 1;
+      return a.id - b.id;
+    });
     rows.push({
       key,
       label: EXPENSE_SUBGROUP_LABELS[key],
       amount: round2(v.amount),
       count: v.count,
       pct: round1(pct),
+      items: sortedItems,
     });
   }
   rows.sort((a, b) => b.amount - a.amount);

--- a/src/lib/queries/financeDashboard/pnlDetail.ts
+++ b/src/lib/queries/financeDashboard/pnlDetail.ts
@@ -11,8 +11,10 @@ import {
   PENDING_EXPENSE_STATUSES,
 } from '@/lib/utils/invoice-status';
 import {
+  buildInvoicePdfUrl,
   classifyExpenseSubgroup,
   summarizeExpenseSubgroups,
+  type ExpenseSubgroupItem,
   type ExpenseSubgroupKey,
   type ExpenseSubgroupRow,
 } from './expenseSubgroups';
@@ -78,6 +80,7 @@ export async function getFinancePnL(filters: PnLFilters = {}): Promise<FinancePn
   const [rows, cobradoYTDRows, pagadoYTDRows] = await Promise.all([
     db
       .select({
+        id: invoices.id,
         kind: invoices.kind,
         status: invoices.status,
         totalAmount: invoices.totalAmount,
@@ -89,6 +92,8 @@ export async function getFinancePnL(filters: PnLFilters = {}): Promise<FinancePn
         concept: invoices.concept,
         counterpartyName: invoices.counterpartyName,
         issueDate: invoices.issueDate,
+        invoiceFileId: invoices.invoiceFileId,
+        fileUrl: invoices.fileUrl,
       })
       .from(invoices)
       .where(and(...conds)),
@@ -146,7 +151,7 @@ export async function getFinancePnL(filters: PnLFilters = {}): Promise<FinancePn
 
   const monthMap = new Map<string, { ingresos: number; gastos: number }>();
   const categoryMap = new Map<string, { total: number; count: number }>();
-  const subgroupMap = new Map<ExpenseSubgroupKey, { amount: number; count: number }>();
+  const subgroupMap = new Map<ExpenseSubgroupKey, { amount: number; count: number; items: ExpenseSubgroupItem[] }>();
 
   for (const row of rows) {
     const amount = Number(row.totalAmount ?? 0);
@@ -185,9 +190,22 @@ export async function getFinancePnL(filters: PnLFilters = {}): Promise<FinancePn
         concept: row.concept,
         counterpartyName: row.counterpartyName,
       });
-      const subEntry = subgroupMap.get(subgroupKey) ?? { amount: 0, count: 0 };
+      const subEntry = subgroupMap.get(subgroupKey) ?? { amount: 0, count: 0, items: [] };
       subEntry.amount += amount;
       subEntry.count += 1;
+      subEntry.items.push({
+        id: row.id,
+        issueDate: row.issueDate ?? '',
+        concept: row.concept ?? '',
+        counterpartyName: row.counterpartyName,
+        totalAmount: amount,
+        status: row.status,
+        pdfUrl: buildInvoicePdfUrl({
+          id: row.id,
+          invoiceFileId: row.invoiceFileId,
+          fileUrl: row.fileUrl,
+        }),
+      });
       subgroupMap.set(subgroupKey, subEntry);
     }
 


### PR DESCRIPTION
## Resumen

Cada línea del bloque **"Dónde se ha ido el dinero"** ahora es **expandible**. Al hacer clic se despliega la lista de facturas concretas de esa categoría, ordenadas por `issueDate ASC`.

- **HTML nativo** `<details>`/`<summary>` — sin `'use client'`, sin `useState`, sin `useEffect`.
- **Nuevo subgrupo `Hosting / dominio`** detectado por frontend (Vercel, Cloudflare, Namecheap, GoDaddy, dominio, DNS, SSL) sin tocar DB ni enum.
- **PDF vía proxy interno** `/api/admin/facturacion/{id}/pdf` — nunca se expone URL directa del Blob privado.
- **Sin clasificar** muestra CTA `Clasificar →` que aterriza en `/admin/finanzas/gastos#sin-clasificar`; `GastosPageClient` lee el hash y activa esa tab en el primer render.

Cero DB / schema / migrations / drizzle / crons / emails / Resend / invoice_reminders / OCR / Blob upload / Sheets / RBAC / AR aging / dunning / Tratos / facturación legal / payroll parser / setup2026.

## Ejemplo visual del desplegable

```
▾ Nóminas Pablo               · 4 facturas    6.786 € · 42%
██████████████████████████████████████████░░░░░░░░░░░░

  Fecha        Concepto                                Contraparte              Importe      Estado   PDF
  01 ene 26    Nómina CAMACHO CARRION PABLO 2026-01    ELEVATEX AGENCY PA SL    1.696,55 €   Pagada   Ver PDF
  01 feb 26    Nómina CAMACHO CARRION PABLO 2026-02    ELEVATEX AGENCY PA SL    1.696,55 €   Pagada   Ver PDF
  01 mar 26    Nómina CAMACHO CARRION PABLO 2026-03    ELEVATEX AGENCY PA SL    1.696,55 €   Pagada   Ver PDF
  01 abr 26    Nómina CAMACHO CARRION PABLO 2026-04    ELEVATEX AGENCY PA SL    1.696,55 €   Pagada   Ver PDF

▸ Nóminas Alfonso             · 3 facturas    4.107 € · 25%
▸ Cuota autónomo Pablo        · 6 facturas    1.890 € · 12%
▸ Cuota autónomo Alfonso      · 6 facturas    1.890 € · 12%
▾ Sin clasificar              · 6 facturas    1.664 € · 10%
  ⚠️ Estos gastos aún no tienen categoría asignada.                      Clasificar →

  12 may 26    JOSPO SKINCLUB SHORTS                                             200,00 €    Pagada   Ver PDF
  13 may 26    Gasto operativo desconocido                                         3,50 €    Pagada   —
  ...
```

- El primer subgrupo (mayor importe) abre por defecto (`open={i === 0}`).
- El resto se despliega con clic sobre la fila resumen.
- Colores por categoría (rojo/naranja/amber para Sin clasificar).

## Orden de items

Dentro de cada subgrupo:

```
ORDER BY issueDate ASC, id ASC
```

Enero → febrero → marzo → abril, como esperabas.

## Cómo se genera `pdfUrl`

Helper puro `buildInvoicePdfUrl({ id, invoiceFileId, fileUrl })`:

```
si invoiceFileId !== null OR fileUrl !== null (y no vacío):
    → /api/admin/facturacion/{id}/pdf
si no:
    → null
```

- El proxy existe post-PR #141 (`fix(audit/P1-02)`) con `requirePermission('facturacion','read')`, `Cache-Control: private, no-store`.
- El cliente **nunca** recibe la URL directa del Blob.
- La UI pinta `Ver PDF` sólo cuando `pdfUrl !== null`.

Verificado por 4 tests:
- Con `invoiceFileId=7, fileUrl=null` → `/api/admin/facturacion/42/pdf`
- Con solo `fileUrl` legacy → proxy interno (**no** la URL directa aunque venga con `blob.vercel-storage.com`)
- Con ambos `null` → `null`
- Explícito: `pdfUrl` nunca matchea `/blob\.vercel-storage/` ni empieza por `https://`

## Nuevo subgrupo `Hosting / dominio` (frontend-only)

Regla:

```
si expenseSubtype ∈ {suscripcion_software, herramienta_ia, gasto_general, null}
   y (concept + counterpartyName) matchea /\b(hosting|dominio|domain|vercel|cloudflare|namecheap|godaddy|dns|ssl)\b/i:
    → hosting_dominio  (label: "Hosting / dominio")
```

Guardarraíles verificados con tests:
- `pago_talento` con "Vercel" en concept → **Pagos a talentos** (no reclasifica).
- `marketing_publicidad` con "hosting" → **Marketing** (no reclasifica).
- `suscripcion_software` con "ChatGPT" (sin señal hosting) → **Software / IA** (no confunde con hosting).

## Sin clasificar — CTA

Banner amber dentro del `<details>` expandido:

```
⚠️ Estos gastos aún no tienen categoría asignada.        Clasificar →
```

- `<Link>` (next/link) a `/admin/finanzas/gastos#sin-clasificar`.
- `GastosPageClient` inicializa `useState<TabName>(initialTabFromHash)` — lee `window.location.hash === '#sin-clasificar'` en el primer render (sin useEffect → sin warning `react-hooks/set-state-in-effect`).

## Archivos tocados (5)

- `src/lib/queries/financeDashboard/expenseSubgroups.ts` — hosting_dominio + tipo Item + buildInvoicePdfUrl + items en aggregate + orden asc
- `src/lib/queries/financeDashboard/pnlDetail.ts` — SELECT +3 cols (`id`, `invoiceFileId`, `fileUrl`), push de items en el loop
- `src/features/admin/pnl/components/AnnualExpenseBreakdown.tsx` — reescrito con `<details>`/`<summary>` + tabla de items + CTA Sin clasificar
- `src/app/admin/(dashboard)/finanzas/gastos/GastosPageClient.tsx` — `initialTabFromHash()` leyendo `window.location.hash`
- `src/__tests__/server/audit-finanzas-expense-breakdown.test.ts` — 81 tests (+26 vs #148)

## Confirmaciones

- ✅ **Cero DB / schema / migrations / drizzle**
- ✅ **Cero crons / emails / Resend / invoice_reminders / dunning**
- ✅ Cálculos contables previos intactos — solo se **añade** un push de items al loop existente
- ✅ **PDF proxy interno** — cliente nunca recibe URL directa de Blob
- ✅ **Sin clasificar** lleva a la tab correcta (`#sin-clasificar` + initializer)
- ✅ **Hosting / dominio** funciona solo por frontend, sin tocar el enum `expense_subtype`
- ✅ **`<details>`/`<summary>` nativo** — sin `'use client'`, sin `useState`, sin `useEffect` en el componente
- ✅ **`humanStatus()`** — labels humanos, nunca `{it.status}` crudo (test estático)
- ✅ **Filtros de `/pl` respetados** — la agregación usa las mismas rows filtradas por from/to/company/brandId/talentId

## Tests

81 tests (26 nuevos sobre el PR #148):

### Hosting / dominio (7 nuevos)
1. `suscripcion_software + "Vercel Pro"` → `hosting_dominio`
2. `herramienta_ia + counterparty "Cloudflare"` → `hosting_dominio`
3. `gasto_general + "Renovación dominio socialpro.es"` → `hosting_dominio`
4. `null + "Namecheap DNS"` → `hosting_dominio`
5. `null + counterparty "GoDaddy"` → `hosting_dominio`
6. `suscripcion_software + "ChatGPT"` → `software_ia` (no confunde)
7. `pago_talento + "Vercel"` → `pagos_talentos` (guardarraíl)
8. `marketing_publicidad + "hosting"` → `marketing` (guardarraíl)

### `buildInvoicePdfUrl` (4 nuevos)
- Con `invoiceFileId` → proxy interno
- Con solo `fileUrl` legacy → proxy interno
- Sin nada → `null`
- Nunca filtra `blob.vercel-storage`, nunca `https://`

### Items (5 nuevos)
- Cada subgrupo incluye `items`
- Orden `issueDate ASC` (con desempate por `id`)
- `count === items.length`
- `SUM(items.totalAmount) === subgroup.amount` (tolerancia < 0.01)
- Ningún item filtra la URL directa de Blob

### Estáticos nuevos
- `getFinancePnL` SELECT añade `id`, `invoiceFileId`, `fileUrl`
- Componente usa `<details>` y `<summary>`
- Sin `useState`, sin `useEffect`, sin `'use client'`
- CTA `Clasificar →` con `/admin/finanzas/gastos#sin-clasificar`
- `GastosPageClient` lee `window.location.hash` con `'#sin-clasificar'`
- `humanStatus()` mapea, no renderiza status raw

### Anti-scope
- Sin Resend, sin `sendEmail`, sin `@/lib/email`
- Sin `invoice_reminders`, sin `dunning`
- `expenseSubgroups.ts` sigue sin `'server-only'`, sin `@/lib/db`, sin `@/db/schema`
- Sin `pgTable`/`alterTable`

## CI local

- ✅ `npx tsc --noEmit` — clean
- ✅ `npm run lint` — 0/0
- ✅ `npm test` — 111 suites · **1952 tests** verdes
- ⚠️ `npm run build` local requiere `.env.local`; Vercel lo corre en el deploy.

## Test plan post-merge

- [ ] `/admin/finanzas/pl` carga con el bloque expandible.
- [ ] Cada línea se abre/cierra al hacer clic.
- [ ] Los items dentro de "Nóminas Pablo" van enero → febrero → marzo → abril.
- [ ] `Ver PDF` abre el PDF de la factura vía proxy en pestaña nueva.
- [ ] Si aparece "Sin clasificar", clicar en `Clasificar →` aterriza en `/admin/finanzas/gastos` con la tab "Sin clasificar" activa.
- [ ] Si hay suscripciones de Vercel/Cloudflare, aparecen agrupadas bajo `Hosting / dominio`.
- [ ] Total del bloque sigue cuadrando con la card "Gastos" del PnL Overview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
