### PR TITLE
docs(td14b): marcar TD-14b como decisión de diseño (no accionable)

### DIFF
--- a/docs/finance-dashboard.md
+++ b/docs/finance-dashboard.md
@@ -239,7 +239,7 @@ El schema marca `invoices.paidAmount` con `@deprecated` explícito. Es una colum
 - ✅ Queries de dashboard nuevas: **cero uso** de `paidAmount`.
 - ✅ `receivables.ts` — migrada a `invoice_payments` (TD-14 cerrado).
 - ✅ `pnl.ts` — dead SELECT de `paidAmount` eliminado.
-- ⚠️ **TD-14b (pendiente)**: `src/lib/queries/invoices.ts::listInvoices()` sigue seleccionando `paidAmount: invoices.paidAmount` como parte del tipo `InvoiceWithRelations`. Consumers múltiples (drawer factura, tabla gastos, exports CSV/PDF). Migrar en PR separado con auditoría de consumers. Ver `docs/tech-debt.md` § TD-14b.
+- 🟨 **TD-14b (no accionable · decisión de diseño 2026-07-02)**: `src/lib/queries/invoices.ts::listInvoices()` mantiene `paidAmount: invoices.paidAmount` como **valor operativo/manual declarado por el usuario** (editable desde `InvoiceDrawer`). Tras auditar los 10 consumers de `listInvoices()`, se confirma que ninguno calcula "cobrado real" a partir de esa column — las vistas críticas de Finanzas ya usan `invoice_payments` en queries dedicadas. Si aparece necesidad futura de cash real en un listado genérico, crear función paralela `listInvoicesWithPayments()`, **no** modificar `listInvoices()`. Ver `docs/tech-debt.md` § TD-14b.
 
 ---
 
@@ -359,7 +359,7 @@ src/app/api/cron/generate-recurring-expenses/route.ts
 
 vercel.json                       Registro de crons (incluye recurring desde jul/2026)
 
-docs/tech-debt.md                 TD-14 cerrado, TD-14b pendiente
+docs/tech-debt.md                 TD-14 cerrado, TD-14b decisión de diseño
 ```
 
 ---
@@ -372,6 +372,6 @@ docs/tech-debt.md                 TD-14 cerrado, TD-14b pendiente
 - ✅ Bloque expandible "Dónde se ha ido el dinero" con subtotales por categoría.
 - ✅ Cron de recurrentes activo diario, plantillas Pablo cuota + Alfonso seguro + Gestoría en marcha.
 - ✅ Fuente canónica `invoice_payments` en todas las queries relevantes; `paidAmount` deprecated eliminado de queries de dashboard.
-- ⚠️ TD-14b residual: `listInvoices()` genérico sigue con `paidAmount`. PR separado con scope grande.
+- 🟨 TD-14b: `listInvoices()` genérico mantiene `paidAmount` como valor manual — decisión de diseño (2026-07-02) tras auditar 10 consumers. No accionable.
 
 Cierre del bloque de rediseño de Finanzas de la semana del 2026-07-01.

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -125,13 +125,28 @@ Los 76 warnings del linter son todos `no-unused-vars`. Los más repetidos:
 **Corrección:** El internal path de `getReceivables()` ahora calcula `paidAmount` como `COALESCE(SUM(invoice_payments.amount), 0)` con LEFT JOIN + GROUP BY, mismo patrón que el issued path y que `arAging.ts` / `finanzasResumenV2.ts`. También se limpió `pnl.ts` que seleccionaba `paidAmount` sin usarlo (dead SELECT).
 **Estado:** `receivables.ts` y `pnl.ts` ya no leen `invoices.paidAmount`. Ver TD-14b para el residual pendiente.
 
-### TD-14b · `listInvoices()` general expone `paidAmount` column deprecated
+### TD-14b · `listInvoices()` expone `paidAmount` column — 🟨 NO ACCIONABLE (decisión de diseño, 2026-07-02)
 **Archivo:** `src/lib/queries/invoices.ts:68`
-**Contexto:** `listInvoices()` es la query genérica del módulo de facturación (`/admin/facturacion`, `/admin/finanzas/gastos`, drawers, tabs, exports). Selecciona `paidAmount: invoices.paidAmount` como parte del `InvoiceWithRelations` que consumen múltiples componentes de UI y utilidades de export.
-**Consecuencia:** Los componentes que muestran "paidAmount" (drawer de factura, tabla de gastos, export CSV/PDF) siguen leyendo la column legacy. En la práctica se sincroniza al aplicar `invoice_payments` desde conciliación, pero cualquier drift silencioso mostraría un valor incorrecto en la UI de facturación.
-**Acción:** Migrar en PR separado — reemplazar la column por `SUM(invoice_payments.amount)` con LEFT JOIN + GROUP BY sobre 4 queries de `listInvoices()`. Requiere auditar todos los consumers del tipo `InvoiceWithRelations` para asegurar que `.paidAmount` siga siendo un `string` numérico. Riesgo medio por scope amplio.
-**Riesgo:** Bajo mientras coexista con conciliación bien sincronizada. Medio si aparece drift.
-**Esfuerzo:** 1-2h (query + tipos + tests + smoke UI).
+
+**Decisión (2026-07-02):** tras diagnóstico exhaustivo de los 10 consumers de `listInvoices()`, **no se migra**. La column `invoices.paidAmount` deja de considerarse "deuda a corregir" y pasa a ser **valor operativo manual declarado por el usuario**.
+
+**Semántica actual (documentada y aceptada):**
+- `invoices.paidAmount` (column) = valor operativo/manual editable desde `InvoiceDrawer` — lo que el usuario declara como cobrado/pagado.
+- `invoice_payments` (tabla) = fuente canónica de **cash real conciliado** con `bank_transaction`.
+- Ambos conceptos pueden coexistir independientemente. Ver `docs/finance-dashboard.md` § 10 (Convención `status='pagada'` sin `invoice_payments`).
+
+**Análisis de consumers (10 archivos):**
+Ninguno calcula "cobrado real" o "pendiente real" a partir de `.paidAmount`. Los que muestran cifras de cash (`ReceivablesTable`, `ArAgingTable`, resumen V2) reciben `paidAmount` desde queries dedicadas (`arAging.ts`, `receivables.ts`, `finanzasResumenV2.ts`) que ya usan `invoice_payments`. El único consumer que lee la column directamente es `InvoiceDrawer.tsx:390` como `defaultValue` del input editable — semánticamente correcto para el rol de "valor manual".
+
+**Regla derivada de la decisión:**
+- ✅ `listInvoices()` se mantiene tal cual. `paidAmount` = valor manual declarado.
+- ✅ Vistas críticas de Finanzas (resumen, cobros, pl, mes) deben usar `invoice_payments` o queries dedicadas — nunca `listInvoices().paidAmount`.
+- ✅ Si en el futuro se necesita cash real en un listado genérico, **crear una función paralela** `listInvoicesWithPayments()` que derive desde `invoice_payments`. **No modificar `listInvoices()` directamente** — rompería el drawer editable y ~10 pantallas.
+
+**Protección anti-migración accidental:**
+`src/__tests__/server/finance-td14-invoice-payments.test.ts` incluye un test estático que verifica que `listInvoices()` sigue con `paidAmount: invoices.paidAmount`. Si algún día se migra intencionalmente, ese test debe actualizarse y este bloque de tech-debt también.
+
+**Estado:** cerrado como decisión de diseño. No hay acción pendiente. Sin fecha de reapertura.
 
 ---
 

--- a/src/__tests__/server/docs-finance-dashboard.test.ts
+++ b/src/__tests__/server/docs-finance-dashboard.test.ts
@@ -41,8 +41,9 @@ describe('[docs] finance-dashboard.md — estado tras rediseño 2026-07', () => 
     expect(DOC).toMatch(/TD-14.*cerrado|TD-14 cerrado/i);
   });
 
-  it('menciona TD-14b como residual pendiente', () => {
+  it('menciona TD-14b como decisión de diseño (no accionable)', () => {
     expect(DOC).toMatch(/TD-14b/);
+    expect(DOC).toMatch(/decisi[óo]n de dise[ñn]o|no accionable/i);
   });
 
   it('lista las 5 plantillas de recurring_expenses (2 legacy + 3 activas)', () => {


### PR DESCRIPTION
## Resumen

**Solo docs.** Tras el diagnóstico exhaustivo de esta mañana, marco **TD-14b** como **🟨 no accionable (decisión de diseño, 2026-07-02)**. La column `invoices.paidAmount` deja de ser "deuda a corregir" y pasa a ser oficialmente "valor operativo manual declarado por el usuario".

Cero código de producción tocado. Cero DB / schema / migrations / drizzle / queries / `listInvoices` / `InvoiceDrawer` / `invoicePayments` / crons / emails / Resend / invoice_reminders / OCR / Blob / Sheets / RBAC / dunning / Tratos / facturación legal / payroll parser.

## Base de la decisión

Diagnóstico completo de los 10 consumers de `listInvoices()`:

- **Ningún consumer** calcula "cobrado real" con `.paidAmount`.
- **Vistas críticas** (resumen, cobros, pl, mes) ya usan queries dedicadas con `invoice_payments`.
- **Único consumer** que lee la column directamente: `InvoiceDrawer.tsx:390` como `defaultValue` del input editable — semánticamente correcto.
- **4 escritores** de la column (`applyInvoicePayment`, `deal-movimiento-action`, `issued-invoices-actions`, drawer form) mantienen la column como verdad manual/operativa.

**Regla derivada**: si aparece necesidad futura de cash real en un listado genérico, **crear función paralela** `listInvoicesWithPayments()` — **no** modificar `listInvoices()`.

## Cambios (3 archivos)

- `docs/tech-debt.md § TD-14b` — reescrito completamente: 🟨 no accionable, semántica dual documentada, regla de función paralela, protección anti-migración accidental.
- `docs/finance-dashboard.md § 11` — sustituye "⚠️ (pendiente)" por "🟨 (no accionable · decisión de diseño 2026-07-02)".
- `docs/finance-dashboard.md` (2 refs secundarias) — coherentes con la decisión.
- `src/__tests__/server/docs-finance-dashboard.test.ts` — test renombrado y ampliado (verifica \"decisión de diseño\" o \"no accionable\").

## Protección vigente

`src/__tests__/server/finance-td14-invoice-payments.test.ts` sigue verificando que `listInvoices()` mantiene `paidAmount: invoices.paidAmount`. Si algún día se migra intencionalmente, ese test y estos docs deben actualizarse juntos.

## CI local

- ✅ `npx tsc --noEmit` — clean
- ✅ `npm run lint` — 0/0
- ✅ `npm test` — 118 suites · **2136 tests** verdes

🤖 Generated with [Claude Code](https://claude.com/claude-code)