### PR TITLE
docs(finance): reescritura completa de docs/finance-dashboard.md

### DIFF
--- a/docs/finance-dashboard.md
+++ b/docs/finance-dashboard.md
@@ -1,168 +1,356 @@
-# Finance Dashboard — Documentación
+# Finanzas — Documentación del módulo
 
-## Estado (2026-07-01, Fase 1A.2)
+Última actualización: **2026-07-02** (cierre del loop nocturno: rediseño resumen V2 + TD-14).
 
-**La home financiera principal es `/admin/finanzas/resumen`.**
+Documento de referencia para entender qué muestra cada pantalla del panel `/admin/finanzas`, cómo se calcula cada cifra y qué gastos recurrentes están dados de alta.
 
-La ruta legacy `/admin/facturacion/dashboard` **redirige de forma permanente** (308) a `/admin/finanzas/resumen`. Ya no debe usarse como URL de destino ni como referencia.
+---
 
-Bloques que vivían en la ruta legacy y que se han **diferido a fases futuras**:
+## 1. `/admin/finanzas/resumen` — Home CEO/YTD
 
-| Bloque | Destino futuro |
-|---|---|
-| CashflowChart 12m | Fase 1B/3 — vive mejor en `/admin/finanzas/pl` (histórico) o widget dedicado. |
-| ReconciliationPanel | Ya existe la vista completa en `/admin/facturacion/bancos/conciliacion`. |
-| CampaignMarginsTable | Fase 2 — rentabilidad de campañas, no home financiera. |
-| FinanceKPIGrid (10 KPIs técnicos) | Reemplazado por los 6 KPIs CEO-friendly de `/admin/finanzas/resumen`. |
+**Ruta canónica**: `/admin/finanzas/resumen`. Es la home financiera desde el sidebar admin (`Finanzas → /resumen`) y el destino del redirect legacy `/admin/facturacion/dashboard` → 308.
 
-Los componentes `FinanceKPIGrid.tsx`, `CashflowChart.tsx`, `ReconciliationPanel.tsx` y `CampaignMarginsTable.tsx` **han sido borrados**. Cuando alguna de las fases futuras los necesite se reescribirán limpios (o se recuperan del historial de git).
+Responde de un vistazo a *"de lo que hemos facturado, cuánto se queda SocialPro"*.
 
-Las queries subyacentes **siguen exportadas** desde `src/lib/queries/financeDashboard/index.ts` porque `deriveAlerts()` y otras herramientas del asistente IA las consumen — ver más abajo.
+Rango por defecto: **YTD (año en curso)** — 1-ene → hoy (Europe/Madrid). Selector `from`/`to` deep-linkable (`?from=YYYY-MM-DD&to=YYYY-MM-DD`) para acotar cualquier periodo.
 
-## Ruta
+**Bloques (en orden):**
 
-| Ruta | Descripción |
-|---|---|
-| `/admin/finanzas/resumen` | **Home financiera principal (Fase 1A.1).** Control mensual CEO-friendly. |
-| `/admin/facturacion/dashboard` | Redirect 308 → `/admin/finanzas/resumen`. |
+1. **Ingresos** — cobrados / pendientes de cobro / total facturado.
+2. **Costes directos + margen bruto** — pagos a talentos y costes producción, junto al margen bruto cobrado y el pendiente.
+3. **Nóminas socios** — separadas Pablo / Alfonso / (sin identificar).
+4. **Impuestos y cargas** — cuotas autónomo por socio, Seguridad Social, fiscal/impuestos.
+5. **Gastos operativos** — gestoría, software/IA, hosting/dominio, seguro médico, comisiones, marketing, otros.
+6. **Resultado operativo** — con desplegable "Ver cómo se calcula" que muestra la fórmula paso a paso.
+7. **Pendientes destacados** — 3 columnas top 5 (cobros campañas, pagos talento, pagos operativo) + margen pendiente estimado.
 
-## Arquitectura de datos (agregador `getFinanceDashboard`)
-
-Sigue disponible y en uso por `/admin/finanzas/resumen` (alertas + receivables) y por las AI tools:
+**Fórmulas (todas base caja, fuente canónica `invoice_payments`):**
 
 ```
-getFinanceDashboard()              ← composición en paralelo
-  ├─ getFinanceDashboardKPIs()     ← kpis.ts
-  ├─ getCashflowSeries(12)         ← cashflow.ts
-  ├─ getReceivables()              ← receivables.ts
-  ├─ getReconciliationSummary()    ← reconciliation.ts
-  ├─ getCampaignMargins()          ← campaignMargins.ts
-  └─ deriveAlerts() [in-memory]    ← alerts.ts (pure function)
+ingresosCobrados      = SUM(invoice_payments.amount) income ∈ periodo
+ingresosFacturados    = SUM(totalAmount) income no-anulada ∈ periodo
+pendienteCobrar       = facturados − cobrados
+
+costesDirectosPagados = SUM(invoice_payments.amount)
+                        invoices.expenseGroup = 'campaign_direct' ∈ periodo
+costesDirectosPend    = totalAmount campaign_direct no-anulada
+                        − pagosCash proporcional al accrual
+
+margenBrutoCobrado    = ingresosCobrados − costesDirectosPagados
+margenBrutoPendiente  = pendienteCobrar  − costesDirectosPendientes
+
+nominasTotal          = SUM(nomina_socio) no-anulada
+impuestosTotal        = cuota_autonomo + factura_autonomo + seguridad_social
+                        + fiscal_impuestos + ajuste_fiscal
+operativosTotal       = operational excluyendo nóminas e impuestos
+
+resultadoOperativo    = margenBrutoCobrado − nominasTotal − impuestosTotal
+                        − operativosTotal
+
+margenPendienteEstimado = cobrosCampanasPendientes − pagosTalentoPendientes
 ```
 
-## KPIs (`kpis.ts`)
+Query única (`server-only`): `src/lib/queries/financeDashboard/finanzasResumenV2.ts`. Lógica pura testeable en `finanzasResumenV2.shared.ts`. **No lee `invoices.paidAmount`** (deprecated) — usa `invoice_payments` como fuente canónica.
 
-| KPI | Fuente | Base |
+---
+
+## 2. `/admin/finanzas/mes` — Control mensual (legacy)
+
+**Ruta anterior**: era `/admin/finanzas/resumen`; se movió a `/mes` en el rediseño de julio 2026 para dejar libre la ruta principal para el YTD nuevo. La sidebar admin sigue apuntando `Finanzas → /resumen` (el nuevo).
+
+Enfoque **mensual**: siempre un mes concreto (selector `MonthSelector` que hace `router.push('/admin/finanzas/mes?mes=YYYY-MM')`).
+
+**Contenido:**
+
+- 6 KPIs CEO-friendly del mes: Facturado / Cobrado / Pendiente cobrar / Gastado / Resultado / Pendiente pagar.
+- Alertas (si hay).
+- Breakdown de gastos del mes por subtipo.
+- Widget "Cobros pendientes" (top 30 receivables).
+- Documentos del mes.
+
+Query base: `getMonthlyFinanceFlow`, `getFinanceStockKPIs`, `getMonthlyExpenseBreakdown`, `getMonthlyDocs`, `getFinanceDashboard()` (agregador).
+
+**Nota TD-14 cerrada**: hasta 2026-07-02 el widget "Cobros pendientes" leía `invoices.paidAmount` deprecated para el path internal. Ya migrado a `SUM(invoice_payments.amount)` — mismos números que las otras vistas.
+
+---
+
+## 3. `/admin/finanzas/pl` — Histórico mensual y P&L
+
+Enfoque **anual/YTD** con filtros ricos (`from`, `to`, `company`, `brandId`, `talentId`).
+
+**Contenido:**
+
+- `PnLOverviewCards` — 8 cards: ingresos, gastos, margen, comisión agencia, pagos a creadores, pendiente cobro/pago, cobrado YTD, pagado YTD.
+- Grid de 3 cards por `expenseGroup`: Costes directos / Gastos operativos / Sin clasificar (amber si > 0).
+- Caja YTD: cobrado (real) y pagado (accrual).
+- **Bloque expandible "Dónde se ha ido el dinero"** — el más útil para negocio. 17 subgrupos con desglose por socio (Nóminas Pablo/Alfonso, Cuota Pablo/Alfonso) y detalle expandible con `<details>/<summary>`. Al final subtotales por categoría: `Costes directos de campaña` / `Gastos operativos` / (`Sin clasificar` si > 0) + Total gastos.
+- Tabla mensual + top categorías legacy.
+
+Query: `getFinancePnL(filters)` en `src/lib/queries/financeDashboard/pnlDetail.ts`. Agregación en memoria en `expenseSubgroups.ts` con `classifyExpenseSubgroup()` (partner-aware para nóminas/cuotas).
+
+---
+
+## 4. `/admin/finanzas/cobros` — AR aging
+
+Vista dedicada a lo pendiente de cobrar (AR aging sin dunning automático).
+
+**Contenido:**
+
+- 6 KPIs: Total pendiente / Total vencido / Facturas vencidas / Pendiente por vencer / Mayor deuda por marca / Promedio días de retraso.
+- 5 barras horizontales por antigüedad: Por vencer, 0-30, 31-60, 61-90, +90 días.
+- Tabla completa con filtros (`bucket`, `entity`, `brand`, `source`) deep-linkables.
+
+Query: `src/lib/queries/financeDashboard/arAging.ts`. Fuente canónica de pagos: `invoice_payments`. Fallback de vencimiento: `issueDate + 30 días` si `dueDate=null` (etiquetado como "Vencimiento estimado").
+
+---
+
+## 5. Diferencia entre **pagos a talentos** y **gastos operativos**
+
+**Pagos a talentos** = *coste directo de campaña*.
+
+Cuando cobramos a una marca 1.000 € y pagamos 800 € al influencer, esos 800 € no son un "gasto de la empresa" al mismo nivel que gestoría o software. Son parte del coste directo del deal.
+
+- `expenseGroup = 'campaign_direct'`
+- `expenseSubtype = 'pago_talento'`
+- Suelen tener `talentId` y `campaignId` no-nulos.
+- Aparecen en el bloque **"Pagos a talentos"** dentro de `Costes directos` en el resumen y en el P&L.
+- Restan del **margen bruto**, NO del resultado operativo directamente (van antes en la fórmula).
+
+**Gastos operativos** = gastos reales de estructura de empresa:
+
+- Gestoría, software/IA, hosting/dominio, seguro médico, comisiones bancarias/crypto, marketing, seguridad social (parte empresa), etc.
+- `expenseGroup = 'operational'`
+- No dependen de una campaña concreta.
+- Aparecen en el bloque **"Gastos operativos"**.
+- Restan del **resultado operativo**.
+
+**Ejemplo real**: en la operación de JOSPO cobramos 500 € (id 76), pagamos 200 € al talento (id 77) — coste directo, `campaign_direct + pago_talento` — y 3,50 € de comisión bancaria (id 78) — gasto operativo, `operational + comision_bancaria`.
+
+---
+
+## 6. Diferencia entre **nóminas**, **impuestos/cargas** y **operativos**
+
+Todos son `expenseGroup = 'operational'`, pero el resumen los separa en 3 bloques para dar contexto a dirección:
+
+| Bloque | Subtypes incluidos | Concepto |
 |---|---|---|
-| `cobradoRealMes` | SUM(invoice_payments.amount) del mes actual | Caja |
-| `incomeTotal` | SUM(invoices.totalAmount) kind=income, no anulada | Devengado |
-| `expenseTotal` | SUM(invoices.totalAmount) kind=expense, no anulada | Devengado |
-| `netTotal` | incomeTotal − expenseTotal | Devengado |
-| `beneficioNeto` | incomeSettled − expenseCampanaSettled − expenseEmpresaSettled | Devengado |
-| `pendingCobro` | invoices income con status emitida/no_cobrada/pendiente | Devengado |
-| `pendingPago` | invoices expense con status emitida/no_pagada/pendiente | Devengado |
-| `gastosCampana` / `gastosEmpresa` | Por scope (campaign/company) | Devengado |
-| `pendingApplyPayment` | bank_transactions matched LEFT JOIN invoice_payments WHERE ip.id IS NULL | — |
-| `unconciliatedMovements` | bank_transactions con status='imported' | — |
+| **Nóminas socios** | `nomina_socio` | Dinero que los socios (Pablo, Alfonso) cobran como sueldo. Es gasto contable de la empresa pero también es liquidez que vuelve a los socios. |
+| **Impuestos y cargas** | `cuota_autonomo`, `factura_autonomo`, `seguridad_social`, `fiscal_impuestos`, `ajuste_fiscal` | Cargas fiscales y previsionales — no son gastos "elegibles" ni operativos reales, son obligaciones. |
+| **Gastos operativos** | `gestoria`, `suscripcion_software`, `herramienta_ia`, `seguro_medico`, `comision_bancaria`, `comision_plataforma`, `marketing_publicidad`, `gasto_general`, hosting/dominio (detectado por regex) | Costes reales de operar la empresa. |
 
-## Cashflow mensual (`cashflow.ts`)
+Detección Pablo/Alfonso en nóminas y cuotas: `detectPartner(concept + counterparty)` con regex `\b(pablo|camacho|keko)\b/i` y `\b(alfonso|arias)\b/i`. Guardarraíl: solo se aplica en subtipos partner-aware, nunca en `pago_talento`.
 
-Serie de 12 meses con dos series:
+---
 
-| Serie | Descripción |
-|---|---|
-| `cobrado` | SUM(invoice_payments.amount) agrupado por `payment_date` — **base caja real** |
-| `pagado` | SUM(invoices.totalAmount) kind=expense, no anulada, agrupado por `issue_date` — **base devengado** |
+## 7. **Margen bruto**
 
-**Nota:** `pagado` usa base devengado porque el "apply payment" para gastos (`expense` matchType) está pendiente de implementar ("Próximamente"). En cuanto se implemente, habrá que actualizar `cashflow.ts` para usar `invoice_payments` en el lado de los gastos también.
-
-## Cobros pendientes (`receivables.ts`)
-
-UNION en memoria de dos fuentes:
-
-| Fuente | Filtro de status | `paidAmount` |
-|---|---|---|
-| `issued_invoices` | `emitida`, `vencida`, `parcial` | SUM(invoice_payments.amount) via LEFT JOIN — calculado en query |
-| `invoices` kind=income | `PENDING_INCOME_STATUSES` | Columna `paidAmount` directa |
-
-Máximo 30 filas por fuente. Orden final: por `dueDate ASC` (nulls al final).
-
-**issuedInvoices vs invoices:** Las facturas emitidas no tienen columna `paidAmount`; el importe pagado se calcula vía `invoice_payments` en la misma query con GROUP BY.
-
-## Conciliación (`reconciliation.ts`)
-
-Wrapper sobre `getBankReconciliationKpis()` + query adicional para `pendingApplyPayment` (matched sin invoice_payment). La UI operativa vive en `/admin/facturacion/bancos/conciliacion`.
-
-## Márgenes campañas (`campaignMargins.ts`)
-
-Wrapper sobre `getCampaignMarginSummary()` (de `tools/campaigns.ts`) con flag `isLow = computedMarginPct < 20`.
-
-**Importante:** Los márgenes son sobre presupuesto estimado (`amountBrand`/`amountTalent`), NO sobre pagos reales.
-
-## Alertas (`alerts.ts`)
-
-Función pura — **sin queries adicionales**. Derivadas en memoria de los demás resultados:
-
-| Tipo | Condición | Severidad |
-|---|---|---|
-| `overdue_receivable` | receivables con `isOverdue=true` | high si total > €5.000, medium en otro caso |
-| `low_margin` | campaigns con `isLow=true` | medium siempre |
-| `pending_apply_payment` | kpis.pendingApplyPayment > 0 | high si > 5, low en otro caso |
-| `unreconciled` | reconciliation.importedUnmatched > 0 | medium si > 20, low en otro caso |
-
-Orden de presentación: high → medium → low.
-
-## AI Tools
-
-5 herramientas (solo lectura), registradas en `tools/index.ts`:
-
-| Tool | Descripción |
-|---|---|
-| `getFinanceDashboardSummary` | KPIs accrual + cash real + estado bancario |
-| `getCashflowTrend` | Serie mensual 12 meses (cobrado cash + pagado devengado) |
-| `getReceivablesRiskSummary` | Cobros vencidos y pendientes agrupados, top 5 vencidos |
-| `getCampaignMarginAlerts` | Campañas con margen < 20% |
-| `getFinanceAlerts` | Alertas derivadas del estado actual |
-
-## Archivos
+Es lo que queda de los ingresos después de los costes directos de campaña.
 
 ```
-src/types/financeDashboard.ts
-  FinanceDashboardKPIs, CashflowMonthPoint, ReceivableRow, CampaignMarginRow,
-  ReconciliationSummary, FinanceAlert, FinanceDashboardData
+margen bruto = ingresos − costes directos
+```
+
+Se calcula en dos variantes:
+
+- **Cobrado** — `ingresosCobrados − costesDirectosPagados`. Base caja pura.
+- **Pendiente estimado** — `pendienteCobrar − costesDirectosPendientes`.
+
+Es el KPI clave para saber *cuánto de lo facturado sobrevive a los pagos a talentos*. No incluye nóminas, impuestos ni operativos — esos vienen después.
+
+---
+
+## 8. **Resultado operativo**
+
+Es lo que queda **después de todo lo que la empresa paga cada mes**.
+
+```
+resultado operativo = margen bruto cobrado
+                      − nóminas
+                      − impuestos y cargas
+                      − gastos operativos
+```
+
+Enfoque base caja: usa `margenBrutoCobrado` como base, no el pendiente. Refleja lo que efectivamente ha entrado y salido en el periodo, no lo aún por materializar.
+
+El bloque incluye desplegable `<details>` con la fórmula desglosada línea a línea.
+
+---
+
+## 9. **Margen pendiente estimado**
+
+Métrica de proyección para el bloque "Pendientes destacados":
+
+```
+margen pendiente estimado = cobros pendientes de campañas
+                           − pagos pendientes a talentos
+```
+
+**No resta gastos operativos pendientes** porque esos no son costes de campaña — ya están capturados en `gastos operativos` del periodo. La cifra responde: *"si cobrara todo lo pendiente y pagara a todos los talentos pendientes, ¿cuánto margen bruto extra tendría?"*.
+
+Verde si positivo, rojo si negativo.
+
+---
+
+## 10. Fuente canónica de pagos = `invoice_payments`
+
+`invoice_payments` es la tabla que representa cada cobro/pago humano explícito (vinculando una `bank_transaction` con una `issued_invoice` o una `invoice` interna).
+
+Todas las queries **nuevas** de Finanzas usan esta tabla:
+
+| Query | Uso |
+|---|---|
+| `arAging.ts` | Cobros pendientes con `paidAmount = SUM(invoice_payments.amount)` para ambas fuentes. |
+| `finanzasResumenV2.ts` | 7 queries paralelas, todas basadas en `invoice_payments` para cash. |
+| `receivables.ts` | **Migrada 2026-07-02** — ambos paths (issued + internal) ahora usan `SUM(invoice_payments.amount)`. |
+| `cashflow.ts` | Serie mensual de cobros reales. |
+| `kpis.ts` | `cobradoRealMes = SUM(invoice_payments.amount)` del mes. |
+
+Cualquier query nueva que calcule "cobrado" o "pagado" **debe** usar `invoice_payments`, nunca `invoices.paidAmount`.
+
+---
+
+## 11. `invoices.paidAmount` deprecated
+
+El schema marca `invoices.paidAmount` con `@deprecated` explícito. Es una columna heredada que se mantenía sincronizada por Server Actions al aplicar `invoice_payments`, pero no debe usarse como fuente en queries nuevas.
+
+**Estado (2026-07-02):**
+
+- ✅ Queries de dashboard nuevas: **cero uso** de `paidAmount`.
+- ✅ `receivables.ts` — migrada a `invoice_payments` (TD-14 cerrado).
+- ✅ `pnl.ts` — dead SELECT de `paidAmount` eliminado.
+- ⚠️ **TD-14b (pendiente)**: `src/lib/queries/invoices.ts::listInvoices()` sigue seleccionando `paidAmount: invoices.paidAmount` como parte del tipo `InvoiceWithRelations`. Consumers múltiples (drawer factura, tabla gastos, exports CSV/PDF). Migrar en PR separado con auditoría de consumers. Ver `docs/tech-debt.md` § TD-14b.
+
+---
+
+## 12. Gastos recurrentes activos
+
+Plantillas en `recurring_expenses` que el cron mensual genera automáticamente. Al confirmar `2026-07-02`:
+
+| id | name | amount | dayOfMonth | startDate | subtype | active |
+|---|---|---:|---:|---|---|:---:|
+| 1 | Cuota autónomo — Keko | 315 € | 1 | 2026-01-01 | (null) | ❌ inactive (legacy) |
+| 2 | Cuota autónomo — Zack | 315 € | 1 | 2026-01-01 | (null) | ❌ inactive (legacy) |
+| **3** | **Cuota autónomo — Pablo** | **315 €** | **29** | **2026-07-01** | `cuota_autonomo` | ✅ |
+| **4** | **Seguro médico — Alfonso** | **54 €** | **1** | **2026-01-01** | `seguro_medico` | ✅ |
+| **5** | **Gestoría** | **185 €** | **29** | **2026-01-01** | `gestoria` | ✅ |
+
+Los 3 activos (**id=3, 4, 5**) tienen `expenseGroup='operational'` y `expenseSubtype` asignado.
+
+**Idempotencia:** cada invoice generada lleva `txId = 'recurring:{templateId}:{YYYY-MM}'`. Si el cron corre dos veces el mismo mes, la segunda hace skip.
+
+**Backfill histórico ya aplicado:**
+
+- Alfonso seguro médico ene-jun 2026 (ids 93-98) — status `pagada`.
+- Gestoría ene-jul 2026 (ids 101-107) — ene-jun `pagada`, jul `pendiente`.
+- Pablo cuota autónomo ene-jun 2026 (ids 81-86) creadas manualmente sin `txId`. Julio (id=99) creada por script one-off `apply-recurring-julio-2026.ts` con `txId=recurring:3:2026-07`.
+- Alfonso seguro médico jul 2026 (id=100) creada por el mismo script one-off con `txId=recurring:4:2026-07`.
+
+Alfonso cuota autónomo — **desactivada intencionalmente**. Ya no la paga. Las 6 filas históricas (ids 64-69) generadas por la plantilla id=1 se mantienen para el histórico.
+
+---
+
+## 13. Cron `generate-recurring-expenses`
+
+**Ruta**: `/api/cron/generate-recurring-expenses`
+
+**Schedule** (`vercel.json`, activo desde 2026-07-01):
+
+```json
+{
+  "path": "/api/cron/generate-recurring-expenses",
+  "schedule": "0 3 * * *"
+}
+```
+
+Corre **diario a las 03:00 UTC**. La ruta es idempotente por `txId=recurring:{templateId}:{YYYY-MM}`; correr diario permite:
+
+- Cubrir plantillas creadas a mitad de mes o después del día 1.
+- Recuperarse de fallos puntuales sin esperar al mes siguiente.
+- Cero riesgo de duplicados (SELECT antes de INSERT).
+
+**Auth**: `assertCronAuth(req)` exige `Authorization: Bearer ${CRON_SECRET}` con `timingSafeEqual`. Test estático en `src/__tests__/server/vercel-crons-schedule.test.ts` verifica que el schedule está registrado y que el guard sigue intacto.
+
+**Lógica**:
+
+1. `getActiveTemplatesForMonth('YYYY-MM')` — plantillas activas con `startDate ≤ mesActual` y `endDate = null` o `≥ mesActual`.
+2. Para cada plantilla, `invoiceExistsForMonth(templateId, monthStr)` — skip si ya existe.
+3. `createInvoiceForMonth(template, monthStr)` — INSERT con `status='pendiente'`, `issueDate = min(dayOfMonth, lastDayOfMonth)`, `txId` canónico, importe `totalAmount = netAmount × (1 + (vatPct - withholdingPct)/100)`.
+
+---
+
+## Nav de Finanzas
+
+Tabs dentro de `/admin/finanzas/*` (`FinanzasNav.tsx`):
+
+```
+Resumen               → /admin/finanzas/resumen  (home CEO YTD)
+Control mensual       → /admin/finanzas/mes
+Cobros pendientes     → /admin/finanzas/cobros
+Histórico mensual     → /admin/finanzas/pl
+Gastos y clasificación → /admin/finanzas/gastos
+Importar documentos   → /admin/finanzas/herramientas
+```
+
+Sidebar admin sigue apuntando `Finanzas → /admin/finanzas/resumen`.
+
+---
+
+## Archivos clave
+
+```
+src/app/admin/(dashboard)/finanzas/
+  resumen/page.tsx                RSC — nueva home YTD (PR B/3 rediseño)
+  mes/page.tsx                    RSC — control mensual movido aquí
+  pl/page.tsx                     RSC — histórico mensual
+  cobros/page.tsx                 RSC — AR aging
+  gastos/page.tsx                 RSC — clasificación de gastos
+  herramientas/                   Setup, importar, nóminas
 
 src/lib/queries/financeDashboard/
-  cashflow.ts        — getCashflowSeries(months)
-  kpis.ts            — getFinanceDashboardKPIs()
-  receivables.ts     — getReceivables()
-  reconciliation.ts  — getReconciliationSummary()
-  campaignMargins.ts — getCampaignMargins(), LOW_MARGIN_THRESHOLD
-  alerts.ts          — deriveAlerts() [pure]
-  index.ts           — getFinanceDashboard() + re-exports
-
-src/lib/services/ai-assistant/tools/financeDashboard.ts
-  getFinanceDashboardSummary, getCashflowTrend, getReceivablesRiskSummary,
-  getCampaignMarginAlerts, getFinanceAlerts
-
-src/app/admin/(dashboard)/facturacion/dashboard/page.tsx
-  permanentRedirect → /admin/finanzas/resumen  (Fase 1A.2)
-
-src/app/admin/(dashboard)/finanzas/resumen/page.tsx
-  RSC — requirePermission('facturacion','read') + FinanceMonthlyControl (Fase 1A.1)
+  finanzasResumenV2.ts            server-only — query principal del resumen YTD
+  finanzasResumenV2.shared.ts     pure — clasificadores y agregadores
+  arAging.ts                      server-only — cobros AR aging
+  arAging.shared.ts               pure — clasificación bucket
+  expenseSubgroups.ts             pure — 17 subgrupos + detección Pablo/Alfonso
+  pnlDetail.ts                    server-only — P&L YTD
+  receivables.ts                  server-only — receivables (widget /mes)
+  cashflow.ts                     server-only — serie mensual caja
+  kpis.ts                         server-only — KPIs agregados
+  reconciliation.ts               server-only — conciliación bancaria
+  recurringExpenses.ts            (server) plantillas + createInvoiceForMonth
+  index.ts                        composición getFinanceDashboard()
 
 src/features/admin/finance-dashboard/components/
-  FinanceMonthlyControl.tsx — control mensual CEO (6 KPIs + breakdown + docs)
-  ReceivablesTable.tsx      — tabla cobros pendientes con isOverdue highlight
-  FinanceAlertsList.tsx     — lista alertas por severidad
-  FinanceResumenBlocks.tsx  — bloques reutilizables del resumen
-  BulkClassifyPanel.tsx     — clasificación masiva de gastos
-  ExpensesClassifyTable.tsx / ExpenseClassifyInline.tsx — clasificación individual
+  resumen-v2/                     8 componentes RSC + 1 client (ResumenFilters)
+  FinanceMonthlyControl.tsx       (client) — control mensual
+  ReceivablesTable.tsx            (client) — widget cobros pendientes
+  ArAgingTable.tsx                (RSC) — tabla AR aging
+  ArAgingFilters.tsx              (client) — filtros AR aging
 
-src/__tests__/server/finance-dashboard.test.ts
-  22 tests — deriveAlerts (pure), LOW_MARGIN_THRESHOLD, ReceivableRow semantics,
-  CampaignMarginRow isLow flag
+src/features/admin/pnl/components/
+  AnnualExpenseBreakdown.tsx      (RSC) — bloque "Dónde se ha ido el dinero"
+  PnLOverviewCards.tsx            (RSC) — 8 KPI cards
+  PnLBreakdownTable.tsx           (RSC) — desglose mensual
+  PnLFilters.tsx                  (client) — filtros /pl
+
+src/app/api/cron/generate-recurring-expenses/route.ts
+  GET — invocado diario por Vercel (0 3 * * * UTC), protegido por CRON_SECRET
+
+vercel.json                       Registro de crons (incluye recurring desde jul/2026)
+
+docs/tech-debt.md                 TD-14 cerrado, TD-14b pendiente
 ```
 
-## Permisos
+---
 
-Usa `requirePermission('facturacion', 'read')` — mismos roles que el módulo de facturación existente (admin, manager, finance).
+## Estado tras el rediseño (julio 2026)
 
-## Límites
+- ✅ Resumen YTD con selector `from/to` y bloque de pendientes destacados.
+- ✅ Control mensual conservado en `/mes`.
+- ✅ Cobros AR aging con filtros.
+- ✅ Bloque expandible "Dónde se ha ido el dinero" con subtotales por categoría.
+- ✅ Cron de recurrentes activo diario, plantillas Pablo cuota + Alfonso seguro + Gestoría en marcha.
+- ✅ Fuente canónica `invoice_payments` en todas las queries relevantes; `paidAmount` deprecated eliminado de queries de dashboard.
+- ⚠️ TD-14b residual: `listInvoices()` genérico sigue con `paidAmount`. PR separado con scope grande.
 
-- Solo lectura — sin mutaciones desde la home financiera
-- Sin conexiones bancarias externas (no Wise, Stripe, Open Banking)
-- Sin auto-pagos ni auto-conciliación
-- `pagado` en el cashflow es base devengado hasta que se implemente apply-payment para gastos
-- Los márgenes de campaña son estimados (budget), no pagos reales
-- Máximo 30 receivables por fuente (60 total)
-- Moneda: EUR únicamente. Si hay registros en otra divisa, los totales pueden estar mezclados (no se hace conversión)
+Cierre del bloque de rediseño de Finanzas de la semana del 2026-07-01.

--- a/src/__tests__/server/docs-finance-dashboard.test.ts
+++ b/src/__tests__/server/docs-finance-dashboard.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Verifica que docs/finance-dashboard.md cubre las 13 secciones pedidas
+ * en el loop nocturno (Tarea 3) y menciona los conceptos clave del
+ * rediseño de julio 2026.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const PROJECT_ROOT = path.resolve(__dirname, '..', '..', '..');
+const DOC = fs.readFileSync(path.join(PROJECT_ROOT, 'docs/finance-dashboard.md'), 'utf-8');
+
+describe('[docs] finance-dashboard.md — cobertura de secciones', () => {
+  const requiredSections: Array<[string, RegExp]> = [
+    ['1. /admin/finanzas/resumen',                     /\/admin\/finanzas\/resumen/],
+    ['2. /admin/finanzas/mes',                          /\/admin\/finanzas\/mes/],
+    ['3. /admin/finanzas/pl',                           /\/admin\/finanzas\/pl/],
+    ['4. /admin/finanzas/cobros',                       /\/admin\/finanzas\/cobros/],
+    ['5. Pagos a talentos vs Gastos operativos',        /pagos? a talentos[\s\S]*gastos operativos|Pagos a talentos[\s\S]*coste directo/i],
+    ['6. Nóminas vs Impuestos vs Operativos',           /Nóminas[\s\S]*Impuestos[\s\S]*Operativos|nomina_socio[\s\S]*cuota_autonomo/i],
+    ['7. Margen bruto',                                 /Margen bruto/i],
+    ['8. Resultado operativo',                          /Resultado operativo/i],
+    ['9. Margen pendiente estimado',                    /Margen pendiente estimado/i],
+    ['10. invoice_payments canónico',                   /invoice_payments/],
+    ['11. paidAmount deprecated',                       /paidAmount[\s\S]*deprecated|@deprecated/i],
+    ['12. Recurrentes activos Pablo/Alfonso/Gestoría',  /Cuota autónomo — Pablo[\s\S]*Seguro médico — Alfonso[\s\S]*Gestoría/i],
+    ['13. Cron generate-recurring-expenses',            /generate-recurring-expenses[\s\S]*0 3 \* \* \*/i],
+  ];
+
+  it.each(requiredSections)('cubre sección: %s', (_label, pattern) => {
+    expect(DOC).toMatch(pattern);
+  });
+});
+
+describe('[docs] finance-dashboard.md — estado tras rediseño 2026-07', () => {
+  it('menciona la fecha de última actualización', () => {
+    expect(DOC).toMatch(/2026-07-\d{2}/);
+  });
+
+  it('indica que TD-14 está cerrado', () => {
+    expect(DOC).toMatch(/TD-14.*cerrado|TD-14 cerrado/i);
+  });
+
+  it('menciona TD-14b como residual pendiente', () => {
+    expect(DOC).toMatch(/TD-14b/);
+  });
+
+  it('lista las 5 plantillas de recurring_expenses (2 legacy + 3 activas)', () => {
+    for (const name of [
+      'Cuota autónomo — Keko',
+      'Cuota autónomo — Zack',
+      'Cuota autónomo — Pablo',
+      'Seguro médico — Alfonso',
+      'Gestoría',
+    ]) {
+      expect(DOC).toContain(name);
+    }
+  });
+
+  it('indica que el schedule del cron es diario 03:00 UTC', () => {
+    expect(DOC).toMatch(/0 3 \* \* \*/);
+    expect(DOC).toMatch(/diario/i);
+  });
+});


### PR DESCRIPTION
## Resumen

**Tarea 3 del loop nocturno.** Reescribe `docs/finance-dashboard.md` para reflejar el estado tras el rediseño de julio 2026 y cubrir las 13 secciones pedidas.

Cero código de producción tocado. Cero DB / schema / migrations / crons / emails / Resend / invoice_reminders / OCR / Blob / Sheets / RBAC / dunning / Tratos / facturación legal / payroll parser.

## Cobertura de las 13 secciones

1. `/admin/finanzas/resumen` — home CEO/YTD con selector `from`/`to`.
2. `/admin/finanzas/mes` — control mensual (movido desde `/resumen`).
3. `/admin/finanzas/pl` — histórico y P&L.
4. `/admin/finanzas/cobros` — AR aging.
5. Diferencia **pagos a talentos** (`campaign_direct + pago_talento`) vs **gastos operativos**.
6. Diferencia **nóminas** vs **impuestos/cargas** vs **operativos reales**.
7. **Margen bruto** (cobrado + pendiente estimado).
8. **Resultado operativo** (base caja).
9. **Margen pendiente estimado** (cobros pendientes − pagos talento pendientes).
10. **`invoice_payments` canónico** en todas las queries nuevas.
11. **`paidAmount` deprecated** + TD-14 cerrado / TD-14b residual.
12. **Recurrentes activos**: Pablo cuota autónomo (id=3), Alfonso seguro médico (id=4), Gestoría (id=5). Tabla completa con las 5 plantillas y estado active/inactive.
13. **Cron `generate-recurring-expenses`** — schedule `0 3 * * *` diario UTC, idempotencia por `txId`, protección `CRON_SECRET`.

## Añadidos adicionales

- Fórmulas exactas de cada bloque del resumen.
- Mapa de archivos clave del módulo (queries, componentes, cron).
- Sección "Estado tras el rediseño" con checklist ✅/⚠️.

## Tests (18 nuevos)

`src/__tests__/server/docs-finance-dashboard.test.ts`:
- Verifica que las 13 secciones están presentes con patrones regex.
- Verifica fecha `2026-07-XX` de última actualización.
- Verifica menciones a TD-14 cerrado + TD-14b residual.
- Verifica que las 5 plantillas de `recurring_expenses` aparecen listadas por nombre.
- Verifica schedule cron `0 3 * * *` + palabra "diario".

## CI local

- ✅ `npx tsc --noEmit` — clean
- ✅ `npm run lint` — 0/0
- ✅ `npm test` — 118 suites · **2134 tests** verdes (18 nuevos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)