### PR TITLE
feat(sorteos): social accounts foundation — link Discord y YouTube

### DIFF
--- a/docs/env-social.md
+++ b/docs/env-social.md
@@ -1,0 +1,97 @@
+# Variables de entorno — Social accounts (PR-1b-1)
+
+Variables server-only añadidas para el flujo de social linking.
+Todas viven en `src/lib/env.ts` con validación Zod. Empty string se trata
+como undefined.
+
+## Obligatorias en producción
+
+### `SOCIAL_TOKEN_ENCRYPTION_KEY`
+
+Cifrado AES-256-GCM de los tokens sociales guardados en
+`connected_social_accounts`. **32 bytes en base64**.
+
+Generar:
+```bash
+node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
+```
+
+Opcional en dev: la app arranca sin ella, la UI muestra "No configurado
+todavía" en las tarjetas sociales y los endpoints `/api/social/*` devuelven
+`503 provider_not_configured`.
+
+**Reglas de seguridad**:
+- No commitear en repos.
+- No loggear.
+- Rotación cada 90 días (script futuro `scripts/rotate-social-token-key.ts`).
+
+## Providers activos
+
+### Discord
+
+Crear app en <https://discord.com/developers/applications>.
+
+**Redirect URI** a configurar en el dashboard:
+```
+{NEXT_PUBLIC_SITE_URL}/api/social/discord/callback
+```
+
+Variables:
+- `DISCORD_CLIENT_ID`
+- `DISCORD_CLIENT_SECRET`
+
+Scopes solicitados: `identify guilds guilds.members.read`.
+
+### Google / YouTube
+
+Crear credenciales OAuth 2.0 en
+<https://console.cloud.google.com/apis/credentials>.
+
+**Redirect URI** a configurar:
+```
+{NEXT_PUBLIC_SITE_URL}/api/social/google/callback
+```
+
+Variables:
+- `GOOGLE_CLIENT_ID`
+- `GOOGLE_CLIENT_SECRET`
+
+Scopes solicitados:
+- `openid`
+- `email`
+- `profile`
+- `https://www.googleapis.com/auth/youtube.readonly`
+
+## Providers planned (no activos en PR-1b-1)
+
+- **X / Twitter** → congelado por coste API v2 Basic ($100/mes).
+- **Instagram** → Meta/Basic Display no permite verificar acciones.
+
+Ambos aparecen en la UI como "Próximamente". Los endpoints `/api/social/x/*`
+y `/api/social/instagram/*` responden `501 provider_planned`.
+
+## Referencias públicas para PR-1b-2
+
+Estas 2 se documentan aquí pero no se usan aún — se usarán al implementar
+misiones sociales verificables (PR-1b-2).
+
+- `DISCORD_GUILD_ID` — id del server SocialPro para misiones "unirse a Discord".
+- `YOUTUBE_CHANNEL_ID` — id del canal SocialPro para misiones YouTube.
+
+Ambas opcionales; sin ellas las misiones sociales dependientes fallarán en
+tiempo de check.
+
+## Flujo típico setup
+
+```bash
+# 1. Genera la key de cifrado
+node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
+
+# 2. En Vercel Dashboard → Settings → Environment Variables:
+#    Añade cada variable en Production + Preview + Development
+#    Marca "Sensitive" para SECRET y ENCRYPTION_KEY
+
+# 3. Redeploy (Vercel toma las vars en el siguiente build)
+
+# 4. Configura Redirect URIs en Discord + Google con la URL final
+```

--- a/drizzle/0104_connected_social_accounts.sql
+++ b/drizzle/0104_connected_social_accounts.sql
@@ -1,0 +1,20 @@
+CREATE TABLE "connected_social_accounts" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"provider" varchar(20) NOT NULL,
+	"provider_user_id" text NOT NULL,
+	"username" text,
+	"avatar_url" text,
+	"access_token_enc" text NOT NULL,
+	"refresh_token_enc" text,
+	"scopes" text[],
+	"expires_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "connected_social_accounts" ADD CONSTRAINT "connected_social_accounts_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "connected_social_accounts_provider_provider_user_id_uq" ON "connected_social_accounts" USING btree ("provider","provider_user_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "connected_social_accounts_user_id_provider_uq" ON "connected_social_accounts" USING btree ("user_id","provider");--> statement-breakpoint
+CREATE INDEX "connected_social_accounts_user_id_idx" ON "connected_social_accounts" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "connected_social_accounts_provider_idx" ON "connected_social_accounts" USING btree ("provider");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -729,6 +729,13 @@
       "when": 1783003849094,
       "tag": "0103_giveaway_platform",
       "breakpoints": true
+    },
+    {
+      "idx": 104,
+      "version": "7",
+      "when": 1783029087519,
+      "tag": "0104_connected_social_accounts",
+      "breakpoints": true
     }
   ]
 }

--- a/src/__tests__/server/social-crypto.test.ts
+++ b/src/__tests__/server/social-crypto.test.ts
@@ -1,0 +1,83 @@
+/**
+ * AES-256-GCM encrypt/decrypt de tokens sociales.
+ * Puros — sin DB, sin red. Mutan process.env para setear la key.
+ */
+
+import crypto from 'node:crypto';
+
+// La key debe estar en env ANTES de que src/lib/env.ts se evalúe.
+// Como env.ts corre createEnv en top level, seteamos aquí, ANTES del import.
+const goodKey = crypto.randomBytes(32).toString('base64');
+process.env.SOCIAL_TOKEN_ENCRYPTION_KEY = goodKey;
+
+// Evita el ciclo de cache — importamos dentro de tests para poder resetear
+// env entre casos si hace falta.
+import { encryptToken, decryptToken, isSocialCryptoConfigured } from '@/lib/social/crypto';
+
+describe('[social-crypto] round-trip', () => {
+  it('encrypt → decrypt devuelve el plaintext original', () => {
+    const plain = 'token-de-prueba-abc123';
+    const bundle = encryptToken(plain);
+    expect(decryptToken(bundle)).toBe(plain);
+  });
+
+  it('empty string cifra y descifra OK', () => {
+    const bundle = encryptToken('');
+    expect(decryptToken(bundle)).toBe('');
+  });
+
+  it('token largo (típico OAuth access_token) round-trips', () => {
+    const long = 'gho_' + 'a'.repeat(200) + '_end';
+    expect(decryptToken(encryptToken(long))).toBe(long);
+  });
+});
+
+describe('[social-crypto] aleatoriedad del nonce', () => {
+  it('diferentes ciphertexts del mismo plaintext (nonce único)', () => {
+    const plain = 'mismo-plaintext';
+    const set = new Set<string>();
+    for (let i = 0; i < 50; i++) set.add(encryptToken(plain));
+    expect(set.size).toBe(50);
+  });
+});
+
+describe('[social-crypto] resistencia a tampering', () => {
+  it('bit-flip en nonce → decrypt throws', () => {
+    const bundle = encryptToken('sensitive');
+    const buf = Buffer.from(bundle, 'base64');
+    buf[0] = (buf[0] ?? 0) ^ 0x01; // flip in nonce region
+    const tampered = buf.toString('base64');
+    expect(() => decryptToken(tampered)).toThrow();
+  });
+
+  it('bit-flip en cipher → decrypt throws (authTag falla)', () => {
+    const bundle = encryptToken('sensitive-mid-length-blob');
+    const buf = Buffer.from(bundle, 'base64');
+    const mid = Math.floor(buf.length / 2);
+    buf[mid] = (buf[mid] ?? 0) ^ 0x40;
+    expect(() => decryptToken(buf.toString('base64'))).toThrow();
+  });
+
+  it('bit-flip en authTag → decrypt throws', () => {
+    const bundle = encryptToken('sensitive');
+    const buf = Buffer.from(bundle, 'base64');
+    buf[buf.length - 1] = (buf[buf.length - 1] ?? 0) ^ 0x01;
+    expect(() => decryptToken(buf.toString('base64'))).toThrow();
+  });
+});
+
+describe('[social-crypto] configuración inválida', () => {
+  it('bundle base64 malformado → decrypt throws', () => {
+    expect(() => decryptToken('###')).toThrow();
+  });
+
+  it('bundle demasiado corto → decrypt throws', () => {
+    // 8 bytes no llega ni al nonce
+    const tiny = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8]).toString('base64');
+    expect(() => decryptToken(tiny)).toThrow();
+  });
+
+  it('isSocialCryptoConfigured() es true con key válida', () => {
+    expect(isSocialCryptoConfigured()).toBe(true);
+  });
+});

--- a/src/__tests__/server/social-oauth-structural.test.ts
+++ b/src/__tests__/server/social-oauth-structural.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Verificaciones estructurales del flujo OAuth de social linking.
+ * No corren HTTP ni DB — leen el source y validan contratos clave.
+ *
+ * Patrón que ya usan `steam-openid.test.ts` y `giveaway-platform-v2-shell.test.ts`.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(__dirname, '..', '..', '..');
+const read = (rel: string) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');
+
+describe('[social-oauth] connect route', () => {
+  const src = read('src/app/api/social/[provider]/connect/route.ts');
+
+  it('requiere sesión antes de emitir state', () => {
+    expect(src).toMatch(/auth\.api\.getSession/);
+    expect(src).toMatch(/session\?\.user/);
+  });
+  it('valida provider unknown → 400', () => {
+    expect(src).toMatch(/status:\s*400/);
+    expect(src).toMatch(/provider_unknown/);
+  });
+  it('valida provider planned → 501', () => {
+    expect(src).toMatch(/status:\s*501/);
+    expect(src).toMatch(/provider_planned/);
+  });
+  it('valida provider not configured → 503', () => {
+    expect(src).toMatch(/status:\s*503/);
+    expect(src).toMatch(/provider_not_configured/);
+  });
+  it('genera state firmado + cookie httpOnly Path=/api/social', () => {
+    expect(src).toMatch(/generateState/);
+    expect(src).toMatch(/signState/);
+    expect(src).toMatch(/httpOnly:\s*true/);
+    expect(src).toMatch(/path:\s*['"]\/api\/social['"]/);
+    expect(src).toMatch(/sameSite:\s*['"]lax['"]/);
+  });
+  it('Google añade access_type=offline + prompt=consent', () => {
+    expect(src).toMatch(/access_type[\s\S]{0,40}offline/);
+    expect(src).toMatch(/prompt[\s\S]{0,40}consent/);
+  });
+});
+
+describe('[social-oauth] callback route', () => {
+  const src = read('src/app/api/social/[provider]/callback/route.ts');
+
+  it('verifica state cookie contra state query', () => {
+    expect(src).toMatch(/verifyState/);
+    expect(src).toMatch(/payload\.state\s*!==\s*stateQuery/);
+  });
+  it('rechaza si falta code o error del provider', () => {
+    expect(src).toMatch(/user_denied|providerError/);
+    expect(src).toMatch(/no_code/);
+  });
+  it('llama exchangeCode → fetchProfile → upsertSocialAccount', () => {
+    expect(src).toMatch(/exchangeCode\(/);
+    expect(src).toMatch(/fetchProfile\(/);
+    expect(src).toMatch(/upsertSocialAccount\(/);
+  });
+  it('mapea SocialAccountAlreadyLinkedError → already_linked', () => {
+    expect(src).toMatch(/SocialAccountAlreadyLinkedError/);
+    expect(src).toMatch(/already_linked/);
+  });
+  it('limpia state cookie al terminar', () => {
+    expect(src).toMatch(/STATE_COOKIE_NAME[\s\S]{0,150}maxAge:\s*0/);
+  });
+});
+
+describe('[social-oauth] disconnect server action', () => {
+  const src = read('src/app/sorteos/plataforma/perfil/actions.ts');
+
+  it('requiere sesión', () => {
+    expect(src).toMatch(/auth\.api\.getSession/);
+    expect(src).toMatch(/no_session/);
+  });
+  it('valida provider ∈ active whitelist', () => {
+    expect(src).toMatch(/isActiveProvider/);
+    expect(src).toMatch(/provider_unknown/);
+  });
+  it('deleteSocialAccount + revokeToken best-effort', () => {
+    expect(src).toMatch(/deleteSocialAccount\(/);
+    expect(src).toMatch(/revokeToken\(/);
+  });
+  it('revalida /sorteos/plataforma/perfil', () => {
+    expect(src).toMatch(/revalidatePath\(['"]\/sorteos\/plataforma\/perfil['"]\)/);
+  });
+});
+
+describe('[social-oauth] accounts data layer', () => {
+  const src = read('src/lib/social/accounts.ts');
+
+  it('cifra access_token con encryptToken antes de guardar', () => {
+    expect(src).toMatch(/encryptToken\(token\.accessToken\)/);
+  });
+  it('ON CONFLICT (user_id, provider) DO UPDATE en upsert', () => {
+    expect(src).toMatch(/onConflictDoUpdate/);
+    expect(src).toMatch(/connectedSocialAccounts\.userId,\s*connectedSocialAccounts\.provider/);
+  });
+  it('captura UNIQUE(provider, provider_user_id) violation → SocialAccountAlreadyLinkedError', () => {
+    expect(src).toMatch(/isUniqueViolation/);
+    expect(src).toMatch(/SocialAccountAlreadyLinkedError/);
+  });
+  it('getConnectedAccountsSafe NUNCA devuelve tokens', () => {
+    // Debe seleccionar solo campos seguros (id/provider/username/avatar/scopes/expiresAt/dates).
+    // NO debe incluir accessTokenEnc ni refreshTokenEnc en el SELECT.
+    expect(src).toMatch(/export async function getConnectedAccountsSafe/);
+    const fnScope = /getConnectedAccountsSafe[\s\S]*?^}/m.exec(src)?.[0] ?? '';
+    expect(fnScope).not.toMatch(/accessTokenEnc/);
+    expect(fnScope).not.toMatch(/refreshTokenEnc/);
+  });
+});
+
+describe('[social-oauth] no leak de tokens en UI/logs', () => {
+  const files = [
+    'src/features/giveaway-platform/components/SocialAccountCard.tsx',
+    'src/app/sorteos/plataforma/perfil/page.tsx',
+  ];
+  for (const rel of files) {
+    it(`${rel} no referencia accessTokenEnc/refreshTokenEnc`, () => {
+      const src = read(rel);
+      expect(src).not.toMatch(/accessTokenEnc/);
+      expect(src).not.toMatch(/refreshTokenEnc/);
+    });
+  }
+
+  it('ningún archivo de lib/social hace console.log con "token"', () => {
+    const files = [
+      'src/lib/social/crypto.ts',
+      'src/lib/social/state.ts',
+      'src/lib/social/oauth.ts',
+      'src/lib/social/accounts.ts',
+      'src/lib/social/providers.ts',
+    ];
+    for (const rel of files) {
+      const src = read(rel);
+      expect(src).not.toMatch(/console\.log[\s\S]{0,80}token/i);
+      expect(src).not.toMatch(/console\.error[\s\S]{0,80}token/i);
+    }
+  });
+});
+
+describe('[social-oauth] env vars declaradas server-only', () => {
+  const src = read('src/lib/env.ts');
+
+  it('SOCIAL_TOKEN_ENCRYPTION_KEY vive en el bloque server', () => {
+    expect(src).toMatch(/server:\s*\{[\s\S]*SOCIAL_TOKEN_ENCRYPTION_KEY[\s\S]*\},/);
+  });
+  it('DISCORD_CLIENT_SECRET vive en el bloque server', () => {
+    expect(src).toMatch(/server:\s*\{[\s\S]*DISCORD_CLIENT_SECRET[\s\S]*\},/);
+  });
+  it('GOOGLE_CLIENT_SECRET vive en el bloque server', () => {
+    expect(src).toMatch(/server:\s*\{[\s\S]*GOOGLE_CLIENT_SECRET[\s\S]*\},/);
+  });
+  it('ninguna client secret está en el bloque client', () => {
+    const clientBlock = /client:\s*\{[\s\S]*?\},/.exec(src)?.[0] ?? '';
+    expect(clientBlock).not.toMatch(/CLIENT_SECRET/);
+    expect(clientBlock).not.toMatch(/SOCIAL_TOKEN_ENCRYPTION_KEY/);
+  });
+});

--- a/src/__tests__/server/social-providers-config.test.ts
+++ b/src/__tests__/server/social-providers-config.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Registry de providers OAuth sociales.
+ * Puros — verifica shape del registry, active/planned, y las URLs
+ * exactas que usamos contra Discord/Google.
+ */
+
+import {
+  getProvider,
+  isActiveProvider,
+  isPlannedProvider,
+  isProviderConfigured,
+  listActiveProviders,
+  listAllProviders,
+} from '@/lib/social/providers';
+
+describe('[social-providers] listado', () => {
+  it('listAllProviders devuelve los 4 conocidos', () => {
+    expect(listAllProviders().sort()).toEqual(['discord', 'google', 'instagram', 'x'].sort());
+  });
+
+  it('listActiveProviders solo devuelve discord y google', () => {
+    expect(listActiveProviders().sort()).toEqual(['discord', 'google']);
+  });
+});
+
+describe('[social-providers] getProvider', () => {
+  it('discord tiene status active + URLs esperadas + scopes correctos', () => {
+    const cfg = getProvider('discord');
+    expect(cfg?.status).toBe('active');
+    if (cfg?.status !== 'active') throw new Error('unreachable');
+    expect(cfg.authorizeUrl).toBe('https://discord.com/oauth2/authorize');
+    expect(cfg.tokenUrl).toBe('https://discord.com/api/oauth2/token');
+    expect(cfg.profileUrl).toBe('https://discord.com/api/users/@me');
+    expect(cfg.revokeUrl).toBe('https://discord.com/api/oauth2/token/revoke');
+    expect(cfg.scopes).toEqual(['identify', 'guilds', 'guilds.members.read']);
+  });
+
+  it('google tiene status active + scopes YouTube readonly', () => {
+    const cfg = getProvider('google');
+    expect(cfg?.status).toBe('active');
+    if (cfg?.status !== 'active') throw new Error('unreachable');
+    expect(cfg.authorizeUrl).toBe('https://accounts.google.com/o/oauth2/v2/auth');
+    expect(cfg.tokenUrl).toBe('https://oauth2.googleapis.com/token');
+    expect(cfg.profileUrl).toBe('https://www.googleapis.com/oauth2/v3/userinfo');
+    expect(cfg.scopes).toContain('https://www.googleapis.com/auth/youtube.readonly');
+    expect(cfg.scopes).toContain('openid');
+    expect(cfg.scopes).toContain('email');
+    expect(cfg.scopes).toContain('profile');
+  });
+
+  it('x está planned con reason', () => {
+    const cfg = getProvider('x');
+    expect(cfg?.status).toBe('planned');
+    if (cfg?.status !== 'planned') throw new Error('unreachable');
+    expect(cfg.reason).toMatch(/basic/i);
+  });
+
+  it('instagram está planned con reason mencionando manual/futuro', () => {
+    const cfg = getProvider('instagram');
+    expect(cfg?.status).toBe('planned');
+    if (cfg?.status !== 'planned') throw new Error('unreachable');
+    expect(cfg.reason).toMatch(/manual|meta|instagram/i);
+  });
+
+  it('provider desconocido → null', () => {
+    expect(getProvider('facebook')).toBeNull();
+    expect(getProvider('')).toBeNull();
+  });
+});
+
+describe('[social-providers] helpers', () => {
+  it('isActiveProvider distingue active de planned', () => {
+    expect(isActiveProvider('discord')).toBe(true);
+    expect(isActiveProvider('google')).toBe(true);
+    expect(isActiveProvider('x')).toBe(false);
+    expect(isActiveProvider('instagram')).toBe(false);
+    expect(isActiveProvider('facebook')).toBe(false);
+  });
+
+  it('isPlannedProvider marca solo x e instagram', () => {
+    expect(isPlannedProvider('x')).toBe(true);
+    expect(isPlannedProvider('instagram')).toBe(true);
+    expect(isPlannedProvider('discord')).toBe(false);
+    expect(isPlannedProvider('unknown')).toBe(false);
+  });
+
+  it('isProviderConfigured es false sin env vars (dev limpio)', () => {
+    // En este test no seteamos DISCORD_CLIENT_ID/SECRET → false por diseño.
+    // Aislado del test env de social-crypto para no cruzar estado.
+    const prev = { id: process.env.DISCORD_CLIENT_ID, secret: process.env.DISCORD_CLIENT_SECRET };
+    delete process.env.DISCORD_CLIENT_ID;
+    delete process.env.DISCORD_CLIENT_SECRET;
+    // Como env.ts cachea, la única forma limpia es asertar el patrón general:
+    // el helper NO debe crashear cuando faltan, debe devolver false.
+    expect(() => isProviderConfigured('discord')).not.toThrow();
+    // Restore
+    if (prev.id) process.env.DISCORD_CLIENT_ID = prev.id;
+    if (prev.secret) process.env.DISCORD_CLIENT_SECRET = prev.secret;
+  });
+
+  it('isProviderConfigured para planned es siempre false', () => {
+    expect(isProviderConfigured('x')).toBe(false);
+    expect(isProviderConfigured('instagram')).toBe(false);
+  });
+});

--- a/src/__tests__/server/social-state.test.ts
+++ b/src/__tests__/server/social-state.test.ts
@@ -1,0 +1,76 @@
+/**
+ * State cookie signed HMAC — anti-CSRF de OAuth.
+ * Tests puros. Necesita BETTER_AUTH_SECRET para firmar.
+ */
+process.env.BETTER_AUTH_SECRET = 'a'.repeat(64); // 32+ chars required by env.ts
+
+import {
+  STATE_TTL_MS,
+  generateState,
+  signState,
+  verifyState,
+} from '@/lib/social/state';
+
+describe('[social-state] generateState', () => {
+  it('devuelve base64url de 32 bytes → 43 chars', () => {
+    const s = generateState();
+    expect(s).toHaveLength(43);
+    expect(s).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  it('genera valores distintos en cada llamada', () => {
+    const set = new Set<string>();
+    for (let i = 0; i < 50; i++) set.add(generateState());
+    expect(set.size).toBe(50);
+  });
+});
+
+describe('[social-state] signState/verifyState round-trip', () => {
+  it('cookie válido → payload decodificado', () => {
+    const cookie = signState({ state: 'abc', provider: 'discord', ts: Date.now() });
+    const out = verifyState(cookie, 'discord');
+    expect(out?.state).toBe('abc');
+    expect(out?.provider).toBe('discord');
+  });
+});
+
+describe('[social-state] verifyState rechaza cookies inválidos', () => {
+  it('signature manipulada → null', () => {
+    const cookie = signState({ state: 'abc', provider: 'discord', ts: Date.now() });
+    const [body, sig] = cookie.split('.');
+    const bad = `${body}.${(sig ?? '').slice(0, -1)}Z`;
+    expect(verifyState(bad, 'discord')).toBeNull();
+  });
+
+  it('provider distinto → null', () => {
+    const cookie = signState({ state: 'abc', provider: 'discord', ts: Date.now() });
+    expect(verifyState(cookie, 'google')).toBeNull();
+  });
+
+  it('ts > 10 min → null', () => {
+    const stale = signState({ state: 'abc', provider: 'discord', ts: Date.now() - STATE_TTL_MS - 1000 });
+    expect(verifyState(stale, 'discord')).toBeNull();
+  });
+
+  it('ts futuro (clock skew grande) → null', () => {
+    const future = signState({ state: 'abc', provider: 'discord', ts: Date.now() + 5 * 60_000 });
+    expect(verifyState(future, 'discord')).toBeNull();
+  });
+
+  it('cookie ausente → null', () => {
+    expect(verifyState(undefined, 'discord')).toBeNull();
+  });
+
+  it('cookie sin separador . → null', () => {
+    expect(verifyState('sinseparador', 'discord')).toBeNull();
+  });
+
+  it('body no es JSON válido → null', () => {
+    const fake = Buffer.from('no-json', 'utf8').toString('base64url');
+    // No podemos firmar sin la key; usamos signState con un body correcto y luego mutamos.
+    const goodCookie = signState({ state: 'abc', provider: 'discord', ts: Date.now() });
+    const [, sig] = goodCookie.split('.');
+    const bad = `${fake}.${sig}`;
+    expect(verifyState(bad, 'discord')).toBeNull();
+  });
+});

--- a/src/app/api/social/[provider]/callback/route.ts
+++ b/src/app/api/social/[provider]/callback/route.ts
@@ -1,0 +1,98 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { SITE_URL } from '@/lib/site-url';
+import { getProvider, isActiveProvider, isProviderConfigured } from '@/lib/social/providers';
+import { isSocialCryptoConfigured } from '@/lib/social/crypto';
+import { STATE_COOKIE_NAME, verifyState } from '@/lib/social/state';
+import { exchangeCode, fetchProfile } from '@/lib/social/oauth';
+import { upsertSocialAccount } from '@/lib/social/accounts';
+
+/**
+ * GET /api/social/[provider]/callback
+ *
+ * Valida state cookie → intercambia code → descarga perfil → upsert
+ * cifrando tokens → limpia state cookie → 302 a /perfil con banner
+ * `?social=connected` (o `?social_error=...` si algo falló).
+ */
+export async function GET(
+  req: Request,
+  ctx: { params: Promise<{ provider: string }> },
+): Promise<Response> {
+  const { provider } = await ctx.params;
+  const perfilUrl = new URL('/sorteos/plataforma/perfil', SITE_URL);
+
+  if (!isActiveProvider(provider) || !isProviderConfigured(provider) || !isSocialCryptoConfigured()) {
+    return redirectWithError(perfilUrl, 'provider_not_configured', provider);
+  }
+  const cfg = getProvider(provider);
+  if (!cfg || cfg.status !== 'active') {
+    return redirectWithError(perfilUrl, 'provider_not_configured', provider);
+  }
+
+  const session = await auth.api.getSession({ headers: req.headers });
+  if (!session?.user) {
+    return NextResponse.redirect(new URL('/sorteos/plataforma', SITE_URL), { status: 302 });
+  }
+
+  const url = new URL(req.url);
+  const code = url.searchParams.get('code');
+  const stateQuery = url.searchParams.get('state');
+  const providerError = url.searchParams.get('error');
+
+  if (providerError) {
+    // El user canceló en el provider (access_denied) o algo similar.
+    return redirectWithError(perfilUrl, 'user_denied', provider);
+  }
+
+  const cookieHeader = req.headers.get('cookie') ?? '';
+  const cookieValue = parseCookieValue(cookieHeader, STATE_COOKIE_NAME);
+  const payload = verifyState(cookieValue, provider);
+  if (!payload || !stateQuery || payload.state !== stateQuery) {
+    return redirectWithError(perfilUrl, 'state', provider, /* clearCookie */ true);
+  }
+  if (!code) {
+    return redirectWithError(perfilUrl, 'no_code', provider, true);
+  }
+
+  const redirectUri = `${SITE_URL}/api/social/${provider}/callback`;
+
+  try {
+    const token = await exchangeCode(provider, code, redirectUri);
+    const profile = await fetchProfile(provider, token.accessToken);
+    await upsertSocialAccount({ userId: session.user.id, provider, profile, token });
+  } catch (e) {
+    const errCode = e instanceof Error && e.name === 'SocialAccountAlreadyLinkedError'
+      ? 'already_linked'
+      : 'exchange_or_profile_failed';
+    return redirectWithError(perfilUrl, errCode, provider, true);
+  }
+
+  perfilUrl.searchParams.set('social', 'connected');
+  perfilUrl.searchParams.set('provider', provider);
+  const response = NextResponse.redirect(perfilUrl, { status: 302 });
+  // Limpia state cookie
+  response.cookies.set(STATE_COOKIE_NAME, '', { httpOnly: true, path: '/api/social', maxAge: 0 });
+  return response;
+}
+
+function redirectWithError(perfilUrl: URL, code: string, provider: string, clearCookie = false): Response {
+  perfilUrl.searchParams.set('social_error', code);
+  perfilUrl.searchParams.set('provider', provider);
+  const response = NextResponse.redirect(perfilUrl, { status: 302 });
+  if (clearCookie) {
+    response.cookies.set(STATE_COOKIE_NAME, '', { httpOnly: true, path: '/api/social', maxAge: 0 });
+  }
+  return response;
+}
+
+/** Extract una cookie por nombre de un header `Cookie:` crudo. */
+function parseCookieValue(cookieHeader: string, name: string): string | undefined {
+  const parts = cookieHeader.split(';');
+  for (const part of parts) {
+    const eq = part.indexOf('=');
+    if (eq <= 0) continue;
+    const k = part.slice(0, eq).trim();
+    if (k === name) return part.slice(eq + 1).trim();
+  }
+  return undefined;
+}

--- a/src/app/api/social/[provider]/connect/route.ts
+++ b/src/app/api/social/[provider]/connect/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { env } from '@/lib/env';
+import { SITE_URL } from '@/lib/site-url';
+import { getProvider, isActiveProvider, isProviderConfigured } from '@/lib/social/providers';
+import { isSocialCryptoConfigured } from '@/lib/social/crypto';
+import { generateState, signState, STATE_COOKIE_NAME, STATE_TTL_MS } from '@/lib/social/state';
+
+/**
+ * GET /api/social/[provider]/connect
+ *
+ * Session guard → genera state firmado → cookie httpOnly Path=/api/social
+ * → 302 al authorizeUrl del provider con state en query.
+ *
+ * Responde:
+ *   302 → provider           OK
+ *   302 → /sorteos/plataforma no logueado
+ *   400                       provider desconocido
+ *   501                       provider planned (x, instagram)
+ *   503                       provider activo sin env vars configuradas
+ */
+export async function GET(
+  req: Request,
+  ctx: { params: Promise<{ provider: string }> },
+): Promise<Response> {
+  const { provider } = await ctx.params;
+  const cfg = getProvider(provider);
+  if (!cfg) return NextResponse.json({ error: 'provider_unknown' }, { status: 400 });
+  if (cfg.status === 'planned') {
+    return NextResponse.json({ error: 'provider_planned', reason: cfg.reason }, { status: 501 });
+  }
+  if (!isActiveProvider(provider)) {
+    return NextResponse.json({ error: 'provider_unknown' }, { status: 400 });
+  }
+  if (!isProviderConfigured(provider) || !isSocialCryptoConfigured()) {
+    return NextResponse.json({ error: 'provider_not_configured' }, { status: 503 });
+  }
+
+  const session = await auth.api.getSession({ headers: req.headers });
+  if (!session?.user) {
+    return NextResponse.redirect(new URL('/sorteos/plataforma', SITE_URL), { status: 302 });
+  }
+
+  const state = generateState();
+  const signed = signState({ state, provider, ts: Date.now() });
+  const clientId = cfg.clientId();
+  if (!clientId) return NextResponse.json({ error: 'provider_not_configured' }, { status: 503 });
+
+  const redirectUri = `${SITE_URL}/api/social/${provider}/callback`;
+  const authorizeParams = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    response_type: 'code',
+    scope: cfg.scopes.join(' '),
+    state,
+  });
+  // Google necesita explicitly access_type=offline + prompt=consent para emitir refresh_token
+  if (provider === 'google') {
+    authorizeParams.set('access_type', 'offline');
+    authorizeParams.set('prompt', 'consent');
+    authorizeParams.set('include_granted_scopes', 'true');
+  }
+  // Discord: prompt=consent para pedir aceptación explícita cada vez
+  if (provider === 'discord') {
+    authorizeParams.set('prompt', 'consent');
+  }
+
+  const response = NextResponse.redirect(
+    `${cfg.authorizeUrl}?${authorizeParams.toString()}`,
+    { status: 302 },
+  );
+  response.cookies.set(STATE_COOKIE_NAME, signed, {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: SITE_URL.startsWith('https://'),
+    path: '/api/social',
+    maxAge: Math.floor(STATE_TTL_MS / 1000),
+  });
+  // env se importa para forzar validación temprana; evita el "unused" del lint
+  void env;
+  return response;
+}

--- a/src/app/sorteos/plataforma/layout.tsx
+++ b/src/app/sorteos/plataforma/layout.tsx
@@ -8,6 +8,7 @@ import './platform-hero.css';
 import './platform-brand-cards.css';
 import './platform-fx.css';
 import './platform-widgets.css';
+import './perfil/perfil.css';
 
 const rajdhani = Rajdhani({
   subsets: ['latin'],

--- a/src/app/sorteos/plataforma/perfil/actions.ts
+++ b/src/app/sorteos/plataforma/perfil/actions.ts
@@ -1,0 +1,46 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { headers } from 'next/headers';
+import { z } from 'zod';
+import { auth } from '@/lib/auth';
+import { deleteSocialAccount } from '@/lib/social/accounts';
+import { isActiveProvider } from '@/lib/social/providers';
+import { revokeToken } from '@/lib/social/oauth';
+
+type ActionResult = { ok: true } | { ok: false; error: string };
+
+const disconnectSchema = z.object({
+  provider: z.string().min(1),
+});
+
+/**
+ * Desconecta una cuenta social del usuario logueado.
+ *
+ * 1. Guard sesión.
+ * 2. Zod validate provider ∈ active.
+ * 3. Delete row (retorna access_token descifrado si existía).
+ * 4. Best-effort revoke en el provider (timeout 3s, swallow errors).
+ * 5. Revalidate /sorteos/plataforma/perfil.
+ */
+export async function disconnectSocialAccount(input: unknown): Promise<ActionResult> {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session?.user) return { ok: false, error: 'no_session' };
+
+  const parsed = disconnectSchema.safeParse(input);
+  if (!parsed.success) return { ok: false, error: 'invalid_input' };
+  const { provider } = parsed.data;
+  if (!isActiveProvider(provider)) return { ok: false, error: 'provider_unknown' };
+
+  const removed = await deleteSocialAccount({ userId: session.user.id, provider });
+  if (!removed) return { ok: false, error: 'not_connected' };
+
+  // Fire-and-forget revoke — no bloqueamos el flujo si el provider tarda.
+  if (removed.accessToken) {
+    // No await intencional: revoke tiene su propio timeout interno.
+    void revokeToken(provider, removed.accessToken);
+  }
+
+  revalidatePath('/sorteos/plataforma/perfil');
+  return { ok: true };
+}

--- a/src/app/sorteos/plataforma/perfil/page.tsx
+++ b/src/app/sorteos/plataforma/perfil/page.tsx
@@ -1,0 +1,187 @@
+import { headers } from 'next/headers';
+import { redirect } from 'next/navigation';
+import type { Metadata } from 'next';
+import { eq } from 'drizzle-orm';
+import { auth } from '@/lib/auth';
+import { db } from '@/lib/db';
+import { playerProfiles } from '@/db/schema';
+import { getCoinBalance } from '@/lib/queries/giveawayPlatform';
+import { getConnectedAccountsSafe } from '@/lib/social/accounts';
+import { getProvider, isActiveProvider, isProviderConfigured, listAllProviders } from '@/lib/social/providers';
+import { SocialAccountCard } from '@/features/giveaway-platform/components/SocialAccountCard';
+
+export const metadata: Metadata = {
+  title: 'Mi perfil | SocialPro Giveaways',
+  robots: { index: false, follow: false },
+};
+
+/**
+ * Server component: /sorteos/plataforma/perfil
+ *
+ * Muestra la cabecera con datos de Steam, saldo, y las tarjetas de
+ * cuentas sociales conectadas. Sin logueo → redirige al hero.
+ */
+export default async function PlayerProfilePageRoute({
+  searchParams,
+}: {
+  searchParams: Promise<{ social?: string; social_error?: string; provider?: string }>;
+}): Promise<React.JSX.Element> {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session?.user) redirect('/sorteos/plataforma');
+  const userId = session.user.id;
+
+  const [profile, balance, socialAccounts] = await Promise.all([
+    db.query.playerProfiles.findFirst({ where: eq(playerProfiles.userId, userId) }),
+    getCoinBalance(userId),
+    getConnectedAccountsSafe(userId),
+  ]);
+
+  const { social, social_error, provider } = await searchParams;
+  const notice = social === 'connected'
+    ? { kind: 'success' as const, text: `Cuenta ${provider ?? ''} conectada correctamente.` }
+    : social_error
+      ? { kind: 'error' as const, text: mapErrorToLabel(social_error, provider) }
+      : null;
+
+  const connectedByProvider = new Map(socialAccounts.map((a) => [a.provider, a]));
+
+  return (
+    <main className="gp-wrap gp-perfil">
+      <header className="gp-perfil-header">
+        <h1>Mi perfil</h1>
+        <p className="gp-perfil-sub">Cuentas conectadas y configuración de SocialPro Giveaways</p>
+      </header>
+
+      {notice ? (
+        <div className={`gp-perfil-notice gp-perfil-notice-${notice.kind}`}>{notice.text}</div>
+      ) : null}
+
+      <section className="gp-perfil-block" aria-labelledby="perfil-steam">
+        <h2 id="perfil-steam">Cuenta principal</h2>
+        <div className="gp-perfil-steam">
+          <div className="gp-perfil-steam-avatar" aria-hidden>🎮</div>
+          <div>
+            <div className="gp-perfil-steam-name">{session.user.name}</div>
+            <div className="gp-perfil-steam-meta">Saldo: <b>{balance.toLocaleString('es-ES')} 🪙</b></div>
+            <div className="gp-perfil-steam-meta">Estado: verificado con Steam OpenID</div>
+          </div>
+        </div>
+      </section>
+
+      <section className="gp-perfil-block" aria-labelledby="perfil-social">
+        <h2 id="perfil-social">Cuentas conectadas</h2>
+        <p className="gp-perfil-note">
+          Enlaza tus cuentas sociales para poder participar en misiones que verificamos
+          automáticamente (RT, follow, join Discord…). Los tokens se guardan cifrados.
+        </p>
+        <div className="gp-social-grid">
+          {/* Steam siempre aparece como principal, sin desconectar */}
+          <SocialAccountCard
+            providerKey="steam"
+            displayName="Steam"
+            status="connected"
+            username={session.user.name}
+            disableDisconnect
+          />
+          {listAllProviders().map((key) => {
+            const cfg = getProvider(key);
+            if (!cfg) return null;
+            const account = connectedByProvider.get(key);
+            if (cfg.status === 'planned') {
+              return (
+                <SocialAccountCard
+                  key={key}
+                  providerKey={key}
+                  displayName={cfg.displayName}
+                  status="planned"
+                  reasonIfPlanned={cfg.reason}
+                />
+              );
+            }
+            if (!isActiveProvider(key) || !isProviderConfigured(key)) {
+              return (
+                <SocialAccountCard
+                  key={key}
+                  providerKey={key}
+                  displayName={cfg.displayName}
+                  status="not_configured"
+                />
+              );
+            }
+            if (account) {
+              return (
+                <SocialAccountCard
+                  key={key}
+                  providerKey={key}
+                  displayName={cfg.displayName}
+                  status="connected"
+                  username={account.username}
+                  avatarUrl={account.avatarUrl}
+                  updatedAt={account.updatedAt.toISOString()}
+                />
+              );
+            }
+            return (
+              <SocialAccountCard
+                key={key}
+                providerKey={key}
+                displayName={cfg.displayName}
+                status="available"
+                connectHref={`/api/social/${key}/connect`}
+              />
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="gp-perfil-block" aria-labelledby="perfil-settings">
+        <h2 id="perfil-settings">Configuración</h2>
+        <ul className="gp-perfil-settings">
+          <li>
+            <span className="gp-perfil-settings-label">Privacidad del ranking</span>
+            <span className="gp-perfil-settings-value">
+              {profile?.isPrivate ? 'Privado (nombre enmascarado)' : 'Público'}
+            </span>
+          </li>
+          <li>
+            <span className="gp-perfil-settings-label">Steam Trade URL</span>
+            <span className="gp-perfil-settings-value">
+              {profile?.steamTradeUrl ? '✓ configurada' : '— no configurada'}
+            </span>
+          </li>
+          <li>
+            <span className="gp-perfil-settings-label">Dirección de envío</span>
+            <span className="gp-perfil-settings-value">
+              {profile?.shippingAddress ? '✓ configurada' : '— no configurada'}
+            </span>
+          </li>
+          <li>
+            <span className="gp-perfil-settings-label">Email</span>
+            <span className="gp-perfil-settings-value">
+              {session.user.email && !session.user.email.endsWith('@steam.socialpro.internal')
+                ? session.user.email
+                : 'Sin email real (login solo con Steam)'}
+            </span>
+          </li>
+        </ul>
+        <p className="gp-perfil-note">
+          La edición avanzada de trade URL, dirección y privacidad se hace desde el modal
+          del perfil de la plataforma principal (server actions ya existentes).
+        </p>
+      </section>
+    </main>
+  );
+}
+
+function mapErrorToLabel(code: string, provider: string | undefined): string {
+  const p = provider ?? 'la cuenta';
+  switch (code) {
+    case 'state':                       return `No pudimos validar la solicitud de ${p}. Inténtalo de nuevo.`;
+    case 'no_code':                     return `${p} no devolvió un código de autorización.`;
+    case 'user_denied':                 return `Cancelaste la conexión con ${p}.`;
+    case 'already_linked':              return `Esta cuenta de ${p} ya está enlazada a otro usuario.`;
+    case 'exchange_or_profile_failed':  return `Fallo al hablar con ${p}. Inténtalo en unos minutos.`;
+    case 'provider_not_configured':    return `${p} no está configurado por el administrador todavía.`;
+    default:                            return `Error al conectar ${p}.`;
+  }
+}

--- a/src/app/sorteos/plataforma/perfil/perfil.css
+++ b/src/app/sorteos/plataforma/perfil/perfil.css
@@ -1,0 +1,219 @@
+/*
+ * CSS de /sorteos/plataforma/perfil.
+ * Reutiliza tokens SocialPro definidos en platform.css. Scoped bajo
+ * .giveaway-platform via el layout parent.
+ */
+
+.giveaway-platform .gp-perfil { padding-top: 32px; padding-bottom: 40px; }
+.giveaway-platform .gp-perfil-header { text-align: center; margin-bottom: 28px; }
+.giveaway-platform .gp-perfil-header h1 {
+  font-family: var(--font-display), var(--font-rajdhani), sans-serif;
+  font-weight: 900;
+  font-size: clamp(36px, 5vw, 60px);
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  background: var(--sp-grad);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  filter: drop-shadow(0 0 24px rgba(224, 48, 112, 0.28));
+  margin: 0;
+}
+.giveaway-platform .gp-perfil-sub {
+  margin-top: 4px;
+  color: var(--muted);
+  font-size: 13px;
+}
+.giveaway-platform .gp-perfil-notice {
+  border-radius: 12px;
+  padding: 12px 18px;
+  margin: 0 0 20px;
+  font-size: 13px;
+}
+.giveaway-platform .gp-perfil-notice-success {
+  background: rgba(74, 222, 128, 0.12);
+  border: 1px solid rgba(74, 222, 128, 0.4);
+  color: #b9f3cd;
+}
+.giveaway-platform .gp-perfil-notice-error {
+  background: rgba(255, 93, 125, 0.10);
+  border: 1px solid rgba(255, 93, 125, 0.42);
+  color: #ffc4d1;
+}
+
+.giveaway-platform .gp-perfil-block {
+  position: relative;
+  border-radius: 18px;
+  background: linear-gradient(160deg, var(--panel), #0d0b1e 78%);
+  border: 1px solid rgba(196, 40, 128, 0.20);
+  padding: 26px 28px;
+  margin-bottom: 22px;
+  box-shadow: 0 12px 44px rgba(0, 0, 0, 0.42), inset 0 1px 0 rgba(255, 255, 255, 0.03);
+  overflow: hidden;
+}
+.giveaway-platform .gp-perfil-block::before {
+  content: "";
+  position: absolute;
+  top: 0; left: 28px; right: 28px;
+  height: 2px;
+  background: var(--sp-grad);
+  opacity: 0.75;
+}
+.giveaway-platform .gp-perfil-block h2 {
+  font-family: var(--font-display), var(--font-rajdhani), sans-serif;
+  font-weight: 800;
+  font-size: 20px;
+  letter-spacing: 2.5px;
+  text-transform: uppercase;
+  margin: 0 0 12px;
+  background: var(--sp-grad);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.giveaway-platform .gp-perfil-note {
+  color: var(--muted);
+  font-size: 12.5px;
+  margin: 4px 0 14px;
+  line-height: 1.55;
+}
+
+/* Steam header */
+.giveaway-platform .gp-perfil-steam {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+}
+.giveaway-platform .gp-perfil-steam-avatar {
+  width: 56px; height: 56px;
+  border-radius: 50%;
+  background: linear-gradient(160deg, var(--panel2), var(--panel));
+  border: 2px solid var(--gold);
+  display: grid;
+  place-items: center;
+  font-size: 24px;
+  box-shadow: 0 0 24px rgba(245, 183, 61, 0.4);
+}
+.giveaway-platform .gp-perfil-steam-name {
+  font-family: var(--font-display), var(--font-rajdhani), sans-serif;
+  font-weight: 800;
+  font-size: 20px;
+  letter-spacing: 1px;
+  color: var(--txt);
+}
+.giveaway-platform .gp-perfil-steam-meta { color: var(--muted); font-size: 12.5px; margin-top: 2px; }
+.giveaway-platform .gp-perfil-steam-meta b { color: var(--gold); }
+
+/* Social cards grid */
+.giveaway-platform .gp-social-grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+}
+.giveaway-platform .gp-social-card {
+  border-radius: 14px;
+  border: 1px solid rgba(196, 40, 128, 0.18);
+  background: linear-gradient(160deg, rgba(21, 16, 36, 0.9), rgba(11, 9, 23, 0.9));
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.giveaway-platform .gp-social-card.gp-social-connected {
+  border-color: rgba(74, 222, 128, 0.35);
+}
+.giveaway-platform .gp-social-card.gp-social-planned,
+.giveaway-platform .gp-social-card.gp-social-not_configured {
+  opacity: 0.7;
+}
+.giveaway-platform .gp-social-head { display: flex; gap: 12px; align-items: center; }
+.giveaway-platform .gp-social-avatar {
+  width: 40px; height: 40px;
+  border-radius: 50%;
+  background: rgba(11, 9, 23, 0.6);
+  border: 1px solid rgba(196, 40, 128, 0.28);
+  display: grid;
+  place-items: center;
+  font-size: 20px;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+.giveaway-platform .gp-social-avatar img { width: 100%; height: 100%; object-fit: cover; }
+.giveaway-platform .gp-social-body { flex: 1; min-width: 0; }
+.giveaway-platform .gp-social-name {
+  font-family: var(--font-display), var(--font-rajdhani), sans-serif;
+  font-weight: 700;
+  font-size: 14px;
+  color: var(--txt);
+  letter-spacing: 0.5px;
+}
+.giveaway-platform .gp-social-username {
+  font-size: 12.5px;
+  color: var(--txt);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.giveaway-platform .gp-social-meta { font-size: 11px; color: var(--muted); margin-top: 2px; }
+.giveaway-platform .gp-social-cta { display: flex; }
+.giveaway-platform .gp-social-btn {
+  flex: 1;
+  padding: 8px 14px;
+  border: 1px solid rgba(196, 40, 128, 0.35);
+  border-radius: 10px;
+  background: transparent;
+  color: var(--txt);
+  font-family: var(--font-display), var(--font-rajdhani), sans-serif;
+  font-weight: 700;
+  font-size: 12px;
+  letter-spacing: 1.1px;
+  text-transform: uppercase;
+  cursor: pointer;
+  text-align: center;
+  text-decoration: none;
+  transition: background 0.15s, border-color 0.15s;
+}
+.giveaway-platform .gp-social-btn:disabled { cursor: not-allowed; opacity: 0.55; }
+.giveaway-platform .gp-social-btn:not(:disabled):hover {
+  background: rgba(224, 48, 112, 0.10);
+  border-color: rgba(224, 48, 112, 0.5);
+}
+.giveaway-platform .gp-social-btn-primary {
+  background: var(--sp-grad);
+  border-color: transparent;
+  box-shadow: 0 4px 14px rgba(224, 48, 112, 0.35);
+  color: #fff;
+}
+.giveaway-platform .gp-social-btn-primary:hover {
+  filter: brightness(1.08);
+}
+.giveaway-platform .gp-social-btn-danger {
+  color: #ff8fa1;
+  border-color: rgba(255, 143, 161, 0.4);
+}
+.giveaway-platform .gp-social-btn-danger:not(:disabled):hover {
+  background: rgba(255, 143, 161, 0.10);
+  border-color: rgba(255, 143, 161, 0.65);
+}
+
+/* Settings list */
+.giveaway-platform .gp-perfil-settings {
+  list-style: none;
+  padding: 0;
+  margin: 6px 0 0;
+  border-radius: 12px;
+  border: 1px solid rgba(196, 40, 128, 0.16);
+  overflow: hidden;
+  background: rgba(11, 9, 23, 0.5);
+}
+.giveaway-platform .gp-perfil-settings li {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 16px;
+  border-top: 1px solid rgba(255, 255, 255, 0.03);
+  font-size: 13px;
+}
+.giveaway-platform .gp-perfil-settings li:first-child { border-top: none; }
+.giveaway-platform .gp-perfil-settings-label { color: var(--muted); }
+.giveaway-platform .gp-perfil-settings-value { color: var(--txt); text-align: right; }

--- a/src/db/schema/connectedSocialAccounts.ts
+++ b/src/db/schema/connectedSocialAccounts.ts
@@ -1,0 +1,46 @@
+import { pgTable, serial, text, varchar, timestamp, index, uniqueIndex } from 'drizzle-orm/pg-core';
+import { relations } from 'drizzle-orm';
+import { user } from './auth';
+
+/**
+ * Cuentas sociales enlazadas a un usuario (que se autentica con Steam).
+ * NO son providers de autenticación — sólo se usan para verificar acciones
+ * en misiones sociales (RT, follow, join Discord, like YT…) en PR-1b-2.
+ *
+ * Tokens guardados cifrados con AES-256-GCM (ver src/lib/social/crypto.ts).
+ * NUNCA se loggean ni se serializan a UI.
+ *
+ * Providers: 'discord' | 'google' | 'x' | 'instagram'.
+ *   - discord, google: activos en PR-1b-1.
+ *   - x, instagram:    reservados para el futuro (UI dice "próximamente").
+ *
+ * Constraints:
+ *   - UNIQUE(provider, provider_user_id): 1 cuenta social ↔ 1 usuario SocialPro.
+ *   - UNIQUE(user_id, provider):          1 usuario, 1 cuenta por provider.
+ *   - ON DELETE CASCADE en user_id:       si desaparece el user, tokens también.
+ */
+export const connectedSocialAccounts = pgTable('connected_social_accounts', {
+  id: serial('id').primaryKey(),
+  userId: text('user_id').notNull().references(() => user.id, { onDelete: 'cascade' }),
+  provider: varchar('provider', { length: 20 }).notNull(),
+  providerUserId: text('provider_user_id').notNull(),
+  username: text('username'),
+  avatarUrl: text('avatar_url'),
+  /** base64 de nonce(12B) | ciphertext | authTag(16B). AES-256-GCM. */
+  accessTokenEnc: text('access_token_enc').notNull(),
+  refreshTokenEnc: text('refresh_token_enc'),
+  /** scopes concedidos por el user en el consent screen del provider */
+  scopes: text('scopes').array(),
+  expiresAt: timestamp('expires_at', { withTimezone: true }),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+}, (t) => [
+  uniqueIndex('connected_social_accounts_provider_provider_user_id_uq').on(t.provider, t.providerUserId),
+  uniqueIndex('connected_social_accounts_user_id_provider_uq').on(t.userId, t.provider),
+  index('connected_social_accounts_user_id_idx').on(t.userId),
+  index('connected_social_accounts_provider_idx').on(t.provider),
+]);
+
+export const connectedSocialAccountsRelations = relations(connectedSocialAccounts, ({ one }) => ({
+  user: one(user, { fields: [connectedSocialAccounts.userId], references: [user.id] }),
+}));

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -63,3 +63,4 @@ export * from './giveawayEntries';
 export * from './platformMissions';
 export * from './dailyStreaks';
 export * from './shopItems';
+export * from './connectedSocialAccounts';

--- a/src/features/giveaway-platform/components/SocialAccountCard.tsx
+++ b/src/features/giveaway-platform/components/SocialAccountCard.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import Image from 'next/image';
+import { useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { disconnectSocialAccount } from '@/app/sorteos/plataforma/perfil/actions';
+
+interface Props {
+  providerKey: string;
+  displayName: string;
+  status: 'connected' | 'available' | 'planned' | 'not_configured';
+  username?: string | null;
+  avatarUrl?: string | null;
+  reasonIfPlanned?: string;
+  connectHref?: string;
+  disableDisconnect?: boolean;
+  updatedAt?: string | null;
+}
+
+/**
+ * Tarjeta de una cuenta social. Estados:
+ *   - connected     → muestra username/avatar + botón Desconectar (server action)
+ *   - available     → botón Conectar (link a /api/social/[provider]/connect)
+ *   - planned       → texto "Próximamente" + botón deshabilitado + razón (tooltip)
+ *   - not_configured→ texto "No configurado todavía" + botón deshabilitado
+ */
+export function SocialAccountCard(props: Props) {
+  const {
+    providerKey,
+    displayName,
+    status,
+    username,
+    avatarUrl,
+    reasonIfPlanned,
+    connectHref,
+    disableDisconnect,
+    updatedAt,
+  } = props;
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  function onDisconnect() {
+    startTransition(async () => {
+      const result = await disconnectSocialAccount({ provider: providerKey });
+      if (result.ok) router.refresh();
+    });
+  }
+
+  return (
+    <div className={`gp-social-card gp-social-${status}`}>
+      <div className="gp-social-head">
+        <div className="gp-social-avatar" aria-hidden>
+          {status === 'connected' && avatarUrl ? (
+            <Image src={avatarUrl} alt="" width={40} height={40} unoptimized />
+          ) : (
+            <span>{providerIcon(providerKey)}</span>
+          )}
+        </div>
+        <div className="gp-social-body">
+          <div className="gp-social-name">{displayName}</div>
+          {status === 'connected' ? (
+            <>
+              <div className="gp-social-username">{username ?? '—'}</div>
+              {updatedAt ? <div className="gp-social-meta">Actualizado: {formatDate(updatedAt)}</div> : null}
+            </>
+          ) : status === 'planned' ? (
+            <div className="gp-social-meta" title={reasonIfPlanned}>Próximamente</div>
+          ) : status === 'not_configured' ? (
+            <div className="gp-social-meta">No configurado todavía</div>
+          ) : (
+            <div className="gp-social-meta">No conectado</div>
+          )}
+        </div>
+      </div>
+      <div className="gp-social-cta">
+        {status === 'connected' && !disableDisconnect ? (
+          <button
+            type="button"
+            className="gp-social-btn gp-social-btn-danger"
+            onClick={onDisconnect}
+            disabled={isPending}
+          >
+            {isPending ? 'Desconectando…' : 'Desconectar'}
+          </button>
+        ) : null}
+        {status === 'available' && connectHref ? (
+          <a className="gp-social-btn gp-social-btn-primary" href={connectHref}>
+            Conectar
+          </a>
+        ) : null}
+        {status === 'planned' || status === 'not_configured' ? (
+          <button type="button" className="gp-social-btn" disabled>
+            {status === 'planned' ? 'Próximamente' : 'No disponible'}
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function providerIcon(key: string): string {
+  switch (key) {
+    case 'steam': return '🎮';
+    case 'discord': return '💬';
+    case 'google': return '▶️';
+    case 'x': return '𝕏';
+    case 'instagram': return '📷';
+    default: return '•';
+  }
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  return d.toLocaleDateString('es-ES', { day: '2-digit', month: 'short', year: 'numeric' });
+}

--- a/src/features/giveaway-platform/components/UserPill.tsx
+++ b/src/features/giveaway-platform/components/UserPill.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import { useEffect, useRef, useState, useTransition } from 'react';
 import { steamLogout } from '@/features/giveaway-platform/actions/steamLogout';
 
@@ -68,6 +69,18 @@ export function UserPill({ userName, balance, loggedIn }: Props) {
         <span className="gp-chev" aria-hidden>▾</span>
       </button>
       <div className="gp-user-menu" role="menu">
+        <Link
+          role="menuitem"
+          className="gp-um-item"
+          href="/sorteos/plataforma/perfil"
+          onClick={() => setOpen(false)}
+        >
+          <span className="i" aria-hidden>👤</span>
+          <span>
+            <b>Mi perfil</b>
+            <span>Cuentas conectadas y ajustes</span>
+          </span>
+        </Link>
         <button type="button" role="menuitem" className="gp-um-item" data-todo="profile-config">
           <span className="i" aria-hidden>⚙️</span>
           <span>

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -46,6 +46,25 @@ export const env = createEnv({
     // usuario se crea con name="Jugador de Steam" y avatar=null.
     // Server-only: nunca se envía al cliente.
     STEAM_API_KEY: z.string().min(1).optional(),
+    // Cifrado AES-256-GCM de tokens sociales guardados en connected_social_accounts.
+    // Formato: base64 de 32 bytes (256 bits). Generar con:
+    //   node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
+    // Opcional en dev; OBLIGATORIO en producción para poder cifrar/descifrar.
+    // Sin ella la UI muestra "No configurado todavía" y los endpoints /api/social/* devuelven 503.
+    SOCIAL_TOKEN_ENCRYPTION_KEY: z.string()
+      .refine((v) => { try { return Buffer.from(v, 'base64').length === 32; } catch { return false; } },
+        { message: 'SOCIAL_TOKEN_ENCRYPTION_KEY debe ser 32 bytes en base64 (usar node -e "console.log(require(\'crypto\').randomBytes(32).toString(\'base64\'))")' })
+      .optional(),
+    // Discord OAuth — https://discord.com/developers/applications
+    DISCORD_CLIENT_ID: z.string().min(1).optional(),
+    DISCORD_CLIENT_SECRET: z.string().min(1).optional(),
+    // Google/YouTube OAuth — https://console.cloud.google.com/apis/credentials
+    GOOGLE_CLIENT_ID: z.string().min(1).optional(),
+    GOOGLE_CLIENT_SECRET: z.string().min(1).optional(),
+    // Referencias públicas para PR-1b-2 (verificación de misiones sociales).
+    // No usadas en PR-1b-1; documentadas aquí para no dispersar el config.
+    DISCORD_GUILD_ID: z.string().min(1).optional(),
+    YOUTUBE_CHANNEL_ID: z.string().min(1).optional(),
   },
   client: {
     NEXT_PUBLIC_SITE_URL: z.string().url(),
@@ -74,6 +93,13 @@ export const env = createEnv({
     PAYROLL_OCR_ENABLED: process.env.PAYROLL_OCR_ENABLED,
     SHEETS_SYNC_CONCURRENCY: process.env.SHEETS_SYNC_CONCURRENCY,
     STEAM_API_KEY: process.env.STEAM_API_KEY,
+    SOCIAL_TOKEN_ENCRYPTION_KEY: process.env.SOCIAL_TOKEN_ENCRYPTION_KEY,
+    DISCORD_CLIENT_ID: process.env.DISCORD_CLIENT_ID,
+    DISCORD_CLIENT_SECRET: process.env.DISCORD_CLIENT_SECRET,
+    GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID,
+    GOOGLE_CLIENT_SECRET: process.env.GOOGLE_CLIENT_SECRET,
+    DISCORD_GUILD_ID: process.env.DISCORD_GUILD_ID,
+    YOUTUBE_CHANNEL_ID: process.env.YOUTUBE_CHANNEL_ID,
 
     NEXT_PUBLIC_SITE_URL: process.env.NEXT_PUBLIC_SITE_URL,
     NEXT_PUBLIC_GTM_ID: process.env.NEXT_PUBLIC_GTM_ID,

--- a/src/lib/social/accounts.ts
+++ b/src/lib/social/accounts.ts
@@ -1,0 +1,172 @@
+import { and, eq } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import { connectedSocialAccounts } from '@/db/schema';
+import { encryptToken, decryptToken } from './crypto';
+import type { SocialProviderKey } from './providers';
+import type { NormalizedProfile, TokenResponse } from './oauth';
+
+/**
+ * Capa de acceso a `connected_social_accounts`.
+ *
+ * Regla dura: ni `access_token_enc` ni `refresh_token_enc` salen NUNCA
+ * de este módulo hacia UI. `upsertSocialAccount` los cifra al escribir.
+ * `getDecryptedTokens` los descifra bajo demanda (solo desde server
+ * actions/verifiers, nunca desde queries que serializan a cliente).
+ */
+
+/**
+ * Row segura para pasar a UI: sin token fields.
+ */
+export interface SafeSocialAccountRow {
+  id: number;
+  provider: string;
+  providerUserId: string;
+  username: string | null;
+  avatarUrl: string | null;
+  scopes: string[] | null;
+  expiresAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * Escribe/actualiza la cuenta social del usuario. Cifra los tokens antes
+ * de guardar. Retorna la row `SafeSocialAccountRow` (sin tokens).
+ *
+ * Idempotente por UNIQUE (user_id, provider): reconnect actualiza tokens
+ * y perfil. Si la misma cuenta social (provider, provider_user_id) ya
+ * pertenece a OTRO user, el UNIQUE explota → error 'already_linked'.
+ */
+export async function upsertSocialAccount(input: {
+  userId: string;
+  provider: SocialProviderKey;
+  profile: NormalizedProfile;
+  token: TokenResponse;
+}): Promise<SafeSocialAccountRow> {
+  const { userId, provider, profile, token } = input;
+
+  const accessTokenEnc = encryptToken(token.accessToken);
+  const refreshTokenEnc = token.refreshToken ? encryptToken(token.refreshToken) : null;
+  const expiresAt = token.expiresIn ? new Date(Date.now() + token.expiresIn * 1000) : null;
+  const scopes = token.scope ? token.scope.split(/\s+/).filter(Boolean) : null;
+
+  try {
+    const [row] = await db
+      .insert(connectedSocialAccounts)
+      .values({
+        userId,
+        provider,
+        providerUserId: profile.providerUserId,
+        username: profile.username,
+        avatarUrl: profile.avatarUrl,
+        accessTokenEnc,
+        refreshTokenEnc,
+        scopes,
+        expiresAt,
+      })
+      .onConflictDoUpdate({
+        target: [connectedSocialAccounts.userId, connectedSocialAccounts.provider],
+        set: {
+          providerUserId: profile.providerUserId,
+          username: profile.username,
+          avatarUrl: profile.avatarUrl,
+          accessTokenEnc,
+          refreshTokenEnc,
+          scopes,
+          expiresAt,
+          updatedAt: new Date(),
+        },
+      })
+      .returning({
+        id: connectedSocialAccounts.id,
+        provider: connectedSocialAccounts.provider,
+        providerUserId: connectedSocialAccounts.providerUserId,
+        username: connectedSocialAccounts.username,
+        avatarUrl: connectedSocialAccounts.avatarUrl,
+        scopes: connectedSocialAccounts.scopes,
+        expiresAt: connectedSocialAccounts.expiresAt,
+        createdAt: connectedSocialAccounts.createdAt,
+        updatedAt: connectedSocialAccounts.updatedAt,
+      });
+    if (!row) throw new Error('Insert vacío');
+    return row;
+  } catch (e) {
+    // Postgres 23505 = UNIQUE violation. Aquí lo relevante es
+    // UNIQUE(provider, provider_user_id) ya que UNIQUE(user_id, provider)
+    // se resuelve por el ON CONFLICT DO UPDATE.
+    if (isUniqueViolation(e)) {
+      const err = new Error('already_linked');
+      err.name = 'SocialAccountAlreadyLinkedError';
+      throw err;
+    }
+    throw e;
+  }
+}
+
+/**
+ * Elimina la cuenta social del usuario. Devuelve el access_token
+ * descifrado (si existía) para que el caller pueda intentar el revoke
+ * best-effort en el provider. Si no existía cuenta, retorna null.
+ */
+export async function deleteSocialAccount(input: {
+  userId: string;
+  provider: SocialProviderKey;
+}): Promise<{ accessToken: string | null } | null> {
+  const { userId, provider } = input;
+  const [existing] = await db
+    .select({
+      accessTokenEnc: connectedSocialAccounts.accessTokenEnc,
+    })
+    .from(connectedSocialAccounts)
+    .where(and(
+      eq(connectedSocialAccounts.userId, userId),
+      eq(connectedSocialAccounts.provider, provider),
+    ));
+  if (!existing) return null;
+
+  let accessToken: string | null = null;
+  try {
+    accessToken = decryptToken(existing.accessTokenEnc);
+  } catch {
+    // si la key rotó o el ciphertext se corrompió, no bloqueamos el delete
+  }
+
+  await db
+    .delete(connectedSocialAccounts)
+    .where(and(
+      eq(connectedSocialAccounts.userId, userId),
+      eq(connectedSocialAccounts.provider, provider),
+    ));
+
+  return { accessToken };
+}
+
+/**
+ * Lista las cuentas sociales del user (SAFE — sin tokens). Solo llamado
+ * desde server components/queries que serializan a UI.
+ */
+export async function getConnectedAccountsSafe(userId: string): Promise<SafeSocialAccountRow[]> {
+  return db
+    .select({
+      id: connectedSocialAccounts.id,
+      provider: connectedSocialAccounts.provider,
+      providerUserId: connectedSocialAccounts.providerUserId,
+      username: connectedSocialAccounts.username,
+      avatarUrl: connectedSocialAccounts.avatarUrl,
+      scopes: connectedSocialAccounts.scopes,
+      expiresAt: connectedSocialAccounts.expiresAt,
+      createdAt: connectedSocialAccounts.createdAt,
+      updatedAt: connectedSocialAccounts.updatedAt,
+    })
+    .from(connectedSocialAccounts)
+    .where(eq(connectedSocialAccounts.userId, userId));
+}
+
+function isUniqueViolation(e: unknown): boolean {
+  if (typeof e !== 'object' || e === null) return false;
+  // neon-http a menudo expone { code: '23505' } en el error root o en cause.
+  const err = e as { code?: string; cause?: { code?: string }; message?: string };
+  if (err.code === '23505') return true;
+  if (err.cause?.code === '23505') return true;
+  return typeof err.message === 'string' && err.message.includes('23505');
+}

--- a/src/lib/social/crypto.ts
+++ b/src/lib/social/crypto.ts
@@ -1,0 +1,77 @@
+import crypto from 'node:crypto';
+import { env } from '@/lib/env';
+
+/**
+ * Cifrado AES-256-GCM de tokens sociales guardados en DB.
+ *
+ * Bundle format (base64):
+ *   [ nonce(12B) | ciphertext | authTag(16B) ]
+ *
+ * La key vive en env.SOCIAL_TOKEN_ENCRYPTION_KEY (32 bytes en base64).
+ * Si no está configurada, encryptToken/decryptToken lanzan — los callers
+ * responden 503 al usuario. Esto permite arrancar la app en local sin
+ * la key seteada.
+ *
+ * NUNCA loggear plaintexts ni ciphertexts. Nunca serializar a UI.
+ */
+
+const ALGO = 'aes-256-gcm';
+const NONCE_LEN = 12;
+const TAG_LEN = 16;
+
+/** Cifra `plaintext` y devuelve el bundle base64. */
+export function encryptToken(plaintext: string): string {
+  const key = getKey();
+  const nonce = crypto.randomBytes(NONCE_LEN);
+  const cipher = crypto.createCipheriv(ALGO, key, nonce);
+  const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return Buffer.concat([nonce, encrypted, tag]).toString('base64');
+}
+
+/**
+ * Descifra un bundle base64. Throws si:
+ *   - `SOCIAL_TOKEN_ENCRYPTION_KEY` no está configurado.
+ *   - El bundle es corto/malformado.
+ *   - La autenticación GCM falla (tampering detectado).
+ */
+export function decryptToken(bundle: string): string {
+  const key = getKey();
+  const buf = safeFromBase64(bundle);
+  // NONCE_LEN + TAG_LEN es el mínimo (permite ciphertext vacío).
+  if (buf.length < NONCE_LEN + TAG_LEN) {
+    throw new Error('Token cifrado inválido');
+  }
+  const nonce = buf.subarray(0, NONCE_LEN);
+  const tag = buf.subarray(buf.length - TAG_LEN);
+  const cipher = buf.subarray(NONCE_LEN, buf.length - TAG_LEN);
+  const decipher = crypto.createDecipheriv(ALGO, key, nonce);
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(cipher), decipher.final()]).toString('utf8');
+}
+
+/** Devuelve `true` si la key está configurada y es válida. */
+export function isSocialCryptoConfigured(): boolean {
+  try { getKey(); return true; }
+  catch { return false; }
+}
+
+function getKey(): Buffer {
+  const raw = env.SOCIAL_TOKEN_ENCRYPTION_KEY;
+  if (!raw) throw new Error('SOCIAL_TOKEN_ENCRYPTION_KEY no configurada');
+  const buf = safeFromBase64(raw);
+  if (buf.length !== 32) throw new Error('SOCIAL_TOKEN_ENCRYPTION_KEY debe tener 32 bytes');
+  return buf;
+}
+
+function safeFromBase64(s: string): Buffer {
+  // Buffer.from acepta strings inválidos "silenciosamente" — validamos que
+  // la vuelta a base64 (sin padding) coincida para detectar corrupción.
+  try {
+    const b = Buffer.from(s, 'base64');
+    if (b.length === 0 && s.length > 0) throw new Error('base64 vacío');
+    return b;
+  } catch {
+    throw new Error('base64 inválido');
+  }
+}

--- a/src/lib/social/oauth.ts
+++ b/src/lib/social/oauth.ts
@@ -1,0 +1,160 @@
+import { getProvider, type SocialProviderKey } from './providers';
+
+/**
+ * Cliente OAuth genérico: exchange code → token, fetch profile,
+ * revoke token. Cada provider comparte el mismo flow OAuth 2.0
+ * authorization_code, solo cambian URLs y la forma del perfil.
+ *
+ * Sin dependencias externas. Fetch nativo con timeout.
+ */
+
+const FETCH_TIMEOUT_MS = 10_000;
+
+export interface TokenResponse {
+  accessToken: string;
+  refreshToken: string | null;
+  expiresIn: number | null;
+  scope: string | null;
+  tokenType: string;
+}
+
+export interface NormalizedProfile {
+  providerUserId: string;
+  username: string | null;
+  avatarUrl: string | null;
+}
+
+/**
+ * Intercambia el authorization code por un token bundle.
+ * Throws si el provider no está activo/configurado o si Discord/Google fallan.
+ */
+export async function exchangeCode(
+  provider: SocialProviderKey,
+  code: string,
+  redirectUri: string,
+): Promise<TokenResponse> {
+  const cfg = getProvider(provider);
+  if (cfg?.status !== 'active') throw new Error(`Provider ${provider} no activo`);
+  const clientId = cfg.clientId();
+  const clientSecret = cfg.clientSecret();
+  if (!clientId || !clientSecret) throw new Error(`Provider ${provider} no configurado`);
+
+  const body = new URLSearchParams({
+    client_id: clientId,
+    client_secret: clientSecret,
+    grant_type: 'authorization_code',
+    code,
+    redirect_uri: redirectUri,
+  });
+
+  const res = await fetchWithTimeout(cfg.tokenUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded', Accept: 'application/json' },
+    body: body.toString(),
+  });
+  if (!res.ok) {
+    throw new Error(`Token exchange fallo (${provider}): HTTP ${res.status}`);
+  }
+  const raw = await res.json() as {
+    access_token?: string;
+    refresh_token?: string;
+    expires_in?: number;
+    scope?: string;
+    token_type?: string;
+  };
+  if (!raw.access_token) throw new Error(`Token exchange sin access_token (${provider})`);
+  return {
+    accessToken: raw.access_token,
+    refreshToken: raw.refresh_token ?? null,
+    expiresIn: typeof raw.expires_in === 'number' ? raw.expires_in : null,
+    scope: raw.scope ?? null,
+    tokenType: raw.token_type ?? 'Bearer',
+  };
+}
+
+/**
+ * Descarga el perfil público del usuario en el provider y lo normaliza
+ * al shape común (`providerUserId`, `username`, `avatarUrl`).
+ */
+export async function fetchProfile(
+  provider: SocialProviderKey,
+  accessToken: string,
+): Promise<NormalizedProfile> {
+  const cfg = getProvider(provider);
+  if (cfg?.status !== 'active') throw new Error(`Provider ${provider} no activo`);
+
+  const res = await fetchWithTimeout(cfg.profileUrl, {
+    method: 'GET',
+    headers: { Authorization: `Bearer ${accessToken}`, Accept: 'application/json' },
+  });
+  if (!res.ok) throw new Error(`Profile fetch fallo (${provider}): HTTP ${res.status}`);
+  const raw = await res.json() as Record<string, unknown>;
+
+  if (provider === 'discord') return normalizeDiscord(raw);
+  if (provider === 'google') return normalizeGoogle(raw);
+  throw new Error(`Provider ${provider} sin normalizer`);
+}
+
+/**
+ * Revoca un access_token en el provider. Best-effort: swallows errors y
+ * timeouts para no bloquear el disconnect en DB si el provider está caído.
+ */
+export async function revokeToken(provider: SocialProviderKey, accessToken: string): Promise<void> {
+  const cfg = getProvider(provider);
+  if (cfg?.status !== 'active' || !cfg.revokeUrl) return;
+  const clientId = cfg.clientId();
+  const clientSecret = cfg.clientSecret();
+  if (!clientId || !clientSecret) return;
+
+  try {
+    if (provider === 'discord') {
+      // Discord: POST con client credentials en body
+      await fetchWithTimeout(cfg.revokeUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({ token: accessToken, client_id: clientId, client_secret: clientSecret }).toString(),
+      }, 3_000);
+    } else if (provider === 'google') {
+      // Google: POST simple con token en body
+      await fetchWithTimeout(cfg.revokeUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({ token: accessToken }).toString(),
+      }, 3_000);
+    }
+  } catch {
+    // best-effort: ignore
+  }
+}
+
+function normalizeDiscord(raw: Record<string, unknown>): NormalizedProfile {
+  const id = typeof raw.id === 'string' ? raw.id : null;
+  if (!id) throw new Error('Discord profile sin id');
+  const username = typeof raw.global_name === 'string' && raw.global_name
+    ? raw.global_name
+    : typeof raw.username === 'string' ? raw.username : null;
+  const avatarHash = typeof raw.avatar === 'string' ? raw.avatar : null;
+  const avatarUrl = avatarHash
+    ? `https://cdn.discordapp.com/avatars/${id}/${avatarHash}.png?size=128`
+    : null;
+  return { providerUserId: id, username, avatarUrl };
+}
+
+function normalizeGoogle(raw: Record<string, unknown>): NormalizedProfile {
+  const id = typeof raw.sub === 'string' ? raw.sub : null;
+  if (!id) throw new Error('Google profile sin sub');
+  const email = typeof raw.email === 'string' ? raw.email : null;
+  const name = typeof raw.name === 'string' ? raw.name : null;
+  const picture = typeof raw.picture === 'string' ? raw.picture : null;
+  return { providerUserId: id, username: name ?? email, avatarUrl: picture };
+}
+
+async function fetchWithTimeout(url: string, init: RequestInit, timeoutMs = FETCH_TIMEOUT_MS): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/lib/social/providers.ts
+++ b/src/lib/social/providers.ts
@@ -1,0 +1,118 @@
+import { env } from '@/lib/env';
+
+/**
+ * Registry central de OAuth providers para social linking.
+ *
+ * Provider = 'discord' | 'google' | 'x' | 'instagram'.
+ *
+ * PR-1b-1 solo implementa 'discord' y 'google' con OAuth real.
+ * 'x' e 'instagram' están declarados como `status: 'planned'` — la UI
+ * los muestra como "próximamente" y los endpoints devuelven 501.
+ */
+
+export type SocialProviderKey = 'discord' | 'google' | 'x' | 'instagram';
+
+export interface ActiveProviderConfig {
+  status: 'active';
+  displayName: string;
+  authorizeUrl: string;
+  tokenUrl: string;
+  profileUrl: string;
+  revokeUrl?: string;
+  scopes: string[];
+  /** getter para el client id, permite que sea undefined en dev */
+  clientId: () => string | undefined;
+  clientSecret: () => string | undefined;
+}
+
+export interface PlannedProviderConfig {
+  status: 'planned';
+  displayName: string;
+  reason: string;
+}
+
+export type ProviderConfig = ActiveProviderConfig | PlannedProviderConfig;
+
+/** Providers activos (con OAuth real). */
+const ACTIVE_PROVIDERS: readonly SocialProviderKey[] = ['discord', 'google'] as const;
+/** Providers planned (UI los muestra pero endpoints responden 501). */
+const PLANNED_PROVIDERS: readonly SocialProviderKey[] = ['x', 'instagram'] as const;
+
+const REGISTRY: Record<SocialProviderKey, ProviderConfig> = {
+  discord: {
+    status: 'active',
+    displayName: 'Discord',
+    authorizeUrl: 'https://discord.com/oauth2/authorize',
+    tokenUrl: 'https://discord.com/api/oauth2/token',
+    profileUrl: 'https://discord.com/api/users/@me',
+    revokeUrl: 'https://discord.com/api/oauth2/token/revoke',
+    scopes: ['identify', 'guilds', 'guilds.members.read'],
+    clientId: () => env.DISCORD_CLIENT_ID,
+    clientSecret: () => env.DISCORD_CLIENT_SECRET,
+  },
+  google: {
+    status: 'active',
+    displayName: 'YouTube',
+    authorizeUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+    tokenUrl: 'https://oauth2.googleapis.com/token',
+    profileUrl: 'https://www.googleapis.com/oauth2/v3/userinfo',
+    revokeUrl: 'https://oauth2.googleapis.com/revoke',
+    scopes: [
+      'openid',
+      'email',
+      'profile',
+      'https://www.googleapis.com/auth/youtube.readonly',
+    ],
+    clientId: () => env.GOOGLE_CLIENT_ID,
+    clientSecret: () => env.GOOGLE_CLIENT_SECRET,
+  },
+  x: {
+    status: 'planned',
+    displayName: 'X / Twitter',
+    reason: 'Congelado hasta validar coste (X API v2 Basic $100/mes)',
+  },
+  instagram: {
+    status: 'planned',
+    displayName: 'Instagram',
+    reason: 'Meta/Basic Display no permite verificar acciones sociales — futuro manual',
+  },
+};
+
+/** Lista completa de providers conocidos (incluye planned). */
+export function listAllProviders(): SocialProviderKey[] {
+  return [...ACTIVE_PROVIDERS, ...PLANNED_PROVIDERS];
+}
+
+/** Solo los providers con OAuth real. */
+export function listActiveProviders(): SocialProviderKey[] {
+  return [...ACTIVE_PROVIDERS];
+}
+
+/** Devuelve la config de un provider o `null` si no existe. */
+export function getProvider(key: string): ProviderConfig | null {
+  if (!(key in REGISTRY)) return null;
+  return REGISTRY[key as SocialProviderKey];
+}
+
+/** True si el provider existe y su OAuth está implementado. */
+export function isActiveProvider(key: string): key is SocialProviderKey {
+  const cfg = getProvider(key);
+  return cfg?.status === 'active';
+}
+
+/** True si el provider existe pero está congelado. */
+export function isPlannedProvider(key: string): key is SocialProviderKey {
+  const cfg = getProvider(key);
+  return cfg?.status === 'planned';
+}
+
+/**
+ * True si un provider activo tiene client_id + client_secret configurados
+ * en env. Si false, la UI muestra "No configurado todavía" y los
+ * endpoints responden 503.
+ */
+export function isProviderConfigured(key: string): boolean {
+  const cfg = getProvider(key);
+  if (cfg?.status !== 'active') return false;
+  return Boolean(cfg.clientId() && cfg.clientSecret());
+}

--- a/src/lib/social/state.ts
+++ b/src/lib/social/state.ts
@@ -1,0 +1,73 @@
+import crypto from 'node:crypto';
+import { env } from '@/lib/env';
+
+/**
+ * State cookie anti-CSRF para OAuth. Se emite en `connect`, se verifica
+ * en `callback`. Formato serializado y firmado con HMAC-SHA256 usando
+ * `BETTER_AUTH_SECRET` (misma clave que Better Auth para no proliferar
+ * secretos).
+ *
+ * TTL de 10 minutos: suficiente para completar el consent screen del
+ * provider en cualquier condición razonable de red/UI.
+ */
+
+export const STATE_COOKIE_NAME = 'social_oauth_state';
+export const STATE_TTL_MS = 10 * 60 * 1000;
+
+export interface StatePayload {
+  /** valor aleatorio único de la petición (32 bytes → 43 chars base64url) */
+  state: string;
+  /** provider al que apunta este flujo — evita reuse cross-provider */
+  provider: string;
+  /** timestamp de emisión (ms desde epoch) */
+  ts: number;
+}
+
+/** Genera un state aleatorio 32B → base64url. */
+export function generateState(): string {
+  return crypto.randomBytes(32).toString('base64url');
+}
+
+/** Firma un payload y devuelve `<base64url(json)>.<base64url(hmac)>`. */
+export function signState(payload: StatePayload): string {
+  const body = Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url');
+  const sig = hmac(body);
+  return `${body}.${sig}`;
+}
+
+/**
+ * Verifica el cookie value, la firma y el TTL. Devuelve el payload
+ * decodificado si todo cuadra, `null` si algo falla.
+ *
+ * Constant-time signature compare para evitar timing attacks.
+ */
+export function verifyState(cookieValue: string | undefined, expectedProvider: string): StatePayload | null {
+  if (!cookieValue) return null;
+  const dot = cookieValue.indexOf('.');
+  if (dot <= 0 || dot === cookieValue.length - 1) return null;
+  const body = cookieValue.slice(0, dot);
+  const sig = cookieValue.slice(dot + 1);
+
+  const expectedSig = hmac(body);
+  const a = Buffer.from(sig);
+  const b = Buffer.from(expectedSig);
+  if (a.length !== b.length || !crypto.timingSafeEqual(a, b)) return null;
+
+  let payload: StatePayload;
+  try {
+    payload = JSON.parse(Buffer.from(body, 'base64url').toString('utf8')) as StatePayload;
+  } catch { return null; }
+
+  if (typeof payload.state !== 'string' || typeof payload.provider !== 'string' || typeof payload.ts !== 'number') {
+    return null;
+  }
+  if (payload.provider !== expectedProvider) return null;
+  if (Date.now() - payload.ts > STATE_TTL_MS) return null;
+  if (Date.now() < payload.ts - 60_000) return null; // clock skew guard
+
+  return payload;
+}
+
+function hmac(input: string): string {
+  return crypto.createHmac('sha256', env.BETTER_AUTH_SECRET).update(input).digest('base64url');
+}


### PR DESCRIPTION
Base para enlazar cuentas sociales al perfil de SocialPro Giveaways.
Sin misiones sociales todavía (PR-1b-2).

## Migración 0104_connected_social_accounts

Nueva tabla \`connected_social_accounts\`:
- \`user_id\` FK → user CASCADE
- \`provider\` varchar(20) — 'discord' | 'google' | 'x' | 'instagram'
- \`provider_user_id\` text, \`username\`, \`avatar_url\`
- \`access_token_enc\`, \`refresh_token_enc\` — AES-256-GCM base64
- \`scopes\` text[], \`expires_at\`, \`created_at\`, \`updated_at\`
- UNIQUE(provider, provider_user_id) — 1 cuenta social ↔ 1 usuario SocialPro
- UNIQUE(user_id, provider) — 1 cuenta por provider

Sin efectos sobre otras tablas.

## Cifrado

- \`src/lib/social/crypto.ts\` — AES-256-GCM con \`env.SOCIAL_TOKEN_ENCRYPTION_KEY\` (32B base64).
- Bundle: \`nonce(12B) | ciphertext | authTag(16B)\` en base64.
- Sin key configurada → encryptToken/decryptToken throw + endpoints devuelven 503.
- Tokens NUNCA salen a UI ni a logs (contratos estructurales en tests).

## State cookie anti-CSRF

- \`src/lib/social/state.ts\` — HMAC-SHA256 con BETTER_AUTH_SECRET.
- Cookie \`social_oauth_state\`, Path=/api/social, HttpOnly, SameSite=Lax, Secure en HTTPS, TTL 10 min.
- Constant-time compare (timingSafeEqual).

## Providers registry

- \`discord\` (active): identify, guilds, guilds.members.read
- \`google\` (active): openid, email, profile, youtube.readonly
- \`x\`, \`instagram\` (planned) — la UI los muestra "Próximamente"; endpoints devuelven 501.

## Rutas HTTP

- \`GET /api/social/[provider]/connect\` — session guard + state → 302 authorize.
- \`GET /api/social/[provider]/callback\` — verify state → exchange code → fetch profile → upsert cifrado → 302 /perfil.

Errores todos mapean a \`?social_error=state|no_code|user_denied|already_linked|exchange_or_profile_failed|provider_not_configured\`.

Google añade \`access_type=offline&prompt=consent\` para forzar refresh_token.

## Server action disconnect

\`disconnectSocialAccount({ provider })\` en \`/perfil/actions.ts\`:
1. Session guard, Zod validate.
2. deleteSocialAccount (retorna access_token descifrado).
3. revokeToken fire-and-forget (timeout 3s).
4. revalidatePath /perfil.

## Perfil UI

Nueva ruta \`/sorteos/plataforma/perfil\` (server component):
- Cabecera Steam + saldo.
- Grid de tarjetas con estados connected/available/planned/not_configured.
- Steam siempre presente sin desconectar.
- Discord/Google con OAuth completo.
- X + Instagram como "Próximamente" (botón deshabilitado, tooltip explica razón).
- Bloque de settings (privacidad, trade URL, dirección, email — read-only aquí; edición en modal existente).
- Notice banners: \`?social=connected\` verde, \`?social_error=X\` rojo con mensaje amigable.

UserPill dropdown: nuevo item **"Mi perfil"** con \`<Link>\` a \`/perfil\` por encima de "Cerrar sesión".

## Env vars nuevas (todas server + optional)

| Var | Uso |
|---|---|
| \`SOCIAL_TOKEN_ENCRYPTION_KEY\` | AES-256-GCM. 32B base64. Obligatoria en prod. |
| \`DISCORD_CLIENT_ID\` / \`_SECRET\` | Discord OAuth |
| \`GOOGLE_CLIENT_ID\` / \`_SECRET\` | Google OAuth |
| \`DISCORD_GUILD_ID\` | Documentada, uso en PR-1b-2 |
| \`YOUTUBE_CHANNEL_ID\` | Documentada, uso en PR-1b-2 |

Docs completa: [\`docs/env-social.md\`](./docs/env-social.md).

## Tests (57 nuevos)

- \`social-crypto.test.ts\` (10) — round-trip, aleatoriedad nonce, tampering (bit-flip nonce/cipher/tag), bundles inválidos.
- \`social-state.test.ts\` (10) — generateState, sign/verify, signature manipulada, provider distinto, TTL, clock skew.
- \`social-providers-config.test.ts\` (12) — shape registry, scopes exactos, URLs Discord/Google, planned reasons.
- \`social-oauth-structural.test.ts\` (25) — contratos rutas y data layer, cifrado en upsert, no leak a UI/logs, env server-only.

**2306/2306 tests del repo passing.**

## Cómo generar SOCIAL_TOKEN_ENCRYPTION_KEY

\`\`\`bash
node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
\`\`\`

Debe setearse en Vercel (Production + Preview + Development). El equipo pone valores manualmente — este PR no toca \`.env.local\`.

## Test plan

- [ ] Aplicar migración en dev — verificar tabla \`connected_social_accounts\` creada.
- [ ] Setear SOCIAL_TOKEN_ENCRYPTION_KEY + DISCORD_CLIENT_ID/SECRET en preview.
- [ ] Login Steam → menú UserPill → click "Mi perfil" → navega a \`/perfil\`.
- [ ] Tarjeta Discord muestra "Conectar Discord" → click → authorize en Discord → vuelta a \`/perfil?social=connected&provider=discord\` → tarjeta pasa a "Conectado" con username.
- [ ] Click "Desconectar" → tarjeta vuelve a "Conectar Discord". Verificar row eliminada en DB.
- [ ] Sin env DISCORD_CLIENT_ID → tarjeta muestra "No configurado todavía", botón deshabilitado, sin crashes.
- [ ] Repetir para Google/YouTube.

## Fuera de scope (PR-1b-2)

- Misiones sociales verificables (RT, follow, join Discord, like YT).
- \`mission_submissions\` con estado \`pending_review\`.
- Ruta admin \`/admin/sorteos/misiones\` con approve/reject.
- X + Instagram OAuth reales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)