### PR TITLE
feat(audit/finanzas): selector from/to + pendientes destacados (PR C/3)

### DIFF
--- a/src/__tests__/server/finanzas-resumen-v2-filtros-pendientes.test.ts
+++ b/src/__tests__/server/finanzas-resumen-v2-filtros-pendientes.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Tests estáticos para PR C/3 del resumen V2:
+ *   - Selector `from` / `to` en `/admin/finanzas/resumen`.
+ *   - Bloque de pendientes destacados (top 5 + margen pendiente estimado).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const PROJECT_ROOT = path.resolve(__dirname, '..', '..', '..');
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(PROJECT_ROOT, rel), 'utf-8');
+}
+
+function exists(rel: string): boolean {
+  return fs.existsSync(path.join(PROJECT_ROOT, rel));
+}
+
+// ── page.tsx ──────────────────────────────────────────────────────────────
+
+describe('[Resumen V2 · PR C] /admin/finanzas/resumen/page.tsx', () => {
+  const src = read('src/app/admin/(dashboard)/finanzas/resumen/page.tsx');
+
+  it('acepta searchParams (Promise) y extrae from / to', () => {
+    expect(src).toMatch(/searchParams\?:\s*Promise<Record<string/);
+    expect(src).toMatch(/firstParam\(sp\.from\)/);
+    expect(src).toMatch(/firstParam\(sp\.to\)/);
+  });
+
+  it('valida from / to con regex ISO YYYY-MM-DD antes de pasarlas a la query', () => {
+    expect(src).toMatch(/\/\^\\d\{4\}-\\d\{2\}-\\d\{2\}\$\//);
+    expect(src).toMatch(/safeIsoDate\(/);
+  });
+
+  it('pasa from / to a getFinanzasResumenV2', () => {
+    expect(src).toMatch(/getFinanzasResumenV2\s*\(\s*\{/);
+    // El spread condicional evita mandar undefined al filtro.
+    expect(src).toMatch(/\.\.\.\(from \? \{ from \} : \{\}\)/);
+    expect(src).toMatch(/\.\.\.\(to \? \{ to \} : \{\}\)/);
+  });
+
+  it('renderiza ResumenFilters con `applied` y `defaults`', () => {
+    expect(src).toMatch(/<ResumenFilters\s+applied=\{data\.period\}\s+defaults=\{defaults\}/);
+  });
+
+  it('renderiza ResumenPendientesBlock', () => {
+    expect(src).toMatch(/<ResumenPendientesBlock\s+pendientes=\{data\.pendientes\}/);
+  });
+
+  it("no declara 'use client'", () => {
+    expect(src.split('\n')[0]?.trim()).not.toBe("'use client';");
+    expect(src).not.toMatch(/^['"]use client['"];/m);
+  });
+});
+
+// ── ResumenFilters ────────────────────────────────────────────────────────
+
+describe('[Resumen V2 · PR C] ResumenFilters', () => {
+  const rel = 'src/features/admin/finance-dashboard/components/resumen-v2/ResumenFilters.tsx';
+
+  it('existe', () => { expect(exists(rel)).toBe(true); });
+
+  const src = read(rel);
+
+  it("declara 'use client' en la primera línea", () => {
+    expect(src.split('\n')[0]?.trim()).toBe("'use client';");
+  });
+
+  it('usa useRouter + useSearchParams + useTransition', () => {
+    expect(src).toMatch(/useRouter/);
+    expect(src).toMatch(/useSearchParams/);
+    expect(src).toMatch(/useTransition/);
+  });
+
+  it('navega a /admin/finanzas/resumen preservando o limpiando query string', () => {
+    expect(src).toMatch(/router\.push\([^)]*\/admin\/finanzas\/resumen/);
+  });
+
+  it('acepta inputs type="date" para from y to', () => {
+    expect(src).toMatch(/type="date"/);
+  });
+
+  it('botón "Restablecer" cuando el rango ya no es el default (YTD)', () => {
+    expect(src).toMatch(/Restablecer/);
+  });
+});
+
+// ── ResumenPendientesBlock ────────────────────────────────────────────────
+
+describe('[Resumen V2 · PR C] ResumenPendientesBlock', () => {
+  const rel = 'src/features/admin/finance-dashboard/components/resumen-v2/ResumenPendientesBlock.tsx';
+
+  it('existe', () => { expect(exists(rel)).toBe(true); });
+
+  const src = read(rel);
+
+  it("no declara 'use client' (Server Component)", () => {
+    expect(src.split('\n')[0]?.trim()).not.toBe("'use client';");
+    expect(src).not.toMatch(/^['"]use client['"];/m);
+  });
+
+  it('sin useState / useEffect', () => {
+    expect(src).not.toMatch(/useState\(/);
+    expect(src).not.toMatch(/useEffect\(/);
+  });
+
+  it('renderiza las 3 columnas: cobros campañas, pagos talento, pagos operativo', () => {
+    expect(src).toMatch(/Pendiente de cobro \(campañas\)/);
+    expect(src).toMatch(/Pendiente de pago a talentos/);
+    expect(src).toMatch(/Pendiente de pago operativo/);
+  });
+
+  it('cada columna enlaza a /admin/finanzas/cobros o /admin/finanzas/gastos vía <Link>', () => {
+    expect(src).toMatch(/import\s+Link\s+from\s+['"]next\/link['"]/);
+    expect(src).toMatch(/href="\/admin\/finanzas\/cobros"/);
+    expect(src).toMatch(/href="\/admin\/finanzas\/gastos"/);
+  });
+
+  it('muestra "Margen pendiente estimado"', () => {
+    expect(src).toMatch(/Margen pendiente estimado/);
+  });
+
+  it('marca vencidas con "vencida hace Nd" cuando daysOverdue > 0', () => {
+    expect(src).toMatch(/vencida hace \{item\.daysOverdue\}d/);
+  });
+
+  it('empty state "Al día ✓" cuando el bucket no tiene items', () => {
+    expect(src).toMatch(/Al día/);
+  });
+});
+
+// ── Anti-scope-creep ─────────────────────────────────────────────────────
+
+describe('[Resumen V2 · PR C] anti-scope-creep', () => {
+  const files = [
+    'src/app/admin/(dashboard)/finanzas/resumen/page.tsx',
+    'src/features/admin/finance-dashboard/components/resumen-v2/ResumenFilters.tsx',
+    'src/features/admin/finance-dashboard/components/resumen-v2/ResumenPendientesBlock.tsx',
+  ];
+
+  it.each(files)('%s no importa Resend/emails/dunning/invoice_reminders', (rel) => {
+    const src = read(rel);
+    expect(src).not.toMatch(/from\s+['"]resend['"]/);
+    expect(src).not.toMatch(/@\/lib\/email/);
+    expect(src).not.toMatch(/sendEmail/);
+    expect(src).not.toMatch(/invoice_reminders/);
+    expect(src).not.toMatch(/dunning/i);
+  });
+
+  it.each(files)('%s no define ni altera tablas', (rel) => {
+    const src = read(rel);
+    expect(src).not.toMatch(/pgTable\s*\(/);
+    expect(src).not.toMatch(/alterTable/);
+  });
+});

--- a/src/app/admin/(dashboard)/finanzas/resumen/page.tsx
+++ b/src/app/admin/(dashboard)/finanzas/resumen/page.tsx
@@ -1,24 +1,56 @@
 import { requirePermission } from '@/lib/permissions';
 import { getFinanzasResumenV2 } from '@/lib/queries/financeDashboard/finanzasResumenV2';
+import { ResumenFilters } from '@/features/admin/finance-dashboard/components/resumen-v2/ResumenFilters';
 import { ResumenIngresosBlock } from '@/features/admin/finance-dashboard/components/resumen-v2/ResumenIngresosBlock';
 import { ResumenCostesMargenBlock } from '@/features/admin/finance-dashboard/components/resumen-v2/ResumenCostesMargenBlock';
 import { ResumenNominasBlock } from '@/features/admin/finance-dashboard/components/resumen-v2/ResumenNominasBlock';
 import { ResumenImpuestosBlock } from '@/features/admin/finance-dashboard/components/resumen-v2/ResumenImpuestosBlock';
 import { ResumenOperativosBlock } from '@/features/admin/finance-dashboard/components/resumen-v2/ResumenOperativosBlock';
 import { ResumenResultadoBlock } from '@/features/admin/finance-dashboard/components/resumen-v2/ResumenResultadoBlock';
+import { ResumenPendientesBlock } from '@/features/admin/finance-dashboard/components/resumen-v2/ResumenPendientesBlock';
 
 export const metadata = { title: 'Resumen · Finanzas' };
 
-function monthLabel(iso: string): string {
-  const [y, m, d] = iso.split('-').map(Number);
-  if (!y || !m || !d) return iso;
-  return new Date(y, m - 1, d).toLocaleDateString('es-ES', { day: '2-digit', month: 'short', year: 'numeric' });
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+function todayInMadrid(): string {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Europe/Madrid',
+    year: 'numeric', month: '2-digit', day: '2-digit',
+  }).format(new Date());
 }
 
-export default async function FinanzasResumenPage(): Promise<React.ReactElement> {
+function firstParam(v: string | string[] | undefined): string | undefined {
+  if (v === undefined) return undefined;
+  return Array.isArray(v) ? v[0] : v;
+}
+
+function safeIsoDate(v: string | undefined): string | undefined {
+  if (!v || !ISO_DATE_RE.test(v)) return undefined;
+  return v;
+}
+
+type PageProps = {
+  readonly searchParams?: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export default async function FinanzasResumenPage({ searchParams }: PageProps): Promise<React.ReactElement> {
   await requirePermission('facturacion', 'read');
 
-  const data = await getFinanzasResumenV2();
+  const sp = (await searchParams) ?? {};
+  const from = safeIsoDate(firstParam(sp.from));
+  const to = safeIsoDate(firstParam(sp.to));
+
+  const data = await getFinanzasResumenV2({
+    ...(from ? { from } : {}),
+    ...(to ? { to } : {}),
+  });
+
+  const today = todayInMadrid();
+  const defaults = {
+    from: `${today.slice(0, 4)}-01-01`,
+    to: today,
+  };
 
   return (
     <div className="space-y-5 pt-2">
@@ -26,10 +58,12 @@ export default async function FinanzasResumenPage(): Promise<React.ReactElement>
         <div>
           <h1 className="text-xl font-bold text-sp-admin-fg">Resumen económico</h1>
           <p className="text-sm text-sp-admin-muted">
-            {monthLabel(data.period.from)} — {monthLabel(data.period.to)}
+            De lo facturado, cuánto se queda SocialPro después de talents, nóminas, impuestos y gastos operativos.
           </p>
         </div>
       </header>
+
+      <ResumenFilters applied={data.period} defaults={defaults} />
 
       <ResumenIngresosBlock ingresos={data.ingresos} />
 
@@ -51,6 +85,8 @@ export default async function FinanzasResumenPage(): Promise<React.ReactElement>
         operativos={data.operativos}
         resultado={data.resultado}
       />
+
+      <ResumenPendientesBlock pendientes={data.pendientes} />
     </div>
   );
 }

--- a/src/features/admin/finance-dashboard/components/resumen-v2/ResumenFilters.tsx
+++ b/src/features/admin/finance-dashboard/components/resumen-v2/ResumenFilters.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useCallback, useTransition } from 'react';
+import type { FinanzasPeriod } from '@/types/finanzasResumen';
+
+type Props = {
+  readonly applied: FinanzasPeriod;
+  /** Default YTD, para el botón "Restablecer". */
+  readonly defaults: FinanzasPeriod;
+};
+
+const YTD_LABEL = 'Año en curso';
+
+function formatDate(iso: string): string {
+  const [y, m, d] = iso.split('-').map(Number);
+  if (!y || !m || !d) return iso;
+  return new Date(y, m - 1, d).toLocaleDateString('es-ES', {
+    day: '2-digit', month: 'short', year: 'numeric',
+  });
+}
+
+/**
+ * Selector de rango `from` / `to` para el resumen económico.
+ * Al cambiar cualquiera de los dos inputs, hace `router.push` con los
+ * nuevos searchParams; la página RSC se re-renderiza con el nuevo periodo.
+ *
+ * @kind client
+ * @feature admin/finance-dashboard/resumen-v2
+ */
+export function ResumenFilters({ applied, defaults }: Props): React.ReactElement {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [pending, startTransition] = useTransition();
+
+  const update = useCallback(
+    (key: 'from' | 'to', value: string) => {
+      const params = new URLSearchParams(searchParams?.toString() ?? '');
+      if (value) {
+        params.set(key, value);
+      } else {
+        params.delete(key);
+      }
+      const qs = params.toString();
+      startTransition(() => {
+        router.push(qs ? `/admin/finanzas/resumen?${qs}` : '/admin/finanzas/resumen');
+      });
+    },
+    [router, searchParams],
+  );
+
+  const reset = useCallback(() => {
+    startTransition(() => {
+      router.push('/admin/finanzas/resumen');
+    });
+  }, [router]);
+
+  const isYTD = applied.from === defaults.from && applied.to === defaults.to;
+
+  return (
+    <div
+      className={`flex flex-wrap items-end gap-3 rounded-xl border border-sp-admin-border bg-sp-admin-card p-4 ${pending ? 'opacity-70' : ''}`}
+      aria-busy={pending}
+    >
+      <FilterInput label="Desde" value={applied.from} onChange={(v) => update('from', v)} />
+      <FilterInput label="Hasta" value={applied.to}   onChange={(v) => update('to', v)} />
+
+      <div className="ml-auto flex items-baseline gap-3">
+        <span className="text-xs text-sp-admin-muted">
+          {isYTD ? YTD_LABEL : `${formatDate(applied.from)} — ${formatDate(applied.to)}`}
+        </span>
+        {!isYTD && (
+          <button
+            type="button"
+            onClick={reset}
+            className="rounded-lg border border-sp-admin-border px-3 py-1.5 text-xs font-medium text-sp-admin-muted hover:border-sp-orange hover:text-sp-admin-fg"
+          >
+            Restablecer
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+type FilterInputProps = {
+  readonly label: string;
+  readonly value: string;
+  readonly onChange: (v: string) => void;
+};
+
+function FilterInput({ label, value, onChange }: FilterInputProps): React.ReactElement {
+  return (
+    <label className="flex flex-col gap-1">
+      <span className="text-[10px] font-semibold uppercase tracking-[0.16em] text-sp-admin-muted">
+        {label}
+      </span>
+      <input
+        type="date"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="rounded-lg border border-sp-admin-border bg-sp-admin-card px-3 py-1.5 text-sm font-medium text-sp-admin-fg focus:outline-none focus:ring-1 focus:ring-sp-orange"
+      />
+    </label>
+  );
+}

--- a/src/features/admin/finance-dashboard/components/resumen-v2/ResumenPendientesBlock.tsx
+++ b/src/features/admin/finance-dashboard/components/resumen-v2/ResumenPendientesBlock.tsx
@@ -1,0 +1,131 @@
+import Link from 'next/link';
+import type {
+  FinanzasResumenPendienteBucket,
+  FinanzasResumenPendientes,
+  PendienteItem,
+} from '@/types/finanzasResumen';
+import { SectionCard } from './SectionCard';
+
+const EUR = new Intl.NumberFormat('es-ES', {
+  style: 'currency', currency: 'EUR', maximumFractionDigits: 0,
+});
+const EUR2 = new Intl.NumberFormat('es-ES', {
+  style: 'currency', currency: 'EUR', maximumFractionDigits: 2,
+});
+
+type Props = { readonly pendientes: FinanzasResumenPendientes };
+
+export function ResumenPendientesBlock({ pendientes }: Props): React.ReactElement {
+  return (
+    <SectionCard title="Pendientes destacados" subtitle="Lo que queda por cobrar, por pagar a talentos y por pagar operativo. Top 5 por importe.">
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        <PendienteColumn
+          label="Pendiente de cobro (campañas)"
+          bucket={pendientes.cobrosCampanas}
+          href="/admin/finanzas/cobros"
+          hrefLabel="Ver todos los cobros pendientes →"
+          accent="income"
+        />
+        <PendienteColumn
+          label="Pendiente de pago a talentos"
+          bucket={pendientes.pagosTalento}
+          href="/admin/finanzas/gastos"
+          hrefLabel="Ver todos los gastos →"
+          accent="expense"
+        />
+        <PendienteColumn
+          label="Pendiente de pago operativo"
+          bucket={pendientes.pagosOperativo}
+          href="/admin/finanzas/gastos"
+          hrefLabel="Ver todos los gastos →"
+          accent="expense"
+        />
+      </div>
+
+      <div className="mt-4 rounded-xl border border-sp-admin-border/60 p-4">
+        <div className="flex items-baseline justify-between gap-3">
+          <span className="text-[11px] font-semibold uppercase tracking-[0.16em] text-sp-admin-muted">
+            Margen pendiente estimado
+          </span>
+          <span className={`text-2xl font-black tabular-nums ${pendientes.margenPendienteEstimado >= 0 ? 'text-emerald-400' : 'text-red-400'}`}>
+            {EUR.format(pendientes.margenPendienteEstimado)}
+          </span>
+        </div>
+        <p className="mt-1 text-[10px] italic text-sp-admin-muted">
+          = pendiente de cobro campañas − pendiente de pago a talentos
+        </p>
+      </div>
+    </SectionCard>
+  );
+}
+
+// ── Columna por bucket ─────────────────────────────────────────────────────
+
+type ColumnProps = {
+  readonly label: string;
+  readonly bucket: FinanzasResumenPendienteBucket;
+  readonly href: string;
+  readonly hrefLabel: string;
+  readonly accent: 'income' | 'expense';
+};
+
+function PendienteColumn({ label, bucket, href, hrefLabel, accent }: ColumnProps): React.ReactElement {
+  const totalColor = accent === 'income' ? 'text-emerald-400' : 'text-red-400';
+
+  return (
+    <div className="flex flex-col gap-3 rounded-xl border border-sp-admin-border/60 p-4">
+      <div>
+        <p className="text-[10px] font-semibold uppercase tracking-[0.15em] text-sp-admin-muted">
+          {label}
+        </p>
+        <p className={`mt-1 text-2xl font-black tabular-nums ${totalColor}`}>
+          {EUR.format(bucket.total)}
+        </p>
+        <p className="text-[10px] text-sp-admin-muted">
+          {bucket.count === 0 ? 'sin pendientes' : bucket.count === 1 ? '1 factura' : `${bucket.count} facturas`}
+        </p>
+      </div>
+
+      {bucket.top.length === 0 ? (
+        <p className="py-2 text-center text-xs italic text-sp-admin-muted">Al día ✓</p>
+      ) : (
+        <ul className="space-y-1.5">
+          {bucket.top.map((it) => (
+            <PendienteRow key={`${it.source}-${it.id}`} item={it} accent={accent} />
+          ))}
+        </ul>
+      )}
+
+      <Link
+        href={href}
+        className="mt-auto text-xs text-sp-blue hover:underline"
+      >
+        {hrefLabel}
+      </Link>
+    </div>
+  );
+}
+
+// ── Fila de item ───────────────────────────────────────────────────────────
+
+function PendienteRow({ item, accent }: { readonly item: PendienteItem; readonly accent: 'income' | 'expense' }): React.ReactElement {
+  const amountColor = accent === 'income' ? 'text-emerald-400' : 'text-red-400';
+  const overdueColor = 'text-red-400';
+  const dueBadge = item.daysOverdue !== null && item.daysOverdue > 0
+    ? <span className={`ml-2 text-[9px] font-semibold uppercase tracking-wider ${overdueColor}`}>
+        · vencida hace {item.daysOverdue}d
+      </span>
+    : null;
+
+  return (
+    <li className="flex items-baseline justify-between gap-2 text-xs">
+      <span className="min-w-0 truncate text-sp-admin-fg">
+        {item.label}
+        {dueBadge}
+      </span>
+      <span className={`shrink-0 tabular-nums ${amountColor}`}>
+        {EUR2.format(item.amount)}
+      </span>
+    </li>
+  );
+}


### PR DESCRIPTION
## Resumen

**PR C/3** — cierre del rediseño del resumen económico. Añade:

1. **Selector `from` / `to`** en `/admin/finanzas/resumen` (Client Component).
2. **Bloque "Pendientes destacados"** con 3 columnas top 5 + margen pendiente estimado (Server Component).

Cero nuevas queries — la query `getFinanzasResumenV2` (PR A/3) ya devuelve `pendientes` y aceptaba `{ from, to }`. Este PR solo consume esos campos.

Cero DB / schema / migrations / drizzle / crons / emails / Resend / invoice_reminders / OCR / Blob / Sheets / RBAC / dunning / Tratos / facturación legal / payroll parser / endpoint recurring / receivables.ts legacy (TD-14 documentado).

## Selector `from` / `to` (ResumenFilters.tsx, `'use client'`)

```
┌─ Filtros ─────────────────────────────────────────────────────────┐
│ Desde  [2026-01-01]   Hasta  [2026-07-01]        Año en curso    │
└───────────────────────────────────────────────────────────────────┘
```

- 2 inputs `type="date"`.
- `useRouter` + `useSearchParams` + `useTransition`: al cambiar cualquiera de los dos, hace `router.push('/admin/finanzas/resumen?from=…&to=…')`. La página RSC re-renderiza con el nuevo periodo.
- Chip informativo derecha: **"Año en curso"** cuando el rango es el default YTD (2026-01-01 → hoy), o `"DD MMM YY — DD MMM YY"` si es custom.
- Botón **"Restablecer"** visible solo cuando el rango difiere del default.
- Deep-linkable: `/admin/finanzas/resumen?from=2026-04-01&to=2026-06-30` funciona.

## Pendientes destacados (ResumenPendientesBlock.tsx, Server Component)

```
┌─ PENDIENTES DESTACADOS ────────────────────────────────────────────┐
│                                                                    │
│  Pendiente cobro     Pendiente pago     Pendiente pago             │
│  (campañas)          a talentos         operativo                  │
│                                                                    │
│  1.600 €             1.100 €            185 €                      │
│  2 facturas          2 facturas         1 factura                  │
│                                                                    │
│  • SkinsMonkey · vencida hace 3d   • Talento X            1.696€  │
│    1.600 €                         • Talento Y              200€  │
│  • W88                             ...                             │
│    500 €                                                            │
│                                                                    │
│  Ver todos los         Ver todos los         Ver todos los         │
│  cobros pendientes →   gastos →              gastos →              │
│                                                                    │
├───────────────────────────────────────────────────────────────────┤
│                                                                    │
│  Margen pendiente estimado                              700 €      │
│  = pendiente de cobro campañas − pendiente de pago a talentos      │
│                                                                    │
└────────────────────────────────────────────────────────────────────┘
```

### Cada columna:
- Total del bucket + count de facturas.
- **Top 5** por importe con label human-friendly:
  - Cobros: brand > client > counterparty > `#id`.
  - Pagos talento: `talents.name` > concept > `#id`.
  - Pagos operativo: counterparty > concept > `#id`.
- Badge **"vencida hace Nd"** en rojo si `daysOverdue > 0`.
- Empty state **"Al día ✓"** si el bucket está vacío.
- Link inferior con `<Link>` (next/link) a `/admin/finanzas/cobros` o `/admin/finanzas/gastos`.

### Card final:
- **"Margen pendiente estimado"** = cobros pendientes − pagos talento pendientes. Verde si positivo, rojo si negativo.

## Confirmaciones

- ✅ Cero DB / schema / migrations / drizzle.
- ✅ Cero crons / emails / Resend / invoice_reminders / dunning.
- ✅ Cero nuevas queries — la query V2 se mantiene inalterada.
- ✅ `ResumenPendientesBlock` es Server Component (sin `'use client'`, sin `useState`, sin `useEffect`).
- ✅ `ResumenFilters` es Client Component minimalista (solo `useRouter` + `useSearchParams` + `useTransition`).
- ✅ Validación de `from` / `to` en el server: regex ISO estricta, se descartan valores inválidos silenciosamente para no romper.
- ✅ Links a `/cobros` y `/gastos` con `<Link>` (next/link), no `<a>`.

## Archivos (4)

**Nuevos (3):**
- `src/features/admin/finance-dashboard/components/resumen-v2/ResumenFilters.tsx`
- `src/features/admin/finance-dashboard/components/resumen-v2/ResumenPendientesBlock.tsx`
- `src/__tests__/server/finanzas-resumen-v2-filtros-pendientes.test.ts` — 26 tests

**Modificado (1):**
- `src/app/admin/(dashboard)/finanzas/resumen/page.tsx` — acepta `searchParams`, valida from/to, renderiza filtros + pendientes.

## Tests (26 nuevos)

### `page.tsx` (6)
- Acepta `searchParams` (Promise) y extrae from/to.
- Regex ISO validation antes de la query.
- Spread condicional para no pasar `undefined`.
- Renderiza `<ResumenFilters>` y `<ResumenPendientesBlock>`.
- No declara `'use client'`.

### `ResumenFilters` (6)
- `'use client'` en primera línea.
- Usa `useRouter` + `useSearchParams` + `useTransition`.
- `router.push` a `/admin/finanzas/resumen`.
- Inputs `type="date"`.
- Botón "Restablecer".

### `ResumenPendientesBlock` (8)
- Server Component (sin `'use client'`, `useState`, `useEffect`).
- 3 columnas: cobros campañas, pagos talento, pagos operativo.
- `<Link>` a `/cobros` y `/gastos`.
- "Margen pendiente estimado" visible.
- Badge "vencida hace Nd".
- Empty state "Al día ✓".

### Anti-scope-creep (6 via `it.each`)
- Sin `resend` / `sendEmail` / `@/lib/email`.
- Sin `invoice_reminders` / `dunning`.
- Sin `pgTable` / `alterTable`.

## CI local

- ✅ `npx tsc --noEmit` — clean
- ✅ `npm run lint` — 0/0
- ✅ `npm test` — 115 suites · **2089 tests** verdes
- ⚠️ Build local requiere `.env.local`; Vercel lo corre.

## Test plan post-merge

- [ ] `/admin/finanzas/resumen` muestra 2 inputs date + chip "Año en curso" al inicio.
- [ ] Cambiar `Desde` a otra fecha actualiza los 7 bloques + el chip cambia + aparece botón "Restablecer".
- [ ] Deep-link directo `?from=2026-04-01&to=2026-06-30` carga con esos valores.
- [ ] `Restablecer` vuelve a YTD (rango default).
- [ ] Bloque "Pendientes destacados" al final muestra 3 columnas con top 5 y links funcionales a `/cobros` y `/gastos`.
- [ ] Badge "vencida hace Nd" aparece en items con `daysOverdue > 0`.
- [ ] "Margen pendiente estimado" = suma cobros pendientes − suma pagos talento pendientes.

## Trilogía cerrada

- PR A/3 (#152) — query V2 + tipos + tests (`invoice_payments` canónico).
- PR B/3 (#153) — UI con 6 bloques + mensual a `/mes`.
- **PR C/3 (este)** — selector `from/to` + pendientes destacados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
