### PR TITLE
fix(cron): registrar generate-recurring-expenses en vercel.json (schedule diario)

### DIFF
--- a/src/__tests__/server/vercel-crons-schedule.test.ts
+++ b/src/__tests__/server/vercel-crons-schedule.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Verifica que el schedule del endpoint `/api/cron/generate-recurring-expenses`
+ * queda registrado en `vercel.json` y que la ruta sigue protegida por
+ * `assertCronAuth` (CRON_SECRET Bearer).
+ *
+ * Motivo: hasta 2026-07-01 el endpoint existía pero no tenía schedule en
+ * vercel.json → nunca se ejecutaba solo. Este test evita que un revert futuro
+ * lo vuelva a dejar sin schedule sin darse cuenta.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const PROJECT_ROOT = path.resolve(__dirname, '..', '..', '..');
+
+type VercelCron = { readonly path: string; readonly schedule: string };
+type VercelConfig = { readonly crons?: readonly VercelCron[] };
+
+function readVercelJson(): VercelConfig {
+  const raw = fs.readFileSync(path.join(PROJECT_ROOT, 'vercel.json'), 'utf-8');
+  return JSON.parse(raw) as VercelConfig;
+}
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(PROJECT_ROOT, rel), 'utf-8');
+}
+
+describe('vercel.json — crons.generate-recurring-expenses', () => {
+  const cfg = readVercelJson();
+  const crons = cfg.crons ?? [];
+  const target = crons.find((c) => c.path === '/api/cron/generate-recurring-expenses');
+
+  it('vercel.json parsea como JSON válido', () => {
+    expect(typeof cfg).toBe('object');
+    expect(Array.isArray(crons)).toBe(true);
+  });
+
+  it('incluye una entrada para /api/cron/generate-recurring-expenses', () => {
+    expect(target).toBeDefined();
+  });
+
+  it('schedule es un cron válido diario a las 03:00 UTC', () => {
+    expect(target?.schedule).toBe('0 3 * * *');
+  });
+
+  it('no hay duplicados de path para el endpoint', () => {
+    const matches = crons.filter((c) => c.path === '/api/cron/generate-recurring-expenses');
+    expect(matches.length).toBe(1);
+  });
+
+  it('todos los paths de crons empiezan por /api/cron/', () => {
+    for (const c of crons) {
+      expect(c.path.startsWith('/api/cron/')).toBe(true);
+    }
+  });
+});
+
+describe('endpoint sigue protegido por CRON_SECRET', () => {
+  const routeSrc = read('src/app/api/cron/generate-recurring-expenses/route.ts');
+  const assertSrc = read('src/lib/security/assertCronAuth.ts');
+
+  it('el route.ts sigue invocando assertCronAuth como primer guard', () => {
+    expect(routeSrc).toMatch(/import\s+\{\s*assertCronAuth\s*\}\s+from\s+['"]@\/lib\/security\/assertCronAuth['"]/);
+    expect(routeSrc).toMatch(/const\s+authError\s*=\s*assertCronAuth\(req\)/);
+    expect(routeSrc).toMatch(/if\s*\(authError\)\s*return\s+authError/);
+  });
+
+  it('assertCronAuth exige Authorization: Bearer ${CRON_SECRET}', () => {
+    expect(assertSrc).toMatch(/env\.CRON_SECRET/);
+    expect(assertSrc).toMatch(/Bearer\s+\$\{cronSecret\}/);
+    expect(assertSrc).toMatch(/timingSafeEqual/);
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -23,6 +23,10 @@
     {
       "path": "/api/cron/sync-sheet-sources",
       "schedule": "0 23 * * *"
+    },
+    {
+      "path": "/api/cron/generate-recurring-expenses",
+      "schedule": "0 3 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Resumen

El endpoint `/api/cron/generate-recurring-expenses` **existía pero no tenía schedule** en `vercel.json`. Vercel no lo ejecutaba nunca por sí solo → las plantillas de gastos recurrentes (cuotas autónomo, seguro médico, …) no generaban facturas automáticamente. Había que llamarlo manualmente con el `CRON_SECRET`.

**Fix:** registrar el endpoint en `vercel.json` con schedule diario `0 3 * * *`.

Cero DB / schema / migrations / drizzle / endpoint logic / `recurringExpenses.ts` / OCR / Blob / Sheets / RBAC / AR aging / dunning / emails / Resend / `invoice_reminders` / Tratos / facturación legal.

## Contenido final de `vercel.json`

```json
{
  "crons": [
    { "path": "/api/cron/snapshot-metrics",             "schedule": "0 6 * * *" },
    { "path": "/api/cron/rollover-tasks",               "schedule": "0 5 * * 1" },
    { "path": "/api/cron/backup",                       "schedule": "0 2 * * *" },
    { "path": "/api/cron/sync-metrics",                 "schedule": "0 7 * * 1" },
    { "path": "/api/cron/sync-news-alerts",             "schedule": "0 7 * * *" },
    { "path": "/api/cron/sync-sheet-sources",           "schedule": "0 23 * * *" },
    { "path": "/api/cron/generate-recurring-expenses",  "schedule": "0 3 * * *" }
  ]
}
```

## Por qué schedule diario y no mensual

El endpoint es idempotente por `txId` (`recurring:{templateId}:{YYYY-MM}`). Llamarlo N veces el mismo mes crea 1 sola invoice y hace skip en el resto.

**Ventajas del diario:**
- Cubre plantillas creadas a mitad de mes o después del día 1 sin esperar al ciclo siguiente (caso real hoy: la plantilla `Cuota autónomo — Pablo` se creó el 1 de julio con `startDate=2026-07-01` y hubo que crear julio manualmente).
- Cubre fallos puntuales (deploy fallido, error transitorio, quota Vercel). El día siguiente reintenta.
- No hay coste extra: si ya se generó todo, el endpoint hace 1 SELECT por plantilla activa + 0 INSERTs.

## Endpoint sigue protegido por `CRON_SECRET`

Confirmado por test estático:

```ts
// route.ts primer guard
const authError = assertCronAuth(req);
if (authError) return authError;

// assertCronAuth exige
Authorization: Bearer ${CRON_SECRET}     // comparado en tiempo constante
```

Sin cambios en `src/lib/security/assertCronAuth.ts` ni en la lógica del endpoint.

## Archivos tocados (2)

**Modificado:** `vercel.json` — una entrada nueva en `crons` (+4 líneas).

**Nuevo:** `src/__tests__/server/vercel-crons-schedule.test.ts` — 7 tests estáticos:
1. `vercel.json` parsea como JSON válido.
2. Incluye entry para `/api/cron/generate-recurring-expenses`.
3. `schedule = "0 3 * * *"`.
4. Sin duplicados de path.
5. Todos los paths empiezan por `/api/cron/`.
6. `route.ts` sigue llamando `assertCronAuth` como primer guard.
7. `assertCronAuth` sigue exigiendo Bearer + `timingSafeEqual`.

## Confirmaciones

- ✅ **`vercel.json` queda como JSON válido** (test 1).
- ✅ **Endpoint sigue protegido por `CRON_SECRET`** (tests 6, 7).
- ✅ **Sin cambios en la lógica del endpoint** — no se toca `route.ts` ni `recurringExpenses.ts` ni `assertCronAuth.ts`. Solo `vercel.json` + un test.
- ✅ **Schedule diario no duplica por idempotencia** — el endpoint hace `invoiceExistsForMonth(templateId, monthStr)` y skip si `txId=recurring:{id}:{YYYY-MM}` ya existe.

## Impacto operativo esperado

En el próximo deploy a producción, Vercel activa el nuevo cron. A las 03:00 UTC del día siguiente:
- `id=3 "Cuota autónomo — Pablo"` para el mes actual → skip si ya existe `recurring:3:2026-07` (que ya creamos manualmente hoy).
- `id=4 "Seguro médico — Alfonso"` para el mes actual → skip si ya existe `recurring:4:2026-07` (idem).
- `id=1`, `id=2` (inactive) → excluidos por el WHERE de `getActiveTemplatesForMonth`.

A partir del 1 de agosto 2026 (o el primer día que corra tras esa fecha), generará agosto para las 2 plantillas activas con `status='pendiente'`.

## CI local

- ✅ `npx tsc --noEmit` — clean
- ✅ `npm run lint` — 0/0
- ✅ `npm test` — 112 suites · **1959 tests** verdes (7 nuevos)

## Test plan post-merge

- [ ] Verificar en Vercel Dashboard → Settings → Cron Jobs que aparece la nueva entrada `/api/cron/generate-recurring-expenses` con schedule `0 3 * * *`.
- [ ] Esperar a la primera ejecución (dashboard muestra la última run + resultado). Ejecución esperada: 0 created, 2 skipped (las 2 filas de julio ya existen). Sin errores 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
