### PR TITLE
feat(giveaways): añadir ZACKETIZOR como creador de la plataforma

### DIFF
--- a/scripts/check-platform-photos.ts
+++ b/scripts/check-platform-photos.ts
@@ -5,7 +5,7 @@ import { inArray } from 'drizzle-orm';
 
 async function main() {
   const r = await db.query.talents.findMany({
-    where: inArray(talents.slug, ['naow', 'huasopeek', 'martinez']),
+    where: inArray(talents.slug, ['naow', 'huasopeek', 'martinez', 'zacketizor']),
     columns: { slug: true, name: true, photoUrl: true },
   });
   console.log(`Filas encontradas: ${r.length}`);

--- a/src/__tests__/server/creator-zacketizor.test.ts
+++ b/src/__tests__/server/creator-zacketizor.test.ts
@@ -1,0 +1,87 @@
+/**
+ * PR-1c-0: ZACKETIZOR está registrado consistentemente en la plataforma.
+ *
+ * Verifica los 3 puntos de acoplamiento:
+ *   - PLATFORM_CREATOR_SLUGS incluye 'zacketizor' (server whitelist).
+ *   - PLATFORM_CREATOR_VISUALS['zacketizor'] existe con code='ZACKCSGO'.
+ *   - Sin fugas del código promocional real en fuentes no relacionadas.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  PLATFORM_CREATOR_SLUGS,
+} from '@/lib/giveaway-platform/constants';
+import {
+  PLATFORM_CREATOR_VISUALS,
+  getCreatorVisual,
+} from '@/features/giveaway-platform/constants/creators';
+
+const ROOT = path.resolve(__dirname, '..', '..', '..');
+
+describe('[creator-zacketizor] server whitelist', () => {
+  it('PLATFORM_CREATOR_SLUGS incluye zacketizor en último lugar', () => {
+    expect([...PLATFORM_CREATOR_SLUGS]).toContain('zacketizor');
+    expect(PLATFORM_CREATOR_SLUGS[PLATFORM_CREATOR_SLUGS.length - 1]).toBe('zacketizor');
+  });
+
+  it('los 4 creadores esperados están presentes sin duplicados', () => {
+    expect([...PLATFORM_CREATOR_SLUGS].sort()).toEqual(
+      ['huasopeek', 'martinez', 'naow', 'zacketizor'],
+    );
+    const asSet = new Set(PLATFORM_CREATOR_SLUGS);
+    expect(asSet.size).toBe(PLATFORM_CREATOR_SLUGS.length);
+  });
+});
+
+describe('[creator-zacketizor] visual config', () => {
+  it('PLATFORM_CREATOR_VISUALS tiene entrada zacketizor', () => {
+    expect(PLATFORM_CREATOR_VISUALS.zacketizor).toBeDefined();
+  });
+
+  it('display name / code / sub esperados', () => {
+    const v = PLATFORM_CREATOR_VISUALS.zacketizor;
+    expect(v?.code).toBe('ZACKCSGO');
+    expect(v?.sub).toMatch(/CS/i);
+    expect(typeof v?.emoji).toBe('string');
+    expect(typeof v?.color).toBe('string');
+    expect(v?.color).toMatch(/^#[0-9a-f]{6}$/i);
+  });
+
+  it('getCreatorVisual(zacketizor) devuelve la config real, no fallback', () => {
+    const v = getCreatorVisual('zacketizor');
+    expect(v.code).toBe('ZACKCSGO');
+    // El fallback usaría code = slug.toUpperCase() = 'ZACKETIZOR'.
+    expect(v.code).not.toBe('ZACKETIZOR');
+  });
+
+  it('cada slug del whitelist tiene entrada en VISUALS', () => {
+    for (const slug of PLATFORM_CREATOR_SLUGS) {
+      expect(PLATFORM_CREATOR_VISUALS[slug]).toBeDefined();
+    }
+  });
+});
+
+describe('[creator-zacketizor] no leaks de promocode fuera de creators.ts', () => {
+  // El código promocional real ZACKCSGO no debe aparecer:
+  //   - hardcoded en archivos de UI (page.tsx, componentes)
+  //   - hardcoded en tests distintos a este
+  //   - hardcoded en docs públicos
+  // Sí debe aparecer en creators.ts (fuente autoritativa) y en este test.
+  const forbidden = [
+    'src/app/sorteos/plataforma/page.tsx',
+    'src/features/giveaway-platform/components/PlatformNav.tsx',
+    'src/features/giveaway-platform/components/PlatformHero.tsx',
+    'src/features/giveaway-platform/components/BrandBonusesSection.tsx',
+    'README.md',
+    'CLAUDE.md',
+  ];
+  for (const rel of forbidden) {
+    it(`${rel} no menciona ZACKCSGO`, () => {
+      const abs = path.join(ROOT, rel);
+      if (!fs.existsSync(abs)) return; // ok si el archivo no existe
+      const src = fs.readFileSync(abs, 'utf-8');
+      expect(src).not.toMatch(/ZACKCSGO/);
+    });
+  }
+});

--- a/src/features/giveaway-platform/constants/creators.ts
+++ b/src/features/giveaway-platform/constants/creators.ts
@@ -18,6 +18,9 @@ export const PLATFORM_CREATOR_VISUALS: Record<string, PlatformCreatorVisual> = {
   naow: { emoji: '🎯', color: '#28d7ff', code: 'NAOW', sub: 'Creador de CS · SocialPro' },
   huasopeek: { emoji: '🔥', color: '#ff9d2e', code: 'HUASOPEEK', sub: 'Creador de CS · SocialPro' },
   martinez: { emoji: '⚔️', color: '#4ade80', code: 'MARTINEZ', sub: 'Creador de CS · SocialPro' },
+  // ZACKETIZOR: display name en KeyDrop es "zack", código promocional real
+  // es ZACKCSGO (no ZACKETIZOR — descubierto en el probe de la API KeyDrop).
+  zacketizor: { emoji: '🎬', color: '#e03070', code: 'ZACKCSGO', sub: 'Creador CS2 · SocialPro' },
 };
 
 export function getCreatorVisual(slug: string): PlatformCreatorVisual {

--- a/src/lib/giveaway-platform/constants.ts
+++ b/src/lib/giveaway-platform/constants.ts
@@ -11,7 +11,7 @@ export const ENTRY_COIN_REWARD = 20;
 export const STREAK_REWARDS = [10, 15, 20, 25, 30, 40, 60] as const;
 
 /** Slugs de talents visibles en el selector de creador de la plataforma. */
-export const PLATFORM_CREATOR_SLUGS = ['naow', 'huasopeek', 'martinez'] as const;
+export const PLATFORM_CREATOR_SLUGS = ['naow', 'huasopeek', 'martinez', 'zacketizor'] as const;
 
 /** Zona horaria para el corte del día de la racha y el mes del ranking. */
 export const PLATFORM_TZ = 'Europe/Madrid';


### PR DESCRIPTION
Cuarto creador visible en \`/sorteos/plataforma\`. Preparación para PR-1c-1 (integración KeyDrop API).

## Descubrimientos del probe KeyDrop

Antes de este PR probé la API de KeyDrop con la clave de afiliado. Aparecieron 2 datos que corrijo aquí:

- El **display username en KeyDrop es \`zack\`** (minúsculas), no ZACKETIZOR.
- El **código promocional real es \`ZACKCSGO\`**, no \`ZACKETIZOR\` como asumíamos.

Ambos van al \`PLATFORM_CREATOR_VISUALS['zacketizor']\` como fuente de verdad.

## Cambios

- \`PLATFORM_CREATOR_SLUGS\`: 3 → 4 entries. \`zacketizor\` al final.
- \`PLATFORM_CREATOR_VISUALS.zacketizor\`:
  - \`code: 'ZACKCSGO'\` — código promo real
  - \`sub: 'Creador CS2 · SocialPro'\`
  - \`emoji: '🎬'\` — fallback si photoUrl null
  - \`color: '#e03070'\` (SP pink) — acento del avatar en el dropdown
- \`scripts/check-platform-photos.ts\` — incluye \`zacketizor\` en el check DB.

## Cero cambios de DB

El talent ya existía: \`id=219, slug='zacketizor', photoUrl=YES\`. El \`CreatorDropdown\` lee \`talents.photoUrl\` desde el server component, así que la foto real aparece automáticamente sin nueva migración ni seed.

## Tests (12 nuevos)

\`src/__tests__/server/creator-zacketizor.test.ts\`:

- Whitelist server: \`zacketizor\` presente, sin duplicados, orden esperado.
- Visual config: \`code='ZACKCSGO'\`, \`sub\` matchea CS, formato hex color válido.
- \`getCreatorVisual('zacketizor')\` devuelve config real, NO el fallback que produciría \`code='ZACKETIZOR'\` (guard contra typo).
- Cada slug del whitelist tiene entry en VISUALS (invariante estructural).
- \`ZACKCSGO\` no aparece hardcoded fuera de \`creators.ts\` — evita duplicación en page/componentes/docs.

**2261/2261 tests del repo passing** (12 nuevos + 2249 previos).

## Fuera de scope

- Integración KeyDrop API (PR-1c-1 siguiente).
- Cambios de schema — nada nuevo.
- Monedas / misiones / tickets internos — sin cambios.

## Test plan

- [ ] Abrir \`/sorteos/plataforma\` → dropdown de creador muestra ahora 4 opciones (NAOW, HUASOPEEK, MARTINEZ, ZACKETIZOR).
- [ ] Seleccionar ZACKETIZOR → hero cambia a \"GIVEAWAYS DE ZACKETIZOR\" (o el name real de DB con capitalización).
- [ ] Avatar del dropdown muestra la foto real de \`talents.photoUrl\`.
- [ ] URL query \`?creador=zacketizor\` se refleja tras el select.

🤖 Generated with [Claude Code](https://claude.com/claude-code)