### PR TITLE
feat(audit/finanzas): UI del nuevo resumen económico anual/YTD (PR B/3)

### DIFF
--- a/src/__tests__/server/audit-finanzas-1a1-dashboard.test.ts
+++ b/src/__tests__/server/audit-finanzas-1a1-dashboard.test.ts
@@ -29,8 +29,11 @@ const read = (rel: string): string => fs.readFileSync(path.join(PROJECT_ROOT, re
 
 // ── [1] Página llama a getFinanceDashboard y propaga alerts/receivables ─────
 
-describe('finanzas/resumen/page.tsx — wiring del dashboard', () => {
-  const src = read('src/app/admin/(dashboard)/finanzas/resumen/page.tsx');
+// Nota: el control mensual se movió de /admin/finanzas/resumen a /admin/finanzas/mes
+// en el rediseño del resumen V2. Estos wiring checks se mantienen apuntando a la nueva
+// ubicación para asegurar que no hay regresión en la pantalla mensual.
+describe('finanzas/mes/page.tsx — wiring del control mensual', () => {
+  const src = read('src/app/admin/(dashboard)/finanzas/mes/page.tsx');
 
   it('[1a] importa getFinanceDashboard desde @/lib/queries/financeDashboard', () => {
     expect(src).toMatch(/import\s*\{\s*getFinanceDashboard\s*\}\s*from\s*['"]@\/lib\/queries\/financeDashboard['"]/);

--- a/src/__tests__/server/audit-finanzas-1a2-dedup.test.ts
+++ b/src/__tests__/server/audit-finanzas-1a2-dedup.test.ts
@@ -90,35 +90,35 @@ describe('[Fase 1A.2] Deduplicación dashboard financiero — verificación est�
     });
   });
 
-  // ── 4. /admin/finanzas/resumen intacto ─────────────────────────────────────
+  // ── 4. /admin/finanzas/mes intacto (movido en PR B/3 del resumen V2) ──────
 
-  describe('/admin/finanzas/resumen sigue siendo la home financiera funcional', () => {
-    const resumen = read('src/app/admin/(dashboard)/finanzas/resumen/page.tsx');
+  describe('/admin/finanzas/mes sigue siendo el control mensual funcional', () => {
+    const mensual = read('src/app/admin/(dashboard)/finanzas/mes/page.tsx');
 
     it('mantiene requirePermission("facturacion", "read")', () => {
-      expect(resumen).toMatch(
+      expect(mensual).toMatch(
         /requirePermission\(\s*['"]facturacion['"]\s*,\s*['"]read['"]\s*\)/,
       );
     });
 
     it('renderiza FinanceMonthlyControl', () => {
-      expect(resumen).toMatch(/FinanceMonthlyControl/);
+      expect(mensual).toMatch(/FinanceMonthlyControl/);
     });
 
     it('sigue invocando las queries del control mensual', () => {
-      expect(resumen).toMatch(/getMonthlyFinanceFlow/);
-      expect(resumen).toMatch(/getFinanceStockKPIs/);
-      expect(resumen).toMatch(/getMonthlyExpenseBreakdown/);
-      expect(resumen).toMatch(/getMonthlyDocs/);
+      expect(mensual).toMatch(/getMonthlyFinanceFlow/);
+      expect(mensual).toMatch(/getFinanceStockKPIs/);
+      expect(mensual).toMatch(/getMonthlyExpenseBreakdown/);
+      expect(mensual).toMatch(/getMonthlyDocs/);
     });
 
     it('sigue invocando getFinanceDashboard() para alerts + receivables', () => {
-      expect(resumen).toMatch(/getFinanceDashboard\s*\(/);
+      expect(mensual).toMatch(/getFinanceDashboard\s*\(/);
     });
 
     it('pasa alerts y receivables como props al FinanceMonthlyControl', () => {
-      expect(resumen).toMatch(/alerts=\{dashboard\.alerts\}/);
-      expect(resumen).toMatch(/receivables=\{dashboard\.receivables\}/);
+      expect(mensual).toMatch(/alerts=\{dashboard\.alerts\}/);
+      expect(mensual).toMatch(/receivables=\{dashboard\.receivables\}/);
     });
   });
 

--- a/src/__tests__/server/finance-resumen.test.ts
+++ b/src/__tests__/server/finance-resumen.test.ts
@@ -261,11 +261,11 @@ describe('FinanzasNav — etiquetas de tabs', () => {
   );
   const source = fs.readFileSync(navPath, 'utf-8');
 
+  it('tab "Resumen" (nueva V2 YTD) existe', () => { expect(source).toContain("label: 'Resumen'"); });
   it('tab "Control mensual" existe', () => { expect(source).toContain('Control mensual'); });
   it('tab "Histórico mensual" existe', () => { expect(source).toContain('Histórico mensual'); });
   it('tab "Gastos y clasificación" existe', () => { expect(source).toContain('Gastos y clasificación'); });
   it('tab "Importar documentos" existe', () => { expect(source).toContain('Importar documentos'); });
-  it('tab antiguo "Resumen" eliminado', () => { expect(source).not.toContain("label: 'Resumen'"); });
   it('tab antiguo "Resultados" eliminado', () => { expect(source).not.toContain("label: 'Resultados'"); });
   it('tab antiguo "Herramientas" eliminado', () => { expect(source).not.toContain("label: 'Herramientas'"); });
 });

--- a/src/__tests__/server/finanzas-resumen-v2-ui.test.ts
+++ b/src/__tests__/server/finanzas-resumen-v2-ui.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Tests estáticos para la UI del nuevo `/admin/finanzas/resumen` (PR B/3).
+ *
+ * Cubre:
+ *   - `page.tsx` nuevo llama a `getFinanzasResumenV2()` y renderiza los 6 bloques.
+ *   - El resumen mensual actual se mueve a `/admin/finanzas/mes`.
+ *   - FinanzasNav incluye tab "Resumen" y "Control mensual" con href `/mes`.
+ *   - Los 6 componentes de bloques existen como Server Components (sin
+ *     `'use client'`, sin `useState`, sin `useEffect`).
+ *   - Anti-scope-creep: sin schema/cron/Resend/emails.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const PROJECT_ROOT = path.resolve(__dirname, '..', '..', '..');
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(PROJECT_ROOT, rel), 'utf-8');
+}
+
+function exists(rel: string): boolean {
+  return fs.existsSync(path.join(PROJECT_ROOT, rel));
+}
+
+// ── Nuevo /admin/finanzas/resumen ─────────────────────────────────────────
+
+describe('[Resumen V2] /admin/finanzas/resumen', () => {
+  const resumenSrc = read('src/app/admin/(dashboard)/finanzas/resumen/page.tsx');
+
+  it('requirePermission("facturacion", "read")', () => {
+    expect(resumenSrc).toMatch(/requirePermission\(\s*['"]facturacion['"]\s*,\s*['"]read['"]\s*\)/);
+  });
+
+  it('importa y llama a getFinanzasResumenV2()', () => {
+    expect(resumenSrc).toMatch(/from\s+['"]@\/lib\/queries\/financeDashboard\/finanzasResumenV2['"]/);
+    expect(resumenSrc).toMatch(/getFinanzasResumenV2\s*\(/);
+  });
+
+  it('renderiza los 6 bloques', () => {
+    expect(resumenSrc).toMatch(/ResumenIngresosBlock/);
+    expect(resumenSrc).toMatch(/ResumenCostesMargenBlock/);
+    expect(resumenSrc).toMatch(/ResumenNominasBlock/);
+    expect(resumenSrc).toMatch(/ResumenImpuestosBlock/);
+    expect(resumenSrc).toMatch(/ResumenOperativosBlock/);
+    expect(resumenSrc).toMatch(/ResumenResultadoBlock/);
+  });
+
+  it("no declara 'use client'", () => {
+    expect(resumenSrc.split('\n')[0]?.trim()).not.toBe("'use client';");
+    expect(resumenSrc).not.toMatch(/^['"]use client['"];/m);
+  });
+});
+
+// ── Resumen mensual movido a /admin/finanzas/mes ──────────────────────────
+
+describe('[Resumen V2] /admin/finanzas/mes (mensual)', () => {
+  it('existe la página en la nueva ubicación', () => {
+    expect(exists('src/app/admin/(dashboard)/finanzas/mes/page.tsx')).toBe(true);
+  });
+
+  it('el mensual sigue usando FinanceMonthlyControl', () => {
+    const src = read('src/app/admin/(dashboard)/finanzas/mes/page.tsx');
+    expect(src).toMatch(/FinanceMonthlyControl/);
+    expect(src).toMatch(/getMonthlyFinanceFlow/);
+    expect(src).toMatch(/getFinanceStockKPIs/);
+    expect(src).toMatch(/getFinanceDashboard/);
+  });
+
+  it('MonthSelector navega a /admin/finanzas/mes (no al viejo resumen)', () => {
+    const src = read('src/features/admin/finance-dashboard/components/FinanceMonthlyControl.tsx');
+    expect(src).toMatch(/\/admin\/finanzas\/mes/);
+    expect(src).not.toMatch(/\/admin\/finanzas\/resumen\?mes=/);
+  });
+});
+
+// ── FinanzasNav ────────────────────────────────────────────────────────────
+
+describe('[Resumen V2] FinanzasNav', () => {
+  const nav = read('src/app/admin/(dashboard)/finanzas/FinanzasNav.tsx');
+
+  it('incluye tab "Resumen" con href /admin/finanzas/resumen', () => {
+    expect(nav).toMatch(/href:\s*['"]\/admin\/finanzas\/resumen['"]/);
+    expect(nav).toMatch(/label:\s*['"]Resumen['"]/);
+  });
+
+  it('incluye tab "Control mensual" con href /admin/finanzas/mes', () => {
+    expect(nav).toMatch(/href:\s*['"]\/admin\/finanzas\/mes['"]/);
+    expect(nav).toMatch(/label:\s*['"]Control mensual['"]/);
+  });
+});
+
+// ── Componentes de bloques ────────────────────────────────────────────────
+
+describe('[Resumen V2] componentes de bloques', () => {
+  const blocks = [
+    'src/features/admin/finance-dashboard/components/resumen-v2/SectionCard.tsx',
+    'src/features/admin/finance-dashboard/components/resumen-v2/ResumenIngresosBlock.tsx',
+    'src/features/admin/finance-dashboard/components/resumen-v2/ResumenCostesMargenBlock.tsx',
+    'src/features/admin/finance-dashboard/components/resumen-v2/ResumenNominasBlock.tsx',
+    'src/features/admin/finance-dashboard/components/resumen-v2/ResumenImpuestosBlock.tsx',
+    'src/features/admin/finance-dashboard/components/resumen-v2/ResumenOperativosBlock.tsx',
+    'src/features/admin/finance-dashboard/components/resumen-v2/ResumenResultadoBlock.tsx',
+  ];
+
+  it.each(blocks)('%s existe', (rel) => {
+    expect(exists(rel)).toBe(true);
+  });
+
+  it.each(blocks)('%s es Server Component (sin "use client", sin useState/useEffect)', (rel) => {
+    const src = read(rel);
+    expect(src.split('\n')[0]?.trim()).not.toBe("'use client';");
+    expect(src).not.toMatch(/^['"]use client['"];/m);
+    expect(src).not.toMatch(/useState\(/);
+    expect(src).not.toMatch(/useEffect\(/);
+  });
+});
+
+// ── revalidatePath incluye /mes ──────────────────────────────────────────
+
+describe('[Resumen V2] revalidatePath actualizado', () => {
+  it('finanzas-actions.ts revalida /admin/finanzas/mes', () => {
+    const src = read('src/app/admin/(dashboard)/finanzas/finanzas-actions.ts');
+    expect(src).toMatch(/revalidatePath\(['"]\/admin\/finanzas\/mes['"]\)/);
+  });
+
+  it('setup-2026/actions.ts revalida /admin/finanzas/mes', () => {
+    const src = read('src/app/admin/(dashboard)/finanzas/setup-2026/actions.ts');
+    expect(src).toMatch(/revalidatePath\(['"]\/admin\/finanzas\/mes['"]\)/);
+  });
+});
+
+// ── Anti-scope-creep ─────────────────────────────────────────────────────
+
+describe('[Resumen V2] anti-scope-creep', () => {
+  const files = [
+    'src/app/admin/(dashboard)/finanzas/resumen/page.tsx',
+    'src/app/admin/(dashboard)/finanzas/mes/page.tsx',
+    'src/features/admin/finance-dashboard/components/resumen-v2/ResumenIngresosBlock.tsx',
+    'src/features/admin/finance-dashboard/components/resumen-v2/ResumenCostesMargenBlock.tsx',
+    'src/features/admin/finance-dashboard/components/resumen-v2/ResumenNominasBlock.tsx',
+    'src/features/admin/finance-dashboard/components/resumen-v2/ResumenImpuestosBlock.tsx',
+    'src/features/admin/finance-dashboard/components/resumen-v2/ResumenOperativosBlock.tsx',
+    'src/features/admin/finance-dashboard/components/resumen-v2/ResumenResultadoBlock.tsx',
+  ];
+
+  it.each(files)('%s no importa Resend/emails/dunning/invoice_reminders', (rel) => {
+    const src = read(rel);
+    expect(src).not.toMatch(/from\s+['"]resend['"]/);
+    expect(src).not.toMatch(/@\/lib\/email/);
+    expect(src).not.toMatch(/sendEmail/);
+    expect(src).not.toMatch(/invoice_reminders/);
+    expect(src).not.toMatch(/dunning/i);
+  });
+
+  it('no se ha creado ninguna migration nueva para PR B', () => {
+    const src = read('src/lib/queries/financeDashboard/finanzasResumenV2.ts');
+    expect(src).not.toMatch(/pgTable\s*\(/);
+    expect(src).not.toMatch(/alterTable/);
+  });
+});

--- a/src/app/admin/(dashboard)/finanzas/FinanzasNav.tsx
+++ b/src/app/admin/(dashboard)/finanzas/FinanzasNav.tsx
@@ -10,7 +10,8 @@ type Tab = {
 };
 
 const TABS: readonly Tab[] = [
-  { href: '/admin/finanzas/resumen', label: 'Control mensual' },
+  { href: '/admin/finanzas/resumen', label: 'Resumen' },
+  { href: '/admin/finanzas/mes', label: 'Control mensual' },
   { href: '/admin/finanzas/cobros', label: 'Cobros pendientes' },
   { href: '/admin/finanzas/pl', label: 'Histórico mensual' },
   {

--- a/src/app/admin/(dashboard)/finanzas/finanzas-actions.ts
+++ b/src/app/admin/(dashboard)/finanzas/finanzas-actions.ts
@@ -67,6 +67,7 @@ export async function classifyExpensesAction(
 
   revalidatePath('/admin/finanzas');
   revalidatePath('/admin/finanzas/resumen');
+  revalidatePath('/admin/finanzas/mes');
   revalidatePath('/admin/finanzas/pl');
   revalidatePath('/admin/finanzas/costes');
   revalidatePath('/admin/finanzas/gastos-operativos');
@@ -116,6 +117,7 @@ export async function updateExpenseClassificationAction(
 
   revalidatePath('/admin/finanzas');
   revalidatePath('/admin/finanzas/resumen');
+  revalidatePath('/admin/finanzas/mes');
   revalidatePath('/admin/finanzas/pl');
   revalidatePath('/admin/finanzas/costes');
   revalidatePath('/admin/finanzas/gastos-operativos');

--- a/src/app/admin/(dashboard)/finanzas/mes/page.tsx
+++ b/src/app/admin/(dashboard)/finanzas/mes/page.tsx
@@ -1,0 +1,48 @@
+import { requirePermission } from '@/lib/permissions';
+import {
+  getMonthlyFinanceFlow,
+  getFinanceStockKPIs,
+  getMonthlyExpenseBreakdown,
+  getMonthlyDocs,
+  parseYearMonth,
+  monthRange,
+} from '@/lib/queries/financeDashboard/financeResumen';
+import { getFinanceDashboard } from '@/lib/queries/financeDashboard';
+import { FinanceMonthlyControl } from '@/features/admin/finance-dashboard/components/FinanceMonthlyControl';
+
+export const metadata = { title: 'Control mensual · Finanzas' };
+
+type PageProps = {
+  readonly searchParams?: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export default async function FinanzasResumenPage({ searchParams }: PageProps): Promise<React.ReactElement> {
+  await requirePermission('facturacion', 'read');
+
+  const sp = (await searchParams) ?? {};
+  const rawMes = Array.isArray(sp.mes) ? sp.mes[0] : sp.mes;
+  const mes = parseYearMonth(rawMes);
+  const { from, to } = monthRange(mes);
+
+  const [flow, stock, breakdown, docs, dashboard] = await Promise.all([
+    getMonthlyFinanceFlow(from, to),
+    getFinanceStockKPIs(),
+    getMonthlyExpenseBreakdown(from, to),
+    getMonthlyDocs(from, to),
+    getFinanceDashboard(),
+  ]);
+
+  return (
+    <div className="space-y-6 pt-2">
+      <FinanceMonthlyControl
+        mes={mes}
+        flow={flow}
+        stock={stock}
+        breakdown={breakdown}
+        docs={docs}
+        alerts={dashboard.alerts}
+        receivables={dashboard.receivables}
+      />
+    </div>
+  );
+}

--- a/src/app/admin/(dashboard)/finanzas/resumen/page.tsx
+++ b/src/app/admin/(dashboard)/finanzas/resumen/page.tsx
@@ -1,47 +1,55 @@
 import { requirePermission } from '@/lib/permissions';
-import {
-  getMonthlyFinanceFlow,
-  getFinanceStockKPIs,
-  getMonthlyExpenseBreakdown,
-  getMonthlyDocs,
-  parseYearMonth,
-  monthRange,
-} from '@/lib/queries/financeDashboard/financeResumen';
-import { getFinanceDashboard } from '@/lib/queries/financeDashboard';
-import { FinanceMonthlyControl } from '@/features/admin/finance-dashboard/components/FinanceMonthlyControl';
+import { getFinanzasResumenV2 } from '@/lib/queries/financeDashboard/finanzasResumenV2';
+import { ResumenIngresosBlock } from '@/features/admin/finance-dashboard/components/resumen-v2/ResumenIngresosBlock';
+import { ResumenCostesMargenBlock } from '@/features/admin/finance-dashboard/components/resumen-v2/ResumenCostesMargenBlock';
+import { ResumenNominasBlock } from '@/features/admin/finance-dashboard/components/resumen-v2/ResumenNominasBlock';
+import { ResumenImpuestosBlock } from '@/features/admin/finance-dashboard/components/resumen-v2/ResumenImpuestosBlock';
+import { ResumenOperativosBlock } from '@/features/admin/finance-dashboard/components/resumen-v2/ResumenOperativosBlock';
+import { ResumenResultadoBlock } from '@/features/admin/finance-dashboard/components/resumen-v2/ResumenResultadoBlock';
 
-export const metadata = { title: 'Finanzas' };
+export const metadata = { title: 'Resumen · Finanzas' };
 
-type PageProps = {
-  readonly searchParams?: Promise<Record<string, string | string[] | undefined>>;
-};
+function monthLabel(iso: string): string {
+  const [y, m, d] = iso.split('-').map(Number);
+  if (!y || !m || !d) return iso;
+  return new Date(y, m - 1, d).toLocaleDateString('es-ES', { day: '2-digit', month: 'short', year: 'numeric' });
+}
 
-export default async function FinanzasResumenPage({ searchParams }: PageProps): Promise<React.ReactElement> {
+export default async function FinanzasResumenPage(): Promise<React.ReactElement> {
   await requirePermission('facturacion', 'read');
 
-  const sp = (await searchParams) ?? {};
-  const rawMes = Array.isArray(sp.mes) ? sp.mes[0] : sp.mes;
-  const mes = parseYearMonth(rawMes);
-  const { from, to } = monthRange(mes);
-
-  const [flow, stock, breakdown, docs, dashboard] = await Promise.all([
-    getMonthlyFinanceFlow(from, to),
-    getFinanceStockKPIs(),
-    getMonthlyExpenseBreakdown(from, to),
-    getMonthlyDocs(from, to),
-    getFinanceDashboard(),
-  ]);
+  const data = await getFinanzasResumenV2();
 
   return (
-    <div className="space-y-6 pt-2">
-      <FinanceMonthlyControl
-        mes={mes}
-        flow={flow}
-        stock={stock}
-        breakdown={breakdown}
-        docs={docs}
-        alerts={dashboard.alerts}
-        receivables={dashboard.receivables}
+    <div className="space-y-5 pt-2">
+      <header className="flex items-start justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-bold text-sp-admin-fg">Resumen económico</h1>
+          <p className="text-sm text-sp-admin-muted">
+            {monthLabel(data.period.from)} — {monthLabel(data.period.to)}
+          </p>
+        </div>
+      </header>
+
+      <ResumenIngresosBlock ingresos={data.ingresos} />
+
+      <ResumenCostesMargenBlock
+        costesDirectos={data.costesDirectos}
+        margenBruto={data.margenBruto}
+      />
+
+      <ResumenNominasBlock nominas={data.nominas} />
+
+      <ResumenImpuestosBlock impuestos={data.impuestos} />
+
+      <ResumenOperativosBlock operativos={data.operativos} />
+
+      <ResumenResultadoBlock
+        margenBruto={data.margenBruto}
+        nominas={data.nominas}
+        impuestos={data.impuestos}
+        operativos={data.operativos}
+        resultado={data.resultado}
       />
     </div>
   );

--- a/src/app/admin/(dashboard)/finanzas/setup-2026/actions.ts
+++ b/src/app/admin/(dashboard)/finanzas/setup-2026/actions.ts
@@ -134,6 +134,7 @@ export async function applySetup2026Action(
 
   revalidatePath('/admin/finanzas');
   revalidatePath('/admin/finanzas/resumen');
+  revalidatePath('/admin/finanzas/mes');
   revalidatePath('/admin/finanzas/pl');
   revalidatePath('/admin/finanzas/gastos-operativos');
 

--- a/src/features/admin/finance-dashboard/components/FinanceMonthlyControl.tsx
+++ b/src/features/admin/finance-dashboard/components/FinanceMonthlyControl.tsx
@@ -118,7 +118,7 @@ function MonthSelector({ mes }: { readonly mes: string }): React.ReactElement {
   return (
     <select
       value={mes}
-      onChange={(e) => router.push(`/admin/finanzas/resumen?mes=${e.target.value}`)}
+      onChange={(e) => router.push(`/admin/finanzas/mes?mes=${e.target.value}`)}
       className="rounded-lg border border-sp-admin-border bg-sp-admin-card px-3 py-1.5 text-sm font-medium text-sp-admin-fg focus:outline-none focus:ring-1 focus:ring-sp-orange"
       aria-label="Seleccionar mes"
     >

--- a/src/features/admin/finance-dashboard/components/resumen-v2/ResumenCostesMargenBlock.tsx
+++ b/src/features/admin/finance-dashboard/components/resumen-v2/ResumenCostesMargenBlock.tsx
@@ -1,0 +1,81 @@
+import type { FinanzasResumenCostesDirectos, FinanzasResumenMargenBruto } from '@/types/finanzasResumen';
+import { SectionCard } from './SectionCard';
+
+const EUR = new Intl.NumberFormat('es-ES', {
+  style: 'currency', currency: 'EUR', maximumFractionDigits: 0,
+});
+
+type Props = {
+  readonly costesDirectos: FinanzasResumenCostesDirectos;
+  readonly margenBruto:    FinanzasResumenMargenBruto;
+};
+
+export function ResumenCostesMargenBlock({ costesDirectos, margenBruto }: Props): React.ReactElement {
+  return (
+    <SectionCard title="Costes directos de campaña + Margen bruto" subtitle="Lo que pagamos a talentos y produce cada trato, y el margen que queda">
+      <dl className="grid grid-cols-1 gap-3 md:grid-cols-2">
+        <div className="space-y-3">
+          <p className="text-[10px] font-semibold uppercase tracking-widest text-sp-admin-muted">
+            Costes directos
+          </p>
+          <LineRow label="Pagos a talentos (pagados)" amount={costesDirectos.pagosTalento.pagados} accent="expense" />
+          <LineRow label="Pagos a talentos (pendientes)" amount={costesDirectos.pagosTalento.pendientes} accent="warn" />
+          {(costesDirectos.costesProduccion.pagados > 0 || costesDirectos.costesProduccion.pendientes > 0) && (
+            <>
+              <LineRow label="Costes producción (pagados)" amount={costesDirectos.costesProduccion.pagados} accent="expense" />
+              <LineRow label="Costes producción (pendientes)" amount={costesDirectos.costesProduccion.pendientes} accent="warn" />
+            </>
+          )}
+          <div className="mt-2 border-t border-sp-admin-border/40 pt-2">
+            <LineRow label="Total costes directos" amount={costesDirectos.total} accent="expense" strong />
+          </div>
+        </div>
+
+        <div className="space-y-3">
+          <p className="text-[10px] font-semibold uppercase tracking-widest text-sp-admin-muted">
+            Margen bruto
+          </p>
+          <LineRow
+            label="Margen bruto cobrado"
+            amount={margenBruto.cobrado}
+            accent={margenBruto.cobrado >= 0 ? 'income' : 'expense'}
+            strong
+          />
+          <p className="text-[10px] italic text-sp-admin-muted">
+            = ingresos cobrados − costes directos pagados
+          </p>
+          <LineRow
+            label="Margen bruto pendiente (estimado)"
+            amount={margenBruto.pendiente}
+            accent={margenBruto.pendiente >= 0 ? 'warn' : 'expense'}
+          />
+          <p className="text-[10px] italic text-sp-admin-muted">
+            = pendiente cobrar − pendiente pagar directo
+          </p>
+        </div>
+      </dl>
+    </SectionCard>
+  );
+}
+
+type Accent = 'income' | 'expense' | 'warn' | 'neutral';
+
+function LineRow({ label, amount, accent, strong }: {
+  readonly label: string;
+  readonly amount: number;
+  readonly accent: Accent;
+  readonly strong?: boolean;
+}): React.ReactElement {
+  const color =
+    accent === 'income'  ? 'text-emerald-400'
+    : accent === 'expense' ? 'text-red-400'
+    : accent === 'warn'  ? 'text-amber-400'
+    :                       'text-sp-admin-fg';
+
+  return (
+    <div className="flex items-baseline justify-between gap-3 text-sm">
+      <span className={strong ? 'font-semibold text-sp-admin-fg' : 'text-sp-admin-fg'}>{label}</span>
+      <span className={`tabular-nums ${color} ${strong ? 'font-black' : ''}`}>{EUR.format(amount)}</span>
+    </div>
+  );
+}

--- a/src/features/admin/finance-dashboard/components/resumen-v2/ResumenImpuestosBlock.tsx
+++ b/src/features/admin/finance-dashboard/components/resumen-v2/ResumenImpuestosBlock.tsx
@@ -1,0 +1,57 @@
+import type { FinanzasResumenImpuestos } from '@/types/finanzasResumen';
+import { SectionCard } from './SectionCard';
+
+const EUR = new Intl.NumberFormat('es-ES', {
+  style: 'currency', currency: 'EUR', maximumFractionDigits: 0,
+});
+
+type Props = { readonly impuestos: FinanzasResumenImpuestos };
+
+export function ResumenImpuestosBlock({ impuestos }: Props): React.ReactElement {
+  if (impuestos.count === 0) {
+    return (
+      <SectionCard title="Impuestos y cargas" subtitle="Autónomos, Seguridad Social, fiscal">
+        <p className="py-2 text-center text-sm text-sp-admin-muted">No hay impuestos ni cargas registradas.</p>
+      </SectionCard>
+    );
+  }
+
+  return (
+    <SectionCard title="Impuestos y cargas" subtitle="Autónomos, Seguridad Social, fiscal">
+      <ul className="space-y-2">
+        {impuestos.cuotaAutonomoPablo > 0 && (
+          <Line label="Cuota autónomo Pablo" amount={impuestos.cuotaAutonomoPablo} />
+        )}
+        {impuestos.cuotaAutonomoAlfonso > 0 && (
+          <Line label="Cuota autónomo Alfonso" amount={impuestos.cuotaAutonomoAlfonso} />
+        )}
+        {impuestos.cuotaAutonomoOtros > 0 && (
+          <Line label="Cuota autónomo (sin identificar)" amount={impuestos.cuotaAutonomoOtros} muted />
+        )}
+        {impuestos.seguridadSocial > 0 && (
+          <Line label="Seguridad Social" amount={impuestos.seguridadSocial} />
+        )}
+        {impuestos.fiscal > 0 && (
+          <Line label="Fiscal / impuestos" amount={impuestos.fiscal} />
+        )}
+        <li className="mt-2 flex items-baseline justify-between gap-3 border-t border-sp-admin-border/40 pt-2 text-sm">
+          <span className="font-semibold text-sp-admin-fg">Total impuestos y cargas</span>
+          <span className="tabular-nums font-black text-orange-400">{EUR.format(impuestos.total)}</span>
+        </li>
+      </ul>
+    </SectionCard>
+  );
+}
+
+function Line({ label, amount, muted }: {
+  readonly label: string;
+  readonly amount: number;
+  readonly muted?: boolean;
+}): React.ReactElement {
+  return (
+    <li className="flex items-baseline justify-between gap-3 text-sm">
+      <span className={muted ? 'text-sp-admin-muted' : 'text-sp-admin-fg'}>{label}</span>
+      <span className={`tabular-nums ${muted ? 'text-sp-admin-muted' : 'text-orange-400'}`}>{EUR.format(amount)}</span>
+    </li>
+  );
+}

--- a/src/features/admin/finance-dashboard/components/resumen-v2/ResumenIngresosBlock.tsx
+++ b/src/features/admin/finance-dashboard/components/resumen-v2/ResumenIngresosBlock.tsx
@@ -1,0 +1,47 @@
+import type { FinanzasResumenIngresos } from '@/types/finanzasResumen';
+import { SectionCard } from './SectionCard';
+
+const EUR = new Intl.NumberFormat('es-ES', {
+  style: 'currency', currency: 'EUR', maximumFractionDigits: 0,
+});
+
+type Props = { readonly ingresos: FinanzasResumenIngresos };
+
+export function ResumenIngresosBlock({ ingresos }: Props): React.ReactElement {
+  return (
+    <SectionCard title="Ingresos" subtitle="Cobrado y facturado en el periodo">
+      <dl className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        <Row label="Cobrados en el año" amount={ingresos.cobrados} accent="income" hint="Entradas reales en caja" />
+        <Row label="Pendientes de cobro" amount={ingresos.pendientes} accent={ingresos.pendientes > 0 ? 'warn' : 'neutral'} hint="Facturado − cobrado" />
+        <Row label="Total facturado" amount={ingresos.facturados} accent="neutral" hint="Base devengado" />
+      </dl>
+    </SectionCard>
+  );
+}
+
+// ── Row ────────────────────────────────────────────────────────────────────
+
+type Accent = 'income' | 'expense' | 'warn' | 'neutral';
+
+function Row({ label, amount, accent, hint }: {
+  readonly label: string;
+  readonly amount: number;
+  readonly accent: Accent;
+  readonly hint?: string;
+}): React.ReactElement {
+  const color =
+    accent === 'income'  ? 'text-emerald-400'
+    : accent === 'expense' ? 'text-red-400'
+    : accent === 'warn'  ? 'text-amber-400'
+    :                       'text-sp-admin-fg';
+
+  return (
+    <div className="flex flex-col gap-1 rounded-xl border border-sp-admin-border/60 p-3">
+      <dt className="text-[10px] font-semibold uppercase tracking-[0.15em] text-sp-admin-muted">
+        {label}
+      </dt>
+      <dd className={`text-2xl font-black tabular-nums ${color}`}>{EUR.format(amount)}</dd>
+      {hint && <dd className="text-[10px] text-sp-admin-muted">{hint}</dd>}
+    </div>
+  );
+}

--- a/src/features/admin/finance-dashboard/components/resumen-v2/ResumenNominasBlock.tsx
+++ b/src/features/admin/finance-dashboard/components/resumen-v2/ResumenNominasBlock.tsx
@@ -1,0 +1,47 @@
+import type { FinanzasResumenNominas } from '@/types/finanzasResumen';
+import { SectionCard } from './SectionCard';
+
+const EUR = new Intl.NumberFormat('es-ES', {
+  style: 'currency', currency: 'EUR', maximumFractionDigits: 0,
+});
+
+type Props = { readonly nominas: FinanzasResumenNominas };
+
+export function ResumenNominasBlock({ nominas }: Props): React.ReactElement {
+  if (nominas.count === 0) {
+    return (
+      <SectionCard title="Nóminas socios" subtitle="Nóminas registradas en el periodo">
+        <p className="py-2 text-center text-sm text-sp-admin-muted">No hay nóminas registradas en este rango.</p>
+      </SectionCard>
+    );
+  }
+
+  return (
+    <SectionCard title="Nóminas socios" subtitle="Dinero que cobramos como socios de la empresa">
+      <ul className="space-y-2">
+        <Line label="Nóminas Pablo" amount={nominas.pablo} />
+        <Line label="Nóminas Alfonso" amount={nominas.alfonso} />
+        {nominas.otros > 0 && (
+          <Line label="Nóminas (sin identificar)" amount={nominas.otros} muted />
+        )}
+        <li className="mt-2 flex items-baseline justify-between gap-3 border-t border-sp-admin-border/40 pt-2 text-sm">
+          <span className="font-semibold text-sp-admin-fg">Total nóminas</span>
+          <span className="tabular-nums font-black text-red-400">{EUR.format(nominas.total)}</span>
+        </li>
+      </ul>
+    </SectionCard>
+  );
+}
+
+function Line({ label, amount, muted }: {
+  readonly label: string;
+  readonly amount: number;
+  readonly muted?: boolean;
+}): React.ReactElement {
+  return (
+    <li className="flex items-baseline justify-between gap-3 text-sm">
+      <span className={muted ? 'text-sp-admin-muted' : 'text-sp-admin-fg'}>{label}</span>
+      <span className={`tabular-nums ${muted ? 'text-sp-admin-muted' : 'text-red-400'}`}>{EUR.format(amount)}</span>
+    </li>
+  );
+}

--- a/src/features/admin/finance-dashboard/components/resumen-v2/ResumenOperativosBlock.tsx
+++ b/src/features/admin/finance-dashboard/components/resumen-v2/ResumenOperativosBlock.tsx
@@ -1,0 +1,58 @@
+import type { FinanzasResumenOperativos } from '@/types/finanzasResumen';
+import { SectionCard } from './SectionCard';
+
+const EUR = new Intl.NumberFormat('es-ES', {
+  style: 'currency', currency: 'EUR', maximumFractionDigits: 0,
+});
+
+type Props = { readonly operativos: FinanzasResumenOperativos };
+
+export function ResumenOperativosBlock({ operativos }: Props): React.ReactElement {
+  if (operativos.count === 0) {
+    return (
+      <SectionCard title="Gastos operativos" subtitle="Gestoría, software, hosting, seguros, comisiones, marketing">
+        <p className="py-2 text-center text-sm text-sp-admin-muted">No hay gastos operativos en este rango.</p>
+      </SectionCard>
+    );
+  }
+
+  const items: Array<[string, number]> = [
+    ['Gestoría',            operativos.gestoria],
+    ['Software / IA',       operativos.softwareIa],
+    ['Hosting / dominio',   operativos.hostingDominio],
+    ['Seguro médico',       operativos.seguroMedico],
+    ['Comisiones bancarias', operativos.comisiones],
+    ['Marketing',           operativos.marketing],
+    ['Otros gastos',        operativos.otros],
+  ];
+
+  return (
+    <SectionCard title="Gastos operativos" subtitle="Gastos reales de empresa (no nóminas ni impuestos)">
+      <ul className="space-y-2">
+        {items.map(([label, amount]) => amount > 0 && (
+          <Line key={label} label={label} amount={amount} />
+        ))}
+        {operativos.sinClasificar > 0 && (
+          <Line label="Sin clasificar" amount={operativos.sinClasificar} amber />
+        )}
+        <li className="mt-2 flex items-baseline justify-between gap-3 border-t border-sp-admin-border/40 pt-2 text-sm">
+          <span className="font-semibold text-sp-admin-fg">Total gastos operativos</span>
+          <span className="tabular-nums font-black text-red-400">{EUR.format(operativos.total)}</span>
+        </li>
+      </ul>
+    </SectionCard>
+  );
+}
+
+function Line({ label, amount, amber }: {
+  readonly label: string;
+  readonly amount: number;
+  readonly amber?: boolean;
+}): React.ReactElement {
+  return (
+    <li className="flex items-baseline justify-between gap-3 text-sm">
+      <span className={amber ? 'text-amber-400' : 'text-sp-admin-fg'}>{label}</span>
+      <span className={`tabular-nums ${amber ? 'text-amber-400' : 'text-red-400'}`}>{EUR.format(amount)}</span>
+    </li>
+  );
+}

--- a/src/features/admin/finance-dashboard/components/resumen-v2/ResumenResultadoBlock.tsx
+++ b/src/features/admin/finance-dashboard/components/resumen-v2/ResumenResultadoBlock.tsx
@@ -1,0 +1,73 @@
+import type {
+  FinanzasResumenImpuestos,
+  FinanzasResumenMargenBruto,
+  FinanzasResumenNominas,
+  FinanzasResumenOperativos,
+  FinanzasResumenResultado,
+} from '@/types/finanzasResumen';
+import { SectionCard } from './SectionCard';
+
+const EUR = new Intl.NumberFormat('es-ES', {
+  style: 'currency', currency: 'EUR', maximumFractionDigits: 0,
+});
+
+type Props = {
+  readonly margenBruto: FinanzasResumenMargenBruto;
+  readonly nominas:     FinanzasResumenNominas;
+  readonly impuestos:   FinanzasResumenImpuestos;
+  readonly operativos:  FinanzasResumenOperativos;
+  readonly resultado:   FinanzasResumenResultado;
+};
+
+export function ResumenResultadoBlock({ margenBruto, nominas, impuestos, operativos, resultado }: Props): React.ReactElement {
+  const positive = resultado.operativo >= 0;
+  const bigColor = positive ? 'text-emerald-400' : 'text-red-400';
+  const borderColor = positive ? 'border-emerald-500/40' : 'border-red-500/40';
+
+  return (
+    <SectionCard title="Resultado operativo" subtitle="Lo que queda después de nóminas, impuestos y gastos operativos">
+      <div className={`rounded-xl border ${borderColor} bg-sp-admin-card p-5`}>
+        <div className="flex items-baseline justify-between gap-3">
+          <span className="text-[11px] font-semibold uppercase tracking-[0.16em] text-sp-admin-muted">
+            Resultado operativo (base caja)
+          </span>
+          <span className={`text-4xl font-black tabular-nums ${bigColor}`}>
+            {EUR.format(resultado.operativo)}
+          </span>
+        </div>
+      </div>
+
+      <details className="mt-4 rounded-xl border border-sp-admin-border/60">
+        <summary className="cursor-pointer list-none px-4 py-2 text-xs text-sp-admin-muted hover:text-sp-admin-fg">
+          Ver cómo se calcula
+        </summary>
+        <ul className="space-y-1.5 px-4 py-3 text-xs">
+          <FormulaRow label="Margen bruto cobrado" amount={margenBruto.cobrado} sign="+" />
+          <FormulaRow label="Nóminas socios"       amount={nominas.total}       sign="−" />
+          <FormulaRow label="Impuestos y cargas"   amount={impuestos.total}     sign="−" />
+          <FormulaRow label="Gastos operativos"    amount={operativos.total}    sign="−" />
+          <li className="mt-2 flex items-baseline justify-between gap-3 border-t border-sp-admin-border/40 pt-2 text-sm">
+            <span className="font-semibold text-sp-admin-fg">= Resultado operativo</span>
+            <span className={`tabular-nums font-black ${bigColor}`}>{EUR.format(resultado.operativo)}</span>
+          </li>
+        </ul>
+      </details>
+    </SectionCard>
+  );
+}
+
+function FormulaRow({ label, amount, sign }: {
+  readonly label: string;
+  readonly amount: number;
+  readonly sign: '+' | '−';
+}): React.ReactElement {
+  return (
+    <li className="flex items-baseline justify-between gap-3">
+      <span className="text-sp-admin-fg">
+        <span className="mr-2 inline-block w-3 text-center text-sp-admin-muted">{sign}</span>
+        {label}
+      </span>
+      <span className="tabular-nums text-sp-admin-fg">{EUR.format(amount)}</span>
+    </li>
+  );
+}

--- a/src/features/admin/finance-dashboard/components/resumen-v2/SectionCard.tsx
+++ b/src/features/admin/finance-dashboard/components/resumen-v2/SectionCard.tsx
@@ -1,0 +1,29 @@
+/**
+ * Card contenedor para cada bloque del resumen económico V2.
+ * Server Component — sin `'use client'`, sin useState.
+ */
+
+type Props = {
+  readonly title: string;
+  readonly subtitle?: string;
+  readonly children: React.ReactNode;
+};
+
+export function SectionCard({ title, subtitle, children }: Props): React.ReactElement {
+  return (
+    <section
+      aria-label={title}
+      className="rounded-2xl border border-sp-admin-border bg-sp-admin-card p-5"
+    >
+      <header className="mb-4">
+        <h2 className="text-[11px] font-semibold uppercase tracking-widest text-sp-admin-muted">
+          {title}
+        </h2>
+        {subtitle && (
+          <p className="mt-0.5 text-[10px] text-sp-admin-muted/70">{subtitle}</p>
+        )}
+      </header>
+      {children}
+    </section>
+  );
+}


### PR DESCRIPTION
## Resumen

**PR B/3** del rediseño del resumen económico. Reemplaza `/admin/finanzas/resumen` por la nueva vista CEO/YTD que consume `getFinanzasResumenV2()` (mergeada en PR A/3, #152). El control mensual actual se mueve a `/admin/finanzas/mes`.

Cero DB / schema / migrations / drizzle / crons / emails / Resend / invoice_reminders / OCR / Blob / Sheets / RBAC / dunning / Tratos / facturación legal / payroll parser / endpoint recurring / query V2.

## Nueva navegación de Finanzas

```
Resumen               → /admin/finanzas/resumen  (NUEVO YTD, home CEO)
Control mensual       → /admin/finanzas/mes      (movido de /resumen)
Cobros pendientes     → /admin/finanzas/cobros
Histórico mensual     → /admin/finanzas/pl
Gastos y clasificación → /admin/finanzas/gastos
Importar documentos   → /admin/finanzas/herramientas
```

El sidebar admin sigue apuntando `Finanzas → /admin/finanzas/resumen`, que ahora es la home CEO.

## 6 bloques del nuevo resumen

Todos son **Server Components** — sin `'use client'`, sin `useState`, sin `useEffect`. El desplegable del resultado usa `<details>/<summary>` HTML nativo.

### 1. Ingresos
```
Cobrados en el año | Pendientes de cobro | Total facturado
    X €                  X €                    X €
```

### 2. Costes directos + Margen bruto
```
COSTES DIRECTOS                    MARGEN BRUTO
  Pagos a talentos (pagados)         Margen bruto cobrado   X €
  Pagos a talentos (pendientes)         = ingresos cobrados − costes pagados
  [Costes producción si existen]     Margen bruto pendiente X €
  ──────────                            = pendiente cobrar − pendiente pagar directo
  Total costes directos
```

### 3. Nóminas socios
```
Nóminas Pablo           X €
Nóminas Alfonso         X €
[Nóminas sin identificar si existen]
──────────
Total nóminas           X €
```

### 4. Impuestos y cargas
```
Cuota autónomo Pablo       X €
Cuota autónomo Alfonso     X €
[Seguridad Social si existe]
[Fiscal / impuestos si existe]
──────────
Total impuestos y cargas   X €
```

### 5. Gastos operativos
```
Gestoría                X €
Software / IA           X €
Hosting / dominio       X €
Seguro médico           X €
Comisiones bancarias    X €
Marketing               X €
Otros gastos            X €
[Sin clasificar amber si existe]
──────────
Total gastos operativos  X €
```

### 6. Resultado operativo
```
┌─────────────────────────────────────────────┐
│  RESULTADO OPERATIVO (base caja)      X €   │  ← verde si positivo, rojo si negativo
└─────────────────────────────────────────────┘
▸ Ver cómo se calcula
    + Margen bruto cobrado    X €
    − Nóminas socios          X €
    − Impuestos y cargas      X €
    − Gastos operativos       X €
    ─────────────────────────
    = Resultado operativo     X €
```

## Confirmaciones

- ✅ **Cero DB / schema / migrations / drizzle**
- ✅ **Cero crons / emails / Resend / invoice_reminders / dunning**
- ✅ Cero cambios en `getFinanzasResumenV2` (query mergeada en PR A/3, este PR solo la consume).
- ✅ **Nueva UI sin `'use client'`, sin `useState`, sin `useEffect`** — RSC + HTML nativo.
- ✅ **`receivables.ts` legacy intacto** — TD-14 sigue documentado; nuevo resumen usa `invoice_payments` como fuente canónica desde PR A.
- ✅ **Control mensual sin regresión**: el `FinanceMonthlyControl` se mueve a `/mes` con todas sus queries; el `MonthSelector` actualiza `/admin/finanzas/mes?mes=...`.
- ✅ Labels humanos: nunca strings crudos, siempre "Nóminas Pablo", "Cuota autónomo Alfonso", "Gestoría", etc.

## Archivos (17)

**Nuevos (9):**
- `src/app/admin/(dashboard)/finanzas/resumen/page.tsx` — nueva (reescrita, ~55 LOC)
- `src/app/admin/(dashboard)/finanzas/mes/page.tsx` — control mensual movido aquí
- `src/features/admin/finance-dashboard/components/resumen-v2/SectionCard.tsx`
- `src/features/admin/finance-dashboard/components/resumen-v2/ResumenIngresosBlock.tsx`
- `src/features/admin/finance-dashboard/components/resumen-v2/ResumenCostesMargenBlock.tsx`
- `src/features/admin/finance-dashboard/components/resumen-v2/ResumenNominasBlock.tsx`
- `src/features/admin/finance-dashboard/components/resumen-v2/ResumenImpuestosBlock.tsx`
- `src/features/admin/finance-dashboard/components/resumen-v2/ResumenOperativosBlock.tsx`
- `src/features/admin/finance-dashboard/components/resumen-v2/ResumenResultadoBlock.tsx`
- `src/__tests__/server/finanzas-resumen-v2-ui.test.ts` — 20 tests estáticos

**Modificados (8):**
- `src/app/admin/(dashboard)/finanzas/FinanzasNav.tsx` — +tab "Resumen", "Control mensual" → `/mes`
- `src/features/admin/finance-dashboard/components/FinanceMonthlyControl.tsx` — `MonthSelector` navega a `/mes`
- `src/app/admin/(dashboard)/finanzas/finanzas-actions.ts` — `revalidatePath('/admin/finanzas/mes')`
- `src/app/admin/(dashboard)/finanzas/setup-2026/actions.ts` — idem
- 3 tests estáticos legacy (`audit-finanzas-1a1`, `audit-finanzas-1a2`, `finance-resumen`) actualizados para reflejar la nueva ubicación del control mensual y aceptar el tab "Resumen"

## Tests

- ✅ 20 tests nuevos en `finanzas-resumen-v2-ui.test.ts`
- ✅ 3 tests legacy actualizados para no romper con la reubicación
- ✅ `npx tsc --noEmit` — clean
- ✅ `npm run lint` — 0/0
- ✅ `npm test` — 114 suites · **2063 tests** verdes
- ⚠️ Build local requiere `.env.local`; Vercel lo corre.

## Test plan post-merge

- [ ] `/admin/finanzas/resumen` carga la nueva vista con 6 bloques.
- [ ] `/admin/finanzas/mes` carga el control mensual con selector de mes funcional.
- [ ] Cambiar de mes en `/mes` navega correctamente y actualiza los KPIs.
- [ ] `FinanzasNav` muestra las 6 tabs con "Resumen" al principio.
- [ ] `Total nóminas` en el resumen coincide con lo que ves en el bloque "Nóminas Pablo" del `/pl` para el mismo periodo.
- [ ] `Resultado operativo` desplegable muestra la fórmula.
- [ ] Sidebar admin `Finanzas` sigue llevando a la nueva `/resumen`.

## Siguiente

**PR C/3** después de validar B: selector interactivo `from/to` + bloque de pendientes destacados (top 5) con links a `/cobros` y `/gastos`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
