### PR TITLE
feat(giveaways): integrar sorteos KeyDrop de ZACKETIZOR

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -138,6 +138,9 @@ const nextConfig: NextConfig = {
       { protocol: 'https', hostname: '*.ytimg.com' },
       // Imgur — brand logos entered via admin panel
       { protocol: 'https', hostname: 'i.imgur.com' },
+      // KeyDrop CDN — imágenes de premios de sorteos (PR-1c-1)
+      { protocol: 'https', hostname: 'cdnkd.com' },
+      { protocol: 'https', hostname: '*.cdnkd.com' },
     ],
   },
   // pdfjs-dist, mupdf, tesseract.js are external so nft doesn't auto-trace their

--- a/src/__tests__/server/keydrop-client.test.ts
+++ b/src/__tests__/server/keydrop-client.test.ts
@@ -1,0 +1,110 @@
+/**
+ * KeyDrop API client — verificaciones estructurales.
+ *
+ * NO ejecuta requests reales (no hay clave en el entorno de test). Verifica
+ * contratos por inspección de código:
+ *   - env var es server-only y opcional.
+ *   - x-api-key va en header, NUNCA en URL.
+ *   - jamás se loggea la key ni el header completo.
+ *   - timeout implementado.
+ *   - fallback silencioso si falta env.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(__dirname, '..', '..', '..');
+const read = (rel: string) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');
+
+describe('[keydrop] env var declaración', () => {
+  const src = read('src/lib/env.ts');
+  it('KEYDROP_ZACKETIZOR_API_KEY vive en el bloque server', () => {
+    expect(src).toMatch(/server:\s*\{[\s\S]*KEYDROP_ZACKETIZOR_API_KEY[\s\S]*\},/);
+  });
+  it('KEYDROP_ZACKETIZOR_API_KEY es opcional (no crashea sin ella)', () => {
+    expect(src).toMatch(/KEYDROP_ZACKETIZOR_API_KEY:\s*z\.string\(\)\.min\(1\)\.optional\(\)/);
+  });
+  it('KEYDROP_ZACKETIZOR_API_KEY NO aparece en el bloque client', () => {
+    const clientBlock = /client:\s*\{[\s\S]*?\},/.exec(src)?.[0] ?? '';
+    expect(clientBlock).not.toMatch(/KEYDROP/);
+  });
+  it('runtimeEnv incluye la mapping', () => {
+    expect(src).toMatch(/KEYDROP_ZACKETIZOR_API_KEY:\s*process\.env\.KEYDROP_ZACKETIZOR_API_KEY/);
+  });
+});
+
+describe('[keydrop] client contratos de seguridad', () => {
+  const src = read('src/lib/keydrop/client.ts');
+
+  it('usa x-api-key header, JAMÁS en URL query', () => {
+    expect(src).toMatch(/'x-api-key':\s*apiKey/);
+    // No debe aparecer nada como ?api_key= o &key= en URLs
+    expect(src).not.toMatch(/\?api_key=/);
+    expect(src).not.toMatch(/&key=/);
+    expect(src).not.toMatch(/\?key=/);
+  });
+
+  it('nunca loggea `apiKey` ni contenido de header', () => {
+    // Ningún console.* debe recibir apiKey o el header completo
+    expect(src).not.toMatch(/console\.[a-z]+\([^)]*apiKey/);
+    expect(src).not.toMatch(/console\.[a-z]+\([^)]*x-api-key/i);
+    expect(src).not.toMatch(/console\.[a-z]+\([^)]*Authorization/i);
+  });
+
+  it('implementa timeout con AbortController', () => {
+    expect(src).toMatch(/AbortController/);
+    expect(src).toMatch(/FETCH_TIMEOUT_MS|setTimeout\([^)]*,\s*\d{4,}/);
+  });
+
+  it('gate por env: sin key devuelve not_configured', () => {
+    expect(src).toMatch(/if\s*\(!apiKey\)\s*return\s*\{\s*ok:\s*false,\s*error:\s*'not_configured'/);
+  });
+
+  it('cache Next revalidate configurado', () => {
+    expect(src).toMatch(/next:\s*\{\s*revalidate:\s*REVALIDATE_SECONDS/);
+    expect(src).toMatch(/REVALIDATE_SECONDS\s*=\s*60/);
+  });
+
+  it('usa BASE_URL fijo (no construido con env)', () => {
+    expect(src).toMatch(/BASE_URL\s*=\s*'https:\/\/ws-2071\.socket-cs\.com\/v1\/giveaway-user'/);
+  });
+
+  it('errores clasificados sin leak de body', () => {
+    // Los console.warn solo indican el tipo de error + path, nunca el body
+    expect(src).toMatch(/console\.warn\(`\[keydrop\] fetch \$\{path\} shape_mismatch`\)/);
+    expect(src).toMatch(/console\.warn\(`\[keydrop\] fetch \$\{path\} http_\$\{res\.status\}`\)/);
+  });
+});
+
+describe('[keydrop] client shape', () => {
+  const src = read('src/lib/keydrop/client.ts');
+
+  it('exporta fetchKeydropList y fetchKeydropGiveaway', () => {
+    expect(src).toMatch(/export async function fetchKeydropList/);
+    expect(src).toMatch(/export async function fetchKeydropGiveaway\(id: string\)/);
+  });
+  it('exporta isKeydropConfigured para gate UI', () => {
+    expect(src).toMatch(/export function isKeydropConfigured/);
+  });
+  it('encodeURIComponent aplicado al id del detail', () => {
+    expect(src).toMatch(/encodeURIComponent\(id\)/);
+  });
+});
+
+describe('[keydrop] no leak en UI/queries', () => {
+  const uiFiles = [
+    'src/features/giveaway-platform/components/KeydropGiveawaysSection.tsx',
+    'src/lib/queries/keydropGiveaways.ts',
+    'src/lib/keydrop/mappers.ts',
+    'src/lib/keydrop/types.ts',
+  ];
+  for (const rel of uiFiles) {
+    it(`${rel} no referencia KEYDROP_ZACKETIZOR_API_KEY ni env.KEYDROP`, () => {
+      const src = read(rel);
+      expect(src).not.toMatch(/KEYDROP_ZACKETIZOR_API_KEY/);
+      expect(src).not.toMatch(/env\.KEYDROP/);
+      // Ningún tipo debe exponer un campo llamado `apiKey`, `token`, etc.
+      expect(src).not.toMatch(/apiKey:\s*string/);
+    });
+  }
+});

--- a/src/__tests__/server/keydrop-integration-structural.test.ts
+++ b/src/__tests__/server/keydrop-integration-structural.test.ts
@@ -23,11 +23,25 @@ describe('[keydrop-integration] page.tsx', () => {
     expect(src).toMatch(/import\s+\{\s*getKeydropZacketizorGiveaways/);
   });
 
-  it('solo llama getKeydropZacketizorGiveaways si active.slug === "zacketizor"', () => {
-    expect(src).toMatch(/active\.slug\s*===\s*'zacketizor'\s*\?\s*getKeydropZacketizorGiveaways/);
+  it('define isKeydropCreator = active.slug === "zacketizor"', () => {
+    expect(src).toMatch(/const\s+isKeydropCreator\s*=\s*active\.slug\s*===\s*'zacketizor'/);
   });
 
-  it('el fallback devuelve status not_configured (no lanza)', () => {
+  it('solo llama getKeydropZacketizorGiveaways si isKeydropCreator', () => {
+    expect(src).toMatch(/isKeydropCreator\s*\?\s*getKeydropZacketizorGiveaways\(\)/);
+  });
+
+  it('para zacketizor NO carga sorteos internos del CRM', () => {
+    // giveawaysData = isKeydropCreator ? [] : await getGiveawaysWithEntryData(...)
+    expect(src).toMatch(/const\s+giveawaysData\s*=\s*isKeydropCreator[\s\S]{0,80}\[\][\s\S]{0,120}getGiveawaysWithEntryData/);
+  });
+
+  it('para zacketizor OCULTA la <section id="sorteos"> interna', () => {
+    // {isKeydropCreator ? null : (<section id="sorteos">...</section>)}
+    expect(src).toMatch(/isKeydropCreator\s*\?\s*null\s*:\s*\(\s*<section\s+id="sorteos"/);
+  });
+
+  it('el fallback KeyDrop devuelve status not_configured (no lanza)', () => {
     expect(src).toMatch(/status:\s*'not_configured'/);
   });
 
@@ -100,9 +114,11 @@ describe('[keydrop-integration] UI del component', () => {
     expect(src).toMatch(/sections\.active\.length\s*===\s*0\s*&&\s*sections\.finished\.length\s*===\s*0[\s\S]{0,40}return\s*null/);
   });
 
-  it('botón "Ver sorteo" abre en nueva pestaña con rel noopener noreferrer', () => {
+  it('botón "Ver en KeyDrop" abre en nueva pestaña con rel noopener noreferrer', () => {
     // <a target="_blank" rel="noopener noreferrer" ...
     expect(src).toMatch(/target="_blank"[\s\S]{0,80}rel="noopener noreferrer"/);
+    // Label del botón — no dice "Ver sorteo" o "Ver resultado", sino "Ver en KeyDrop"
+    expect(src).toMatch(/Ver en KeyDrop/);
   });
 
   it('renderiza badge KeyDrop con /images/brands/keydrop.png', () => {

--- a/src/__tests__/server/keydrop-integration-structural.test.ts
+++ b/src/__tests__/server/keydrop-integration-structural.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Contratos estructurales de la integración KeyDrop en /sorteos/plataforma.
+ *
+ * Verifica que:
+ *   - page.tsx solo llama KeyDrop cuando active.slug === 'zacketizor'.
+ *   - No hay coin_transactions ni giveaway_entries desde el flujo KeyDrop.
+ *   - cdnkd.com en remotePatterns de next.config.
+ *   - Component no expone tokens.
+ *   - Botón Ver sorteo abre en nueva pestaña (target=_blank + rel).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(__dirname, '..', '..', '..');
+const read = (rel: string) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');
+
+describe('[keydrop-integration] page.tsx', () => {
+  const src = read('src/app/sorteos/plataforma/page.tsx');
+
+  it('importa la query y el component KeyDrop', () => {
+    expect(src).toMatch(/import\s+\{\s*KeydropGiveawaysSection\s*\}/);
+    expect(src).toMatch(/import\s+\{\s*getKeydropZacketizorGiveaways/);
+  });
+
+  it('solo llama getKeydropZacketizorGiveaways si active.slug === "zacketizor"', () => {
+    expect(src).toMatch(/active\.slug\s*===\s*'zacketizor'\s*\?\s*getKeydropZacketizorGiveaways/);
+  });
+
+  it('el fallback devuelve status not_configured (no lanza)', () => {
+    expect(src).toMatch(/status:\s*'not_configured'/);
+  });
+
+  it('renderiza <KeydropGiveawaysSection> pasando keydropSections y creatorDisplayName', () => {
+    expect(src).toMatch(/<KeydropGiveawaysSection\s+sections=\{keydropSections\}\s+creatorDisplayName=\{active\.name\}/);
+  });
+});
+
+describe('[keydrop-integration] no monedas / no tickets internos', () => {
+  const filesToCheck = [
+    'src/lib/keydrop/client.ts',
+    'src/lib/keydrop/mappers.ts',
+    'src/lib/keydrop/types.ts',
+    'src/lib/queries/keydropGiveaways.ts',
+    'src/features/giveaway-platform/components/KeydropGiveawaysSection.tsx',
+  ];
+  for (const rel of filesToCheck) {
+    it(`${rel} no toca coin_transactions / giveaway_entries / mission_claims`, () => {
+      const src = read(rel);
+      // Filtro fuera de comentarios (JSDoc `*` líneas) para permitir
+      // documentación que describe qué NO toca este módulo.
+      const codeOnly = src
+        .split('\n')
+        .filter((l) => !/^\s*\*/.test(l) && !/^\s*\/\/\s/.test(l))
+        .join('\n');
+      expect(codeOnly).not.toMatch(/coinTransactions/);
+      expect(codeOnly).not.toMatch(/coin_transactions/);
+      expect(codeOnly).not.toMatch(/giveawayEntries/);
+      expect(codeOnly).not.toMatch(/giveaway_entries/);
+      expect(codeOnly).not.toMatch(/missionClaims/);
+      expect(codeOnly).not.toMatch(/mission_claims/);
+    });
+  }
+});
+
+describe('[keydrop-integration] no importa DB desde módulos KeyDrop', () => {
+  const filesToCheck = [
+    'src/lib/keydrop/client.ts',
+    'src/lib/keydrop/mappers.ts',
+    'src/lib/keydrop/types.ts',
+    'src/lib/queries/keydropGiveaways.ts',
+  ];
+  for (const rel of filesToCheck) {
+    it(`${rel} no importa @/lib/db ni @/db/schema`, () => {
+      const src = read(rel);
+      expect(src).not.toMatch(/from\s+['"]@\/lib\/db['"]/);
+      expect(src).not.toMatch(/from\s+['"]@\/db\/schema/);
+    });
+  }
+});
+
+describe('[keydrop-integration] next.config.ts', () => {
+  const src = read('next.config.ts');
+  it('cdnkd.com está en remotePatterns', () => {
+    expect(src).toMatch(/hostname:\s*'cdnkd\.com'/);
+  });
+  it('wildcard *.cdnkd.com está en remotePatterns', () => {
+    expect(src).toMatch(/hostname:\s*'\*\.cdnkd\.com'/);
+  });
+});
+
+describe('[keydrop-integration] UI del component', () => {
+  const src = read('src/features/giveaway-platform/components/KeydropGiveawaysSection.tsx');
+
+  it('devuelve null si status !== "ok" (degradación silenciosa)', () => {
+    expect(src).toMatch(/if\s*\(sections\.status\s*!==\s*'ok'\)\s*return\s*null/);
+  });
+
+  it('devuelve null si no hay sorteos', () => {
+    expect(src).toMatch(/sections\.active\.length\s*===\s*0\s*&&\s*sections\.finished\.length\s*===\s*0[\s\S]{0,40}return\s*null/);
+  });
+
+  it('botón "Ver sorteo" abre en nueva pestaña con rel noopener noreferrer', () => {
+    // <a target="_blank" rel="noopener noreferrer" ...
+    expect(src).toMatch(/target="_blank"[\s\S]{0,80}rel="noopener noreferrer"/);
+  });
+
+  it('renderiza badge KeyDrop con /images/brands/keydrop.png', () => {
+    expect(src).toMatch(/\/images\/brands\/keydrop\.png/);
+  });
+
+  it('finalizados en <details> collapsible', () => {
+    expect(src).toMatch(/<details[\s\S]{0,120}<summary/);
+  });
+});
+
+describe('[keydrop-integration] layout carga el CSS', () => {
+  const src = read('src/app/sorteos/plataforma/layout.tsx');
+  it('platform-keydrop.css se importa desde el layout', () => {
+    expect(src).toMatch(/import\s+['"]\.\/platform-keydrop\.css['"]/);
+  });
+});

--- a/src/__tests__/server/keydrop-mappers.test.ts
+++ b/src/__tests__/server/keydrop-mappers.test.ts
@@ -92,9 +92,11 @@ describe('[keydrop-mappers] toKeydropCard — activo', () => {
     expect(card.promoCode).toBe('ZACKCSGO');
   });
 
-  it('externalUrl construido con el id url-encoded', () => {
+  it('externalUrl apunta al listing genérico (KeyDrop no expone URL individual)', () => {
     const card = toKeydropCard(baseItem);
-    expect(card.externalUrl).toBe('https://key-drop.com/es/giveaway/o3S8gi66000');
+    // KeyDrop no publica URLs individuales por id — el listing es la landing
+    // más específica disponible por ahora.
+    expect(card.externalUrl).toBe('https://key-drop.com/es/giveaways');
   });
 
   it('prizeCount cuenta todos los premios', () => {
@@ -224,11 +226,13 @@ describe('[keydrop-mappers] requirements normalizadas + fullfilled → fulfilled
 });
 
 describe('[keydrop-mappers] buildKeydropExternalUrl', () => {
-  it('template correcto', () => {
-    expect(buildKeydropExternalUrl('abc123')).toBe('https://key-drop.com/es/giveaway/abc123');
-  });
-  it('escapa caracteres especiales', () => {
-    expect(buildKeydropExternalUrl('ab/cd')).toBe('https://key-drop.com/es/giveaway/ab%2Fcd');
+  // KeyDrop no expone URL pública por id — devolvemos el listing genérico
+  // para evitar botones que llevan a 404. El id se ignora por diseño hasta
+  // que KeyDrop publique URLs individuales.
+  it('devuelve el listing público independiente del id', () => {
+    expect(buildKeydropExternalUrl('abc123')).toBe('https://key-drop.com/es/giveaways');
+    expect(buildKeydropExternalUrl('otroId'))
+      .toBe('https://key-drop.com/es/giveaways');
   });
 });
 

--- a/src/__tests__/server/keydrop-mappers.test.ts
+++ b/src/__tests__/server/keydrop-mappers.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Tests puros del mapper KeyDrop → KeydropCard.
+ *
+ * Fixtures basados en el shape real observado durante el probe (2026-07):
+ * organizer, prizes, requirements con typo `fullfilled`, buckets active/finished.
+ */
+
+import {
+  buildKeydropExternalUrl,
+  formatCurrency,
+  toKeydropCard,
+} from '@/lib/keydrop/mappers';
+import {
+  KeydropListItemSchema,
+  KeydropListResponseSchema,
+  type KeydropListItem,
+} from '@/lib/keydrop/types';
+
+const organizer = {
+  idSteam: '76561198000000001',
+  username: 'zack',
+  steamAvatar: 'https://cdnkd.com/avatar/zack.jpg',
+  promocode: 'ZACKCSGO',
+};
+
+const prizeFactory = (overrides: Partial<{ price: number; currency: string; title: string; subtitle: string | null; itemImg: string; id: number }> = {}) => ({
+  id: overrides.id ?? 505255,
+  color: 'gold',
+  itemImg: overrides.itemImg ?? 'https://cdnkd.com/skins/flip.png',
+  title: overrides.title ?? '★ Flip Knife',
+  subtitle: overrides.subtitle ?? 'Lore',
+  phase: null,
+  price: overrides.price ?? 421.25,
+  condition: 'FN',
+  weaponType: 'knife',
+  currency: overrides.currency ?? 'USD',
+});
+
+const baseItem: KeydropListItem = {
+  id: 'o3S8gi66000',
+  hot: 0,
+  boost: null,
+  status: 'new',
+  maxUsers: 0,
+  minUsers: 398,
+  duractionSeconds: 86400,   // sic — typo upstream
+  totalPrizes: 4253.94,
+  organizer,
+  depositAmountRequired: 10,
+  depositAmountRequiredUSD: 10,
+  depositAmountRequiredCurrency: 'USD',
+  createdAt: 1781720838000,
+  deadlineTimestamp: null,
+  prizes: [prizeFactory(), prizeFactory({ id: 2, price: 300, title: 'AK-47', subtitle: 'Redline' })],
+  participantCount: 2,
+  haveIJoined: false,
+  chance: 0,
+};
+
+describe('[keydrop-mappers] toKeydropCard — activo', () => {
+  it('mapea campos básicos correctamente', () => {
+    const card = toKeydropCard(baseItem);
+    expect(card.id).toBe('o3S8gi66000');
+    expect(card.source).toBe('keydrop');
+    expect(card.title).toBe('★ Flip Knife');
+    expect(card.subtitle).toBe('Lore');
+    expect(card.status).toBe('new');
+    expect(card.participantCount).toBe(2);
+    expect(card.maxUsers).toBe(0);
+    expect(card.minUsers).toBe(398);
+  });
+
+  it('imageUrl = prizes[0].itemImg', () => {
+    const card = toKeydropCard(baseItem);
+    expect(card.imageUrl).toBe('https://cdnkd.com/skins/flip.png');
+  });
+
+  it('totalValue usa `totalPrizes` si viene', () => {
+    const card = toKeydropCard(baseItem);
+    expect(card.totalValue).toBe(4253.94);
+  });
+
+  it('totalValue = sum(prizes[].price) si totalPrizes ausente', () => {
+    const item = { ...baseItem, totalPrizes: undefined };
+    const card = toKeydropCard(item);
+    // 421.25 + 300 = 721.25
+    expect(card.totalValue).toBe(721.25);
+  });
+
+  it('promoCode desde organizer si no hay requirements', () => {
+    const card = toKeydropCard(baseItem);
+    expect(card.promoCode).toBe('ZACKCSGO');
+  });
+
+  it('externalUrl construido con el id url-encoded', () => {
+    const card = toKeydropCard(baseItem);
+    expect(card.externalUrl).toBe('https://key-drop.com/es/giveaway/o3S8gi66000');
+  });
+
+  it('prizeCount cuenta todos los premios', () => {
+    const card = toKeydropCard(baseItem);
+    expect(card.prizeCount).toBe(2);
+  });
+
+  it('deadlineTimestamp nullable si viene null', () => {
+    const card = toKeydropCard(baseItem);
+    expect(card.deadlineTimestamp).toBeNull();
+  });
+
+  it('createdAt convertido a Date', () => {
+    const card = toKeydropCard(baseItem);
+    expect(card.createdAt).toBeInstanceOf(Date);
+    expect(card.createdAt.getTime()).toBe(1781720838000);
+  });
+});
+
+describe('[keydrop-mappers] toKeydropCard — finalizado', () => {
+  const finishedItem: KeydropListItem = {
+    ...baseItem,
+    id: 'j43msi31534',
+    status: 'ended',
+    deadlineTimestamp: 1743196228000,
+    participantCount: 1000,
+    winners: [
+      { idSteam: '76561198100000001', username: 'winner1', steamAvatar: 'https://cdnkd.com/w1.jpg', prizeId: 1 },
+      { idSteam: '76561198100000002', username: 'winner2', steamAvatar: 'https://cdnkd.com/w2.jpg', prizeId: 2 },
+    ],
+  };
+
+  it('mapea winners a array normalizado', () => {
+    const card = toKeydropCard(finishedItem);
+    expect(card.winners).toHaveLength(2);
+    expect(card.winners[0]).toEqual({
+      steamId: '76561198100000001',
+      username: 'winner1',
+      avatarUrl: 'https://cdnkd.com/w1.jpg',
+      prizeId: 1,
+    });
+  });
+
+  it('status ended reconocido', () => {
+    expect(toKeydropCard(finishedItem).status).toBe('ended');
+  });
+
+  it('deadlineTimestamp convertido a Date cuando existe', () => {
+    const card = toKeydropCard(finishedItem);
+    expect(card.deadlineTimestamp).toBeInstanceOf(Date);
+    expect(card.deadlineTimestamp?.getTime()).toBe(1743196228000);
+  });
+});
+
+describe('[keydrop-mappers] status desconocido', () => {
+  it('status extraño → "unknown" (no rompe UI)', () => {
+    const item = { ...baseItem, status: 'draft' };
+    expect(toKeydropCard(item).status).toBe('unknown');
+  });
+});
+
+describe('[keydrop-mappers] multi-currency', () => {
+  it('EUR se mapea correctamente al depositCurrency', () => {
+    const item = {
+      ...baseItem,
+      depositAmountRequiredCurrency: 'EUR',
+      prizes: [prizeFactory({ currency: 'EUR' })],
+    };
+    const card = toKeydropCard(item);
+    expect(card.depositCurrency).toBe('EUR');
+    expect(card.currency).toBe('EUR');
+  });
+
+  it('formatCurrency respeta símbolos USD y EUR', () => {
+    expect(formatCurrency(1073.78, 'USD')).toBe('$1,073.78');
+    expect(formatCurrency(10, 'EUR')).toBe('10.00 €');
+    expect(formatCurrency(500, 'BTC')).toBe('500.00 BTC');
+  });
+});
+
+describe('[keydrop-mappers] requirements normalizadas + fullfilled → fulfilled', () => {
+  it('objeto con clave "0" se convierte a array', () => {
+    const withReqs: KeydropListItem & {
+      requirements: Record<string, { type: string; promoCode: string; fullfilled: boolean; refillAmount: number; currency: string }>;
+    } = {
+      ...baseItem,
+      requirements: {
+        '0': {
+          type: 'PROMO_CODE_USAGE',
+          promoCode: 'ZACKCSGO',
+          refillAmount: 10,
+          fullfilled: false,   // sic
+          currency: 'USD',
+        },
+      },
+    };
+    const card = toKeydropCard(withReqs);
+    expect(card.requirements).toHaveLength(1);
+    expect(card.requirements[0]?.type).toBe('PROMO_CODE_USAGE');
+    // Corrección del typo upstream
+    expect(card.requirements[0]?.fulfilled).toBe(false);
+    // Y NO expone `fullfilled` en el shape interno
+    expect(card.requirements[0]).not.toHaveProperty('fullfilled');
+  });
+
+  it('promoCode toma el de requirements si existe', () => {
+    const withReqs: KeydropListItem & {
+      requirements: Record<string, { type: string; promoCode: string; refillAmount: number }>;
+    } = {
+      ...baseItem,
+      requirements: {
+        '0': {
+          type: 'PROMO_CODE_USAGE',
+          promoCode: 'OTHERCODE',   // distinto al de organizer
+          refillAmount: 5,
+        },
+      },
+    };
+    const card = toKeydropCard(withReqs);
+    expect(card.promoCode).toBe('OTHERCODE');
+  });
+
+  it('sin requirements → promoCode desde organizer', () => {
+    const card = toKeydropCard(baseItem);
+    expect(card.promoCode).toBe('ZACKCSGO');
+  });
+});
+
+describe('[keydrop-mappers] buildKeydropExternalUrl', () => {
+  it('template correcto', () => {
+    expect(buildKeydropExternalUrl('abc123')).toBe('https://key-drop.com/es/giveaway/abc123');
+  });
+  it('escapa caracteres especiales', () => {
+    expect(buildKeydropExternalUrl('ab/cd')).toBe('https://key-drop.com/es/giveaway/ab%2Fcd');
+  });
+});
+
+describe('[keydrop-mappers] Zod schemas parsean el shape real', () => {
+  it('KeydropListItemSchema parsea un item mínimo', () => {
+    const result = KeydropListItemSchema.safeParse(baseItem);
+    expect(result.success).toBe(true);
+  });
+
+  it('KeydropListResponseSchema parsea un response completo', () => {
+    const response = {
+      success: true,
+      data: {
+        active: [baseItem],
+        finished: [{ ...baseItem, status: 'ended', deadlineTimestamp: 1743196228000 }],
+      },
+    };
+    const result = KeydropListResponseSchema.safeParse(response);
+    expect(result.success).toBe(true);
+  });
+
+  it('rechaza response sin `data.active`', () => {
+    const bad = { success: true, data: { finished: [] } };
+    expect(KeydropListResponseSchema.safeParse(bad).success).toBe(false);
+  });
+
+  it('acepta prizes con subtitle null', () => {
+    const item = { ...baseItem, prizes: [prizeFactory({ subtitle: null })] };
+    expect(KeydropListItemSchema.safeParse(item).success).toBe(true);
+  });
+});

--- a/src/app/sorteos/plataforma/layout.tsx
+++ b/src/app/sorteos/plataforma/layout.tsx
@@ -8,6 +8,7 @@ import './platform-hero.css';
 import './platform-brand-cards.css';
 import './platform-fx.css';
 import './platform-widgets.css';
+import './platform-keydrop.css';
 
 const rajdhani = Rajdhani({
   subsets: ['latin'],

--- a/src/app/sorteos/plataforma/page.tsx
+++ b/src/app/sorteos/plataforma/page.tsx
@@ -24,6 +24,8 @@ import { MissionsGrid } from '@/features/giveaway-platform/components/MissionsGr
 import { EntryButton } from '@/features/giveaway-platform/components/EntryButton';
 import { PlatformShop } from '@/features/giveaway-platform/components/PlatformShop';
 import { MonthlyRanking } from '@/features/giveaway-platform/components/MonthlyRanking';
+import { KeydropGiveawaysSection } from '@/features/giveaway-platform/components/KeydropGiveawaysSection';
+import { getKeydropZacketizorGiveaways, type KeydropSections } from '@/lib/queries/keydropGiveaways';
 
 /**
  * PR1 (v2 shell): nav sticky + hero Bonuses + tarjetas estáticas de marcas.
@@ -90,9 +92,14 @@ export default async function PlataformaSorteosPage({
       ])
     : [0, [], undefined];
 
-  const [ranking, shopItemsData] = await Promise.all([
+  const [ranking, shopItemsData, keydropSections] = await Promise.all([
     getMonthlyRanking(10),
     getActiveShopItems(),
+    // KeyDrop live-cache: solo para ZACKETIZOR. Degrada a listas vacías
+    // si falta env, si KeyDrop cae, si shape falla — nunca lanza.
+    active.slug === 'zacketizor'
+      ? getKeydropZacketizorGiveaways()
+      : Promise.resolve<KeydropSections>({ active: [], finished: [], status: 'not_configured' }),
   ]);
 
   const today = todayInPlatformTz();
@@ -181,6 +188,9 @@ export default async function PlataformaSorteosPage({
             </div>
           </div>
         </section>
+
+        {/* --- Sorteos KeyDrop de ZACKETIZOR (live-cache, solo lectura) --- */}
+        <KeydropGiveawaysSection sections={keydropSections} creatorDisplayName={active.name} />
 
         <section id="ranking">
           <div className="gp-legacy-block">

--- a/src/app/sorteos/plataforma/page.tsx
+++ b/src/app/sorteos/plataforma/page.tsx
@@ -82,7 +82,14 @@ export default async function PlataformaSorteosPage({
   }
 
   const activeVisual = getCreatorVisual(active.slug);
-  const giveawaysData = await getGiveawaysWithEntryData(active.id, userId);
+  // ZACKETIZOR usa exclusivamente sorteos de KeyDrop (fuente externa vía
+  // API). Para el resto de creadores usamos los sorteos internos gestionados
+  // desde el CRM. Este gate evita mostrar sorteos internos vacíos bajo
+  // ZACKETIZOR y también evita mostrar la sección KeyDrop bajo el resto.
+  const isKeydropCreator = active.slug === 'zacketizor';
+  const giveawaysData = isKeydropCreator
+    ? []
+    : await getGiveawaysWithEntryData(active.id, userId);
 
   const [balance, missions, streak] = userId
     ? await Promise.all([
@@ -97,7 +104,7 @@ export default async function PlataformaSorteosPage({
     getActiveShopItems(),
     // KeyDrop live-cache: solo para ZACKETIZOR. Degrada a listas vacías
     // si falta env, si KeyDrop cae, si shape falla — nunca lanza.
-    active.slug === 'zacketizor'
+    isKeydropCreator
       ? getKeydropZacketizorGiveaways()
       : Promise.resolve<KeydropSections>({ active: [], finished: [], status: 'not_configured' }),
   ]);
@@ -148,46 +155,51 @@ export default async function PlataformaSorteosPage({
           </section>
         )}
 
-        <section id="sorteos">
-          <div className="gp-legacy-block">
-            <h2>Sorteos de {active.name}</h2>
-            <p className="gp-rank-note">
-              Participación gratuita · ganas +{ENTRY_COIN_REWARD} 🪙 por sorteo · fotos reales de las skins
-            </p>
-            <div className="gp-sorteos-grid">
-              {giveawaysData.map((g) => (
-                <article key={g.id} className="gp-sorteo-card">
-                  <div className="gp-sorteo-glow" aria-hidden />
-                  <div className="gp-sorteo-fg">
-                    <div className="gp-sorteo-img">
-                      {g.imageUrl ? (
-                        // eslint-disable-next-line @next/next/no-img-element
-                        <img src={g.imageUrl} alt={g.title} />
-                      ) : (
-                        <div className="gp-sorteo-img-empty">📷 Foto de la skin</div>
-                      )}
+        {/* Sección de sorteos internos del CRM: NAOW/HUASOPEEK/MARTINEZ.  */}
+        {/* Para ZACKETIZOR se oculta y se muestra únicamente el bloque    */}
+        {/* KeyDrop (fuente externa, ver más abajo).                       */}
+        {isKeydropCreator ? null : (
+          <section id="sorteos">
+            <div className="gp-legacy-block">
+              <h2>Sorteos de {active.name}</h2>
+              <p className="gp-rank-note">
+                Participación gratuita · ganas +{ENTRY_COIN_REWARD} 🪙 por sorteo · fotos reales de las skins
+              </p>
+              <div className="gp-sorteos-grid">
+                {giveawaysData.map((g) => (
+                  <article key={g.id} className="gp-sorteo-card">
+                    <div className="gp-sorteo-glow" aria-hidden />
+                    <div className="gp-sorteo-fg">
+                      <div className="gp-sorteo-img">
+                        {g.imageUrl ? (
+                          // eslint-disable-next-line @next/next/no-img-element
+                          <img src={g.imageUrl} alt={g.title} />
+                        ) : (
+                          <div className="gp-sorteo-img-empty">📷 Foto de la skin</div>
+                        )}
+                      </div>
+                      <h3 className="gp-sorteo-title">★ {g.title}</h3>
+                      {g.value ? <div className="gp-sorteo-value">{g.value}</div> : null}
+                      <div className="gp-sorteo-meta">
+                        👥 <b>{g.entryCount.toLocaleString('es-ES')}</b> participantes
+                      </div>
+                      <div className="gp-sorteo-reward">
+                        Gratis · +{ENTRY_COIN_REWARD} 🪙
+                      </div>
+                      <div className="gp-sorteo-cta">
+                        {userId ? (
+                          <EntryButton giveawayId={g.id} initialEntered={g.userHasEntered} />
+                        ) : (
+                          <span className="gp-sorteo-locked">Inicia sesión para participar</span>
+                        )}
+                      </div>
                     </div>
-                    <h3 className="gp-sorteo-title">★ {g.title}</h3>
-                    {g.value ? <div className="gp-sorteo-value">{g.value}</div> : null}
-                    <div className="gp-sorteo-meta">
-                      👥 <b>{g.entryCount.toLocaleString('es-ES')}</b> participantes
-                    </div>
-                    <div className="gp-sorteo-reward">
-                      Gratis · +{ENTRY_COIN_REWARD} 🪙
-                    </div>
-                    <div className="gp-sorteo-cta">
-                      {userId ? (
-                        <EntryButton giveawayId={g.id} initialEntered={g.userHasEntered} />
-                      ) : (
-                        <span className="gp-sorteo-locked">Inicia sesión para participar</span>
-                      )}
-                    </div>
-                  </div>
-                </article>
-              ))}
+                  </article>
+                ))}
+              </div>
             </div>
-          </div>
-        </section>
+          </section>
+        )}
 
         {/* --- Sorteos KeyDrop de ZACKETIZOR (live-cache, solo lectura) --- */}
         <KeydropGiveawaysSection sections={keydropSections} creatorDisplayName={active.name} />

--- a/src/app/sorteos/plataforma/platform-keydrop.css
+++ b/src/app/sorteos/plataforma/platform-keydrop.css
@@ -1,0 +1,132 @@
+/*
+ * Estilos específicos de la sección KeyDrop en /sorteos/plataforma.
+ * Reutiliza `.gp-sorteo-card` + `.gp-sorteo-glow` + `.gp-sorteo-fg` de
+ * platform-fx.css. Solo añade lo específico de KeyDrop (badge, tag, status,
+ * winners, deadline, finished collapsible).
+ *
+ * Scoped bajo .giveaway-platform. Cargado desde el layout.
+ */
+
+.giveaway-platform .gp-keydrop-section { padding-top: 6px; }
+
+.giveaway-platform .gp-keydrop-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+.giveaway-platform .gp-keydrop-code {
+  color: var(--gold);
+  font-family: var(--font-display), var(--font-rajdhani), sans-serif;
+  letter-spacing: 1.5px;
+  font-weight: 800;
+}
+.giveaway-platform .gp-keydrop-badge {
+  flex-shrink: 0;
+  padding: 6px 10px;
+  border-radius: 8px;
+  background: rgba(11, 9, 23, 0.6);
+  border: 1px solid rgba(196, 40, 128, 0.28);
+  display: flex;
+  align-items: center;
+}
+.giveaway-platform .gp-keydrop-badge img { height: auto; max-height: 22px; width: auto; }
+
+/* Card overrides */
+.giveaway-platform .gp-keydrop-card { min-height: 380px; }
+.giveaway-platform .gp-keydrop-tag {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+  font-family: var(--font-display), var(--font-rajdhani), sans-serif;
+  font-size: 10px;
+  letter-spacing: 1.4px;
+  text-transform: uppercase;
+}
+.giveaway-platform .gp-keydrop-tag > span:first-child {
+  color: var(--sp-pink);
+  font-weight: 800;
+}
+.giveaway-platform .gp-keydrop-status {
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-weight: 700;
+}
+.giveaway-platform .gp-keydrop-status-new {
+  background: rgba(245, 183, 61, 0.14);
+  color: var(--gold);
+}
+.giveaway-platform .gp-keydrop-status-started {
+  background: rgba(74, 222, 128, 0.12);
+  color: #4ade80;
+}
+.giveaway-platform .gp-keydrop-status-ended,
+.giveaway-platform .gp-keydrop-status-unknown {
+  background: rgba(255, 143, 161, 0.10);
+  color: #ff8fa1;
+}
+.giveaway-platform .gp-keydrop-sub {
+  color: var(--muted);
+  font-weight: 500;
+  font-size: 12.5px;
+}
+.giveaway-platform .gp-keydrop-multi {
+  font-size: 11px;
+  color: var(--muted);
+  letter-spacing: 0.5px;
+  margin-left: 4px;
+}
+.giveaway-platform .gp-keydrop-deadline {
+  margin-top: 6px;
+  font-size: 11px;
+  color: var(--muted);
+}
+.giveaway-platform .gp-keydrop-winners {
+  margin-top: 8px;
+  padding: 6px 8px;
+  border-radius: 8px;
+  background: rgba(245, 183, 61, 0.08);
+  border: 1px solid rgba(245, 183, 61, 0.22);
+  font-size: 11px;
+  line-height: 1.4;
+}
+.giveaway-platform .gp-keydrop-winners-label {
+  color: var(--gold);
+  font-weight: 700;
+  margin-right: 4px;
+}
+.giveaway-platform .gp-keydrop-winners-list {
+  color: var(--txt);
+  word-break: break-word;
+}
+
+/* Finalizados collapsible */
+.giveaway-platform .gp-keydrop-finished {
+  margin-top: 22px;
+  border-top: 1px solid rgba(196, 40, 128, 0.14);
+  padding-top: 16px;
+}
+.giveaway-platform .gp-keydrop-finished > summary {
+  cursor: pointer;
+  padding: 8px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(196, 40, 128, 0.35);
+  color: var(--txt);
+  font-family: var(--font-display), var(--font-rajdhani), sans-serif;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 1.3px;
+  text-transform: uppercase;
+  list-style: none;
+  display: inline-block;
+  user-select: none;
+  transition: background 0.15s, border-color 0.15s;
+}
+.giveaway-platform .gp-keydrop-finished > summary:hover {
+  background: rgba(224, 48, 112, 0.10);
+  border-color: rgba(224, 48, 112, 0.55);
+}
+.giveaway-platform .gp-keydrop-finished > summary::-webkit-details-marker { display: none; }
+.giveaway-platform .gp-keydrop-finished[open] > summary { margin-bottom: 14px; }

--- a/src/features/giveaway-platform/components/KeydropGiveawaysSection.tsx
+++ b/src/features/giveaway-platform/components/KeydropGiveawaysSection.tsx
@@ -1,0 +1,162 @@
+import Image from 'next/image';
+import type { KeydropCard, KeydropSections } from '@/lib/keydrop/types';
+import { formatCurrency } from '@/lib/keydrop/mappers';
+
+interface Props {
+  sections: KeydropSections;
+  creatorDisplayName: string;
+}
+
+/**
+ * Sección de sorteos KeyDrop del creador ZACKETIZOR.
+ *
+ * Reglas UI:
+ *   - Solo lectura. Botón "Ver sorteo" abre en nueva pestaña.
+ *   - Sin monedas ni tickets internos — este bloque no interactúa con
+ *     coin_transactions ni giveaway_entries.
+ *   - Si `status !== 'ok'` o no hay sorteos → no renderiza nada.
+ *   - Activos arriba; finalizados en <details> colapsable debajo.
+ */
+export function KeydropGiveawaysSection({ sections, creatorDisplayName }: Props) {
+  if (sections.status !== 'ok') return null;
+  if (sections.active.length === 0 && sections.finished.length === 0) return null;
+
+  const promoCode = sections.active[0]?.promoCode ?? sections.finished[0]?.promoCode ?? 'ZACKCSGO';
+
+  return (
+    <section aria-labelledby="keydrop-section" className="gp-keydrop-section">
+      <div className="gp-legacy-block">
+        <div className="gp-keydrop-head">
+          <div>
+            <h2 id="keydrop-section">Sorteos KeyDrop de {creatorDisplayName}</h2>
+            <p className="gp-mission-head">
+              Datos en directo desde KeyDrop · usa el código{' '}
+              <b className="gp-keydrop-code">{promoCode}</b>
+            </p>
+          </div>
+          <div className="gp-keydrop-badge">
+            <Image
+              src="/images/brands/keydrop.png"
+              alt="KeyDrop"
+              width={110}
+              height={26}
+            />
+          </div>
+        </div>
+
+        {sections.active.length > 0 ? (
+          <div className="gp-sorteos-grid">
+            {sections.active.map((g) => (
+              <KeydropCardArticle key={g.id} card={g} />
+            ))}
+          </div>
+        ) : (
+          <p className="gp-mission-head">No hay sorteos activos ahora mismo.</p>
+        )}
+
+        {sections.finished.length > 0 ? (
+          <details className="gp-keydrop-finished">
+            <summary>
+              Ver {sections.finished.length} sorteo{sections.finished.length === 1 ? '' : 's'} finalizado
+              {sections.finished.length === 1 ? '' : 's'}
+            </summary>
+            <div className="gp-sorteos-grid">
+              {sections.finished.map((g) => (
+                <KeydropCardArticle key={g.id} card={g} finished />
+              ))}
+            </div>
+          </details>
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+function KeydropCardArticle({ card, finished = false }: { card: KeydropCard; finished?: boolean }) {
+  return (
+    <article className="gp-sorteo-card gp-keydrop-card">
+      <div className="gp-sorteo-glow" aria-hidden />
+      <div className="gp-sorteo-fg">
+        <div className="gp-keydrop-tag" aria-hidden>
+          <span>KeyDrop</span>
+          <span className={`gp-keydrop-status gp-keydrop-status-${card.status}`}>
+            {statusLabel(card.status, finished)}
+          </span>
+        </div>
+        <div className="gp-sorteo-img">
+          {card.imageUrl ? (
+            <Image
+              src={card.imageUrl}
+              alt={card.imageAlt}
+              width={220}
+              height={128}
+              unoptimized
+            />
+          ) : (
+            <div className="gp-sorteo-img-empty">📷 Sin imagen</div>
+          )}
+        </div>
+        <h3 className="gp-sorteo-title">
+          ★ {card.title}
+          {card.subtitle ? <span className="gp-keydrop-sub"> · {card.subtitle}</span> : null}
+        </h3>
+        <div className="gp-sorteo-value">
+          {formatCurrency(card.totalValue, card.currency)}
+          {card.prizeCount > 1 ? (
+            <span className="gp-keydrop-multi">  · +{card.prizeCount - 1} premios</span>
+          ) : null}
+        </div>
+        <div className="gp-sorteo-meta">
+          👥 <b>{card.participantCount.toLocaleString('es-ES')}</b> participantes
+          {card.minUsers > 0 ? <> · <span>arranca en {card.minUsers}</span></> : null}
+        </div>
+        <div className="gp-sorteo-reward">
+          Depósito mín. <b>{formatCurrency(card.depositRequired, card.depositCurrency)}</b>
+          {' · código '}
+          <b>{card.promoCode}</b>
+        </div>
+        {card.deadlineTimestamp ? (
+          <div className="gp-keydrop-deadline">
+            Finaliza: {formatDeadline(card.deadlineTimestamp)}
+          </div>
+        ) : null}
+        <div className="gp-sorteo-cta">
+          <a
+            className="gp-social-btn gp-social-btn-primary"
+            href={card.externalUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {finished ? 'Ver resultado' : 'Ver sorteo'}
+          </a>
+        </div>
+        {finished && card.winners.length > 0 ? (
+          <div className="gp-keydrop-winners">
+            <span className="gp-keydrop-winners-label">🏆 Ganadores:</span>
+            <span className="gp-keydrop-winners-list">
+              {card.winners.slice(0, 3).map((w) => w.username).join(', ')}
+              {card.winners.length > 3 ? `, +${card.winners.length - 3}` : ''}
+            </span>
+          </div>
+        ) : null}
+      </div>
+    </article>
+  );
+}
+
+function statusLabel(status: KeydropCard['status'], finished: boolean): string {
+  if (finished) return 'Finalizado';
+  switch (status) {
+    case 'new':     return 'En preparación';
+    case 'started': return 'En curso';
+    case 'ended':   return 'Finalizado';
+    case 'unknown': return 'Sorteo';
+    default:        return 'Sorteo';
+  }
+}
+
+function formatDeadline(d: Date): string {
+  return d.toLocaleString('es-ES', {
+    day: '2-digit', month: 'short', hour: '2-digit', minute: '2-digit',
+  });
+}

--- a/src/features/giveaway-platform/components/KeydropGiveawaysSection.tsx
+++ b/src/features/giveaway-platform/components/KeydropGiveawaysSection.tsx
@@ -127,7 +127,7 @@ function KeydropCardArticle({ card, finished = false }: { card: KeydropCard; fin
             target="_blank"
             rel="noopener noreferrer"
           >
-            {finished ? 'Ver resultado' : 'Ver sorteo'}
+            Ver en KeyDrop
           </a>
         </div>
         {finished && card.winners.length > 0 ? (

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -46,6 +46,12 @@ export const env = createEnv({
     // usuario se crea con name="Jugador de Steam" y avatar=null.
     // Server-only: nunca se envía al cliente.
     STEAM_API_KEY: z.string().min(1).optional(),
+    // KeyDrop Giveaway API — clave del afiliado ZACKETIZOR (ZACKCSGO).
+    // Server-only. Opcional en dev: sin ella la sección de sorteos KeyDrop
+    // se oculta con degradación silenciosa (no crash, no error visible).
+    // Base URL: https://ws-2071.socket-cs.com/v1/giveaway-user
+    // Endpoints usados: GET /api/list, GET /api/giveaway/:id
+    KEYDROP_ZACKETIZOR_API_KEY: z.string().min(1).optional(),
   },
   client: {
     NEXT_PUBLIC_SITE_URL: z.string().url(),
@@ -74,6 +80,7 @@ export const env = createEnv({
     PAYROLL_OCR_ENABLED: process.env.PAYROLL_OCR_ENABLED,
     SHEETS_SYNC_CONCURRENCY: process.env.SHEETS_SYNC_CONCURRENCY,
     STEAM_API_KEY: process.env.STEAM_API_KEY,
+    KEYDROP_ZACKETIZOR_API_KEY: process.env.KEYDROP_ZACKETIZOR_API_KEY,
 
     NEXT_PUBLIC_SITE_URL: process.env.NEXT_PUBLIC_SITE_URL,
     NEXT_PUBLIC_GTM_ID: process.env.NEXT_PUBLIC_GTM_ID,

--- a/src/lib/keydrop/client.ts
+++ b/src/lib/keydrop/client.ts
@@ -1,0 +1,102 @@
+import { env } from '@/lib/env';
+import {
+  KeydropDetailResponseSchema,
+  KeydropListResponseSchema,
+  type KeydropDetailResponse,
+  type KeydropListResponse,
+} from './types';
+
+/**
+ * Cliente server-only para la KeyDrop Giveaway API.
+ *
+ * Reglas obligatorias:
+ *   - API key SOLO en `x-api-key` header, JAMÁS en URL query.
+ *   - JAMÁS loggear la key ni el header completo.
+ *   - Timeout 10s por request.
+ *   - Cache Next `revalidate: 60` — 1 request por región cada minuto.
+ *   - Errores devuelven { ok: false, error } sin exponer body de KeyDrop.
+ *
+ * Sin key configurada → devuelve `{ ok: false, error: 'not_configured' }`.
+ * La UI degradará silenciosamente (no muestra el bloque).
+ */
+
+const BASE_URL = 'https://ws-2071.socket-cs.com/v1/giveaway-user';
+const FETCH_TIMEOUT_MS = 10_000;
+/** Cache Next per-region. 60s → 1 req/min máximo por edge. */
+const REVALIDATE_SECONDS = 60;
+
+export type ClientResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; error: 'not_configured' | 'timeout' | 'network' | 'http' | 'parse'; status?: number };
+
+/** True si la key está configurada. Útil para gate UI antes de hacer fetch. */
+export function isKeydropConfigured(): boolean {
+  return typeof env.KEYDROP_ZACKETIZOR_API_KEY === 'string' && env.KEYDROP_ZACKETIZOR_API_KEY.length > 0;
+}
+
+/** GET /api/list — sorteos activos + finalizados del afiliado. */
+export async function fetchKeydropList(): Promise<ClientResult<KeydropListResponse>> {
+  return safeFetch('/api/list', KeydropListResponseSchema);
+}
+
+/** GET /api/giveaway/:id — detalle enriquecido de un sorteo. */
+export async function fetchKeydropGiveaway(id: string): Promise<ClientResult<KeydropDetailResponse>> {
+  // id validado por caller — aquí solo url-encodeamos por defensa.
+  const safeId = encodeURIComponent(id);
+  return safeFetch(`/api/giveaway/${safeId}`, KeydropDetailResponseSchema);
+}
+
+async function safeFetch<T>(
+  path: string,
+  schema: { safeParse: (v: unknown) => { success: boolean; data?: T; error?: unknown } },
+): Promise<ClientResult<T>> {
+  const apiKey = env.KEYDROP_ZACKETIZOR_API_KEY;
+  if (!apiKey) return { ok: false, error: 'not_configured' };
+
+  const url = `${BASE_URL}${path}`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method: 'GET',
+      headers: {
+        'x-api-key': apiKey,
+        Accept: 'application/json',
+        'User-Agent': 'SocialPro-Giveaways/1.0',
+      },
+      signal: controller.signal,
+      // Cache ISR de Next per-region — reduce hits a KeyDrop.
+      next: { revalidate: REVALIDATE_SECONDS, tags: ['keydrop'] },
+    });
+  } catch (e) {
+    const isAbort = e instanceof Error && e.name === 'AbortError';
+    // Log seguro: código de error, NUNCA la URL completa ni el header.
+    console.warn(`[keydrop] fetch ${path} ${isAbort ? 'timeout' : 'network'} error`);
+    return { ok: false, error: isAbort ? 'timeout' : 'network' };
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (!res.ok) {
+    console.warn(`[keydrop] fetch ${path} http_${res.status}`);
+    return { ok: false, error: 'http', status: res.status };
+  }
+
+  let body: unknown;
+  try { body = await res.json(); }
+  catch {
+    console.warn(`[keydrop] fetch ${path} parse (non-json)`);
+    return { ok: false, error: 'parse' };
+  }
+
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) {
+    // Log seguro: solo indica que el shape no cuadra. NO dumpear body.
+    console.warn(`[keydrop] fetch ${path} shape_mismatch`);
+    return { ok: false, error: 'parse' };
+  }
+
+  return { ok: true, data: parsed.data as T };
+}

--- a/src/lib/keydrop/mappers.ts
+++ b/src/lib/keydrop/mappers.ts
@@ -15,16 +15,29 @@ import type { z } from 'zod';
  *   - `totalValue = totalPrizes` si viene; si no, suma de `prizes[].price`.
  *   - `promoCode`: primer requirement con `promoCode`, o `organizer.promocode`
  *     como fallback.
- *   - `externalUrl` construido con el pattern conocido; verificar en QA.
+ *   - `externalUrl`: URL general de giveaways de KeyDrop (KeyDrop no expone
+ *     URL pública individual por giveaway — el patrón /es/giveaway/{id}
+ *     devuelve 404). El botón etiquetado "Ver en KeyDrop" lleva al listing
+ *     general. Si en el futuro KeyDrop publica URLs individuales, actualizar
+ *     `KEYDROP_LISTING_URL` para volver a un patrón por id.
  *   - `imageUrl` = `prizes[0].itemImg` (mostramos solo el primer premio como
  *     portada; el conteo total va en `prizeCount`).
  *   - `status` desconocido → 'unknown' (no rompe UI).
  */
 
-const KEYDROP_GIVEAWAY_URL_TEMPLATE = 'https://key-drop.com/es/giveaway/{id}';
+/** URL genérica del listing público de giveaways de KeyDrop. */
+const KEYDROP_LISTING_URL = 'https://key-drop.com/es/giveaways';
 
-export function buildKeydropExternalUrl(id: string): string {
-  return KEYDROP_GIVEAWAY_URL_TEMPLATE.replace('{id}', encodeURIComponent(id));
+/**
+ * URL destino del botón "Ver en KeyDrop".
+ *
+ * Idealmente sería `https://key-drop.com/es/giveaway/{id}` pero ese patrón
+ * devuelve 404 (verificado 2026-07). Hasta que KeyDrop publique URLs
+ * individuales, apuntamos al listing general — el `id` queda solo como
+ * identificador interno.
+ */
+export function buildKeydropExternalUrl(_id: string): string {
+  return KEYDROP_LISTING_URL;
 }
 
 export function toKeydropCard(item: KeydropListItem): KeydropCard {

--- a/src/lib/keydrop/mappers.ts
+++ b/src/lib/keydrop/mappers.ts
@@ -1,0 +1,121 @@
+import type {
+  KeydropCard,
+  KeydropListItem,
+  KeydropRequirementSchema,
+  KeydropStatus,
+} from './types';
+import type { z } from 'zod';
+
+/**
+ * KeyDrop API → shape interna limpia (`KeydropCard`).
+ *
+ * Reglas:
+ *   - Corrige typo upstream `fullfilled → fulfilled` en `requirements`.
+ *   - `duractionSeconds` NO se expone; solo `deadlineTimestamp` sirve a UI.
+ *   - `totalValue = totalPrizes` si viene; si no, suma de `prizes[].price`.
+ *   - `promoCode`: primer requirement con `promoCode`, o `organizer.promocode`
+ *     como fallback.
+ *   - `externalUrl` construido con el pattern conocido; verificar en QA.
+ *   - `imageUrl` = `prizes[0].itemImg` (mostramos solo el primer premio como
+ *     portada; el conteo total va en `prizeCount`).
+ *   - `status` desconocido → 'unknown' (no rompe UI).
+ */
+
+const KEYDROP_GIVEAWAY_URL_TEMPLATE = 'https://key-drop.com/es/giveaway/{id}';
+
+export function buildKeydropExternalUrl(id: string): string {
+  return KEYDROP_GIVEAWAY_URL_TEMPLATE.replace('{id}', encodeURIComponent(id));
+}
+
+export function toKeydropCard(item: KeydropListItem): KeydropCard {
+  const firstPrize = item.prizes[0];
+  const totalFromSum = item.prizes.reduce((acc, p) => acc + (typeof p.price === 'number' ? p.price : 0), 0);
+  const totalValue = typeof item.totalPrizes === 'number' && item.totalPrizes > 0
+    ? item.totalPrizes
+    : totalFromSum;
+  const currency = firstPrize?.currency ?? item.depositAmountRequiredCurrency;
+
+  const requirements = requirementsToArray(item as { requirements?: Record<string, z.infer<typeof KeydropRequirementSchema>> });
+  const promoCode = requirements.find((r) => typeof r.promoCode === 'string' && r.promoCode.length > 0)?.promoCode
+    ?? item.organizer.promocode;
+
+  const status: KeydropStatus | 'unknown' =
+    item.status === 'new' || item.status === 'started' || item.status === 'ended'
+      ? item.status
+      : 'unknown';
+
+  const title = firstPrize?.title ?? 'Sorteo KeyDrop';
+  const imageUrl = firstPrize?.itemImg ?? '';
+  const imageAlt = firstPrize
+    ? `${firstPrize.title}${firstPrize.subtitle ? ' · ' + firstPrize.subtitle : ''}`
+    : 'Premio KeyDrop';
+
+  const winners = Array.isArray(item.winners)
+    ? item.winners.map((w) => ({
+        steamId: w.idSteam,
+        username: w.username,
+        avatarUrl: w.steamAvatar,
+        prizeId: w.prizeId,
+      }))
+    : [];
+
+  return {
+    id: item.id,
+    source: 'keydrop',
+    title,
+    subtitle: firstPrize?.subtitle ?? null,
+    imageUrl,
+    imageAlt,
+    totalValue: roundTo2(totalValue),
+    currency,
+    depositRequired: item.depositAmountRequired,
+    depositCurrency: item.depositAmountRequiredCurrency,
+    participantCount: item.participantCount,
+    maxUsers: item.maxUsers,
+    minUsers: item.minUsers,
+    status,
+    createdAt: new Date(item.createdAt),
+    deadlineTimestamp: item.deadlineTimestamp !== null ? new Date(item.deadlineTimestamp) : null,
+    promoCode,
+    externalUrl: buildKeydropExternalUrl(item.id),
+    prizeCount: item.prizes.length,
+    winners,
+    requirements,
+  };
+}
+
+/**
+ * Convierte el objeto `requirements: { "0": {...}, "1": {...} }` a array
+ * y corrige `fullfilled → fulfilled`. Devuelve [] si no viene requirements.
+ */
+function requirementsToArray(
+  item: { requirements?: Record<string, z.infer<typeof KeydropRequirementSchema>> },
+): KeydropCard['requirements'] {
+  if (!item.requirements || typeof item.requirements !== 'object') return [];
+  return Object.values(item.requirements).map((r) => ({
+    type: r.type,
+    promoCode: r.promoCode,
+    refillAmount: r.refillAmount,
+    fulfilled: r.fullfilled,   // typo upstream corregido aquí
+    currency: r.currency,
+  }));
+}
+
+function roundTo2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+/**
+ * Formatea el label de moneda + valor para mostrar en cards.
+ * Ejemplos:
+ *   formatCurrency(1073.78, 'USD') → '$1,073.78'
+ *   formatCurrency(10, 'EUR')      → '10 €'
+ *   formatCurrency(1073.78, 'BTC') → '1,073.78 BTC'
+ */
+export function formatCurrency(value: number, currency: string): string {
+  const c = currency.toUpperCase();
+  const num = value.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+  if (c === 'USD') return `$${num}`;
+  if (c === 'EUR') return `${num} €`;
+  return `${num} ${c}`;
+}

--- a/src/lib/keydrop/types.ts
+++ b/src/lib/keydrop/types.ts
@@ -1,0 +1,162 @@
+import { z } from 'zod';
+
+/**
+ * Zod schemas de la KeyDrop Giveaway API (afiliado ZACKETIZOR).
+ *
+ * Base: https://ws-2071.socket-cs.com/v1/giveaway-user
+ * Endpoints: GET /api/list, GET /api/giveaway/:idGiveaway
+ *
+ * Los shapes vienen del probe diagnóstico real (2026-07). Se preservan
+ * los typos upstream (`duractionSeconds`, `fullfilled`) — se corrigen
+ * solo al mapear a nuestra shape interna en `mappers.ts`.
+ *
+ * Sin `.strict()` — la API puede añadir campos y no queremos romper.
+ * Los campos opcionales cubren variaciones entre `active` y `finished`.
+ */
+
+export const KeydropOrganizerSchema = z.object({
+  idSteam: z.string(),
+  username: z.string(),
+  steamAvatar: z.string(),
+  promocode: z.string(),
+});
+
+export const KeydropPrizeSchema = z.object({
+  id: z.number(),
+  color: z.string(),
+  itemImg: z.string(),        // URL — cdnkd.com
+  title: z.string(),
+  subtitle: z.string().nullable().optional(),
+  phase: z.string().nullable().optional(),
+  price: z.number(),
+  condition: z.string(),
+  weaponType: z.string(),
+  currency: z.string(),
+});
+
+export const KeydropWinnerSchema = z.object({
+  idSteam: z.string(),
+  username: z.string(),
+  steamAvatar: z.string(),
+  prizeId: z.number(),
+});
+
+/**
+ * Requirement individual. `fullfilled` es typo upstream — se preserva
+ * en el schema y se corrige en el mapper interno como `fulfilled`.
+ */
+export const KeydropRequirementSchema = z.object({
+  type: z.string(),           // 'PROMO_CODE_USAGE' | ...
+  promoCode: z.string().optional(),
+  refillAmount: z.number().optional(),
+  missingRefillAmount: z.number().optional(),
+  fullfilled: z.boolean().optional(),   // sic — typo upstream preservado
+  currency: z.string().optional(),
+});
+
+export const KeydropStatusSchema = z.enum(['new', 'started', 'ended']);
+export type KeydropStatus = z.infer<typeof KeydropStatusSchema>;
+
+/**
+ * Item del array `data.active[]` o `data.finished[]`.
+ * Los campos opcionales cubren variaciones entre buckets.
+ */
+export const KeydropListItemSchema = z.object({
+  id: z.string(),
+  hot: z.number().nullable().optional(),
+  boost: z.unknown().nullable().optional(),
+  status: z.string(),                    // se valida contra KeydropStatusSchema en el mapper
+  maxUsers: z.number(),
+  minUsers: z.number(),
+  duractionSeconds: z.number(),          // sic — typo upstream preservado
+  totalPrizes: z.number().optional(),    // solo en active
+  organizer: KeydropOrganizerSchema,
+  depositAmountRequired: z.number(),
+  depositAmountRequiredUSD: z.number().optional(),
+  depositAmountRequiredCurrency: z.string(),
+  createdAt: z.number(),                 // unix ms
+  deadlineTimestamp: z.number().nullable(),
+  prize: z.number().optional(),          // índice interno, no usado en UI
+  prizes: z.array(KeydropPrizeSchema),
+  participantCount: z.number(),
+  haveIJoined: z.boolean().optional(),
+  mySlot: z.unknown().nullable().optional(),
+  chance: z.number().optional(),
+  publicHash: z.string().optional(),     // solo finished
+  winners: z.array(KeydropWinnerSchema).optional(),  // solo finished
+  startDate: z.number().nullable().optional(),
+});
+export type KeydropListItem = z.infer<typeof KeydropListItemSchema>;
+
+/** Response de GET /api/list. */
+export const KeydropListResponseSchema = z.object({
+  success: z.boolean(),
+  data: z.object({
+    active: z.array(KeydropListItemSchema),
+    finished: z.array(KeydropListItemSchema),
+  }),
+});
+export type KeydropListResponse = z.infer<typeof KeydropListResponseSchema>;
+
+/** Response de GET /api/giveaway/:id — item + campos extra. */
+export const KeydropDetailResponseSchema = z.object({
+  success: z.boolean(),
+  data: KeydropListItemSchema.extend({
+    entryPercentile: z.number().optional(),
+    entryLevel: z.number().optional(),
+    mySteamId: z.string().nullable().optional(),
+    myJoinCount: z.number().optional(),
+    missingRefillAmount: z.number().optional(),
+    canIJoin: z.boolean().optional(),
+    participants: z.array(z.unknown()).optional(),
+    // requirements viene como objeto con claves numéricas '0', '1', ...
+    requirements: z.record(z.string(), KeydropRequirementSchema).optional(),
+  }),
+});
+export type KeydropDetailResponse = z.infer<typeof KeydropDetailResponseSchema>;
+
+/**
+ * Shape interna limpia — lo que el mapper produce y la UI consume.
+ * Currency y typos corregidos, promoCode / externalUrl derivados.
+ */
+export interface KeydropCard {
+  id: string;
+  source: 'keydrop';
+  title: string;
+  subtitle: string | null;
+  imageUrl: string;
+  imageAlt: string;
+  totalValue: number;
+  currency: string;
+  depositRequired: number;
+  depositCurrency: string;
+  participantCount: number;
+  maxUsers: number;
+  minUsers: number;
+  status: KeydropStatus | 'unknown';
+  createdAt: Date;
+  deadlineTimestamp: Date | null;
+  promoCode: string;
+  externalUrl: string;
+  prizeCount: number;
+  /** Ganadores solo aparecen en finalizados. */
+  winners: Array<{ steamId: string; username: string; avatarUrl: string; prizeId: number }>;
+  /** Debug/audit; nunca renderizar directamente. */
+  requirements: Array<{
+    type: string;
+    promoCode: string | undefined;
+    refillAmount: number | undefined;
+    fulfilled: boolean | undefined;
+    currency: string | undefined;
+  }>;
+}
+
+/**
+ * Shape agregada usada por la UI: dos buckets ya mapeados +
+ * status del fetch para distinguir entre "no configurado" / "error" / "ok".
+ */
+export interface KeydropSections {
+  active: KeydropCard[];
+  finished: KeydropCard[];
+  status: 'ok' | 'not_configured' | 'error';
+}

--- a/src/lib/queries/keydropGiveaways.ts
+++ b/src/lib/queries/keydropGiveaways.ts
@@ -1,0 +1,27 @@
+import { fetchKeydropList, isKeydropConfigured } from '@/lib/keydrop/client';
+import { toKeydropCard } from '@/lib/keydrop/mappers';
+import type { KeydropSections } from '@/lib/keydrop/types';
+
+export type { KeydropSections };
+
+/**
+ * High-level query: sorteos KeyDrop de ZACKETIZOR ya mapeados a card interna.
+ *
+ * Retorna `{ active, finished }` — la UI muestra activos por defecto y
+ * finalizados en desplegable.
+ *
+ * Degradación silenciosa: cualquier fallo (no configurado, timeout, http,
+ * shape mismatch) → listas vacías. Nunca lanza. La página no rompe.
+ */
+export async function getKeydropZacketizorGiveaways(): Promise<KeydropSections> {
+  if (!isKeydropConfigured()) {
+    return { active: [], finished: [], status: 'not_configured' };
+  }
+  const res = await fetchKeydropList();
+  if (!res.ok) {
+    return { active: [], finished: [], status: 'error' };
+  }
+  const active = res.data.data.active.map(toKeydropCard);
+  const finished = res.data.data.finished.map(toKeydropCard);
+  return { active, finished, status: 'ok' };
+}


### PR DESCRIPTION
Muestra los sorteos activos y finalizados de KeyDrop del afiliado ZACKETIZOR dentro de \`/sorteos/plataforma?creador=zacketizor\`. **Solo lectura**; sin monedas, tickets internos ni sync a DB.

## Env var

\`KEYDROP_ZACKETIZOR_API_KEY\` — server-only, opcional. Sin ella la sección se oculta silenciosamente (no crash, no error visible).

## Client seguro

\`src/lib/keydrop/client.ts\`:
- API base \`https://ws-2071.socket-cs.com/v1/giveaway-user\`.
- \`x-api-key\` header — JAMÁS en URL query.
- JAMÁS loggea la key ni el header completo.
- Timeout 10s con AbortController.
- Cache Next \`revalidate: 60\` — 1 req/min por región máximo.
- Errores clasificados: \`not_configured\` | \`timeout\` | \`network\` | \`http\` | \`parse\`.
- Log seguro: solo path + tipo de error, nunca body.

## Zod schemas

\`src/lib/keydrop/types.ts\` — schemas del shape real observado en el probe:
- \`KeydropListResponseSchema\` = \`{ success, data: { active[], finished[] } }\`.
- Typos upstream preservados: \`duractionSeconds\`, \`fullfilled\` en requirements.
- \`KeydropCard\` = shape interna limpia (typos corregidos aquí).

## Mapper

\`src/lib/keydrop/mappers.ts\`:
- \`imageUrl = prizes[0].itemImg\`
- \`totalValue = totalPrizes ?? sum(prizes[].price)\`
- \`promoCode = requirements[0].promoCode ?? organizer.promocode\`
- \`externalUrl = https://key-drop.com/es/giveaway/{id}\`
- \`fullfilled → fulfilled\` (typo corregido en shape interna).
- Status desconocido → \`'unknown'\` (no rompe UI).
- \`formatCurrency\` con símbolos USD (\$) y EUR (€).

## Query high-level

\`src/lib/queries/keydropGiveaways.ts\`:
- \`getKeydropZacketizorGiveaways() → { active, finished, status }\`.
- Degradación silenciosa en cualquier fallo → listas vacías con status \`not_configured\` o \`error\`. Nunca lanza.

## UI

\`src/features/giveaway-platform/components/KeydropGiveawaysSection.tsx\`:
- Server component. \`return null\` si \`status !== 'ok'\` o no hay sorteos.
- Cards activas en grid arriba; finalizados en \`<details>\` collapsible.
- Reutiliza \`.gp-sorteo-card\` con badge KeyDrop, status pill, código promo, deadline, ganadores.
- Botón \"Ver sorteo\" con \`target=\"_blank\" rel=\"noopener noreferrer\"\` al externalUrl.
- Imagen con \`next/image unoptimized\` (KeyDrop CDN + rotación frecuente).

CSS específico: \`platform-keydrop.css\` (132 LOC, scoped bajo \`.giveaway-platform\`).

## \`next.config.ts\`

Añadido \`cdnkd.com\` + \`*.cdnkd.com\` a \`remotePatterns\` (host confirmado en el probe).

## Wiring en \`page.tsx\`

- Import + llamada en \`Promise.all\` paralela junto a ranking/tienda.
- Gate por \`active.slug === 'zacketizor'\` — otros creadores reciben \`{ status: 'not_configured' }\` sync.
- Section renderiza entre \`<section id=\"sorteos\">\` y \`<section id=\"ranking\">\`.

## Tests (53 nuevos)

- \`keydrop-client.test.ts\` (16): env server-only + opcional, x-api-key en header no en URL, no logs de key, AbortController+timeout, gate por env, cache revalidate 60, BASE_URL fijo, errores clasificados sin leak.
- \`keydrop-mappers.test.ts\` (20): mapeo activo/finalizado, imageUrl, totalValue (con/sin totalPrizes), promoCode, externalUrl, prizeCount, deadlineTimestamp, winners, status unknown, multi-currency USD/EUR, \`fullfilled → fulfilled\`, Zod parse del shape real.
- \`keydrop-integration-structural.test.ts\` (17): page.tsx importa y llama query solo si slug=zacketizor, \`KeydropGiveawaysSection\` recibe props esperadas, ningún módulo KeyDrop importa \`@/lib/db\` ni schema, \`cdnkd.com\` en remotePatterns, componente devuelve null cuando debe, \`target=\"_blank\"\` + \`rel\`, badge KeyDrop, layout importa el CSS.

**2324/2324 tests del repo passing.**

## Descripción visual esperada

Sección aparece solo en \`/sorteos/plataforma?creador=zacketizor\` entre el bloque de Sorteos internos y el de Ranking.

- **Header**: título \"Sorteos KeyDrop de ZACKETIZOR\" con badge \`KeyDrop\` a la derecha y subtítulo \"Datos en directo desde KeyDrop · usa el código **ZACKCSGO**\".
- **Cards activas** (5 esperadas según el probe): imagen del premio principal, título \"★ Flip Knife · Lore\" o similar, valor \`$4,253.94\`, badge \`En preparación\`, participantes \`👥 2 · arranca en 398\`, línea \"Depósito mín. \$10 · código ZACKCSGO\", botón gradiente SP \"Ver sorteo\" que abre en nueva pestaña.
- Si un sorteo tiene múltiples premios, muestra \" · +N premios\" junto al total.
- **Finalizados** (11 esperados): botón outline \"Ver 11 sorteos finalizados\" que expande a un grid con la misma anatomía + badge \"Finalizado\" + línea \"🏆 Ganadores: userA, userB, userC, +2\".

## Confirmaciones

- ✅ \`cdnkd.com\` + \`*.cdnkd.com\` en \`remotePatterns\`.
- ✅ Sin logs de key (test estructural \`no console.log con apiKey/x-api-key/Authorization\`).
- ✅ Sin monedas ni tickets internos (test estructural \`no \`coin_transactions\`/\`giveaway_entries\`/\`mission_claims\` en módulos KeyDrop, ignorando comentarios docblock\`).
- ✅ Sin importar \`@/lib/db\` desde módulos KeyDrop (test estructural).
- ✅ Env var solo en bloque server, nunca en client (test estructural).

## Limitaciones

- **URL /es/giveaway/{id}** de KeyDrop asumida por patrón; verificar en QA con click real. Si cambia, ajustar \`KEYDROP_GIVEAWAY_URL_TEMPLATE\` en \`mappers.ts\`.
- KeyDrop **no expone rate-limit headers** → sin visibilidad. La cache 60s de Next mitiga; si aparecen 429 en prod, añadir backoff exponencial.
- **Cero tests contra API real** — los shapes se validan solo por Zod en runtime. El shape lo confirmó el probe diagnóstico previo.

## Test plan

- [ ] Verificar que \`KEYDROP_ZACKETIZOR_API_KEY\` esté en Vercel (Production + Preview).
- [ ] Preview: abrir \`/sorteos/plataforma?creador=zacketizor\` → aparece la sección con 5 sorteos activos.
- [ ] Cambiar creador a NAOW/HUASOPEEK/MARTINEZ → la sección KeyDrop **NO** aparece.
- [ ] Sin env var en preview → app arranca normal, sección KeyDrop oculta.
- [ ] Click \"Ver sorteo\" → abre \`https://key-drop.com/es/giveaway/{id}\` en nueva pestaña.
- [ ] Expandir \"Ver 11 sorteos finalizados\" → aparecen con ganadores.
- [ ] Verificar en Vercel logs que NO aparece la API key en ningún \`console.warn\` ni error.

## Fuera de scope (PR futuro)

- Sync a DB (\`keydrop_giveaways\` + cron) — se decide si aparece necesidad.
- Monedas / tickets internos por participar en un sorteo KeyDrop.
- Cruce con \`giveaway_entries\` / misiones internas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)