### PR TITLE
feat(audit/finanzas): query V2 del resumen económico anual/YTD (PR A/3)

### DIFF
--- a/src/__tests__/server/finanzas-resumen-v2.test.ts
+++ b/src/__tests__/server/finanzas-resumen-v2.test.ts
@@ -1,0 +1,458 @@
+/**
+ * Tests para la lógica pura del resumen económico V2.
+ *
+ * Cubre:
+ *   - classifyResumenSection (4 secciones)
+ *   - aggregateNominas (Pablo/Alfonso/otros/total/count)
+ *   - aggregateImpuestos (5 sub-buckets + total + count)
+ *   - aggregateOperativos (8 sub-buckets + hosting_dominio + sinClasificar)
+ *   - computeResultadoOperativo (fórmula caja)
+ *   - daysOverdue (nulls, fecha vencida, no vencida)
+ *   - topNPendientes (orden, total, count, top-5)
+ *   - computeMargenPendienteEstimado
+ *   - assemblePendientes (integración)
+ *   - Estáticos: query server-only, tipos, no `paidAmount` en SELECT
+ *   - Anti-scope-creep: sin schema/cron/Resend/emails
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  aggregateImpuestos,
+  aggregateNominas,
+  aggregateOperativos,
+  assemblePendientes,
+  classifyResumenSection,
+  computeMargenPendienteEstimado,
+  computeResultadoOperativo,
+  daysOverdue,
+  round2,
+  topNPendientes,
+  type ExpenseRow,
+} from '@/lib/queries/financeDashboard/finanzasResumenV2.shared';
+import type { PendienteItem } from '@/types/finanzasResumen';
+
+const PROJECT_ROOT = path.resolve(__dirname, '..', '..', '..');
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(PROJECT_ROOT, rel), 'utf-8');
+}
+
+function makeExpense(overrides: Partial<ExpenseRow>): ExpenseRow {
+  return {
+    totalAmount: 0,
+    expenseGroup: null,
+    expenseSubtype: null,
+    concept: null,
+    counterpartyName: null,
+    ...overrides,
+  };
+}
+
+function makeItem(overrides: Partial<PendienteItem>): PendienteItem {
+  return {
+    id: 1,
+    source: 'issued',
+    label: 'x',
+    amount: 0,
+    dueDate: null,
+    daysOverdue: null,
+    ...overrides,
+  };
+}
+
+// ── round2 ────────────────────────────────────────────────────────────────
+
+describe('round2()', () => {
+  it('redondea a 2 decimales', () => {
+    expect(round2(1.234)).toBe(1.23);
+    expect(round2(1.235)).toBe(1.24);
+    expect(round2(0)).toBe(0);
+  });
+});
+
+// ── classifyResumenSection ────────────────────────────────────────────────
+
+describe('classifyResumenSection()', () => {
+  it('nomina_socio → nominas', () => {
+    expect(classifyResumenSection({ expenseGroup: 'operational', expenseSubtype: 'nomina_socio' })).toBe('nominas');
+  });
+
+  it('cuota_autonomo → impuestos', () => {
+    expect(classifyResumenSection({ expenseGroup: 'operational', expenseSubtype: 'cuota_autonomo' })).toBe('impuestos');
+  });
+
+  it('factura_autonomo → impuestos', () => {
+    expect(classifyResumenSection({ expenseGroup: 'operational', expenseSubtype: 'factura_autonomo' })).toBe('impuestos');
+  });
+
+  it('seguridad_social → impuestos', () => {
+    expect(classifyResumenSection({ expenseGroup: 'operational', expenseSubtype: 'seguridad_social' })).toBe('impuestos');
+  });
+
+  it('fiscal_impuestos → impuestos', () => {
+    expect(classifyResumenSection({ expenseGroup: 'operational', expenseSubtype: 'fiscal_impuestos' })).toBe('impuestos');
+  });
+
+  it('ajuste_fiscal → impuestos', () => {
+    expect(classifyResumenSection({ expenseGroup: 'operational', expenseSubtype: 'ajuste_fiscal' })).toBe('impuestos');
+  });
+
+  it('campaign_direct + pago_talento → costes_directos', () => {
+    expect(classifyResumenSection({ expenseGroup: 'campaign_direct', expenseSubtype: 'pago_talento' })).toBe('costes_directos');
+  });
+
+  it('campaign_direct sin subtype → costes_directos', () => {
+    expect(classifyResumenSection({ expenseGroup: 'campaign_direct', expenseSubtype: null })).toBe('costes_directos');
+  });
+
+  it('operational + gestoria → operativos', () => {
+    expect(classifyResumenSection({ expenseGroup: 'operational', expenseSubtype: 'gestoria' })).toBe('operativos');
+  });
+
+  it('null + null → operativos (sin clasificar cae aquí)', () => {
+    expect(classifyResumenSection({ expenseGroup: null, expenseSubtype: null })).toBe('operativos');
+  });
+});
+
+// ── aggregateNominas ──────────────────────────────────────────────────────
+
+describe('aggregateNominas()', () => {
+  it('sin filas devuelve todo a 0', () => {
+    const n = aggregateNominas([]);
+    expect(n.pablo).toBe(0);
+    expect(n.alfonso).toBe(0);
+    expect(n.otros).toBe(0);
+    expect(n.total).toBe(0);
+    expect(n.count).toBe(0);
+  });
+
+  it('separa Pablo por concept/counterparty', () => {
+    const n = aggregateNominas([
+      makeExpense({ expenseSubtype: 'nomina_socio', totalAmount: 1696.55, counterpartyName: 'CAMACHO CARRION PABLO' }),
+      makeExpense({ expenseSubtype: 'nomina_socio', totalAmount: 1696.55, counterpartyName: 'CAMACHO CARRION PABLO' }),
+    ]);
+    expect(n.pablo).toBe(3393.10);
+    expect(n.alfonso).toBe(0);
+    expect(n.count).toBe(2);
+  });
+
+  it('separa Alfonso por concept/counterparty', () => {
+    const n = aggregateNominas([
+      makeExpense({ expenseSubtype: 'nomina_socio', totalAmount: 1369, counterpartyName: 'ARIAS EPIFANIO ALFONSO' }),
+    ]);
+    expect(n.alfonso).toBe(1369);
+    expect(n.pablo).toBe(0);
+  });
+
+  it('sin persona detectable → otros', () => {
+    const n = aggregateNominas([
+      makeExpense({ expenseSubtype: 'nomina_socio', totalAmount: 500, counterpartyName: null, concept: 'Nómina genérica' }),
+    ]);
+    expect(n.otros).toBe(500);
+    expect(n.pablo).toBe(0);
+    expect(n.alfonso).toBe(0);
+  });
+
+  it('ignora filas que no son nomina_socio', () => {
+    const n = aggregateNominas([
+      makeExpense({ expenseSubtype: 'gestoria', totalAmount: 999 }),
+      makeExpense({ expenseSubtype: 'nomina_socio', totalAmount: 1000, counterpartyName: 'ALFONSO' }),
+    ]);
+    expect(n.total).toBe(1000);
+    expect(n.count).toBe(1);
+  });
+
+  it('total = pablo + alfonso + otros', () => {
+    const n = aggregateNominas([
+      makeExpense({ expenseSubtype: 'nomina_socio', totalAmount: 100, counterpartyName: 'PABLO' }),
+      makeExpense({ expenseSubtype: 'nomina_socio', totalAmount: 200, counterpartyName: 'ALFONSO' }),
+      makeExpense({ expenseSubtype: 'nomina_socio', totalAmount: 50 }),
+    ]);
+    expect(n.total).toBe(350);
+  });
+});
+
+// ── aggregateImpuestos ────────────────────────────────────────────────────
+
+describe('aggregateImpuestos()', () => {
+  it('split Pablo/Alfonso/otros en cuota_autonomo', () => {
+    const i = aggregateImpuestos([
+      makeExpense({ expenseSubtype: 'cuota_autonomo', totalAmount: 315, concept: 'Cuota de autónomo — Pablo' }),
+      makeExpense({ expenseSubtype: 'cuota_autonomo', totalAmount: 315, concept: 'Cuota de autónomo — Alfonso' }),
+      makeExpense({ expenseSubtype: 'cuota_autonomo', totalAmount: 315, concept: 'Cuota autónomo' }),
+    ]);
+    expect(i.cuotaAutonomoPablo).toBe(315);
+    expect(i.cuotaAutonomoAlfonso).toBe(315);
+    expect(i.cuotaAutonomoOtros).toBe(315);
+    expect(i.count).toBe(3);
+    expect(i.total).toBe(945);
+  });
+
+  it('factura_autonomo también participa del split', () => {
+    const i = aggregateImpuestos([
+      makeExpense({ expenseSubtype: 'factura_autonomo', totalAmount: 200, counterpartyName: 'RETA Pablo García' }),
+    ]);
+    expect(i.cuotaAutonomoPablo).toBe(200);
+  });
+
+  it('seguridad_social va a su propio bucket', () => {
+    const i = aggregateImpuestos([
+      makeExpense({ expenseSubtype: 'seguridad_social', totalAmount: 500 }),
+    ]);
+    expect(i.seguridadSocial).toBe(500);
+    expect(i.total).toBe(500);
+  });
+
+  it('fiscal_impuestos + ajuste_fiscal → fiscal', () => {
+    const i = aggregateImpuestos([
+      makeExpense({ expenseSubtype: 'fiscal_impuestos', totalAmount: 300 }),
+      makeExpense({ expenseSubtype: 'ajuste_fiscal', totalAmount: 50 }),
+    ]);
+    expect(i.fiscal).toBe(350);
+  });
+
+  it('ignora filas no-impuestos', () => {
+    const i = aggregateImpuestos([
+      makeExpense({ expenseSubtype: 'gestoria', totalAmount: 185 }),
+    ]);
+    expect(i.total).toBe(0);
+    expect(i.count).toBe(0);
+  });
+});
+
+// ── aggregateOperativos ───────────────────────────────────────────────────
+
+describe('aggregateOperativos()', () => {
+  it('categoriza cada subtype operational en su bucket', () => {
+    const o = aggregateOperativos([
+      makeExpense({ expenseGroup: 'operational', expenseSubtype: 'gestoria',            totalAmount: 185 }),
+      makeExpense({ expenseGroup: 'operational', expenseSubtype: 'suscripcion_software', totalAmount: 20, concept: 'ChatGPT' }),
+      makeExpense({ expenseGroup: 'operational', expenseSubtype: 'herramienta_ia',       totalAmount: 15, concept: 'Claude' }),
+      makeExpense({ expenseGroup: 'operational', expenseSubtype: 'seguro_medico',        totalAmount: 54 }),
+      makeExpense({ expenseGroup: 'operational', expenseSubtype: 'comision_bancaria',    totalAmount: 3.50 }),
+      makeExpense({ expenseGroup: 'operational', expenseSubtype: 'comision_plataforma',  totalAmount: 1 }),
+      makeExpense({ expenseGroup: 'operational', expenseSubtype: 'marketing_publicidad', totalAmount: 100 }),
+      makeExpense({ expenseGroup: 'operational', expenseSubtype: 'gasto_general',        totalAmount: 40 }),
+    ]);
+    expect(o.gestoria).toBe(185);
+    expect(o.softwareIa).toBe(35);
+    expect(o.seguroMedico).toBe(54);
+    expect(o.comisiones).toBe(4.50);
+    expect(o.marketing).toBe(100);
+    expect(o.otros).toBe(40);
+    expect(o.count).toBe(8);
+    expect(o.total).toBe(round2(185 + 35 + 54 + 4.5 + 100 + 40));
+  });
+
+  it('detecta hosting/dominio en subtypes candidatos', () => {
+    const o = aggregateOperativos([
+      makeExpense({ expenseGroup: 'operational', expenseSubtype: 'suscripcion_software', totalAmount: 20, concept: 'Vercel Pro' }),
+      makeExpense({ expenseGroup: 'operational', expenseSubtype: 'gasto_general',        totalAmount: 15, counterpartyName: 'Cloudflare' }),
+      makeExpense({ expenseGroup: 'operational', expenseSubtype: null,                    totalAmount: 8,  concept: 'Namecheap DNS' }),
+    ]);
+    expect(o.hostingDominio).toBe(43);
+    expect(o.softwareIa).toBe(0);
+  });
+
+  it('operational sin subtype conocido → otros (no sinClasificar)', () => {
+    const o = aggregateOperativos([
+      makeExpense({ expenseGroup: 'operational', expenseSubtype: null, totalAmount: 30 }),
+    ]);
+    expect(o.otros).toBe(30);
+    expect(o.sinClasificar).toBe(0);
+  });
+
+  it('sin group y sin subtype → sinClasificar (bucket amber)', () => {
+    const o = aggregateOperativos([
+      makeExpense({ expenseGroup: null, expenseSubtype: null, totalAmount: 100 }),
+    ]);
+    expect(o.sinClasificar).toBe(100);
+    expect(o.total).toBe(100);
+  });
+
+  it('ignora nóminas, impuestos y costes directos', () => {
+    const o = aggregateOperativos([
+      makeExpense({ expenseGroup: 'operational',     expenseSubtype: 'nomina_socio',  totalAmount: 1000 }),
+      makeExpense({ expenseGroup: 'operational',     expenseSubtype: 'cuota_autonomo', totalAmount: 315 }),
+      makeExpense({ expenseGroup: 'campaign_direct', expenseSubtype: 'pago_talento',  totalAmount: 500 }),
+      makeExpense({ expenseGroup: 'operational',     expenseSubtype: 'gestoria',       totalAmount: 185 }),
+    ]);
+    expect(o.gestoria).toBe(185);
+    expect(o.total).toBe(185);
+    expect(o.count).toBe(1);
+  });
+});
+
+// ── computeResultadoOperativo ─────────────────────────────────────────────
+
+describe('computeResultadoOperativo()', () => {
+  it('operativo = margenBrutoCobrado - nominas - impuestos - operativos', () => {
+    const r = computeResultadoOperativo({
+      margenBrutoCobrado: 10_000,
+      nominasTotal:        4_000,
+      impuestosTotal:      1_000,
+      operativosTotal:     2_000,
+    });
+    expect(r.operativo).toBe(3_000);
+  });
+
+  it('resultado negativo se preserva', () => {
+    const r = computeResultadoOperativo({
+      margenBrutoCobrado: 1_000,
+      nominasTotal:        2_000,
+      impuestosTotal:      500,
+      operativosTotal:     500,
+    });
+    expect(r.operativo).toBe(-2_000);
+  });
+});
+
+// ── daysOverdue ───────────────────────────────────────────────────────────
+
+describe('daysOverdue()', () => {
+  it('null cuando no hay dueDate', () => {
+    expect(daysOverdue('2026-07-01', null)).toBeNull();
+  });
+
+  it('positivo cuando la factura está vencida', () => {
+    expect(daysOverdue('2026-07-15', '2026-07-10')).toBe(5);
+  });
+
+  it('cero cuando vence hoy', () => {
+    expect(daysOverdue('2026-07-10', '2026-07-10')).toBe(0);
+  });
+
+  it('negativo cuando aún no vence', () => {
+    expect(daysOverdue('2026-07-01', '2026-07-10')).toBe(-9);
+  });
+});
+
+// ── topNPendientes ────────────────────────────────────────────────────────
+
+describe('topNPendientes()', () => {
+  it('ordena DESC por amount y devuelve top 5', () => {
+    const items: PendienteItem[] = [
+      makeItem({ id: 1, amount: 100 }),
+      makeItem({ id: 2, amount: 500 }),
+      makeItem({ id: 3, amount: 300 }),
+      makeItem({ id: 4, amount: 200 }),
+      makeItem({ id: 5, amount: 400 }),
+      makeItem({ id: 6, amount: 50  }),
+    ];
+    const b = topNPendientes(items);
+    expect(b.top.map((i) => i.id)).toEqual([2, 5, 3, 4, 1]);
+    expect(b.total).toBe(1550);
+    expect(b.count).toBe(6);
+  });
+
+  it('n personalizado', () => {
+    const b = topNPendientes([
+      makeItem({ id: 1, amount: 10 }),
+      makeItem({ id: 2, amount: 20 }),
+    ], 1);
+    expect(b.top).toHaveLength(1);
+    expect(b.top[0]?.id).toBe(2);
+  });
+
+  it('lista vacía → total=0, top=[]', () => {
+    const b = topNPendientes([]);
+    expect(b.total).toBe(0);
+    expect(b.top).toEqual([]);
+  });
+});
+
+// ── computeMargenPendienteEstimado ────────────────────────────────────────
+
+describe('computeMargenPendienteEstimado()', () => {
+  it('cobros pendientes - pagos talento pendientes', () => {
+    expect(computeMargenPendienteEstimado(2100, 1100)).toBe(1000);
+  });
+
+  it('puede ser negativo si pagamos más de lo que cobramos', () => {
+    expect(computeMargenPendienteEstimado(500, 800)).toBe(-300);
+  });
+});
+
+// ── assemblePendientes (integración) ──────────────────────────────────────
+
+describe('assemblePendientes()', () => {
+  it('junta 3 buckets + margen pendiente estimado', () => {
+    const p = assemblePendientes({
+      cobrosCampanas: [makeItem({ id: 1, amount: 1600 }), makeItem({ id: 2, amount: 500 })],
+      pagosTalento:   [makeItem({ id: 3, amount: 900 }),  makeItem({ id: 4, amount: 200 })],
+      pagosOperativo: [makeItem({ id: 5, amount: 185 })],
+    });
+    expect(p.cobrosCampanas.total).toBe(2100);
+    expect(p.pagosTalento.total).toBe(1100);
+    expect(p.pagosOperativo.total).toBe(185);
+    expect(p.margenPendienteEstimado).toBe(1000);
+  });
+});
+
+// ── Chequeos estáticos ────────────────────────────────────────────────────
+
+describe('finanzasResumenV2 — chequeos estáticos', () => {
+  const querySrc = read('src/lib/queries/financeDashboard/finanzasResumenV2.ts');
+  const sharedSrc = read('src/lib/queries/financeDashboard/finanzasResumenV2.shared.ts');
+  const typesSrc = read('src/types/finanzasResumen.ts');
+
+  it('query.ts declara "server-only"', () => {
+    expect(querySrc).toMatch(/^['"]server-only['"];/m);
+  });
+
+  it('shared.ts NO declara server-only (para permitir tests + reuse en client si hiciera falta)', () => {
+    expect(sharedSrc).not.toMatch(/^['"]server-only['"];/m);
+  });
+
+  it('query no lee invoices.paidAmount deprecated', () => {
+    // Se permite `paidAmount:` como alias local en SELECTs (calculado via SUM(invoice_payments)),
+    // pero NUNCA `invoices.paidAmount` como fuente. Filtramos líneas que sean
+    // documentación (empiezan por *) para no falsear con menciones en JSDoc.
+    const codeOnly = querySrc
+      .split('\n')
+      .filter((l) => !l.trim().startsWith('*') && !l.trim().startsWith('//'))
+      .join('\n');
+    expect(codeOnly).not.toMatch(/invoices\.paidAmount/);
+  });
+
+  it('query usa invoice_payments como fuente canónica de cobros/pagos', () => {
+    expect(querySrc).toMatch(/invoicePayments\b/);
+    expect(querySrc).toMatch(/SUM\(\$\{invoicePayments\.amount\}\)/);
+  });
+
+  it('tipos de root incluyen los 9 bloques esperados', () => {
+    for (const key of [
+      'period', 'ingresos', 'costesDirectos', 'margenBruto',
+      'nominas', 'impuestos', 'operativos', 'resultado', 'pendientes',
+    ]) {
+      expect(typesSrc).toMatch(new RegExp(`readonly ${key}:`));
+    }
+  });
+});
+
+// ── Anti-scope-creep ──────────────────────────────────────────────────────
+
+describe('finanzasResumenV2 — anti-scope-creep', () => {
+  const files = [
+    'src/lib/queries/financeDashboard/finanzasResumenV2.ts',
+    'src/lib/queries/financeDashboard/finanzasResumenV2.shared.ts',
+    'src/types/finanzasResumen.ts',
+  ];
+
+  it.each(files)('%s no importa Resend/emails/dunning/invoice_reminders', (rel) => {
+    const src = read(rel);
+    expect(src).not.toMatch(/from\s+['"]resend['"]/);
+    expect(src).not.toMatch(/@\/lib\/email/);
+    expect(src).not.toMatch(/sendEmail/);
+    expect(src).not.toMatch(/invoice_reminders/);
+    expect(src).not.toMatch(/invoiceReminders/);
+    expect(src).not.toMatch(/dunning/i);
+  });
+
+  it.each(files)('%s no define ni altera tablas', (rel) => {
+    const src = read(rel);
+    expect(src).not.toMatch(/pgTable\s*\(/);
+    expect(src).not.toMatch(/alterTable/);
+  });
+});

--- a/src/lib/queries/financeDashboard/finanzasResumenV2.shared.ts
+++ b/src/lib/queries/financeDashboard/finanzasResumenV2.shared.ts
@@ -1,0 +1,259 @@
+/**
+ * Helpers puros para el resumen económico V2. Sin dependencias de DB ni
+ * server-only. Testeable con fixtures.
+ *
+ * Toda la lógica de clasificación por subtype, split Pablo/Alfonso y
+ * agregación de KPIs vive aquí. La query (`finanzasResumenV2.ts`) trae los
+ * raw rows y llama a estos helpers.
+ */
+
+import { detectPartner } from './expenseSubgroups';
+import type {
+  FinanzasResumenImpuestos,
+  FinanzasResumenNominas,
+  FinanzasResumenOperativos,
+  FinanzasResumenPendienteBucket,
+  FinanzasResumenPendientes,
+  FinanzasResumenResultado,
+  PendienteItem,
+} from '@/types/finanzasResumen';
+
+// ── Fila de gasto que entra al helper (sin importar cómo se obtuvo) ─────────
+
+export type ExpenseRow = {
+  readonly totalAmount: number;
+  readonly expenseGroup: string | null;
+  readonly expenseSubtype: string | null;
+  readonly concept: string | null;
+  readonly counterpartyName: string | null;
+};
+
+// ── Rondeo consistente ─────────────────────────────────────────────────────
+
+export function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+// ── Clasificación por sección del resumen ───────────────────────────────────
+
+export type ResumenSection = 'nominas' | 'impuestos' | 'operativos' | 'costes_directos';
+
+const IMPUESTOS_SUBTYPES: ReadonlySet<string> = new Set([
+  'cuota_autonomo',
+  'factura_autonomo',
+  'seguridad_social',
+  'fiscal_impuestos',
+  'ajuste_fiscal',
+]);
+
+/**
+ * Devuelve la sección del resumen a la que pertenece una fila.
+ *
+ * - `nominas`         → `expenseSubtype = 'nomina_socio'`
+ * - `impuestos`       → subtypes en `IMPUESTOS_SUBTYPES`
+ * - `costes_directos` → `expenseGroup = 'campaign_direct'`
+ * - `operativos`      → resto (incluye `expenseGroup = 'operational'` sin
+ *                       subtype conocido y filas sin clasificar)
+ */
+export function classifyResumenSection(row: {
+  readonly expenseGroup: string | null;
+  readonly expenseSubtype: string | null;
+}): ResumenSection {
+  const subtype = row.expenseSubtype;
+  if (subtype === 'nomina_socio') return 'nominas';
+  if (subtype && IMPUESTOS_SUBTYPES.has(subtype)) return 'impuestos';
+  if (row.expenseGroup === 'campaign_direct') return 'costes_directos';
+  return 'operativos';
+}
+
+// ── Agregación de nóminas ───────────────────────────────────────────────────
+
+export function aggregateNominas(rows: readonly ExpenseRow[]): FinanzasResumenNominas {
+  let pablo = 0, alfonso = 0, otros = 0, count = 0;
+  for (const r of rows) {
+    if (r.expenseSubtype !== 'nomina_socio') continue;
+    count += 1;
+    const partner = detectPartner(`${r.concept ?? ''} ${r.counterpartyName ?? ''}`);
+    if (partner === 'pablo') pablo += r.totalAmount;
+    else if (partner === 'alfonso') alfonso += r.totalAmount;
+    else otros += r.totalAmount;
+  }
+  return {
+    pablo: round2(pablo),
+    alfonso: round2(alfonso),
+    otros: round2(otros),
+    total: round2(pablo + alfonso + otros),
+    count,
+  };
+}
+
+// ── Agregación de impuestos ─────────────────────────────────────────────────
+
+export function aggregateImpuestos(rows: readonly ExpenseRow[]): FinanzasResumenImpuestos {
+  let cuotaPablo = 0, cuotaAlfonso = 0, cuotaOtros = 0;
+  let seguridadSocial = 0, fiscal = 0, count = 0;
+
+  for (const r of rows) {
+    const st = r.expenseSubtype;
+    if (!st || !IMPUESTOS_SUBTYPES.has(st)) continue;
+    count += 1;
+    if (st === 'seguridad_social') {
+      seguridadSocial += r.totalAmount;
+    } else if (st === 'fiscal_impuestos' || st === 'ajuste_fiscal') {
+      fiscal += r.totalAmount;
+    } else {
+      // cuota_autonomo | factura_autonomo → split Pablo/Alfonso
+      const partner = detectPartner(`${r.concept ?? ''} ${r.counterpartyName ?? ''}`);
+      if (partner === 'pablo') cuotaPablo += r.totalAmount;
+      else if (partner === 'alfonso') cuotaAlfonso += r.totalAmount;
+      else cuotaOtros += r.totalAmount;
+    }
+  }
+
+  return {
+    cuotaAutonomoPablo:   round2(cuotaPablo),
+    cuotaAutonomoAlfonso: round2(cuotaAlfonso),
+    cuotaAutonomoOtros:   round2(cuotaOtros),
+    seguridadSocial:      round2(seguridadSocial),
+    fiscal:               round2(fiscal),
+    total: round2(cuotaPablo + cuotaAlfonso + cuotaOtros + seguridadSocial + fiscal),
+    count,
+  };
+}
+
+// ── Agregación de gastos operativos ─────────────────────────────────────────
+
+const HOSTING_RE = /\b(hosting|dominio|domain|vercel|cloudflare|namecheap|godaddy|dns|ssl)\b/i;
+const HOSTING_CANDIDATE_SUBTYPES: ReadonlySet<string | null> = new Set([
+  'suscripcion_software',
+  'herramienta_ia',
+  'gasto_general',
+  null,
+]);
+
+function isHostingRow(row: ExpenseRow): boolean {
+  if (!HOSTING_CANDIDATE_SUBTYPES.has(row.expenseSubtype)) return false;
+  const text = `${row.concept ?? ''} ${row.counterpartyName ?? ''}`;
+  return HOSTING_RE.test(text);
+}
+
+export function aggregateOperativos(rows: readonly ExpenseRow[]): FinanzasResumenOperativos {
+  let gestoria = 0, softwareIa = 0, hostingDominio = 0;
+  let seguroMedico = 0, comisiones = 0, marketing = 0;
+  let otros = 0, sinClasificar = 0, count = 0;
+
+  for (const r of rows) {
+    if (classifyResumenSection(r) !== 'operativos') continue;
+    count += 1;
+
+    // Detectar hosting antes del switch canónico (mismo criterio que
+    // expenseSubgroups.classifyExpenseSubgroup).
+    if (isHostingRow(r)) {
+      hostingDominio += r.totalAmount;
+      continue;
+    }
+
+    switch (r.expenseSubtype) {
+      case 'gestoria':
+        gestoria += r.totalAmount; break;
+      case 'suscripcion_software':
+      case 'herramienta_ia':
+        softwareIa += r.totalAmount; break;
+      case 'seguro_medico':
+        seguroMedico += r.totalAmount; break;
+      case 'comision_bancaria':
+      case 'comision_plataforma':
+        comisiones += r.totalAmount; break;
+      case 'marketing_publicidad':
+        marketing += r.totalAmount; break;
+      case 'gasto_general':
+        otros += r.totalAmount; break;
+      default:
+        if (r.expenseSubtype === null && r.expenseGroup === null) {
+          sinClasificar += r.totalAmount;
+        } else {
+          otros += r.totalAmount;
+        }
+    }
+  }
+
+  return {
+    gestoria:       round2(gestoria),
+    softwareIa:     round2(softwareIa),
+    hostingDominio: round2(hostingDominio),
+    seguroMedico:   round2(seguroMedico),
+    comisiones:     round2(comisiones),
+    marketing:      round2(marketing),
+    otros:          round2(otros),
+    sinClasificar:  round2(sinClasificar),
+    total: round2(gestoria + softwareIa + hostingDominio + seguroMedico + comisiones + marketing + otros + sinClasificar),
+    count,
+  };
+}
+
+// ── Resultado operativo ─────────────────────────────────────────────────────
+
+export function computeResultadoOperativo(input: {
+  readonly margenBrutoCobrado: number;
+  readonly nominasTotal:       number;
+  readonly impuestosTotal:     number;
+  readonly operativosTotal:    number;
+}): FinanzasResumenResultado {
+  return {
+    operativo: round2(
+      input.margenBrutoCobrado - input.nominasTotal - input.impuestosTotal - input.operativosTotal,
+    ),
+  };
+}
+
+// ── Días vencidos ──────────────────────────────────────────────────────────
+
+export function daysOverdue(today: string, dueDate: string | null): number | null {
+  if (!dueDate) return null;
+  const [ya, ma, da] = today.split('-').map(Number);
+  const [yb, mb, db] = dueDate.split('-').map(Number);
+  if (!ya || !ma || !da || !yb || !mb || !db) return null;
+  return Math.round((Date.UTC(ya, ma - 1, da) - Date.UTC(yb, mb - 1, db)) / 86_400_000);
+}
+
+// ── Top-N pendientes ────────────────────────────────────────────────────────
+
+export function topNPendientes(items: readonly PendienteItem[], n = 5): FinanzasResumenPendienteBucket {
+  const total = items.reduce((s, i) => s + i.amount, 0);
+  const sorted = [...items].sort((a, b) => b.amount - a.amount);
+  return {
+    total: round2(total),
+    count: items.length,
+    top: sorted.slice(0, n),
+  };
+}
+
+// ── Margen pendiente estimado ───────────────────────────────────────────────
+
+export function computeMargenPendienteEstimado(
+  cobrosCampanasTotal: number,
+  pagosTalentoTotal: number,
+): number {
+  return round2(cobrosCampanasTotal - pagosTalentoTotal);
+}
+
+// ── Ensamblado de pendientes ────────────────────────────────────────────────
+
+export function assemblePendientes(input: {
+  readonly cobrosCampanas: readonly PendienteItem[];
+  readonly pagosTalento:   readonly PendienteItem[];
+  readonly pagosOperativo: readonly PendienteItem[];
+}): FinanzasResumenPendientes {
+  const cobrosCampanas = topNPendientes(input.cobrosCampanas);
+  const pagosTalento   = topNPendientes(input.pagosTalento);
+  const pagosOperativo = topNPendientes(input.pagosOperativo);
+  return {
+    cobrosCampanas,
+    pagosTalento,
+    pagosOperativo,
+    margenPendienteEstimado: computeMargenPendienteEstimado(
+      cobrosCampanas.total,
+      pagosTalento.total,
+    ),
+  };
+}

--- a/src/lib/queries/financeDashboard/finanzasResumenV2.ts
+++ b/src/lib/queries/financeDashboard/finanzasResumenV2.ts
@@ -1,0 +1,374 @@
+'server-only';
+
+import { and, eq, gte, inArray, lte, ne, or, sql } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import {
+  billingClients,
+  crmBrands,
+  invoicePayments,
+  invoices,
+  issuedInvoices,
+  talents,
+} from '@/db/schema';
+import {
+  PENDING_EXPENSE_FILTER,
+  PENDING_INCOME_FILTER,
+} from '@/lib/utils/invoice-status';
+import type { InvoiceStatus } from '@/types';
+import type {
+  FinanzasPeriod,
+  FinanzasResumenCostesDirectos,
+  FinanzasResumenIngresos,
+  FinanzasResumenMargenBruto,
+  FinanzasResumenV2,
+  PendienteItem,
+} from '@/types/finanzasResumen';
+import {
+  aggregateImpuestos,
+  aggregateNominas,
+  aggregateOperativos,
+  assemblePendientes,
+  classifyResumenSection,
+  computeResultadoOperativo,
+  daysOverdue,
+  round2,
+  type ExpenseRow,
+} from './finanzasResumenV2.shared';
+
+// ── Zona horaria canónica ───────────────────────────────────────────────────
+
+function todayInMadrid(): string {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Europe/Madrid',
+    year: 'numeric', month: '2-digit', day: '2-digit',
+  }).format(new Date());
+}
+
+// ── Filtros ────────────────────────────────────────────────────────────────
+
+export type ResumenFilters = {
+  readonly from?: string; // 'YYYY-MM-DD'
+  readonly to?:   string; // 'YYYY-MM-DD'
+};
+
+function resolvePeriod(filters: ResumenFilters): FinanzasPeriod {
+  const today = todayInMadrid();
+  const year = today.slice(0, 4);
+  return {
+    from: filters.from ?? `${year}-01-01`,
+    to:   filters.to ?? today,
+  };
+}
+
+// ── Query principal ─────────────────────────────────────────────────────────
+
+/**
+ * Resumen económico anual/YTD. Fuente canónica de pagos: `invoice_payments`.
+ * No usa `invoices.paidAmount` (deprecated — TD-14).
+ *
+ * @cache none
+ * @visibility admin
+ */
+export async function getFinanzasResumenV2(
+  filters: ResumenFilters = {},
+): Promise<FinanzasResumenV2> {
+  const period = resolvePeriod(filters);
+  const today = todayInMadrid();
+
+  const [
+    ingresosCobradosRows,
+    ingresosFacturadosRows,
+    expenseRowsPeriod,
+    costesDirectosPagadosRows,
+    receivablesIssuedRows,
+    receivablesInternalRows,
+    payablesRows,
+  ] = await Promise.all([
+    // 1. Ingresos cobrados = SUM(invoice_payments.amount) para income (issued O internal) con paymentDate ∈ periodo
+    db
+      .select({ amount: sql<string>`COALESCE(SUM(${invoicePayments.amount}), 0)::text` })
+      .from(invoicePayments)
+      .where(
+        and(
+          gte(invoicePayments.paymentDate, period.from),
+          lte(invoicePayments.paymentDate, period.to),
+          or(
+            sql`${invoicePayments.issuedInvoiceId} IS NOT NULL`,
+            sql`${invoicePayments.invoiceId} IN (SELECT id FROM invoices WHERE kind = 'income')`,
+          ),
+        ),
+      ),
+
+    // 2. Ingresos facturados = SUM(totalAmount) income no-anulada con issueDate ∈ periodo
+    db
+      .select({ amount: sql<string>`COALESCE(SUM(t), 0)::text` })
+      .from(
+        sql`(
+          SELECT total_amount AS t FROM issued_invoices
+            WHERE status != 'anulada'
+              AND issue_date BETWEEN ${period.from} AND ${period.to}
+          UNION ALL
+          SELECT total_amount AS t FROM invoices
+            WHERE kind = 'income' AND status != 'anulada'
+              AND issue_date BETWEEN ${period.from} AND ${period.to}
+        ) src`,
+      ),
+
+    // 3. Expenses del periodo con detalle — usado para clasificación completa
+    db
+      .select({
+        id: invoices.id,
+        totalAmount: invoices.totalAmount,
+        status: invoices.status,
+        expenseGroup: invoices.expenseGroup,
+        expenseSubtype: invoices.expenseSubtype,
+        concept: invoices.concept,
+        counterpartyName: invoices.counterpartyName,
+        campaignId: invoices.campaignId,
+        talentId: invoices.talentId,
+      })
+      .from(invoices)
+      .where(
+        and(
+          eq(invoices.kind, 'expense'),
+          ne(invoices.status, 'anulada'),
+          gte(invoices.issueDate, period.from),
+          lte(invoices.issueDate, period.to),
+        ),
+      ),
+
+    // 4. Costes directos pagados = SUM(invoice_payments.amount) para invoices campaign_direct con paymentDate ∈ periodo
+    db
+      .select({ amount: sql<string>`COALESCE(SUM(${invoicePayments.amount}), 0)::text` })
+      .from(invoicePayments)
+      .innerJoin(invoices, eq(invoices.id, invoicePayments.invoiceId))
+      .where(
+        and(
+          gte(invoicePayments.paymentDate, period.from),
+          lte(invoicePayments.paymentDate, period.to),
+          eq(invoices.kind, 'expense'),
+          eq(invoices.expenseGroup, 'campaign_direct'),
+        ),
+      ),
+
+    // 5. Pendientes de cobro — issued
+    db
+      .select({
+        id: issuedInvoices.id,
+        invoiceNumber: issuedInvoices.invoiceNumber,
+        totalAmount: issuedInvoices.totalAmount,
+        paidAmount: sql<string>`COALESCE(SUM(${invoicePayments.amount}), 0)::text`,
+        dueDate: issuedInvoices.dueDate,
+        brandName: crmBrands.name,
+        clientName: billingClients.name,
+      })
+      .from(issuedInvoices)
+      .leftJoin(crmBrands,       eq(crmBrands.id, issuedInvoices.relatedBrandId))
+      .leftJoin(billingClients,  eq(billingClients.id, issuedInvoices.billingClientId))
+      .leftJoin(invoicePayments, eq(invoicePayments.issuedInvoiceId, issuedInvoices.id))
+      .where(inArray(issuedInvoices.status, ['emitida', 'vencida', 'parcial']))
+      .groupBy(
+        issuedInvoices.id, issuedInvoices.invoiceNumber, issuedInvoices.totalAmount,
+        issuedInvoices.dueDate, crmBrands.name, billingClients.name,
+      ),
+
+    // 6. Pendientes de cobro — internal (kind=income)
+    db
+      .select({
+        id: invoices.id,
+        number: invoices.number,
+        totalAmount: invoices.totalAmount,
+        paidAmount: sql<string>`COALESCE(SUM(${invoicePayments.amount}), 0)::text`,
+        dueDate: invoices.dueDate,
+        brandName: crmBrands.name,
+        counterpartyName: invoices.counterpartyName,
+      })
+      .from(invoices)
+      .leftJoin(crmBrands,       eq(crmBrands.id, invoices.brandId))
+      .leftJoin(invoicePayments, eq(invoicePayments.invoiceId, invoices.id))
+      .where(
+        and(
+          eq(invoices.kind, 'income'),
+          inArray(invoices.status, PENDING_INCOME_FILTER as InvoiceStatus[]),
+        ),
+      )
+      .groupBy(
+        invoices.id, invoices.number, invoices.totalAmount, invoices.dueDate,
+        crmBrands.name, invoices.counterpartyName,
+      ),
+
+    // 7. Pendientes de pago (expense) — todos, luego split talent/operativo en memoria
+    db
+      .select({
+        id: invoices.id,
+        totalAmount: invoices.totalAmount,
+        paidAmount: sql<string>`COALESCE(SUM(${invoicePayments.amount}), 0)::text`,
+        dueDate: invoices.dueDate,
+        concept: invoices.concept,
+        counterpartyName: invoices.counterpartyName,
+        expenseGroup: invoices.expenseGroup,
+        expenseSubtype: invoices.expenseSubtype,
+        talentId: invoices.talentId,
+        campaignId: invoices.campaignId,
+        talentName: talents.name,
+      })
+      .from(invoices)
+      .leftJoin(talents,         eq(talents.id, invoices.talentId))
+      .leftJoin(invoicePayments, eq(invoicePayments.invoiceId, invoices.id))
+      .where(
+        and(
+          eq(invoices.kind, 'expense'),
+          inArray(invoices.status, PENDING_EXPENSE_FILTER as InvoiceStatus[]),
+        ),
+      )
+      .groupBy(
+        invoices.id, invoices.totalAmount, invoices.dueDate, invoices.concept,
+        invoices.counterpartyName, invoices.expenseGroup, invoices.expenseSubtype,
+        invoices.talentId, invoices.campaignId, talents.name,
+      ),
+  ]);
+
+  // ── Ingresos ─────────────────────────────────────────────────────────────
+  const cobrados   = Number(ingresosCobradosRows[0]?.amount ?? '0');
+  const facturados = Number(ingresosFacturadosRows[0]?.amount ?? '0');
+  const pendientesIngreso = Math.max(0, facturados - cobrados);
+
+  const ingresos: FinanzasResumenIngresos = {
+    cobrados:   round2(cobrados),
+    facturados: round2(facturados),
+    pendientes: round2(pendientesIngreso),
+  };
+
+  // ── Expenses en memoria ─────────────────────────────────────────────────
+  const expenseRows: ExpenseRow[] = expenseRowsPeriod.map((r) => ({
+    totalAmount:      Number(r.totalAmount),
+    expenseGroup:     r.expenseGroup,
+    expenseSubtype:   r.expenseSubtype,
+    concept:          r.concept,
+    counterpartyName: r.counterpartyName,
+  }));
+
+  const nominas     = aggregateNominas(expenseRows);
+  const impuestos   = aggregateImpuestos(expenseRows);
+  const operativos  = aggregateOperativos(expenseRows);
+
+  // ── Costes directos (accrual base periodo) ──────────────────────────────
+  let costesDirectosPagoTalentoAccrual = 0;
+  let costesDirectosProduccionAccrual  = 0;
+  for (const r of expenseRowsPeriod) {
+    if (classifyResumenSection({ expenseGroup: r.expenseGroup, expenseSubtype: r.expenseSubtype }) !== 'costes_directos') continue;
+    if (r.expenseSubtype === 'pago_talento') {
+      costesDirectosPagoTalentoAccrual += Number(r.totalAmount);
+    } else {
+      costesDirectosProduccionAccrual += Number(r.totalAmount);
+    }
+  }
+  const costesDirectosAccrualTotal = costesDirectosPagoTalentoAccrual + costesDirectosProduccionAccrual;
+
+  const costesDirectosPagadosCash = Number(costesDirectosPagadosRows[0]?.amount ?? '0');
+  // Split cash → talento / producción proporcionalmente al accrual del periodo.
+  const shareTalento    = costesDirectosAccrualTotal > 0 ? costesDirectosPagoTalentoAccrual / costesDirectosAccrualTotal : 0;
+  const shareProduccion = costesDirectosAccrualTotal > 0 ? costesDirectosProduccionAccrual  / costesDirectosAccrualTotal : 0;
+  const costesDirectosPagosTalentoCash    = costesDirectosPagadosCash * shareTalento;
+  const costesDirectosProduccionCash      = costesDirectosPagadosCash * shareProduccion;
+
+  const costesDirectosPagosTalentoPendiente = Math.max(0, costesDirectosPagoTalentoAccrual - costesDirectosPagosTalentoCash);
+  const costesDirectosProduccionPendiente   = Math.max(0, costesDirectosProduccionAccrual  - costesDirectosProduccionCash);
+
+  const costesDirectos: FinanzasResumenCostesDirectos = {
+    pagados:    round2(costesDirectosPagadosCash),
+    pendientes: round2(costesDirectosPagosTalentoPendiente + costesDirectosProduccionPendiente),
+    total:      round2(costesDirectosPagadosCash + costesDirectosPagosTalentoPendiente + costesDirectosProduccionPendiente),
+    pagosTalento: {
+      pagados:    round2(costesDirectosPagosTalentoCash),
+      pendientes: round2(costesDirectosPagosTalentoPendiente),
+    },
+    costesProduccion: {
+      pagados:    round2(costesDirectosProduccionCash),
+      pendientes: round2(costesDirectosProduccionPendiente),
+    },
+  };
+
+  // ── Margen bruto ─────────────────────────────────────────────────────────
+  const margenBruto: FinanzasResumenMargenBruto = {
+    cobrado:   round2(ingresos.cobrados   - costesDirectos.pagados),
+    pendiente: round2(ingresos.pendientes - costesDirectos.pendientes),
+  };
+
+  // ── Resultado operativo (caja base) ─────────────────────────────────────
+  const resultado = computeResultadoOperativo({
+    margenBrutoCobrado: margenBruto.cobrado,
+    nominasTotal:       nominas.total,
+    impuestosTotal:     impuestos.total,
+    operativosTotal:    operativos.total,
+  });
+
+  // ── Pendientes destacados ──────────────────────────────────────────────
+  const cobrosCampanasItems: PendienteItem[] = [];
+  for (const r of receivablesIssuedRows) {
+    const pending = Math.max(0, Number(r.totalAmount) - Number(r.paidAmount));
+    if (pending < 0.01) continue;
+    const label = r.brandName ?? r.clientName ?? r.invoiceNumber ?? `#${r.id}`;
+    cobrosCampanasItems.push({
+      id: r.id,
+      source: 'issued',
+      label,
+      amount: round2(pending),
+      dueDate: r.dueDate ?? null,
+      daysOverdue: daysOverdue(today, r.dueDate ?? null),
+    });
+  }
+  for (const r of receivablesInternalRows) {
+    const pending = Math.max(0, Number(r.totalAmount) - Number(r.paidAmount));
+    if (pending < 0.01) continue;
+    const label = r.brandName ?? r.counterpartyName ?? r.number ?? `#${r.id}`;
+    cobrosCampanasItems.push({
+      id: r.id,
+      source: 'internal',
+      label,
+      amount: round2(pending),
+      dueDate: r.dueDate ?? null,
+      daysOverdue: daysOverdue(today, r.dueDate ?? null),
+    });
+  }
+
+  const pagosTalentoItems: PendienteItem[] = [];
+  const pagosOperativoItems: PendienteItem[] = [];
+  for (const r of payablesRows) {
+    const pending = Math.max(0, Number(r.totalAmount) - Number(r.paidAmount));
+    if (pending < 0.01) continue;
+    const item: PendienteItem = {
+      id: r.id,
+      source: 'internal',
+      label: r.expenseSubtype === 'pago_talento'
+        ? (r.talentName ?? r.concept ?? `#${r.id}`)
+        : (r.counterpartyName ?? r.concept ?? `#${r.id}`),
+      amount: round2(pending),
+      dueDate: r.dueDate ?? null,
+      daysOverdue: daysOverdue(today, r.dueDate ?? null),
+    };
+    if (r.expenseSubtype === 'pago_talento' || r.expenseGroup === 'campaign_direct') {
+      pagosTalentoItems.push(item);
+    } else {
+      pagosOperativoItems.push(item);
+    }
+  }
+
+  const pendientes = assemblePendientes({
+    cobrosCampanas: cobrosCampanasItems,
+    pagosTalento:   pagosTalentoItems,
+    pagosOperativo: pagosOperativoItems,
+  });
+
+  return {
+    period,
+    ingresos,
+    costesDirectos,
+    margenBruto,
+    nominas,
+    impuestos,
+    operativos,
+    resultado,
+    pendientes,
+  };
+}

--- a/src/types/finanzasResumen.ts
+++ b/src/types/finanzasResumen.ts
@@ -1,0 +1,133 @@
+/**
+ * Tipos para el resumen económico anual/YTD de Finanzas.
+ *
+ * Fuente canónica de pagos: `invoice_payments`. No se usa `invoices.paidAmount`
+ * (deprecated — TD-14).
+ */
+
+export type FinanzasPeriod = {
+  readonly from: string; // 'YYYY-MM-DD' inclusive
+  readonly to:   string; // 'YYYY-MM-DD' inclusive
+};
+
+// ── Ingresos ────────────────────────────────────────────────────────────────
+
+export type FinanzasResumenIngresos = {
+  /** SUM(invoice_payments.amount) sobre income cuyo paymentDate ∈ periodo. */
+  readonly cobrados: number;
+  /** SUM(totalAmount) de income no-anulada con issueDate ∈ periodo. */
+  readonly facturados: number;
+  /** facturados − cobrados. Nunca negativo. */
+  readonly pendientes: number;
+};
+
+// ── Costes directos de campaña ──────────────────────────────────────────────
+
+export type FinanzasResumenCosteBucket = {
+  readonly pagados:   number;
+  readonly pendientes: number;
+};
+
+export type FinanzasResumenCostesDirectos = {
+  readonly pagados:     number;
+  readonly pendientes:  number;
+  readonly total:       number; // pagados + pendientes
+  readonly pagosTalento:      FinanzasResumenCosteBucket;
+  readonly costesProduccion:  FinanzasResumenCosteBucket;
+};
+
+// ── Margen bruto ────────────────────────────────────────────────────────────
+
+export type FinanzasResumenMargenBruto = {
+  readonly cobrado:   number; // ingresos.cobrados  − costesDirectos.pagados
+  readonly pendiente: number; // ingresos.pendientes − costesDirectos.pendientes
+};
+
+// ── Nóminas ─────────────────────────────────────────────────────────────────
+
+export type FinanzasResumenNominas = {
+  readonly pablo:   number;
+  readonly alfonso: number;
+  readonly otros:   number;
+  readonly total:   number;
+  readonly count:   number;
+};
+
+// ── Impuestos y cargas ──────────────────────────────────────────────────────
+
+export type FinanzasResumenImpuestos = {
+  readonly cuotaAutonomoPablo:   number;
+  readonly cuotaAutonomoAlfonso: number;
+  readonly cuotaAutonomoOtros:   number;
+  readonly seguridadSocial:      number;
+  readonly fiscal:               number; // fiscal_impuestos + ajuste_fiscal
+  readonly total:                number;
+  readonly count:                number;
+};
+
+// ── Gastos operativos reales ────────────────────────────────────────────────
+
+export type FinanzasResumenOperativos = {
+  readonly gestoria:       number;
+  readonly softwareIa:     number;
+  readonly hostingDominio: number;
+  readonly seguroMedico:   number;
+  readonly comisiones:     number;
+  readonly marketing:      number;
+  readonly otros:          number; // gasto_general + operational sin subtype conocido
+  readonly sinClasificar:  number; // expense sin group/subtype
+  readonly total:          number;
+  readonly count:          number;
+};
+
+// ── Resultado operativo ─────────────────────────────────────────────────────
+
+export type FinanzasResumenResultado = {
+  /**
+   * = margenBruto.cobrado − nominas.total − impuestos.total − operativos.total
+   *
+   * Enfoque caja (usa cobrados como base) — refleja lo que efectivamente ha
+   * entrado y salido en el periodo, no lo pendiente.
+   */
+  readonly operativo: number;
+};
+
+// ── Pendientes destacados ───────────────────────────────────────────────────
+
+export type PendienteItem = {
+  readonly id: number;
+  readonly source: 'issued' | 'internal';
+  readonly label: string;
+  readonly amount: number;
+  readonly dueDate: string | null;
+  /** Positivo si vencida hace N días; negativo si aún no vence; null si sin dueDate. */
+  readonly daysOverdue: number | null;
+};
+
+export type FinanzasResumenPendienteBucket = {
+  readonly total: number;
+  readonly count: number;
+  readonly top:   readonly PendienteItem[]; // top 5 por importe pendiente
+};
+
+export type FinanzasResumenPendientes = {
+  readonly cobrosCampanas:  FinanzasResumenPendienteBucket;
+  readonly pagosTalento:    FinanzasResumenPendienteBucket;
+  readonly pagosOperativo:  FinanzasResumenPendienteBucket;
+  /** cobros pendientes − pagos talento pendientes (informativo). */
+  readonly margenPendienteEstimado: number;
+};
+
+// ── Root ────────────────────────────────────────────────────────────────────
+
+export type FinanzasResumenV2 = {
+  readonly period:          FinanzasPeriod;
+  readonly ingresos:        FinanzasResumenIngresos;
+  readonly costesDirectos:  FinanzasResumenCostesDirectos;
+  readonly margenBruto:     FinanzasResumenMargenBruto;
+  readonly nominas:         FinanzasResumenNominas;
+  readonly impuestos:       FinanzasResumenImpuestos;
+  readonly operativos:      FinanzasResumenOperativos;
+  readonly resultado:       FinanzasResumenResultado;
+  readonly pendientes:      FinanzasResumenPendientes;
+};


### PR DESCRIPTION
## Resumen

**PR A/3** del rediseño del resumen económico. **Solo query, tipos y tests.** Cero UI. La UI de `/admin/finanzas/resumen` vendrá en PR B/3, el selector de rango y pendientes destacados en PR C/3.

Fuente canónica de pagos: **`invoice_payments`**. No usa `invoices.paidAmount` (deprecated — TD-14) para no ampliar la deuda.

Cero DB / schema / migrations / drizzle / crons / emails / Resend / invoice_reminders / OCR / Blob / Sheets / RBAC / AR aging / dunning / Tratos / facturación legal / payroll parser / endpoint recurring / UI actual de resumen / componentes.

## API pública

```ts
export async function getFinanzasResumenV2(
  filters: { from?: string; to?: string } = {}
): Promise<FinanzasResumenV2>;
```

Default: YTD (desde 1-ene del año actual hasta hoy en Europe/Madrid).

## Estructura devuelta

```
FinanzasResumenV2 {
  period          : { from, to }
  ingresos        : { cobrados, facturados, pendientes }
  costesDirectos  : { pagados, pendientes, total,
                      pagosTalento, costesProduccion }
  margenBruto     : { cobrado, pendiente }
  nominas         : { pablo, alfonso, otros, total, count }
  impuestos       : { cuotaAutonomoPablo/Alfonso/Otros,
                      seguridadSocial, fiscal, total, count }
  operativos      : { gestoria, softwareIa, hostingDominio,
                      seguroMedico, comisiones, marketing, otros,
                      sinClasificar, total, count }
  resultado       : { operativo }
  pendientes      : { cobrosCampanas, pagosTalento, pagosOperativo,
                      margenPendienteEstimado }
}
```

Cada bucket de `pendientes` lleva **top 5** por importe con label human-friendly (brand > client > counterparty > id), `dueDate` y `daysOverdue`.

## Fórmulas implementadas (todas aprobadas)

```
ingresosCobrados         = SUM(invoice_payments.amount) income ∈ periodo
ingresosFacturados       = SUM(totalAmount) income no-anulada ∈ periodo
pendienteCobrar          = facturados − cobrados

costesDirectosPagados    = SUM(invoice_payments.amount)
                           invoices campaign_direct ∈ periodo
costesDirectosPendientes = totalAmount campaign_direct no-anulada
                           − pagosCash proporcional al accrual

margenBrutoCobrado       = ingresosCobrados − costesDirectosPagados
margenBrutoPendiente     = pendienteCobrar  − costesDirectosPendientes

nominasTotal             = SUM(nomina_socio) no-anulada
  → split Pablo/Alfonso/otros vía detectPartner(concept+counterparty)

impuestosTotal           = cuota_autonomo + factura_autonomo +
                           seguridad_social + fiscal_impuestos + ajuste_fiscal
  → split Pablo/Alfonso/otros en cuota_autonomo/factura_autonomo

operativosTotal          = operational excluyendo nóminas e impuestos
  → 8 buckets: gestoria, softwareIa, hostingDominio, seguroMedico,
    comisiones, marketing, otros, sinClasificar

resultadoOperativo       = margenBrutoCobrado − nominas − impuestos
                           − operativos
```

## Query en detalle

7 queries paralelas con `Promise.all`, luego agregación en memoria:

1. **Ingresos cobrados** — `SUM(invoice_payments.amount)` con paymentDate ∈ periodo, filtrando income (issued o internal).
2. **Ingresos facturados** — `SUM(totalAmount)` de `issued_invoices` + `invoices kind=income` no-anulada, issueDate ∈ periodo.
3. **Expenses del periodo** — `invoices kind=expense` no-anulada con detalle (subtype/concept/counterparty) para clasificación completa.
4. **Costes directos pagados** — `SUM(invoice_payments.amount)` con JOIN a `invoices` filtrando `expenseGroup='campaign_direct'`.
5. **Receivables issued** — pendientes con `paidAmount` via SUM(invoice_payments).
6. **Receivables internal** — idem para `invoices kind=income`.
7. **Payables** — `invoices kind=expense` pending con JOIN a talents para labels.

## Archivos tocados (4 nuevos, 0 modificados)

- **`src/types/finanzasResumen.ts`** (~120 LOC) — contratos.
- **`src/lib/queries/financeDashboard/finanzasResumenV2.shared.ts`** (~200 LOC) — lógica pura testeable, sin DB, sin server-only. Reusa `detectPartner()` ya testeado.
- **`src/lib/queries/financeDashboard/finanzasResumenV2.ts`** (~280 LOC) — `'server-only'`, 7 queries paralelas + agregación.
- **`src/__tests__/server/finanzas-resumen-v2.test.ts`** (~430 LOC) — 50 tests.

## Confirmaciones

- ✅ **Cero DB / schema / migrations / drizzle** — solo tipos, query nueva y tests.
- ✅ **Cero crons / emails / Resend / invoice_reminders / dunning**.
- ✅ **`invoice_payments` como fuente canónica** — test estático verifica que no hay `invoices.paidAmount` en código (solo en docstring documentando).
- ✅ **`shared.ts` es puro** — sin `'server-only'`, sin `@/lib/db`, sin `@/db/schema` → tests unitarios directos.
- ✅ **Reusa `detectPartner()`** del clasificador visual — sin duplicar lógica.
- ✅ **Cero UI cambiada** — este PR no toca `/admin/finanzas/resumen/page.tsx`, ni `FinanceMonthlyControl.tsx`, ni ningún componente.

## Tests (50 nuevos)

### Lógica pura (43 tests)
- `round2`, `classifyResumenSection` (10 casos)
- `aggregateNominas` (5): Pablo/Alfonso/otros/ignore/total
- `aggregateImpuestos` (5): split cuotas + seguridadSocial + fiscal + ignore
- `aggregateOperativos` (5): 7 buckets + hosting/dominio + sinClasificar + ignore
- `computeResultadoOperativo` (2): positivo y negativo
- `daysOverdue` (4): null, vencida, hoy, futura
- `topNPendientes` (3): orden, n personalizado, vacío
- `computeMargenPendienteEstimado` (2): positivo, negativo
- `assemblePendientes` (1): integración de los 3 buckets

### Chequeos estáticos (5)
- `query.ts` declara `'server-only'`
- `shared.ts` NO declara `'server-only'` (permite tests + reuse)
- Query no lee `invoices.paidAmount` en código
- Query usa `invoicePayments` como fuente canónica
- Tipos root incluyen los 9 bloques esperados

### Anti-scope-creep (6 via `it.each` × 3 files)
- Sin `resend` / `sendEmail` / `@/lib/email`
- Sin `invoice_reminders` / `invoiceReminders` / `dunning`
- Sin `pgTable(` / `alterTable`

## CI local

- ✅ `npx tsc --noEmit` — clean
- ✅ `npm run lint` — 0/0
- ✅ `npm test` — 113 suites · **2029 tests** verdes (50 nuevos)
- ⚠️ Build local requiere `.env.local`; Vercel lo corre en el deploy.

## Roadmap

- **Este PR (A/3)**: query + tipos + tests. Sin UI.
- **PR B/3**: `page.tsx` de `/admin/finanzas/resumen` reescrita para renderizar los 7 bloques (ingresos, costes directos + margen, nóminas, impuestos, operativos, resultado). Mueve el resumen mensual actual a `/admin/finanzas/mes`.
- **PR C/3**: selector `from`/`to` interactivo + bloque de pendientes destacados con top 5 y links a `/cobros` y `/gastos`.

## Test plan post-merge

- [ ] No hay cambios de UI en producción — este PR es puramente query.
- [ ] Este PR es la base sobre la que se construirá PR B/3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
