### PR TITLE
feat(audit/finanzas): subtotales por categoría en el bloque expandible

### DIFF
--- a/src/__tests__/server/audit-finanzas-expense-breakdown.test.ts
+++ b/src/__tests__/server/audit-finanzas-expense-breakdown.test.ts
@@ -16,7 +16,9 @@ import {
   buildInvoicePdfUrl,
   classifyExpenseSubgroup,
   detectPartner,
+  subgroupToCategory,
   summarizeExpenseSubgroups,
+  EXPENSE_CATEGORY_LABELS,
   EXPENSE_SUBGROUP_LABELS,
   type ExpenseClassifierInput,
   type ExpenseSubgroupAggregate,
@@ -437,6 +439,41 @@ describe('summarizeExpenseSubgroups()', () => {
   });
 });
 
+// ── Categoría (subtotales) ─────────────────────────────────────────────────
+
+describe('subgroupToCategory()', () => {
+  it('pagos a talentos → campaign_direct', () => {
+    expect(subgroupToCategory('pagos_talentos')).toBe('campaign_direct');
+  });
+
+  it('otros costes de campaña → campaign_direct', () => {
+    expect(subgroupToCategory('campana_otros')).toBe('campaign_direct');
+  });
+
+  it('sin_clasificar → sin_clasificar', () => {
+    expect(subgroupToCategory('sin_clasificar')).toBe('sin_clasificar');
+  });
+
+  const operationalKeys: readonly ExpenseSubgroupKey[] = [
+    'nomina_pablo', 'nomina_alfonso', 'nomina_otros',
+    'cuota_pablo', 'cuota_alfonso', 'cuota_otros',
+    'seguridad_social',
+    'software_ia', 'hosting_dominio', 'gestoria', 'fiscal',
+    'marketing', 'comisiones',
+    'seguro_medico', 'gasto_general',
+  ];
+
+  it.each(operationalKeys)('%s → operational', (key) => {
+    expect(subgroupToCategory(key)).toBe('operational');
+  });
+
+  it('EXPENSE_CATEGORY_LABELS mapea las 3 categorías con textos humanos', () => {
+    expect(EXPENSE_CATEGORY_LABELS.campaign_direct).toBe('Costes directos de campaña');
+    expect(EXPENSE_CATEGORY_LABELS.operational).toBe('Gastos operativos');
+    expect(EXPENSE_CATEGORY_LABELS.sin_clasificar).toBe('Sin clasificar');
+  });
+});
+
 // ── Chequeos estáticos ─────────────────────────────────────────────────────
 
 describe('Integración /admin/finanzas/pl', () => {
@@ -521,6 +558,13 @@ describe('Integración /admin/finanzas/pl', () => {
   it('expenseSubgroups.ts expone el subgrupo hosting_dominio con su label', () => {
     expect(subgroupsSrc).toMatch(/hosting_dominio/);
     expect(subgroupsSrc).toMatch(/Hosting \/ dominio/);
+  });
+
+  it('componente renderiza SubtotalsFooter con labels y "Total gastos"', () => {
+    expect(componentSrc).toMatch(/SubtotalsFooter\b/);
+    expect(componentSrc).toMatch(/subgroupToCategory\(/);
+    expect(componentSrc).toMatch(/EXPENSE_CATEGORY_LABELS\b/);
+    expect(componentSrc).toMatch(/Total gastos/);
   });
 });
 

--- a/src/features/admin/pnl/components/AnnualExpenseBreakdown.tsx
+++ b/src/features/admin/pnl/components/AnnualExpenseBreakdown.tsx
@@ -1,5 +1,12 @@
 import Link from 'next/link';
-import type { ExpenseSubgroupItem, ExpenseSubgroupKey, ExpenseSubgroupRow } from '@/lib/queries/financeDashboard/expenseSubgroups';
+import {
+  EXPENSE_CATEGORY_LABELS,
+  subgroupToCategory,
+  type ExpenseSubgroupCategory,
+  type ExpenseSubgroupItem,
+  type ExpenseSubgroupKey,
+  type ExpenseSubgroupRow,
+} from '@/lib/queries/financeDashboard/expenseSubgroups';
 
 const EUR = new Intl.NumberFormat('es-ES', {
   style: 'currency',
@@ -265,6 +272,65 @@ export function AnnualExpenseBreakdown({ rows, totalExpense, from, to }: Props):
           <SubgroupRow key={r.key} row={r} isFirst={i === 0} />
         ))}
       </div>
+      <SubtotalsFooter rows={rows} totalExpense={totalExpense} />
+    </div>
+  );
+}
+
+// ── Subtotales al pie ──────────────────────────────────────────────────────
+
+function categoryColor(cat: ExpenseSubgroupCategory): string {
+  switch (cat) {
+    case 'campaign_direct': return 'text-red-400';
+    case 'operational':     return 'text-amber-400';
+    case 'sin_clasificar':  return 'text-amber-400';
+  }
+}
+
+type SubtotalsFooterProps = {
+  readonly rows: readonly ExpenseSubgroupRow[];
+  readonly totalExpense: number;
+};
+
+function SubtotalsFooter({ rows, totalExpense }: SubtotalsFooterProps): React.ReactElement {
+  const buckets = new Map<ExpenseSubgroupCategory, { amount: number; count: number }>();
+  for (const r of rows) {
+    const cat = subgroupToCategory(r.key);
+    const b = buckets.get(cat) ?? { amount: 0, count: 0 };
+    b.amount += r.amount;
+    b.count += r.count;
+    buckets.set(cat, b);
+  }
+  const order: readonly ExpenseSubgroupCategory[] = ['campaign_direct', 'operational', 'sin_clasificar'];
+
+  return (
+    <div className="mt-5 border-t border-sp-admin-border/60 pt-3">
+      <p className="mb-2 text-[10px] font-semibold uppercase tracking-widest text-sp-admin-muted">
+        Subtotales
+      </p>
+      <ul className="space-y-1.5">
+        {order.map((cat) => {
+          const b = buckets.get(cat);
+          if (!b || b.count === 0) return null;
+          const pct = totalExpense > 0 ? (b.amount / totalExpense) * 100 : 0;
+          return (
+            <li key={cat} className="flex items-baseline justify-between gap-3 text-sm">
+              <span className="text-sp-admin-fg">
+                {EXPENSE_CATEGORY_LABELS[cat]}
+                <span className="ml-2 text-xs text-sp-admin-muted">· {b.count} {b.count === 1 ? 'factura' : 'facturas'}</span>
+              </span>
+              <span className={`tabular-nums ${categoryColor(cat)}`}>
+                {EUR.format(b.amount)}
+                <span className="text-sp-admin-muted"> · {pct.toFixed(0)}%</span>
+              </span>
+            </li>
+          );
+        })}
+        <li className="mt-2 flex items-baseline justify-between gap-3 border-t border-sp-admin-border/40 pt-2 text-sm font-semibold">
+          <span className="text-sp-admin-fg">Total gastos</span>
+          <span className="tabular-nums text-sp-admin-fg">{EUR.format(totalExpense)}</span>
+        </li>
+      </ul>
     </div>
   );
 }

--- a/src/lib/queries/financeDashboard/expenseSubgroups.ts
+++ b/src/lib/queries/financeDashboard/expenseSubgroups.ts
@@ -58,6 +58,36 @@ export type ExpenseClassifierInput = {
   readonly counterpartyName: string | null;
 };
 
+// ── Mapeo subgrupo → expenseGroup visible ───────────────────────────────────
+
+/**
+ * Categoría visible del subgrupo a nivel `expenseGroup` para agregación en
+ * subtotales del bloque "Dónde se ha ido el dinero".
+ *
+ * - `campaign_direct` → pagos a talentos + otros costes directos de campaña.
+ * - `operational`     → resto de gastos operativos con subtipo conocido.
+ * - `sin_clasificar`  → subgrupo residual (revisar/asignar).
+ */
+export type ExpenseSubgroupCategory = 'campaign_direct' | 'operational' | 'sin_clasificar';
+
+export function subgroupToCategory(key: ExpenseSubgroupKey): ExpenseSubgroupCategory {
+  switch (key) {
+    case 'pagos_talentos':
+    case 'campana_otros':
+      return 'campaign_direct';
+    case 'sin_clasificar':
+      return 'sin_clasificar';
+    default:
+      return 'operational';
+  }
+}
+
+export const EXPENSE_CATEGORY_LABELS: Readonly<Record<ExpenseSubgroupCategory, string>> = {
+  campaign_direct: 'Costes directos de campaña',
+  operational:     'Gastos operativos',
+  sin_clasificar:  'Sin clasificar',
+} as const;
+
 // ── Detección de socio ──────────────────────────────────────────────────────
 
 const PABLO_RE   = /\b(pablo|camacho|keko)\b/i;


### PR DESCRIPTION
## Resumen

Añade al pie del bloque **"Dónde se ha ido el dinero"** en `/admin/finanzas/pl` una sección **"Subtotales"** que agrupa las líneas por categoría de gasto para lectura de una sola pasada.

```
▾ Nóminas Pablo …
▸ Nóminas Alfonso …
▸ Cuota autónomo Pablo …
▸ Pagos a talentos …
▸ Gestoría …
…

──────────────────────────
SUBTOTALES
  Costes directos de campaña · 5 facturas · 1.660 €  · 12%
  Gastos operativos          · 42 facturas · 12.030 € · 87%
  Sin clasificar             · 6 facturas ·   163 €  · 1%   (solo si > 0)
──────────────────────────
  Total gastos                                        13.853 €
```

Cero query nueva — se deriva de los `rows` que ya recibe el componente. Cero cambios de UI en el desglose superior (barras por subgrupo + expandible).

Cero DB / schema / migrations / drizzle / crons / emails / Resend / invoice_reminders / OCR / Blob / Sheets / RBAC / AR aging / dunning / Tratos / facturación legal.

## Clasificador puro (`expenseSubgroups.ts`)

Nuevo tipo + función pura testeable:

```ts
export type ExpenseSubgroupCategory = 'campaign_direct' | 'operational' | 'sin_clasificar';

export function subgroupToCategory(key: ExpenseSubgroupKey): ExpenseSubgroupCategory {
  switch (key) {
    case 'pagos_talentos':
    case 'campana_otros':
      return 'campaign_direct';
    case 'sin_clasificar':
      return 'sin_clasificar';
    default:
      return 'operational';
  }
}

export const EXPENSE_CATEGORY_LABELS = {
  campaign_direct: 'Costes directos de campaña',
  operational:     'Gastos operativos',
  sin_clasificar:  'Sin clasificar',
};
```

## Componente (`AnnualExpenseBreakdown.tsx`)

Nuevo subcomponente `SubtotalsFooter` (RSC, sin `'use client'`, sin `useState`):
- Recorre `rows`, agrupa por categoría, suma amount + count.
- Excluye categorías vacías (`count === 0`) — si no hay pagos a talentos, no aparece la línea.
- Muestra label + count + importe EUR + % del total.
- Línea "Total gastos" al final con separator.
- Colores: rojo para costes directos y sin clasificar, amber para operativos y sin clasificar.

**Sin cambios en `/admin/finanzas/pl/page.tsx`** — el bloque ya se pinta ahí; solo el componente añade la sección al final.

## Confirmaciones

- ✅ **Cero DB / schema / migrations / drizzle**
- ✅ **Cero crons / emails / Resend / invoice_reminders**
- ✅ **Cero cambios en query** (`pnlDetail.ts`, `getFinancePnL`): la nueva sección se deriva de `rows`.
- ✅ **Cero cambios en `/pl/page.tsx`**: el componente sigue recibiendo las mismas 4 props.
- ✅ **Sin `'use client'`, sin `useState`, sin `useEffect`** — HTML nativo puro (test estático).
- ✅ **Labels humanos** — "Costes directos de campaña", "Gastos operativos", "Sin clasificar" — nunca strings crudos.

## Archivos tocados (3)

- `src/lib/queries/financeDashboard/expenseSubgroups.ts` — +tipo + función pura + labels.
- `src/features/admin/pnl/components/AnnualExpenseBreakdown.tsx` — +`SubtotalsFooter`, +import de helpers.
- `src/__tests__/server/audit-finanzas-expense-breakdown.test.ts` — +20 tests (5 casos únicos + 15 keys via `it.each` para operational + 1 label check + 1 estático).

## Tests

- `subgroupToCategory()` — 18 tests (2 campaign_direct + 1 sin_clasificar + 15 operational).
- `EXPENSE_CATEGORY_LABELS` — labels humanos verificados.
- Estático: componente usa `SubtotalsFooter`, `subgroupToCategory`, `EXPENSE_CATEGORY_LABELS`, renderiza "Total gastos".

**Local:**
- ✅ `npx tsc --noEmit` — clean
- ✅ `npm run lint` — 0/0
- ✅ `npm test` — 112 suites · **1979 tests** verdes
- ⚠️ Build local requiere `.env.local`; Vercel lo corre en el deploy.

## Test plan post-merge

- [ ] `/admin/finanzas/pl` muestra la sección "SUBTOTALES" al final del bloque con las 3 categorías (o solo las que tienen datos).
- [ ] Después de la reclasificación de pagos a talentos aplicada hoy, debería aparecer:
      **Costes directos de campaña · 5 facturas · 1.660 € · 12%** aprox.
- [ ] **Sin clasificar** ya no aparece (0 filas activas tras el fix aplicado).
- [ ] Total gastos coincide con la card superior "Gastos" del PnL Overview.
- [ ] Cambiar rango del filtro y verificar que subtotales se recalculan sobre `rows` filtrados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
