### PR TITLE
docs(finance): convención 'status=pagada' sin invoice_payments

### DIFF
--- a/docs/finance-dashboard.md
+++ b/docs/finance-dashboard.md
@@ -207,6 +207,27 @@ Todas las queries **nuevas** de Finanzas usan esta tabla:
 
 Cualquier query nueva que calcule "cobrado" o "pagado" **debe** usar `invoice_payments`, nunca `invoices.paidAmount`.
 
+### Convención: `status='pagada'` sin `invoice_payments`
+
+En la práctica hay dos conceptos que **no son equivalentes**:
+
+| Campo | Significado |
+|---|---|
+| `invoices.status` (o `issued_invoices.status`) | Estado **operativo/manual** de la factura o gasto. `'pagada'` / `'cobrada'` = el usuario declara que la operación se ha materializado desde su cuenta. |
+| `invoice_payments` | **Fuente canónica de pagos conciliados** — cash real. Cada fila vincula la factura con una `bank_transaction` concreta a través del módulo de conciliación bancaria. |
+
+**Ambas cosas pueden coexistir independientemente.** Un gasto marcado como `pagada` puede no tener fila en `invoice_payments` si nunca pasó por conciliación (nóminas importadas via wizard con status ya marcado, recurrentes backfilled con `status='pagada'`, correcciones manuales, etc.). Al 2026-07-02 hay **32 filas** en esa situación — todas gastos de estructura pagados desde el banco pero no conciliados.
+
+**Efecto en las vistas del resumen:**
+
+- Los bloques **Nóminas / Impuestos / Operativos / Resultado operativo** cuentan estas 32 filas correctamente (usan `SUM(totalAmount)` en accrual, no `invoice_payments`).
+- Los KPIs **base caja** (ingresos cobrados, costes directos pagados, cashflow) sólo cuentan lo que tiene fila en `invoice_payments`. Como estas 32 filas son gastos operativos/nóminas/impuestos y no ingresos ni costes directos, no aplica.
+- El módulo de conciliación (`/admin/facturacion/bancos/conciliacion`) no ve estas filas porque no tienen `bank_transaction_id` que las respalde.
+
+**Regla de oro:** para cualquier métrica de tesorería/cash flow usar siempre `invoice_payments`. Para P&L accrual usar `SUM(totalAmount)` sobre `invoices` filtrado por `expenseGroup`/`expenseSubtype` y excluyendo `status='anulada'`.
+
+Herramienta re-ejecutable para reauditar la consistencia: `scripts/audit-finanzas-consistency.ts` (ver informe en `docs/finance-audit-2026-07-02.md`).
+
 ---
 
 ## 11. `invoices.paidAmount` deprecated

--- a/src/__tests__/server/docs-finance-dashboard.test.ts
+++ b/src/__tests__/server/docs-finance-dashboard.test.ts
@@ -61,4 +61,16 @@ describe('[docs] finance-dashboard.md — estado tras rediseño 2026-07', () => 
     expect(DOC).toMatch(/0 3 \* \* \*/);
     expect(DOC).toMatch(/diario/i);
   });
+
+  it("documenta la convención status='pagada' sin invoice_payments", () => {
+    // Nueva sección añadida tras el cierre del loop nocturno.
+    expect(DOC).toMatch(/status='pagada' sin `invoice_payments`|status='pagada'[\s\S]*invoice_payments/i);
+    expect(DOC).toMatch(/32 filas/);
+    expect(DOC).toMatch(/no son equivalentes/i);
+  });
+
+  it('deja claro que invoice_payments = cash real y status = estado operativo', () => {
+    expect(DOC).toMatch(/cash real/i);
+    expect(DOC).toMatch(/estado \*\*operativo\/manual\*\*|estado operativo/i);
+  });
 });


### PR DESCRIPTION
## Resumen

PR pequeño **solo de documentación**. Añade en `docs/finance-dashboard.md` § 10 (Fuente canónica de pagos) una subsección explicando la convención "gasto marcado `pagada` sin fila en `invoice_payments`" identificada durante la Tarea 4 del loop nocturno (32 filas al 2026-07-02, todas gastos de estructura pagados desde el banco pero no conciliados).

Cero DB / schema / migrations / crons / emails / Resend / invoice_reminders / OCR / Blob / Sheets / RBAC / dunning / Tratos / facturación legal / payroll parser / código de producción.

## Contenido

Nueva subsección con:

- Tabla que diferencia semánticamente los dos conceptos:
  - `invoices.status` = estado **operativo/manual** de la factura/gasto.
  - `invoice_payments` = **fuente canónica de pagos conciliados** (cash real, vinculado a `bank_transaction`).
- Explicación de por qué pueden coexistir independientemente.
- Impacto en las vistas del resumen (accrual vs base caja).
- Regla de oro: tesorería/cashflow → `invoice_payments`; P&L accrual → `SUM(totalAmount)` sobre `invoices` filtrado por `expenseGroup`/`expenseSubtype` excluyendo `status='anulada'`.
- Referencia al script re-ejecutable `scripts/audit-finanzas-consistency.ts` y al informe `docs/finance-audit-2026-07-02.md`.

## Archivos (2)

- `docs/finance-dashboard.md` — +33 líneas en § 10.
- `src/__tests__/server/docs-finance-dashboard.test.ts` — +2 tests verificando la nueva subsección.

## Tests

- Verifica que la nueva subsección menciona la convención, las **32 filas** identificadas por el audit y la frase "no son equivalentes".
- Verifica que deja claro que `invoice_payments` = cash real y `status` = estado operativo/manual.

## CI local

- ✅ `npx tsc --noEmit` — clean
- ✅ `npm run lint` — 0/0
- ✅ `npm test` — 118 suites · **2136 tests** verdes (2 nuevos)

## TD-14b — sigue pendiente

Este PR **no toca `listInvoices()`**. TD-14b sigue documentado como pendiente residual para PR separado con auditoría de consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)