### PR TITLE
feat(sorteos): plataforma overnight — perfiles, ranking global, multi-prize UI + plan monedas

### DIFF
--- a/docs/giveaway-coin-economy-plan.md
+++ b/docs/giveaway-coin-economy-plan.md
@@ -1,0 +1,232 @@
+# Plan técnico — Economía de monedas por click / participación
+
+**Estado:** Borrador para revisión — 2026-07-02
+**Ámbito:** `/sorteos/plataforma` — SocialPro Giveaways
+**Autor:** overnight session (Claude)
+**Doc-only:** no toca código en esta iteración.
+
+---
+
+## 1. Objetivo
+
+Definir cómo se ganan, se gastan y se reconcilian las 🪙 monedas dentro de la plataforma de sorteos, con foco en dos vectores nuevos que aún no están implementados:
+
+1. **Monedas por click** — recompensas por acciones "leves" de engagement (visitar un creador, ver un video, seguir un canal externo verificable, unirse a Discord, etc.).
+2. **Monedas por participación** — recompensa por entrar a un sorteo (ya existe en `ENTRY_COIN_REWARD`, pero necesita reglas de anti-farm y cap diario documentadas).
+
+El objetivo es que el saldo sea significativo (afecta al canjeo en tienda) sin abrir vectores de farmeo trivial. Todo lo que aquí se propone se implementa **respetando el ledger existente** (`coin_transactions`), sin nuevas tablas paralelas.
+
+---
+
+## 2. Estado actual (2026-07-02)
+
+- **Ledger único:** `coin_transactions` con columna `source` (enum: `racha | mision | sorteo | tienda | admin`).
+- **`getCoinBalance(userId)`** = `SUM(amount)` sobre el ledger. No hay caché.
+- **Fuentes hoy:**
+  - `racha`: reclamación diaria (`DailyStreakCard`).
+  - `mision`: `MissionsGrid` + `progressFor()` + `loadMissionProgress`.
+  - `sorteo`: `+ENTRY_COIN_REWARD` al entrar a un sorteo interno.
+  - `tienda`: gasto (`-item.costCoins`) al canjear.
+  - `admin`: ajustes manuales.
+- **Sinks hoy:** solo `tienda`. Los canjes descuentan del saldo y reservan stock del `shopItem`.
+
+**No hay hoy:**
+
+- Monedas por acciones fuera del sorteo (visitas, follows, plays).
+- Cap diario/semanal por fuente.
+- Anti-abuse structured (rate limiting por acción, dedup por device).
+- Auditoría periódica (reconciliar `SUM(coin_transactions) === materialized balance`, si algún día se materializa).
+
+---
+
+## 3. Nuevos vectores de ganancia
+
+### 3.1 Monedas por click (acciones micro)
+
+Definimos "click actions" como acciones ligeras pero verificables. Cada acción tiene un `type`, un `reward` en monedas y un `cap` (por día o por lifetime). La granularidad la lleva la tabla existente `mission_claims` — no hace falta esquema nuevo.
+
+Propuesta de acciones iniciales:
+
+| Acción                                    | Reward | Cap                    | Verificación                                                    |
+|-------------------------------------------|:------:|------------------------|-----------------------------------------------------------------|
+| Visitar `/creadores/[slug]` (5s+)         | +2 🪙  | 1× / día / creador     | Beacon `POST /api/giveaway/visit-creator` firmado (ver 5.2)     |
+| Ver un video destacado del creador (30s+) | +5 🪙  | 1× / día / video       | YouTube IFrame API `onStateChange === PLAYING` >= 30s           |
+| Seguir a un canal Twitch (una vez)        | +25 🪙 | 1× lifetime / canal    | Helix `GetUserFollows` cronado (ver §7)                         |
+| Follow en X del creador (una vez)         | +25 🪙 | 1× lifetime / handle   | Verificación diferida por token pegado en bio (bajo, opcional)  |
+| Unirse a Discord del creador              | +50 🪙 | 1× lifetime            | OAuth Discord opcional (feature flag)                           |
+| Compartir un sorteo (Twitter intent)      | +3 🪙  | 3× / día               | Beacon con giveawayId + intent URL (baja fricción)              |
+| Login diario (aparte de la racha)         | 0 🪙   | —                      | La racha ya cubre este vector; NO duplicar reward               |
+
+Reglas transversales:
+
+- Todo insert al ledger pasa por un helper `awardCoins(userId, source, amount, refKey)` (nuevo).
+- `refKey` codifica el evento único (`click:visit-creator:2026-07-02:zacketizor`), es UNIQUE.
+- Cap = UNIQUE index en `(userId, refKey)` — impacto en el ledger, no en tabla nueva.
+
+### 3.2 Monedas por participación (sorteos)
+
+Ya existe `ENTRY_COIN_REWARD` (probable = 20). Reglas nuevas:
+
+- **Cap diario por fuente `sorteo`:** máximo 100 🪙 / día (5 sorteos). Excedente = entry se registra pero no genera transacción positiva.
+- **Anti farm creador:** si el creador es el mismo, cap 3 sorteos / día. Los demás cuentan hacia el cap global.
+- **No hay reward por sorteos externos (KeyDrop, etc.)** — solo internos SocialPro. Esto es política: los externos son señales de marca, no de ganancia interna.
+
+---
+
+## 4. Sinks (canjeos y sanciones)
+
+- **Tienda:** ya implementado. Cost fijo por item.
+- **Pujas privadas (futuro):** sorteos "premium" gated por coste en 🪙 en vez de gratis. Requiere UI extra — fuera del scope inmediato.
+- **Sanciones:** transacción negativa con `source = 'admin'`. Casos:
+  - Cuenta multi-account detectada → devolver bono referido a 0 y bloquear.
+  - Abuso de beacons → decremento simbólico + revocar acceso a acciones micro por 30 días.
+
+---
+
+## 5. Reglas de integridad
+
+### 5.1 UNIQUEs y ledger
+
+- `coin_transactions.ref_key` (nuevo, nullable text) — UNIQUE cuando no es `null`. Permite:
+  - Idempotencia de `awardCoins()` — si el `refKey` ya existe → no-op.
+  - Auditoría por fuente (`admin` reversal referencia el `refKey` original).
+- `mission_claims.mission_id + userId + period` sigue siendo UNIQUE — no cambia.
+- `giveaway_entries.userId + giveawayId` UNIQUE — ya vigente.
+
+### 5.2 Verificación de acciones micro
+
+Regla: el cliente **nunca** dicta el reward. Sólo emite un beacon con `actionType + payload`. El server:
+
+1. Valida `session` (Better Auth).
+2. Valida `actionType` contra whitelist.
+3. Ejecuta el verifier específico:
+   - `visit-creator`: mira `Referer` y timestamp. Rate-limit por IP + userId (Turnstile opcional).
+   - `watch-video`: requiere el `videoId` real; sólo lo consideramos si aparece en `talents.socials.platform_id`.
+   - `follow-twitch`: encolar y verificar en cron via Helix API.
+4. Si todo OK → `awardCoins(userId, 'mision', reward, refKey)` (usamos source `mision` para no crear enum nuevo — es filosóficamente una micro-misión).
+
+Si se decide crear un enum `source = 'action'`, sería una migration menor:
+
+```sql
+ALTER TYPE coin_source ADD VALUE 'action';
+```
+
+Decisión pospuesta hasta que ADR lo justifique.
+
+### 5.3 Rate limiting
+
+- Beacons: `10 requests / minuto / userId` a nivel de middleware.
+- Anti-bot: Turnstile invisible en `awardCoins` (no bloquea, sólo señaliza si el token es débil → transacción queda en cuarentena hasta review admin).
+
+### 5.4 Auditoría
+
+Nuevo cron `/api/cron/coin-audit` diario:
+
+- Compara `SUM(coin_transactions) per user` con caché derivada (si se materializa).
+- Detecta gasto negativo neto imposible (canje > balance en el momento).
+- Alerta en `crm_alerts` si hay drift.
+
+---
+
+## 6. Cambios de esquema propuestos
+
+Todos con migration Drizzle (NUNCA `push`):
+
+```ts
+// src/db/schema/coinTransactions.ts (patch)
+refKey: text('ref_key'),
+// + uniqueIndex('coin_tx_ref_key_uq').on(t.refKey).where(sql`ref_key is not null`),
+```
+
+Nota: partial UNIQUE index requiere `.where()` en Drizzle 0.30+. Verificar sintaxis actual antes de generar.
+
+```ts
+// src/lib/giveaway-platform/awardCoins.ts (nuevo)
+export async function awardCoins(opts: {
+  userId: string;
+  source: CoinSource;
+  amount: number;
+  refKey?: string;
+}): Promise<{ ok: boolean; awarded: number; reason?: 'duplicate' | 'cap_exceeded' }>;
+```
+
+```ts
+// src/lib/giveaway-platform/dailyCaps.ts (nuevo)
+export async function checkDailyCap(userId: string, source: CoinSource): Promise<{
+  awardedToday: number;
+  capForSource: number;
+  remaining: number;
+}>;
+```
+
+No hay tabla nueva. Todo funciona sobre `coin_transactions` + índices.
+
+---
+
+## 7. Verificaciones cron (jobs)
+
+- `/api/cron/verify-twitch-follows` — 1×/hora — procesa cola de acciones `follow-twitch` pendientes. Requiere Helix token del backend (client credentials).
+- `/api/cron/coin-audit` — 1×/día — auditoría integral.
+- `/api/cron/dispatch-referral-bonuses` (futuro) — al invitar Steam → bonus para el invitador cuando el invitado alcance N tickets.
+
+Todos protegidos con `Bearer ${CRON_SECRET}` como el resto de crons del proyecto.
+
+---
+
+## 8. UX changes que implica
+
+Para el usuario:
+
+- Nueva tarjeta "Gana monedas rápido" en `/sorteos/plataforma` con las acciones micro disponibles. UI similar a `MissionsGrid` pero con countdown "1× hoy".
+- En la card de creador (perfil), añadir "🪙 Recompensas por interactuar" y las 3-4 acciones activas para él.
+- En `PlatformShop`, mantener el summary actual pero añadir un "Tu ganancia media / semana" (proyección basada en historial últimas 4 semanas).
+
+Para el admin (fuera de scope inmediato):
+
+- `/admin/sorteos/coin-ledger` — tabla auditable, filtros por source, refKey, userId.
+- `/admin/sorteos/coin-actions` — CRUD del catálogo de acciones micro (feature-flag por acción, reward, cap).
+
+---
+
+## 9. Riesgos
+
+| Riesgo                                            | Mitigación                                                              |
+|---------------------------------------------------|-------------------------------------------------------------------------|
+| Farm de acciones micro (beacons falsos)           | Rate limit + Turnstile + verificadores server-side + refKey UNIQUE      |
+| Inflación (usuarios acumulan sin gastar)          | Cap diario global + expiración blanda (info UI: "próximamente")         |
+| Drift ledger (balance falla)                      | Cron `coin-audit` + alerta crm_alerts                                   |
+| Fricción para el usuario (hoy es muy sencillo)    | Mantener la racha diaria y misiones como camino principal; acciones = extra |
+| Steam multi-account (dos cuentas mismo dueño)     | Anti-fraud diferido (F-print, IP delta, revisión manual)                |
+
+---
+
+## 10. Fases sugeridas
+
+1. **Fase A — Ledger evolutivo (1 PR)**
+   - Añadir `ref_key` a `coin_transactions` + partial UNIQUE.
+   - Helper `awardCoins` + `checkDailyCap` con tests estructurales.
+
+2. **Fase B — Cap sorteos (1 PR)**
+   - Aplicar cap por fuente `sorteo` al entrar. UI: "Ya llegaste al máximo hoy".
+
+3. **Fase C — Acciones micro visibles (1 PR)**
+   - Catálogo estático hardcodeado en constants + página `/sorteos/plataforma` mostrando los cards.
+   - Verificadores solo para `visit-creator` y `share-giveaway` (los que no requieren API externa).
+
+4. **Fase D — Verificaciones externas (1 PR)**
+   - Cron Twitch follow verification.
+   - OAuth Discord opcional.
+
+5. **Fase E — Admin ledger (1 PR)**
+   - Vistas admin + auditoría + alertas.
+
+Total: 5 PRs bien acotados. La fase A es la base; el resto se puede reordenar en función de prioridades comerciales.
+
+---
+
+## 11. Preguntas abiertas
+
+- ¿Los sorteos externos (KeyDrop) suman al ranking global? **Propuesta:** NO — el ranking es sobre `giveawayEntries` internas.
+- ¿Debe caducar el saldo? **Propuesta:** no, pero avisar en UI si pasa X meses sin actividad.
+- ¿Recompensa por referido Steam? **Propuesta:** sí, pero fase F, gated por confirmación de participación mínima del invitado.
+- ¿Tope duro por usuario y mes? **Propuesta:** 3.000 🪙/mes en fase inicial — revisable con métricas reales.

--- a/src/__tests__/server/creator-dropdown-scalable.test.ts
+++ b/src/__tests__/server/creator-dropdown-scalable.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Contratos estructurales del CreatorDropdown escalable a 15+ creadores.
+ *
+ * Verifica:
+ *  - Umbral configurable (SEARCH_THRESHOLD) para mostrar buscador.
+ *  - Filtrado por name/slug/sub via useMemo.
+ *  - Wrapper .gp-dd-scroll para lista scrollable.
+ *  - Estado vacío .gp-dd-empty cuando no hay resultados.
+ *  - CSS que soporta scroll, input de búsqueda y empty state.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(__dirname, '..', '..', '..');
+const read = (rel: string) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');
+
+describe('[creator-dropdown] escalable — component', () => {
+  const src = read('src/features/giveaway-platform/components/CreatorDropdown.tsx');
+
+  it('define constante SEARCH_THRESHOLD', () => {
+    expect(src).toMatch(/const\s+SEARCH_THRESHOLD\s*=\s*\d+/);
+  });
+
+  it('renderiza input de búsqueda condicionalmente (showSearch)', () => {
+    expect(src).toMatch(/showSearch\s*=\s*creators\.length\s*>=\s*SEARCH_THRESHOLD/);
+    expect(src).toMatch(/showSearch\s*\?[\s\S]{0,400}gp-dd-search/);
+  });
+
+  it('filtra por name, slug y sub con useMemo', () => {
+    expect(src).toMatch(/useMemo\(\(\)\s*=>\s*\{[\s\S]{0,400}filter/);
+    expect(src).toMatch(/c\.name\.toLowerCase\(\)\.includes\(q\)/);
+    expect(src).toMatch(/c\.slug\.toLowerCase\(\)\.includes\(q\)/);
+    expect(src).toMatch(/c\.sub\.toLowerCase\(\)\.includes\(q\)/);
+  });
+
+  it('envuelve la lista en .gp-dd-scroll', () => {
+    expect(src).toMatch(/className="gp-dd-scroll"/);
+  });
+
+  it('muestra empty state cuando filtered.length === 0', () => {
+    expect(src).toMatch(/filtered\.length\s*===\s*0[\s\S]{0,200}gp-dd-empty/);
+  });
+
+  it('items son <button> con role=menuitem (a11y)', () => {
+    expect(src).toMatch(/role="menuitem"/);
+    expect(src).toMatch(/type="button"[\s\S]{0,200}gp-dd-item/);
+  });
+
+  it('cierra dropdown y resetea query en click fuera', () => {
+    expect(src).toMatch(/setOpen\(false\);\s*setQuery\(''\);/);
+  });
+});
+
+describe('[creator-dropdown] escalable — CSS', () => {
+  const css = read('src/app/sorteos/plataforma/platform.css');
+
+  it('define .gp-dd-search con estilo de input', () => {
+    expect(css).toMatch(/\.gp-dd-search\s*\{[\s\S]{0,300}background/);
+  });
+
+  it('define .gp-dd-scroll con max-height y overflow-y auto', () => {
+    expect(css).toMatch(/\.gp-dd-scroll\s*\{[\s\S]{0,200}max-height/);
+    expect(css).toMatch(/\.gp-dd-scroll\s*\{[\s\S]{0,200}overflow-y:\s*auto/);
+  });
+
+  it('define .gp-dd-empty con text-align center', () => {
+    expect(css).toMatch(/\.gp-dd-empty\s*\{[\s\S]{0,200}text-align:\s*center/);
+  });
+
+  it('normaliza button.gp-dd-item para reset de estilos nativos', () => {
+    expect(css).toMatch(/button\.gp-dd-item\s*\{[\s\S]{0,200}background:\s*transparent/);
+  });
+});

--- a/src/__tests__/server/creator-profile-placeholder.test.ts
+++ b/src/__tests__/server/creator-profile-placeholder.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Contratos estructurales del perfil de creador placeholder en
+ * /sorteos/plataforma/creadores/[slug].
+ *
+ * Verifica:
+ *  - `notFound()` si el slug no está en PLATFORM_CREATOR_SLUGS.
+ *  - Renderiza hero (avatar, código, bio) + socials + estadísticas "próximamente".
+ *  - CTA hacia el bloque de sorteos del creador en la landing.
+ *  - `generateStaticParams` pre-genera rutas para todos los creadores.
+ *  - CSS del placeholder existe (dashed border + repeating-linear-gradient).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(__dirname, '..', '..', '..');
+const read = (rel: string) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');
+
+describe('[creator-profile-placeholder] page', () => {
+  const src = read('src/app/sorteos/plataforma/creadores/[slug]/page.tsx');
+
+  it('llama notFound() cuando el slug no está en PLATFORM_CREATOR_SLUGS', () => {
+    expect(src).toMatch(/if\s*\(!PLATFORM_CREATOR_SLUGS\.includes\([\s\S]{0,120}\)\)\s*\{\s*notFound\(\)/);
+  });
+
+  it('renderiza hero + socials + próximamente', () => {
+    expect(src).toMatch(/gp-creator-hero/);
+    expect(src).toMatch(/gp-creator-socials/);
+    expect(src).toMatch(/gp-creator-soon/);
+    expect(src).toMatch(/Próximamente/);
+  });
+
+  it('CTA sorteos apunta a /sorteos/plataforma?creador=', () => {
+    expect(src).toMatch(/href=\{\`\/sorteos\/plataforma\?creador=\$\{active\.slug\}#sorteos\`\}/);
+  });
+
+  it('generateStaticParams pre-genera los slugs de la plataforma', () => {
+    expect(src).toMatch(/export function generateStaticParams/);
+    expect(src).toMatch(/PLATFORM_CREATOR_SLUGS\.map\(\(slug\)\s*=>\s*\(\{\s*slug\s*\}\)\)/);
+  });
+
+  it('robots noindex (no público, iteración)', () => {
+    expect(src).toMatch(/robots:\s*\{\s*index:\s*false/);
+  });
+
+  it('resuelve external vs internal para el contador de sorteos', () => {
+    expect(src).toMatch(/isExternalCreator\(active\.slug\)/);
+    expect(src).toMatch(/getExternalGiveawaysForCreator/);
+    expect(src).toMatch(/getGiveawaysWithEntryData/);
+  });
+});
+
+describe('[creator-profile-placeholder] CSS', () => {
+  const css = read('src/app/sorteos/plataforma/platform-creator-profile.css');
+
+  it('define hero con gradient dinámico usando --c1 / --c2', () => {
+    expect(css).toMatch(/\.gp-creator-hero\s*\{[\s\S]{0,600}var\(--c1/);
+    expect(css).toMatch(/\.gp-creator-hero\s*\{[\s\S]{0,600}var\(--c2/);
+  });
+
+  it('próximamente-card usa borde dashed y repeating-linear-gradient', () => {
+    expect(css).toMatch(/\.gp-creator-soon-card\s*\{[\s\S]{0,400}repeating-linear-gradient/);
+    expect(css).toMatch(/\.gp-creator-soon-card\s*\{[\s\S]{0,400}border:\s*1px\s+dashed/);
+  });
+});
+
+describe('[creator-profile-placeholder] layout carga el CSS', () => {
+  const layout = read('src/app/sorteos/plataforma/layout.tsx');
+
+  it("importa './platform-creator-profile.css'", () => {
+    expect(layout).toMatch(/import\s+'\.\/platform-creator-profile\.css'/);
+  });
+});

--- a/src/__tests__/server/keydrop-provider-mapper.test.ts
+++ b/src/__tests__/server/keydrop-provider-mapper.test.ts
@@ -6,7 +6,7 @@
  * buckets active/finished.
  */
 
-import { keydropItemToCard, formatCurrency } from '@/lib/external-giveaways/providers/keydrop/mapper';
+import { keydropItemToCard, formatCurrency, buildKeydropDeepLink } from '@/lib/external-giveaways/providers/keydrop/mapper';
 import {
   KeydropListItemSchema,
   KeydropListResponseSchema,
@@ -54,10 +54,8 @@ const baseItem: KeydropListItem = {
   chance: 0,
 };
 
-const EXTERNAL_URL = 'https://key-drop.com/es/giveaways';
-
 function map(item: KeydropListItem, creatorSlug = 'zacketizor') {
-  return keydropItemToCard({ item, creatorSlug, externalUrl: EXTERNAL_URL });
+  return keydropItemToCard({ item, creatorSlug });
 }
 
 describe('[keydrop-mapper] activo → ExternalGiveawayCard', () => {
@@ -89,8 +87,23 @@ describe('[keydrop-mapper] activo → ExternalGiveawayCard', () => {
     expect(map(baseItem).promoCode).toBe('ZACKCSGO');
   });
 
-  it('externalUrl es el que llega por prop (no lo construye)', () => {
-    expect(map(baseItem).externalUrl).toBe(EXTERNAL_URL);
+  it('externalUrl usa kd.link con code + giveaway id (deep link con promocode)', () => {
+    // baseItem.organizer.promocode = 'ZACKCSGO', item.id = 'o3S8gi66000'
+    expect(map(baseItem).externalUrl).toBe(
+      'https://kd.link/?code=ZACKCSGO&giveaway=o3S8gi66000',
+    );
+  });
+
+  it('externalUrl siempre incluye el id del giveaway (no genérico)', () => {
+    const url = map(baseItem).externalUrl;
+    expect(url).toContain('o3S8gi66000');
+    expect(url).not.toBe('https://keydrop.com/es/giveaways');
+    expect(url).not.toBe('https://key-drop.com/es/giveaways');
+  });
+
+  it('externalUrl usa dominio nuevo keydrop.com (nunca el legacy key-drop.com con guión)', () => {
+    // El dominio antiguo devuelve 403 Cloudflare — nunca lo usamos.
+    expect(map(baseItem).externalUrl).not.toMatch(/key-drop\.com/);
   });
 
   it('prizeCount + prizesPreview + extraPrizeCount coherentes', () => {
@@ -239,5 +252,51 @@ describe('[keydrop-mapper] Zod schemas parsean el shape real', () => {
   it('acepta prizes con subtitle null', () => {
     const item = { ...baseItem, prizes: [prizeFactory({ subtitle: null })] };
     expect(KeydropListItemSchema.safeParse(item).success).toBe(true);
+  });
+});
+
+describe('[keydrop-mapper] buildKeydropDeepLink — deep link con promocode', () => {
+  it('id + promoCode → shortener kd.link con ambos parámetros', () => {
+    expect(buildKeydropDeepLink('o3S8gi66000', 'ZACKCSGO')).toBe(
+      'https://kd.link/?code=ZACKCSGO&giveaway=o3S8gi66000',
+    );
+  });
+
+  it('URL-encodea el id y el promoCode', () => {
+    // Caso extremo: promocode con guion o espacios NO debería llegar, pero
+    // si llegara, se sanea para no romper la URL.
+    expect(buildKeydropDeepLink('id/with slash', 'CODE 1')).toBe(
+      'https://kd.link/?code=CODE%201&giveaway=id%2Fwith%20slash',
+    );
+  });
+
+  it('sin promoCode → path canónico keydrop.com/es/giveaways/{id}', () => {
+    expect(buildKeydropDeepLink('o3S8gi66000', undefined)).toBe(
+      'https://keydrop.com/es/giveaways/o3S8gi66000',
+    );
+    expect(buildKeydropDeepLink('o3S8gi66000', '')).toBe(
+      'https://keydrop.com/es/giveaways/o3S8gi66000',
+    );
+  });
+
+  it('sin id ni promoCode → listing genérico (nunca URL rota /giveaway/ vacío)', () => {
+    expect(buildKeydropDeepLink('', undefined)).toBe('https://keydrop.com/es/giveaways');
+    expect(buildKeydropDeepLink('', '')).toBe('https://keydrop.com/es/giveaways');
+  });
+
+  it('nunca produce URL sobre el dominio legacy key-drop.com (403 Cloudflare)', () => {
+    expect(buildKeydropDeepLink('any', 'ANY')).not.toMatch(/key-drop\.com/);
+    expect(buildKeydropDeepLink('any', undefined)).not.toMatch(/key-drop\.com/);
+    expect(buildKeydropDeepLink('', undefined)).not.toMatch(/key-drop\.com/);
+  });
+
+  it('nunca genera /giveaway/ (singular) — devuelve 404 en keydrop.com', () => {
+    expect(buildKeydropDeepLink('any', 'ANY')).not.toMatch(/\/giveaway\//);
+    expect(buildKeydropDeepLink('any', undefined)).not.toMatch(/\/giveaway\//);
+  });
+
+  it('no pierde el id del giveaway cuando lo tiene', () => {
+    expect(buildKeydropDeepLink('my-real-id', 'PROMO')).toContain('my-real-id');
+    expect(buildKeydropDeepLink('my-real-id', undefined)).toContain('my-real-id');
   });
 });

--- a/src/__tests__/server/keydrop-provider-security.test.ts
+++ b/src/__tests__/server/keydrop-provider-security.test.ts
@@ -97,10 +97,17 @@ describe('[keydrop-provider] fetch.ts sigue el patrón seguro', () => {
     expect(src).toMatch(/authHeader:\s*'x-api-key'/);
   });
 
-  it('externalUrl NO incluye el id (KeyDrop no expone URL individual)', () => {
-    // buildKeydropExternalUrl ignora el argumento _id
-    expect(src).toMatch(/function\s+buildKeydropExternalUrl\(_id:\s*string\)/);
-    expect(src).toMatch(/return\s+KEYDROP_LISTING_URL/);
+  it('externalUrl se construye en el mapper con id + promoCode (deep link)', () => {
+    // Tras el diagnóstico HEAD de 2026-07 el mapper genera la URL con
+    // buildKeydropDeepLink. fetch.ts no debe seguir teniendo el builder legacy.
+    expect(src).not.toMatch(/function\s+buildKeydropExternalUrl/);
+    // Fetch delega en el mapper — pasa solo item + creatorSlug.
+    expect(src).toMatch(/keydropItemToCard\(\{\s*item,\s*creatorSlug\s*\}\)/);
+  });
+
+  it('el listing URL de la config es el dominio actual keydrop.com (no legacy)', () => {
+    expect(src).toMatch(/https:\/\/keydrop\.com\/es\/giveaways/);
+    expect(src).not.toMatch(/https:\/\/key-drop\.com/);
   });
 
   it('providerKey en safeExternalFetch = "keydrop"', () => {

--- a/src/__tests__/server/multiprize-ui.test.ts
+++ b/src/__tests__/server/multiprize-ui.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Contratos estructurales del multi-prize UI en ExternalGiveawayCard.
+ *
+ * Verifica que la card renderiza el strip de miniaturas cuando el sorteo
+ * tiene varios premios, y usa los campos `prizesPreview` y `prizeCount`
+ * que produce el mapper común.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(__dirname, '..', '..', '..');
+const read = (rel: string) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');
+
+describe('[multiprize-ui] ExternalGiveawayCard renderiza multi-prize', () => {
+  const src = read('src/features/giveaway-platform/components/ExternalGiveawayCard.tsx');
+
+  it('renderiza el strip solo cuando prizeCount > 1', () => {
+    expect(src).toMatch(/card\.prizeCount\s*>\s*1[\s\S]{0,200}gp-external-prize-strip/);
+  });
+
+  it('itera prizesPreview.slice(1, 5) para las miniaturas', () => {
+    expect(src).toMatch(/card\.prizesPreview\.slice\(1,\s*5\)/);
+  });
+
+  it('muestra badge "+N" cuando prizeCount > 5', () => {
+    expect(src).toMatch(/card\.prizeCount\s*>\s*5[\s\S]{0,120}gp-external-prize-more/);
+    expect(src).toMatch(/\+\{card\.prizeCount\s*-\s*5\}/);
+  });
+
+  it('cada miniatura usa next/image sin optimizer (CDN provider)', () => {
+    // Dentro del bloque del strip debe haber <Image unoptimized ...
+    expect(src).toMatch(/gp-external-prize-thumb[\s\S]{0,200}unoptimized/);
+  });
+
+  it('imagen principal sigue mostrándose (unchanged)', () => {
+    expect(src).toMatch(/card\.imageUrl\s*\?\s*\(\s*<Image\s+src=\{card\.imageUrl\}/);
+  });
+});
+
+describe('[multiprize-ui] CSS del strip', () => {
+  const css = read('src/app/sorteos/plataforma/platform-external-giveaways.css');
+
+  it('define .gp-external-prize-strip como layer superpuesta a la imagen', () => {
+    expect(css).toMatch(/\.gp-external-prize-strip\s*\{[\s\S]{0,200}position:\s*absolute/);
+  });
+
+  it('define .gp-external-prize-thumb con object-fit contain', () => {
+    expect(css).toMatch(/\.gp-external-prize-thumb\s+img\s*\{[\s\S]{0,80}object-fit:\s*contain/);
+  });
+
+  it('define .gp-external-prize-more con acento SP pink', () => {
+    expect(css).toMatch(/\.gp-external-prize-more\s*\{[\s\S]{0,200}rgba\(224,\s*48,\s*112/);
+  });
+});

--- a/src/__tests__/server/participants-visual.test.ts
+++ b/src/__tests__/server/participants-visual.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Contratos estructurales de la visualización de participantes en la
+ * ExternalGiveawayCard.
+ *
+ * Verifica:
+ *  - Bloque .gp-external-participants con count grande + label.
+ *  - Progressbar accesible con aria-valuenow/min/max cuando faltan users.
+ *  - Etiqueta "arranca en N más" solo cuando participantCount < minUsers.
+ *  - Etiqueta "Mínimo alcanzado" cuando ≥ minUsers.
+ *  - CSS con gradient bar naranja→pink y count grande en sp-pink.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(__dirname, '..', '..', '..');
+const read = (rel: string) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');
+
+describe('[participants-visual] componente', () => {
+  const src = read('src/features/giveaway-platform/components/ExternalGiveawayCard.tsx');
+
+  it('bloque .gp-external-participants existe', () => {
+    expect(src).toMatch(/className="gp-external-participants"/);
+    expect(src).toMatch(/gp-external-participants-count/);
+    expect(src).toMatch(/gp-external-participants-label/);
+  });
+
+  it('count muestra participantCount con toLocaleString es-ES', () => {
+    expect(src).toMatch(/card\.participantCount\.toLocaleString\('es-ES'\)/);
+  });
+
+  it('progressbar con aria completo cuando faltan users', () => {
+    expect(src).toMatch(/role="progressbar"/);
+    expect(src).toMatch(/aria-valuenow=\{card\.participantCount\}/);
+    expect(src).toMatch(/aria-valuemin=\{0\}/);
+    expect(src).toMatch(/aria-valuemax=\{card\.minUsers\}/);
+  });
+
+  it('width fill = participantCount/minUsers * 100 clamped a 100', () => {
+    expect(src).toMatch(/Math\.min\(100,\s*Math\.round\(\(card\.participantCount\s*\/\s*card\.minUsers\)\s*\*\s*100\)\)/);
+  });
+
+  it('condiciones: falta users → progressbar; ≥ minUsers → "Mínimo alcanzado"', () => {
+    expect(src).toMatch(/card\.minUsers\s*>\s*0\s*&&\s*card\.participantCount\s*<\s*card\.minUsers/);
+    expect(src).toMatch(/Mínimo alcanzado/);
+  });
+
+  it('etiqueta "Arranca en N más" con la resta minUsers - participantCount', () => {
+    expect(src).toMatch(/Arranca en\s*\{[\s\S]{0,120}card\.minUsers\s*-\s*card\.participantCount/);
+  });
+
+  it('bloque antiguo gp-sorteo-meta con participantes ha sido reemplazado', () => {
+    expect(src).not.toMatch(/gp-sorteo-meta[\s\S]{0,200}participantes/);
+  });
+});
+
+describe('[participants-visual] CSS', () => {
+  const css = read('src/app/sorteos/plataforma/platform-external-giveaways.css');
+
+  it('.gp-external-participants-count usa sp-pink + font-display', () => {
+    expect(css).toMatch(/\.gp-external-participants-count\s*\{[\s\S]{0,300}var\(--sp-pink\)/);
+    expect(css).toMatch(/\.gp-external-participants-count\s*\{[\s\S]{0,300}var\(--font-display\)/);
+  });
+
+  it('.gp-external-participants-bar-fill usa gradient naranja→pink', () => {
+    expect(css).toMatch(/\.gp-external-participants-bar-fill\s*\{[\s\S]{0,300}linear-gradient\([\s\S]{0,80}var\(--sp-orange\)[\s\S]{0,80}var\(--sp-pink\)/);
+  });
+
+  it('.gp-external-participants-ready usa verde (#4ade80)', () => {
+    expect(css).toMatch(/\.gp-external-participants-ready\s*\{[\s\S]{0,200}#4ade80/);
+  });
+});

--- a/src/__tests__/server/profile-page.test.ts
+++ b/src/__tests__/server/profile-page.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Contratos estructurales del perfil premium de usuario Steam en
+ * /sorteos/plataforma/perfil.
+ *
+ * Verifica:
+ *  - Página protegida (redirect si !userId).
+ *  - Fetch en paralelo de balance/streak/profile/stats/transactions/redemptions.
+ *  - Hero + 4 stat cards + settings form + inventario + transacciones.
+ *  - Form action llama a updateProfile server action.
+ *  - Zod schema valida Steam trade URL.
+ *  - UserPill enlaza al perfil (no más data-todo).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(__dirname, '..', '..', '..');
+const read = (rel: string) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');
+
+describe('[profile] page — auth y data flow', () => {
+  const src = read('src/app/sorteos/plataforma/perfil/page.tsx');
+
+  it('redirige a /sorteos/plataforma si no hay userId', () => {
+    expect(src).toMatch(/if\s*\(!userId\)\s*\{[\s\S]{0,150}redirect\('\/sorteos\/plataforma'\)/);
+  });
+
+  it('fetches datos del perfil en paralelo (Promise.all)', () => {
+    expect(src).toMatch(/Promise\.all\(\[[\s\S]{0,600}getCoinBalance\(userId\)[\s\S]{0,600}getUserStats\(userId\)[\s\S]{0,600}getUserRedemptions\(userId\)/);
+  });
+
+  it('robots noindex en metadata', () => {
+    expect(src).toMatch(/robots:\s*\{\s*index:\s*false/);
+  });
+
+  it('renderiza hero + stats + form + inventario + tx', () => {
+    expect(src).toMatch(/gp-profile-hero/);
+    expect(src).toMatch(/gp-profile-stats/);
+    expect(src).toMatch(/<ProfileSettingsForm/);
+    expect(src).toMatch(/gp-profile-inv/);
+    expect(src).toMatch(/gp-profile-tx/);
+  });
+});
+
+describe('[profile] update server action', () => {
+  const src = read('src/features/giveaway-platform/actions/updateProfile.ts');
+
+  it("usa 'use server' y arranca chequeando la sesión", () => {
+    expect(src).toMatch(/^'use server';/);
+    expect(src).toMatch(/auth\.api\.getSession/);
+    expect(src).toMatch(/if\s*\(!userId\)\s*return\s*\{\s*ok:\s*false,\s*error:\s*'unauthenticated'/);
+  });
+
+  it('valida input con Zod safeParse (regla TS #5)', () => {
+    expect(src).toMatch(/UpdateProfileSchema\.safeParse\(Object\.fromEntries\(formData\)\)/);
+    expect(src).toMatch(/return\s*\{\s*ok:\s*false,\s*fieldErrors/);
+  });
+
+  it('regex Steam trade URL exige partner + token', () => {
+    expect(src).toMatch(/steamcommunity\\\.com\\\/tradeoffer\\\/new/);
+    expect(src).toMatch(/partner=\\d\+&token=/);
+  });
+
+  it('sanea vacíos a null antes de actualizar', () => {
+    expect(src).toMatch(/steamTradeUrl\s*===\s*''\s*\?\s*null/);
+    expect(src).toMatch(/kickUsername\s*===\s*''\s*\?\s*null/);
+  });
+
+  it('revalida /sorteos/plataforma/perfil tras el update', () => {
+    expect(src).toMatch(/revalidatePath\('\/sorteos\/plataforma\/perfil'\)/);
+  });
+});
+
+describe('[profile] settings form (client)', () => {
+  const src = read('src/features/giveaway-platform/components/ProfileSettingsForm.tsx');
+
+  it("es un 'use client' con useTransition", () => {
+    expect(src).toMatch(/^'use client';/);
+    expect(src).toMatch(/useTransition/);
+  });
+
+  it('form action apunta al server action updateProfile', () => {
+    expect(src).toMatch(/updateProfile\(formData\)/);
+    expect(src).toMatch(/<form\s+action=\{handleSubmit\}/);
+  });
+
+  it('inputs para trade URL, kick username y toggle privado', () => {
+    expect(src).toMatch(/name="steamTradeUrl"/);
+    expect(src).toMatch(/name="kickUsername"/);
+    expect(src).toMatch(/name="isPrivate"[\s\S]{0,150}type="checkbox"/);
+  });
+});
+
+describe('[profile] UserPill enlaza al perfil', () => {
+  const src = read('src/features/giveaway-platform/components/UserPill.tsx');
+
+  it('usa <Link> hacia /sorteos/plataforma/perfil', () => {
+    expect(src).toMatch(/href="\/sorteos\/plataforma\/perfil"/);
+  });
+
+  it('elimina los data-todo del menú', () => {
+    expect(src).not.toMatch(/data-todo=/);
+  });
+});
+
+describe('[profile] queries', () => {
+  const src = read('src/lib/queries/giveawayPlatform.ts');
+
+  it('getUserStats agrega entriesTotal/Month + distinctCreators + redemptionsCount', () => {
+    expect(src).toMatch(/export async function getUserStats/);
+    expect(src).toMatch(/distinctCreators/);
+    expect(src).toMatch(/redemptionsCount/);
+    expect(src).toMatch(/count\(distinct\s+\$\{giveaways\.talentId\}\)/);
+  });
+
+  it('getPlayerProfile devuelve la fila player_profiles', () => {
+    expect(src).toMatch(/export async function getPlayerProfile/);
+    expect(src).toMatch(/db\.query\.playerProfiles\.findFirst/);
+  });
+});

--- a/src/__tests__/server/profile-page.test.ts
+++ b/src/__tests__/server/profile-page.test.ts
@@ -50,9 +50,19 @@ describe('[profile] update server action', () => {
     expect(src).toMatch(/if\s*\(!userId\)\s*return\s*\{\s*ok:\s*false,\s*error:\s*'unauthenticated'/);
   });
 
-  it('valida input con Zod safeParse (regla TS #5)', () => {
-    expect(src).toMatch(/UpdateProfileSchema\.safeParse\(Object\.fromEntries\(formData\)\)/);
+  it('valida input con Zod safeParse (regla TS #5) tras normalizar el checkbox', () => {
+    // La normalización del checkbox pasa el objeto ya masajeado a safeParse.
+    expect(src).toMatch(/UpdateProfileSchema\.safeParse\(raw\)/);
     expect(src).toMatch(/return\s*\{\s*ok:\s*false,\s*fieldErrors/);
+  });
+
+  it('normaliza el toggle privado: hasPrivateField=1 + isPrivate ausente → false', () => {
+    // Regla del checkbox HTML nativo: sin el flag no podemos distinguir
+    // "desmarcado" de "no tocado". Con el flag, ausente = desmarcado.
+    expect(src).toMatch(/raw\.hasPrivateField\s*===\s*'1'\s*&&\s*!\(\s*'isPrivate'\s+in\s+raw\s*\)/);
+    expect(src).toMatch(/raw\.isPrivate\s*=\s*'false'/);
+    // El flag se elimina antes del safeParse para no ensuciar el schema.
+    expect(src).toMatch(/delete\s+raw\.hasPrivateField/);
   });
 
   it('regex Steam trade URL exige partner + token', () => {
@@ -87,6 +97,10 @@ describe('[profile] settings form (client)', () => {
     expect(src).toMatch(/name="steamTradeUrl"/);
     expect(src).toMatch(/name="kickUsername"/);
     expect(src).toMatch(/name="isPrivate"[\s\S]{0,150}type="checkbox"/);
+  });
+
+  it('form incluye hidden hasPrivateField para permitir desmarcar el toggle', () => {
+    expect(src).toMatch(/<input[\s\S]{0,120}type="hidden"[\s\S]{0,120}name="hasPrivateField"[\s\S]{0,60}value="1"/);
   });
 });
 

--- a/src/__tests__/server/provider-ranking-placeholder.test.ts
+++ b/src/__tests__/server/provider-ranking-placeholder.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Contratos estructurales del ProviderRankingPlaceholder.
+ *
+ * Verifica:
+ *  - Componente renderiza título con nombre del provider + creador.
+ *  - Genera 5 puestos con skeleton (aria-hidden).
+ *  - Copy "Próximamente" es explícito.
+ *  - Se integra en ExternalGiveawaysSection debajo de finished.
+ *  - CSS con dashed border + skeleton animation + reduced-motion off.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(__dirname, '..', '..', '..');
+const read = (rel: string) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');
+
+describe('[provider-ranking-placeholder] componente', () => {
+  const src = read('src/features/giveaway-platform/components/ProviderRankingPlaceholder.tsx');
+
+  it('recibe providerDisplayName + creatorDisplayName', () => {
+    expect(src).toMatch(/providerDisplayName:\s*string/);
+    expect(src).toMatch(/creatorDisplayName:\s*string/);
+  });
+
+  it('render título "Top participantes en {provider} · {creator}"', () => {
+    expect(src).toMatch(/Top participantes en \{providerDisplayName\} · \{creatorDisplayName\}/);
+  });
+
+  it('genera 5 filas con Array.from({ length: 5 })', () => {
+    expect(src).toMatch(/Array\.from\(\{\s*length:\s*5\s*\}/);
+  });
+
+  it('cada fila es aria-hidden y usa skeleton', () => {
+    expect(src).toMatch(/<li\s+key=\{n\}\s+aria-hidden>/);
+    expect(src).toMatch(/skeleton skeleton-name/);
+    expect(src).toMatch(/skeleton skeleton-value/);
+  });
+
+  it('copy incluye "Próximamente" explícito', () => {
+    expect(src).toMatch(/Próximamente/);
+  });
+});
+
+describe('[provider-ranking-placeholder] integración', () => {
+  const src = read('src/features/giveaway-platform/components/ExternalGiveawaysSection.tsx');
+
+  it('ExternalGiveawaysSection importa y renderiza el placeholder', () => {
+    expect(src).toMatch(/import\s*\{\s*ProviderRankingPlaceholder\s*\}/);
+    expect(src).toMatch(/<ProviderRankingPlaceholder[\s\S]{0,200}providerDisplayName=\{provider\.displayName\}/);
+    expect(src).toMatch(/<ProviderRankingPlaceholder[\s\S]{0,200}creatorDisplayName=\{creatorDisplayName\}/);
+  });
+});
+
+describe('[provider-ranking-placeholder] CSS', () => {
+  const css = read('src/app/sorteos/plataforma/platform-external-giveaways.css');
+
+  it('.gp-provider-rank tiene borde dashed', () => {
+    expect(css).toMatch(/\.gp-provider-rank\s*\{[\s\S]{0,300}border:\s*1px\s+dashed/);
+  });
+
+  it('.skeleton tiene animation gp-skeleton', () => {
+    expect(css).toMatch(/\.skeleton\s*\{[\s\S]{0,400}animation:\s*gp-skeleton/);
+    expect(css).toMatch(/@keyframes\s+gp-skeleton/);
+  });
+
+  it('respeta prefers-reduced-motion desactivando la animación', () => {
+    expect(css).toMatch(/@media\s*\(prefers-reduced-motion:\s*reduce\)[\s\S]{0,200}animation:\s*none/);
+  });
+});

--- a/src/__tests__/server/ranking-global.test.ts
+++ b/src/__tests__/server/ranking-global.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Contratos estructurales del ranking global de la plataforma.
+ *
+ * Verifica:
+ *  - Query `getMonthlyRanking` no filtra por creador (es global).
+ *  - Query `getMonthlyRankingTotal` cuenta jugadores distintos del mes.
+ *  - Componente muestra "Ranking global", tickets, y highlight del user actual.
+ *  - Componente es read-only (no botones de acción, solo listado).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(__dirname, '..', '..', '..');
+const read = (rel: string) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');
+
+describe('[ranking-global] query', () => {
+  const src = read('src/lib/queries/giveawayPlatform.ts');
+
+  it('getMonthlyRanking existe y agrupa por userId (sin creator filter)', () => {
+    expect(src).toMatch(/export async function getMonthlyRanking/);
+    // No debe filtrar giveawayEntries por talent_id / creador
+    const fn = src.slice(src.indexOf('getMonthlyRanking'), src.indexOf('getMonthlyRankingTotal'));
+    expect(fn).not.toMatch(/talentId|creator/i);
+    expect(fn).toMatch(/groupBy\(giveawayEntries\.userId/);
+  });
+
+  it('getMonthlyRankingTotal cuenta distinct userId del mes', () => {
+    expect(src).toMatch(/export async function getMonthlyRankingTotal/);
+    expect(src).toMatch(/count\(distinct\s+\$\{giveawayEntries\.userId\}\)/);
+    expect(src).toMatch(/monthStart\.setUTCDate\(1\)/);
+  });
+
+  it('respeta player_profiles.isPrivate enmascarando el nombre', () => {
+    expect(src).toMatch(/isPrivate\s*===\s*false\s*\?\s*r\.name/);
+    expect(src).toMatch(/\`\$\{r\.name\.slice\(0,\s*1\)\}\*\*\*\*\*\`/);
+  });
+});
+
+describe('[ranking-global] componente', () => {
+  const src = read('src/features/giveaway-platform/components/MonthlyRanking.tsx');
+
+  it('acepta props totalPlayers y currentUserId', () => {
+    expect(src).toMatch(/totalPlayers:\s*number/);
+    expect(src).toMatch(/currentUserId:\s*string\s*\|\s*null/);
+  });
+
+  it('muestra el total de jugadores en la nota', () => {
+    expect(src).toMatch(/totalPlayers\.toLocaleString\('es-ES'\)/);
+    expect(src).toMatch(/jugadores este mes/);
+  });
+
+  it('marca el copy como global y read-only', () => {
+    expect(src).toMatch(/Ranking global/i);
+    expect(src).toMatch(/read-only/);
+  });
+
+  it('resalta al usuario actual con clase `me` y tag', () => {
+    expect(src).toMatch(/const isMe\s*=\s*row\.userId\s*===\s*currentUserId/);
+    expect(src).toMatch(/gp-rank-me-tag/);
+    expect(src).toMatch(/className=\{`gp-rank-podium-card p\$\{pos\}\$\{isMe \? ' me' : ''\}`\}/);
+  });
+
+  it('NO contiene botones interactivos (read-only)', () => {
+    expect(src).not.toMatch(/<button/);
+    expect(src).not.toMatch(/onClick=/);
+    expect(src).not.toMatch(/onChange=/);
+  });
+});
+
+describe('[ranking-global] CSS highlight', () => {
+  const css = read('src/app/sorteos/plataforma/platform-widgets.css');
+
+  it('define .gp-rank-podium-card.me con acento SP pink', () => {
+    expect(css).toMatch(/\.gp-rank-podium-card\.me\s*\{[\s\S]{0,300}rgba\(224,\s*48,\s*112/);
+  });
+
+  it('define .gp-rank-list li.me con background y border-left', () => {
+    expect(css).toMatch(/\.gp-rank-list\s+li\.me\s*\{[\s\S]{0,200}background/);
+    expect(css).toMatch(/\.gp-rank-list\s+li\.me\s*\{[\s\S]{0,200}border-left/);
+  });
+
+  it('define .gp-rank-me-tag con color pink y uppercase', () => {
+    expect(css).toMatch(/\.gp-rank-me-tag\s*\{[\s\S]{0,200}text-transform:\s*uppercase/);
+  });
+});

--- a/src/__tests__/server/shop-enhancement.test.ts
+++ b/src/__tests__/server/shop-enhancement.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Contratos estructurales de la tienda enriquecida (PlatformShop).
+ *
+ * Verifica:
+ *  - Resumen superior con saldo actual + próximo premio a tu alcance.
+ *  - Category tabs con badge de count.
+ *  - Card marca "affordable" cuando balance >= cost && stock > 0.
+ *  - Barra de progreso por card (% balance/cost, clamped 100).
+ *  - Botón muestra "Faltan N 🪙" cuando no alcanza.
+ *  - Empty state cuando el filtro no devuelve items.
+ *  - CSS para summary, badges y progress-fill.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(__dirname, '..', '..', '..');
+const read = (rel: string) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');
+
+describe('[shop-enhancement] componente', () => {
+  const src = read('src/features/giveaway-platform/components/PlatformShop.tsx');
+
+  it('resume el saldo actual y el gap hacia el próximo canjeable', () => {
+    expect(src).toMatch(/gp-shop-summary/);
+    expect(src).toMatch(/gp-shop-balance/);
+    expect(src).toMatch(/cheapestUnaffordable/);
+    expect(src).toMatch(/cheapestUnaffordable\.costCoins\s*-\s*balance/);
+  });
+
+  it('cheapestUnaffordable escoge el item más barato con stock>0 fuera del balance', () => {
+    expect(src).toMatch(/i\.stock\s*>\s*0\s*&&\s*i\.costCoins\s*>\s*balance/);
+    expect(src).toMatch(/a\.costCoins\s*<=\s*b\.costCoins\s*\?\s*a\s*:\s*b/);
+  });
+
+  it('tabs muestran count por categoría', () => {
+    expect(src).toMatch(/gp-shop-tab-count/);
+    expect(src).toMatch(/counts\[c\.key\]/);
+  });
+
+  it('card marca affordable cuando balance >= cost && stock > 0', () => {
+    expect(src).toMatch(/const\s+affordable\s*=\s*balance\s*>=\s*item\.costCoins\s*&&\s*item\.stock\s*>\s*0/);
+    expect(src).toMatch(/gp-shop-card\$\{affordable\s*\?\s*' affordable'\s*:\s*''\}/);
+  });
+
+  it('barra de progreso clamped a 100 usando Math.max(1, cost) para evitar /0', () => {
+    expect(src).toMatch(/Math\.min\(100,\s*Math\.round\(\(balance\s*\/\s*Math\.max\(1,\s*item\.costCoins\)\)\s*\*\s*100\)\)/);
+  });
+
+  it('botón muestra "Faltan N" cuando no puede canjear', () => {
+    expect(src).toMatch(/Faltan\s*\$\{\(item\.costCoins\s*-\s*balance\)/);
+  });
+
+  it('empty state cuando visible.length === 0', () => {
+    expect(src).toMatch(/visible\.length\s*===\s*0\s*\?[\s\S]{0,200}No hay artículos/);
+  });
+});
+
+describe('[shop-enhancement] CSS', () => {
+  const css = read('src/app/sorteos/plataforma/platform-widgets.css');
+
+  it('.gp-shop-summary con borde gold + flex layout', () => {
+    expect(css).toMatch(/\.gp-shop-summary\s*\{[\s\S]{0,400}rgba\(245,\s*183,\s*61/);
+  });
+
+  it('.gp-shop-card.affordable con acento verde', () => {
+    expect(css).toMatch(/\.gp-shop-card\.affordable\s*\{[\s\S]{0,300}rgba\(74,\s*222,\s*128/);
+  });
+
+  it('.gp-shop-badge posicionado top-right con acento verde', () => {
+    expect(css).toMatch(/\.gp-shop-badge\s*\{[\s\S]{0,400}position:\s*absolute/);
+    expect(css).toMatch(/\.gp-shop-badge\s*\{[\s\S]{0,400}rgba\(74,\s*222,\s*128/);
+  });
+
+  it('.gp-shop-progress-fill usa gradient naranja→gold', () => {
+    expect(css).toMatch(/\.gp-shop-progress-fill\s*\{[\s\S]{0,300}linear-gradient\([\s\S]{0,80}var\(--sp-orange\)[\s\S]{0,80}var\(--gold\)/);
+  });
+
+  it('.gp-shop-tab-count define pill con background', () => {
+    expect(css).toMatch(/\.gp-shop-tab-count\s*\{[\s\S]{0,300}border-radius:\s*999px/);
+  });
+});

--- a/src/app/sorteos/plataforma/creadores/[slug]/page.tsx
+++ b/src/app/sorteos/plataforma/creadores/[slug]/page.tsx
@@ -1,0 +1,190 @@
+import { headers } from 'next/headers';
+import Image from 'next/image';
+import { notFound } from 'next/navigation';
+import { inArray } from 'drizzle-orm';
+import { auth } from '@/lib/auth';
+import { db } from '@/lib/db';
+import { talents } from '@/db/schema';
+import {
+  getCoinBalance,
+  getGiveawaysWithEntryData,
+} from '@/lib/queries/giveawayPlatform';
+import { PLATFORM_CREATOR_SLUGS } from '@/lib/giveaway-platform/constants';
+import { getCreatorVisual } from '@/features/giveaway-platform/constants/creators';
+import { PlatformNav } from '@/features/giveaway-platform/components/PlatformNav';
+import { getExternalGiveawaysForCreator } from '@/lib/queries/externalGiveaways';
+import { isExternalCreator } from '@/lib/external-giveaways/creator-bindings';
+
+export const metadata = {
+  title: 'Perfil del creador · SocialPro Sorteos',
+  robots: { index: false, follow: false },
+};
+
+/**
+ * Perfil placeholder de un creador dentro de la plataforma de sorteos.
+ * En esta iteración solo mostramos: bio, avatar, código promocional, socials
+ * (con avg_viewers si lo tenemos) y CTA para ir al bloque de sorteos del
+ * creador en la landing principal. La sección "Estadísticas históricas"
+ * queda marcada como "próximamente" — se activará cuando enganchemos
+ * ranking por creador + histórico de ganadores en PR3.
+ */
+export default async function CreatorProfilePage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+
+  // Guard: solo creadores registrados en la plataforma tienen perfil aquí.
+  if (!PLATFORM_CREATOR_SLUGS.includes(slug as (typeof PLATFORM_CREATOR_SLUGS)[number])) {
+    notFound();
+  }
+
+  const session = await auth.api.getSession({ headers: await headers() });
+  const userId = session?.user?.id ?? null;
+  const userName = session?.user?.name ?? null;
+
+  const [dbCreators, balance] = await Promise.all([
+    db.query.talents.findMany({
+      where: inArray(talents.slug, [...PLATFORM_CREATOR_SLUGS]),
+      with: { socials: true },
+    }),
+    userId ? getCoinBalance(userId) : Promise.resolve(0),
+  ]);
+
+  const active = dbCreators.find((c) => c.slug === slug);
+  if (!active) notFound();
+
+  const activeVisual = getCreatorVisual(active.slug);
+  const creatorOptions = dbCreators.map((c) => {
+    const visual = getCreatorVisual(c.slug);
+    return {
+      slug: c.slug,
+      name: c.name,
+      emoji: visual.emoji,
+      color: visual.color,
+      sub: visual.sub,
+      photoUrl: c.photoUrl,
+    };
+  });
+
+  const isExternal = isExternalCreator(active.slug);
+  const [giveawaysData, externalSections] = await Promise.all([
+    isExternal ? [] : getGiveawaysWithEntryData(active.id, userId),
+    isExternal
+      ? getExternalGiveawaysForCreator(active.slug)
+      : Promise.resolve(null),
+  ]);
+
+  const activeCount = isExternal
+    ? (externalSections?.active.length ?? 0)
+    : giveawaysData.length;
+
+  return (
+    <>
+      <PlatformNav
+        creators={creatorOptions}
+        activeSlug={active.slug}
+        userName={userName}
+        balance={balance}
+        loggedIn={Boolean(userId)}
+      />
+
+      <main className="gp-wrap">
+        <section
+          className="gp-creator-hero"
+          style={{
+            ['--c1' as string]: active.gradientC1,
+            ['--c2' as string]: active.gradientC2,
+          }}
+        >
+          <div className="gp-creator-avatar">
+            {active.photoUrl ? (
+              <Image src={active.photoUrl} alt={active.name} width={144} height={144} unoptimized />
+            ) : (
+              <span className="gp-creator-emoji" aria-hidden>{activeVisual.emoji}</span>
+            )}
+          </div>
+          <div className="gp-creator-head">
+            <span className="gp-creator-code">{activeVisual.code}</span>
+            <h1>{active.name}</h1>
+            <p className="gp-creator-role">{active.role}</p>
+            <p className="gp-creator-bio">{active.bio}</p>
+            <div className="gp-creator-actions">
+              <a href={`/sorteos/plataforma?creador=${active.slug}#sorteos`} className="gp-btn gp-btn-primary">
+                🎯 Ver sorteos {activeCount > 0 ? `(${activeCount})` : ''}
+              </a>
+              <a href={`/sorteos/plataforma?creador=${active.slug}#misiones`} className="gp-btn gp-btn-ghost">
+                ⚡ Misiones
+              </a>
+            </div>
+          </div>
+        </section>
+
+        <section className="gp-legacy-block">
+          <h2>Canales sociales</h2>
+          {active.socials.length === 0 ? (
+            <p className="gp-rank-empty">Este creador aún no tiene canales sincronizados.</p>
+          ) : (
+            <ul className="gp-creator-socials">
+              {active.socials.map((s) => (
+                <li
+                  key={s.id}
+                  style={{ ['--c' as string]: s.hexColor }}
+                >
+                  <span className="p">{s.platform.toUpperCase()}</span>
+                  <b>{s.handle}</b>
+                  <span className="f">{s.followersDisplay} seguidores</span>
+                  {s.profileUrl ? (
+                    <a href={s.profileUrl} target="_blank" rel="noopener noreferrer" className="l">
+                      Abrir →
+                    </a>
+                  ) : null}
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        <section className="gp-legacy-block gp-creator-soon">
+          <h2>📊 Estadísticas históricas</h2>
+          <p className="gp-rank-note">
+            Próximamente: podium mensual por creador, ganadores recientes, evolución de participaciones y
+            record histórico de premios. Se activará cuando el ranking mensual pase a nivel creador (PR3).
+          </p>
+          <div className="gp-creator-soon-grid">
+            <div className="gp-creator-soon-card">
+              <span className="l">🏆 Ganadores</span>
+              <b>Próximamente</b>
+              <span className="s">Últimos 30 días</span>
+            </div>
+            <div className="gp-creator-soon-card">
+              <span className="l">🎁 Premios repartidos</span>
+              <b>Próximamente</b>
+              <span className="s">Valor total en €</span>
+            </div>
+            <div className="gp-creator-soon-card">
+              <span className="l">👥 Comunidad activa</span>
+              <b>Próximamente</b>
+              <span className="s">Participantes únicos / mes</span>
+            </div>
+            <div className="gp-creator-soon-card">
+              <span className="l">🎯 Sorteos totales</span>
+              <b>Próximamente</b>
+              <span className="s">All-time</span>
+            </div>
+          </div>
+        </section>
+
+        <footer className="gp-footer">
+          <b>SOCIALPRO GIVEAWAYS</b> · Sorteos gratuitos de creadores · Sin apuestas · +18
+        </footer>
+      </main>
+    </>
+  );
+}
+
+// Pre-generar rutas para todos los creadores de la plataforma.
+export function generateStaticParams() {
+  return PLATFORM_CREATOR_SLUGS.map((slug) => ({ slug }));
+}

--- a/src/app/sorteos/plataforma/creadores/[slug]/page.tsx
+++ b/src/app/sorteos/plataforma/creadores/[slug]/page.tsx
@@ -43,6 +43,7 @@ export default async function CreatorProfilePage({
   const session = await auth.api.getSession({ headers: await headers() });
   const userId = session?.user?.id ?? null;
   const userName = session?.user?.name ?? null;
+  const userImage = session?.user?.image ?? null;
 
   const [dbCreators, balance] = await Promise.all([
     db.query.talents.findMany({
@@ -86,6 +87,7 @@ export default async function CreatorProfilePage({
         creators={creatorOptions}
         activeSlug={active.slug}
         userName={userName}
+        userImage={userImage}
         balance={balance}
         loggedIn={Boolean(userId)}
       />

--- a/src/app/sorteos/plataforma/layout.tsx
+++ b/src/app/sorteos/plataforma/layout.tsx
@@ -9,6 +9,8 @@ import './platform-brand-cards.css';
 import './platform-fx.css';
 import './platform-widgets.css';
 import './platform-external-giveaways.css';
+import './platform-profile.css';
+import './platform-creator-profile.css';
 
 const rajdhani = Rajdhani({
   subsets: ['latin'],

--- a/src/app/sorteos/plataforma/page.tsx
+++ b/src/app/sorteos/plataforma/page.tsx
@@ -44,6 +44,7 @@ export default async function PlataformaSorteosPage({
   const session = await auth.api.getSession({ headers: await headers() });
   const userId = session?.user?.id ?? null;
   const userName = session?.user?.name ?? null;
+  const userImage = session?.user?.image ?? null;
 
   const dbCreators = await db.query.talents.findMany({
     where: inArray(talents.slug, [...PLATFORM_CREATOR_SLUGS]),
@@ -70,6 +71,7 @@ export default async function PlataformaSorteosPage({
           creators={creatorOptions}
           activeSlug=""
           userName={userName}
+          userImage={userImage}
           balance={0}
           loggedIn={Boolean(userId)}
         />
@@ -123,6 +125,7 @@ export default async function PlataformaSorteosPage({
         creators={creatorOptions}
         activeSlug={active.slug}
         userName={userName}
+        userImage={userImage}
         balance={balance}
         loggedIn={Boolean(userId)}
       />

--- a/src/app/sorteos/plataforma/page.tsx
+++ b/src/app/sorteos/plataforma/page.tsx
@@ -9,6 +9,7 @@ import {
   getGiveawaysWithEntryData,
   getMissionsWithProgress,
   getMonthlyRanking,
+  getMonthlyRankingTotal,
 } from '@/lib/queries/giveawayPlatform';
 import {
   PLATFORM_CREATOR_SLUGS,
@@ -101,8 +102,9 @@ export default async function PlataformaSorteosPage({
       ])
     : [0, [], undefined];
 
-  const [ranking, shopItemsData, externalSections] = await Promise.all([
+  const [ranking, rankingTotal, shopItemsData, externalSections] = await Promise.all([
     getMonthlyRanking(10),
+    getMonthlyRankingTotal(),
     getActiveShopItems(),
     // Sorteos externos: se dispara SOLO si el creador tiene binding externo.
     // Degrada a listas vacías si falta env, provider cae o shape falla —
@@ -209,8 +211,8 @@ export default async function PlataformaSorteosPage({
 
         <section id="ranking">
           <div className="gp-legacy-block">
-            <h2>Ranking mensual</h2>
-            <MonthlyRanking rows={ranking} />
+            <h2>Ranking global · mensual</h2>
+            <MonthlyRanking rows={ranking} totalPlayers={rankingTotal} currentUserId={userId} />
           </div>
         </section>
 

--- a/src/app/sorteos/plataforma/perfil/page.tsx
+++ b/src/app/sorteos/plataforma/perfil/page.tsx
@@ -1,0 +1,204 @@
+import { headers } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { eq, inArray } from 'drizzle-orm';
+import { auth } from '@/lib/auth';
+import { db } from '@/lib/db';
+import { dailyStreaks, talents } from '@/db/schema';
+import {
+  getCoinBalance,
+  getPlayerProfile,
+  getUserRedemptions,
+  getUserStats,
+  getUserTransactions,
+} from '@/lib/queries/giveawayPlatform';
+import { PLATFORM_CREATOR_SLUGS, todayInPlatformTz } from '@/lib/giveaway-platform/constants';
+import { getCreatorVisual } from '@/features/giveaway-platform/constants/creators';
+import { PlatformNav } from '@/features/giveaway-platform/components/PlatformNav';
+import { ProfileSettingsForm } from '@/features/giveaway-platform/components/ProfileSettingsForm';
+
+export const metadata = {
+  title: 'Mi perfil · SocialPro Sorteos',
+  robots: { index: false, follow: false },
+};
+
+const SOURCE_LABEL: Record<string, string> = {
+  racha: 'Racha diaria',
+  mision: 'Misión',
+  sorteo: 'Participación',
+  tienda: 'Canje',
+  admin: 'Ajuste',
+};
+
+const REDEMPTION_STATUS_LABEL: Record<string, string> = {
+  pendiente: 'Pendiente',
+  enviado: 'Enviado',
+  cancelado: 'Cancelado',
+};
+
+function formatDate(d: Date | string): string {
+  const date = typeof d === 'string' ? new Date(d) : d;
+  return date.toLocaleString('es-ES', {
+    day: '2-digit',
+    month: 'short',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+export default async function PerfilPage() {
+  const session = await auth.api.getSession({ headers: await headers() });
+  const userId = session?.user?.id ?? null;
+  const userName = session?.user?.name ?? null;
+  const userImage = session?.user?.image ?? null;
+
+  if (!userId) {
+    // Sin sesión: al login. El nav en la landing es el que ofrece el botón
+    // de Steam, así que redirigimos a la propia plataforma.
+    redirect('/sorteos/plataforma');
+  }
+
+  const dbCreators = await db.query.talents.findMany({
+    where: inArray(talents.slug, [...PLATFORM_CREATOR_SLUGS]),
+  });
+  const creatorOptions = dbCreators.map((c) => {
+    const visual = getCreatorVisual(c.slug);
+    return {
+      slug: c.slug,
+      name: c.name,
+      emoji: visual.emoji,
+      color: visual.color,
+      sub: visual.sub,
+      photoUrl: c.photoUrl,
+    };
+  });
+
+  const [balance, streak, profile, stats, transactions, userRedemptions] = await Promise.all([
+    getCoinBalance(userId),
+    db.query.dailyStreaks.findFirst({ where: eq(dailyStreaks.userId, userId) }),
+    getPlayerProfile(userId),
+    getUserStats(userId),
+    getUserTransactions(userId, 10),
+    getUserRedemptions(userId),
+  ]);
+
+  const today = todayInPlatformTz();
+  const claimedToday = streak?.lastClaimDate === today;
+
+  return (
+    <>
+      <PlatformNav
+        creators={creatorOptions}
+        activeSlug={creatorOptions[0]?.slug ?? ''}
+        userName={userName}
+        balance={balance}
+        loggedIn
+      />
+
+      <main className="gp-wrap">
+        <section className="gp-profile-hero">
+          <div className="gp-profile-avatar">
+            {userImage ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img src={userImage} alt={userName ?? 'Steam avatar'} />
+            ) : (
+              <span aria-hidden>🎮</span>
+            )}
+          </div>
+          <div className="gp-profile-head">
+            <h1>{userName ?? 'Jugador Steam'}</h1>
+            <p className="gp-profile-sub">
+              {profile?.steamId ? <>Steam ID: <code>{profile.steamId}</code></> : 'Perfil vinculado con Steam'}
+              {profile?.isPrivate ? <span className="gp-profile-badge">🔒 Privado</span> : <span className="gp-profile-badge on">🌐 Público</span>}
+            </p>
+          </div>
+        </section>
+
+        <section className="gp-profile-stats">
+          <div className="gp-profile-stat">
+            <span className="l">🪙 Saldo</span>
+            <b>{balance.toLocaleString('es-ES')}</b>
+            <span className="s">monedas disponibles</span>
+          </div>
+          <div className="gp-profile-stat">
+            <span className="l">🔥 Racha</span>
+            <b>{streak?.currentDay ?? 0}<span className="unit">/7</span></b>
+            <span className="s">{claimedToday ? 'reclamada hoy' : 'pendiente hoy'}</span>
+          </div>
+          <div className="gp-profile-stat">
+            <span className="l">🎯 Participaciones</span>
+            <b>{stats.entriesTotal.toLocaleString('es-ES')}</b>
+            <span className="s">{stats.entriesMonth} este mes</span>
+          </div>
+          <div className="gp-profile-stat">
+            <span className="l">👥 Creadores</span>
+            <b>{stats.distinctCreators}</b>
+            <span className="s">jugados en total</span>
+          </div>
+        </section>
+
+        <section className="gp-legacy-block">
+          <h2>Ajustes de cuenta</h2>
+          <ProfileSettingsForm
+            initialIsPrivate={profile?.isPrivate ?? true}
+            initialSteamTradeUrl={profile?.steamTradeUrl ?? null}
+            initialKickUsername={profile?.kickUsername ?? null}
+          />
+        </section>
+
+        <section className="gp-legacy-block">
+          <h2>🎒 Inventario</h2>
+          {userRedemptions.length === 0 ? (
+            <p className="gp-rank-empty">
+              Aún no has canjeado nada en la tienda. Consigue monedas con misiones y sorteos.
+            </p>
+          ) : (
+            <ul className="gp-profile-inv">
+              {userRedemptions.map((r) => (
+                <li key={r.id}>
+                  <div className="gp-profile-inv-thumb" aria-hidden>
+                    {r.shopItem.imageUrl ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img src={r.shopItem.imageUrl} alt="" />
+                    ) : (
+                      <span>🎁</span>
+                    )}
+                  </div>
+                  <div className="gp-profile-inv-body">
+                    <b>{r.shopItem.name}</b>
+                    <span>{formatDate(r.createdAt)}</span>
+                  </div>
+                  <span className={`gp-profile-inv-status s-${r.status}`}>
+                    {REDEMPTION_STATUS_LABEL[r.status] ?? r.status}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        <section className="gp-legacy-block">
+          <h2>🧾 Últimas transacciones</h2>
+          {transactions.length === 0 ? (
+            <p className="gp-rank-empty">Aún no tienes movimientos de monedas.</p>
+          ) : (
+            <ul className="gp-profile-tx">
+              {transactions.map((t) => (
+                <li key={t.id}>
+                  <span className="gp-profile-tx-src">{SOURCE_LABEL[t.source] ?? t.source}</span>
+                  <span className="gp-profile-tx-date">{formatDate(t.createdAt)}</span>
+                  <span className={`gp-profile-tx-amt ${t.amount >= 0 ? 'pos' : 'neg'}`}>
+                    {t.amount > 0 ? '+' : ''}{t.amount.toLocaleString('es-ES')} 🪙
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        <footer className="gp-footer">
+          <b>SOCIALPRO GIVEAWAYS</b> · Sorteos gratuitos de creadores · Sin apuestas · +18
+        </footer>
+      </main>
+    </>
+  );
+}

--- a/src/app/sorteos/plataforma/perfil/page.tsx
+++ b/src/app/sorteos/plataforma/perfil/page.tsx
@@ -90,6 +90,7 @@ export default async function PerfilPage() {
         creators={creatorOptions}
         activeSlug={creatorOptions[0]?.slug ?? ''}
         userName={userName}
+        userImage={userImage}
         balance={balance}
         loggedIn
       />

--- a/src/app/sorteos/plataforma/platform-creator-profile.css
+++ b/src/app/sorteos/plataforma/platform-creator-profile.css
@@ -1,0 +1,192 @@
+/*
+ * Perfil del creador dentro de la plataforma /sorteos/plataforma/creadores/[slug].
+ * Placeholder-friendly: hero + socials + estadísticas "próximamente".
+ * Comparte estética con /perfil y gp-legacy-block.
+ */
+
+.giveaway-platform .gp-creator-hero {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 24px;
+  align-items: center;
+  padding: 28px 26px;
+  margin-bottom: 22px;
+  border-radius: 22px;
+  background:
+    radial-gradient(ellipse at top left, color-mix(in srgb, var(--c1) 22%, transparent), transparent 55%),
+    radial-gradient(ellipse at bottom right, color-mix(in srgb, var(--c2) 22%, transparent), transparent 55%),
+    rgba(11, 9, 23, 0.72);
+  border: 1px solid rgba(224, 48, 112, 0.28);
+  position: relative;
+  overflow: hidden;
+}
+.giveaway-platform .gp-creator-avatar {
+  width: 144px;
+  height: 144px;
+  border-radius: 24px;
+  overflow: hidden;
+  background: #0b0917;
+  border: 2px solid var(--c1, var(--sp-pink));
+  box-shadow: 0 0 32px color-mix(in srgb, var(--c1, var(--sp-pink)) 45%, transparent);
+  display: grid;
+  place-items: center;
+}
+.giveaway-platform .gp-creator-avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.giveaway-platform .gp-creator-emoji { font-size: 56px; }
+
+.giveaway-platform .gp-creator-code {
+  display: inline-block;
+  color: var(--gold);
+  font-family: var(--font-display), var(--font-rajdhani), sans-serif;
+  font-weight: 800;
+  letter-spacing: 2px;
+  font-size: 14px;
+  text-transform: uppercase;
+  margin-bottom: 4px;
+}
+.giveaway-platform .gp-creator-head h1 {
+  font-family: var(--font-display), var(--font-rajdhani), sans-serif;
+  font-weight: 900;
+  font-size: 40px;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  color: #fff;
+  margin: 0 0 4px;
+  line-height: 1.05;
+}
+.giveaway-platform .gp-creator-role {
+  color: var(--sp-pink);
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 1.2px;
+  text-transform: uppercase;
+  margin: 0 0 12px;
+}
+.giveaway-platform .gp-creator-bio {
+  color: var(--txt);
+  font-size: 14px;
+  line-height: 1.55;
+  max-width: 640px;
+  margin: 0 0 18px;
+}
+.giveaway-platform .gp-creator-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.giveaway-platform .gp-btn-ghost {
+  padding: 10px 20px;
+  background: rgba(11, 9, 23, 0.5);
+  border: 1px solid rgba(196, 40, 128, 0.35);
+  color: var(--txt);
+  border-radius: 10px;
+  font-family: var(--font-display), var(--font-rajdhani), sans-serif;
+  font-weight: 700;
+  letter-spacing: 1.2px;
+  text-transform: uppercase;
+  font-size: 12.5px;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+.giveaway-platform .gp-btn-ghost:hover {
+  background: rgba(224, 48, 112, 0.12);
+  border-color: rgba(224, 48, 112, 0.55);
+}
+@media (max-width: 720px) {
+  .giveaway-platform .gp-creator-hero { grid-template-columns: 1fr; text-align: center; }
+  .giveaway-platform .gp-creator-avatar { margin: 0 auto; }
+  .giveaway-platform .gp-creator-actions { justify-content: center; }
+  .giveaway-platform .gp-creator-head h1 { font-size: 32px; }
+}
+
+/* Socials */
+.giveaway-platform .gp-creator-socials {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+}
+.giveaway-platform .gp-creator-socials li {
+  padding: 14px 16px;
+  border-radius: 14px;
+  background: rgba(11, 9, 23, 0.55);
+  border: 1px solid color-mix(in srgb, var(--c, var(--sp-pink)) 30%, transparent);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.giveaway-platform .gp-creator-socials li .p {
+  font-size: 10.5px;
+  letter-spacing: 1.3px;
+  color: var(--c, var(--sp-pink));
+  font-weight: 800;
+  text-transform: uppercase;
+}
+.giveaway-platform .gp-creator-socials li b {
+  font-size: 15px;
+  color: #fff;
+}
+.giveaway-platform .gp-creator-socials li .f {
+  font-size: 12px;
+  color: var(--muted);
+}
+.giveaway-platform .gp-creator-socials li .l {
+  color: var(--sp-pink);
+  font-weight: 700;
+  font-size: 11.5px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  text-decoration: none;
+  margin-top: 4px;
+}
+.giveaway-platform .gp-creator-socials li .l:hover { text-decoration: underline; }
+
+/* Próximamente grid */
+.giveaway-platform .gp-creator-soon-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+  margin-top: 12px;
+}
+.giveaway-platform .gp-creator-soon-card {
+  padding: 16px;
+  border-radius: 14px;
+  background: repeating-linear-gradient(
+    45deg,
+    rgba(11, 9, 23, 0.6),
+    rgba(11, 9, 23, 0.6) 8px,
+    rgba(224, 48, 112, 0.05) 8px,
+    rgba(224, 48, 112, 0.05) 16px
+  );
+  border: 1px dashed rgba(196, 40, 128, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  opacity: 0.85;
+}
+.giveaway-platform .gp-creator-soon-card .l {
+  font-size: 11px;
+  letter-spacing: 1.3px;
+  text-transform: uppercase;
+  color: var(--muted);
+  font-weight: 700;
+}
+.giveaway-platform .gp-creator-soon-card b {
+  font-family: var(--font-display), var(--font-rajdhani), sans-serif;
+  font-size: 16px;
+  color: #fff;
+  font-weight: 900;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+.giveaway-platform .gp-creator-soon-card .s {
+  font-size: 11px;
+  color: var(--muted);
+}

--- a/src/app/sorteos/plataforma/platform-external-giveaways.css
+++ b/src/app/sorteos/plataforma/platform-external-giveaways.css
@@ -83,10 +83,114 @@
   letter-spacing: 0.5px;
   margin-left: 4px;
 }
+/* Multi-prize strip: miniaturas superpuestas al pie de la imagen principal */
+.giveaway-platform .gp-external-img { position: relative; }
+.giveaway-platform .gp-external-prize-strip {
+  position: absolute;
+  left: 6px;
+  right: 6px;
+  bottom: 6px;
+  display: flex;
+  gap: 4px;
+  padding: 4px;
+  border-radius: 6px;
+  background: rgba(11, 9, 23, 0.75);
+  backdrop-filter: blur(6px);
+  pointer-events: none;
+}
+.giveaway-platform .gp-external-prize-thumb {
+  flex-shrink: 0;
+  width: 44px;
+  height: 32px;
+  border-radius: 4px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(196, 40, 128, 0.24);
+  display: grid;
+  place-items: center;
+}
+.giveaway-platform .gp-external-prize-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+.giveaway-platform .gp-external-prize-more {
+  flex-shrink: 0;
+  min-width: 32px;
+  height: 32px;
+  padding: 0 6px;
+  border-radius: 4px;
+  background: rgba(224, 48, 112, 0.16);
+  border: 1px solid rgba(224, 48, 112, 0.4);
+  display: grid;
+  place-items: center;
+  font-family: var(--font-display), var(--font-rajdhani), sans-serif;
+  font-size: 11px;
+  font-weight: 800;
+  color: #fff;
+}
 .giveaway-platform .gp-external-deadline {
   margin-top: 6px;
   font-size: 11px;
   color: var(--muted);
+}
+
+/* Participants block — visual prominence + arranque progress */
+.giveaway-platform .gp-external-participants {
+  margin-top: 10px;
+  padding: 8px 10px;
+  border-radius: 10px;
+  background: rgba(11, 9, 23, 0.55);
+  border: 1px solid rgba(196, 40, 128, 0.18);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.giveaway-platform .gp-external-participants-row {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+.giveaway-platform .gp-external-participants-icon { font-size: 15px; line-height: 1; }
+.giveaway-platform .gp-external-participants-count {
+  font-family: var(--font-display), var(--font-rajdhani), sans-serif;
+  font-size: 22px;
+  font-weight: 900;
+  color: var(--sp-pink);
+  letter-spacing: 0.5px;
+  line-height: 1;
+}
+.giveaway-platform .gp-external-participants-label {
+  font-size: 11px;
+  color: var(--muted);
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  font-weight: 700;
+}
+.giveaway-platform .gp-external-participants-bar {
+  width: 100%;
+  height: 6px;
+  border-radius: 3px;
+  background: rgba(11, 9, 23, 0.8);
+  overflow: hidden;
+  border: 1px solid rgba(196, 40, 128, 0.14);
+}
+.giveaway-platform .gp-external-participants-bar-fill {
+  display: block;
+  height: 100%;
+  background: linear-gradient(90deg, var(--sp-orange), var(--sp-pink));
+  border-radius: 3px;
+  transition: width 0.4s ease-out;
+}
+.giveaway-platform .gp-external-participants-min {
+  font-size: 11px;
+  color: var(--muted);
+}
+.giveaway-platform .gp-external-participants-ready {
+  font-size: 11.5px;
+  color: #4ade80;
+  font-weight: 700;
+  letter-spacing: 0.5px;
 }
 .giveaway-platform .gp-external-winners {
   margin-top: 8px;
@@ -135,3 +239,75 @@
 }
 .giveaway-platform .gp-external-finished > summary::-webkit-details-marker { display: none; }
 .giveaway-platform .gp-external-finished[open] > summary { margin-bottom: 14px; }
+
+/* ================ PROVIDER RANKING PLACEHOLDER ================ */
+.giveaway-platform .gp-provider-rank {
+  margin-top: 22px;
+  padding: 16px 18px;
+  border-radius: 14px;
+  background: rgba(11, 9, 23, 0.5);
+  border: 1px dashed rgba(196, 40, 128, 0.35);
+}
+.giveaway-platform .gp-provider-rank-title {
+  margin: 0 0 4px;
+  font-family: var(--font-display), var(--font-rajdhani), sans-serif;
+  font-size: 14px;
+  font-weight: 800;
+  letter-spacing: 1.2px;
+  text-transform: uppercase;
+  color: var(--gold);
+}
+.giveaway-platform .gp-provider-rank-note {
+  margin: 0 0 12px;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.5;
+}
+.giveaway-platform .gp-provider-rank-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.giveaway-platform .gp-provider-rank-list li {
+  display: grid;
+  grid-template-columns: 24px 1fr 80px;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 12px;
+  background: rgba(11, 9, 23, 0.5);
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+}
+.giveaway-platform .gp-provider-rank-list .num {
+  font-family: var(--font-display), var(--font-rajdhani), sans-serif;
+  font-weight: 800;
+  color: var(--muted);
+  text-align: center;
+  font-size: 13px;
+}
+.giveaway-platform .gp-provider-rank-list .skeleton {
+  display: block;
+  height: 12px;
+  border-radius: 6px;
+  background: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0.04) 0%,
+    rgba(224, 48, 112, 0.14) 50%,
+    rgba(255, 255, 255, 0.04) 100%
+  );
+  background-size: 200% 100%;
+  animation: gp-skeleton 1.8s ease-in-out infinite;
+}
+.giveaway-platform .gp-provider-rank-list .skeleton-name { width: 70%; }
+.giveaway-platform .gp-provider-rank-list .skeleton-value { width: 100%; height: 10px; }
+
+@keyframes gp-skeleton {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .giveaway-platform .gp-provider-rank-list .skeleton { animation: none; }
+}

--- a/src/app/sorteos/plataforma/platform-profile.css
+++ b/src/app/sorteos/plataforma/platform-profile.css
@@ -1,0 +1,286 @@
+/*
+ * Perfil premium del usuario Steam en /sorteos/plataforma/perfil.
+ * Consume las CSS vars del layout (--sp-grad, --panel2, --line, --txt,
+ * --muted, --sp-pink) y sigue la misma estética de gp-legacy-block.
+ */
+
+/* ================ HERO ================ */
+.giveaway-platform .gp-profile-hero {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  padding: 22px 24px;
+  margin-bottom: 22px;
+  border-radius: 20px;
+  background: linear-gradient(135deg, rgba(245, 99, 42, 0.14) 0%, rgba(139, 58, 173, 0.22) 100%);
+  border: 1px solid rgba(224, 48, 112, 0.28);
+}
+.giveaway-platform .gp-profile-avatar {
+  width: 84px;
+  height: 84px;
+  border-radius: 50%;
+  overflow: hidden;
+  flex-shrink: 0;
+  display: grid;
+  place-items: center;
+  background: #0b0917;
+  border: 2px solid var(--sp-pink);
+  box-shadow: 0 0 24px rgba(224, 48, 112, 0.4);
+  font-size: 32px;
+}
+.giveaway-platform .gp-profile-avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.giveaway-platform .gp-profile-head h1 {
+  font-family: var(--font-display), var(--font-rajdhani), sans-serif;
+  font-weight: 900;
+  font-size: 28px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: #fff;
+  margin: 0 0 6px;
+}
+.giveaway-platform .gp-profile-sub {
+  color: var(--muted);
+  font-size: 13px;
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.giveaway-platform .gp-profile-sub code {
+  font-family: var(--font-chakra), monospace;
+  color: var(--txt);
+  background: rgba(11, 9, 23, 0.5);
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+.giveaway-platform .gp-profile-badge {
+  padding: 3px 9px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  background: rgba(11, 9, 23, 0.5);
+  border: 1px solid rgba(196, 40, 128, 0.3);
+  color: var(--muted);
+}
+.giveaway-platform .gp-profile-badge.on {
+  background: rgba(74, 222, 128, 0.12);
+  border-color: rgba(74, 222, 128, 0.4);
+  color: #4ade80;
+}
+
+/* ================ STATS ================ */
+.giveaway-platform .gp-profile-stats {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  margin-bottom: 22px;
+}
+.giveaway-platform .gp-profile-stat {
+  padding: 14px 16px;
+  border-radius: 14px;
+  background: rgba(11, 9, 23, 0.55);
+  border: 1px solid rgba(196, 40, 128, 0.18);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.giveaway-platform .gp-profile-stat .l {
+  font-size: 11px;
+  letter-spacing: 1.3px;
+  text-transform: uppercase;
+  color: var(--muted);
+  font-weight: 700;
+}
+.giveaway-platform .gp-profile-stat b {
+  font-family: var(--font-display), var(--font-rajdhani), sans-serif;
+  font-size: 30px;
+  font-weight: 900;
+  color: #fff;
+  line-height: 1.1;
+}
+.giveaway-platform .gp-profile-stat b .unit {
+  font-size: 15px;
+  color: var(--muted);
+  font-weight: 700;
+  margin-left: 2px;
+}
+.giveaway-platform .gp-profile-stat .s {
+  font-size: 11.5px;
+  color: var(--muted);
+}
+@media (max-width: 900px) {
+  .giveaway-platform .gp-profile-stats { grid-template-columns: repeat(2, 1fr); }
+}
+
+/* ================ FORM ================ */
+.giveaway-platform .gp-profile-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.giveaway-platform .gp-profile-field label {
+  display: block;
+  margin-bottom: 6px;
+}
+.giveaway-platform .gp-profile-field label b {
+  display: block;
+  font-size: 13.5px;
+  color: #fff;
+  margin-bottom: 2px;
+}
+.giveaway-platform .gp-profile-field label span {
+  display: block;
+  font-size: 11.5px;
+  color: var(--muted);
+}
+.giveaway-platform .gp-profile-field input[type="url"],
+.giveaway-platform .gp-profile-field input[type="text"] {
+  width: 100%;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: rgba(11, 9, 23, 0.65);
+  border: 1px solid rgba(196, 40, 128, 0.28);
+  color: var(--txt);
+  font-family: var(--font-body), sans-serif;
+  font-size: 13px;
+  outline: none;
+  transition: border-color 0.15s;
+}
+.giveaway-platform .gp-profile-field input:focus {
+  border-color: rgba(224, 48, 112, 0.55);
+}
+.giveaway-platform .gp-profile-toggle {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  justify-content: space-between;
+}
+.giveaway-platform .gp-profile-toggle input[type="checkbox"] {
+  width: 44px;
+  height: 24px;
+  cursor: pointer;
+  accent-color: var(--sp-pink);
+}
+.giveaway-platform .gp-profile-err {
+  display: block;
+  font-size: 11.5px;
+  color: #ff8fa1;
+  margin-top: 4px;
+}
+.giveaway-platform .gp-profile-ok {
+  font-size: 12.5px;
+  color: #4ade80;
+  font-weight: 700;
+}
+.giveaway-platform .gp-profile-actions {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+.giveaway-platform .gp-btn-primary {
+  background: var(--sp-grad);
+  color: #fff;
+  padding: 10px 20px;
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+  font-family: var(--font-display), var(--font-rajdhani), sans-serif;
+  font-weight: 700;
+  letter-spacing: 1.2px;
+  text-transform: uppercase;
+  font-size: 12.5px;
+  transition: filter 0.15s;
+}
+.giveaway-platform .gp-btn-primary:hover { filter: brightness(1.15); }
+.giveaway-platform .gp-btn-primary:disabled { opacity: 0.5; cursor: default; }
+
+/* ================ INVENTARIO ================ */
+.giveaway-platform .gp-profile-inv,
+.giveaway-platform .gp-profile-tx {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.giveaway-platform .gp-profile-inv li {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  background: rgba(11, 9, 23, 0.5);
+  border-radius: 12px;
+  border: 1px solid rgba(196, 40, 128, 0.14);
+}
+.giveaway-platform .gp-profile-inv-thumb {
+  width: 48px;
+  height: 48px;
+  border-radius: 10px;
+  overflow: hidden;
+  background: rgba(11, 9, 23, 0.8);
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+  font-size: 22px;
+}
+.giveaway-platform .gp-profile-inv-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.giveaway-platform .gp-profile-inv-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+.giveaway-platform .gp-profile-inv-body b { color: var(--txt); font-size: 13.5px; }
+.giveaway-platform .gp-profile-inv-body span { color: var(--muted); font-size: 11.5px; }
+.giveaway-platform .gp-profile-inv-status {
+  padding: 3px 10px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.8px;
+  text-transform: uppercase;
+}
+.giveaway-platform .gp-profile-inv-status.s-pendiente {
+  background: rgba(245, 183, 61, 0.12);
+  color: #f5b73d;
+}
+.giveaway-platform .gp-profile-inv-status.s-enviado {
+  background: rgba(74, 222, 128, 0.14);
+  color: #4ade80;
+}
+.giveaway-platform .gp-profile-inv-status.s-cancelado {
+  background: rgba(255, 143, 161, 0.14);
+  color: #ff8fa1;
+}
+
+/* ================ TRANSACCIONES ================ */
+.giveaway-platform .gp-profile-tx li {
+  display: grid;
+  grid-template-columns: 1.5fr 1fr auto;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  background: rgba(11, 9, 23, 0.5);
+  border-radius: 10px;
+  border: 1px solid rgba(196, 40, 128, 0.12);
+  font-size: 13px;
+}
+.giveaway-platform .gp-profile-tx-src { color: var(--txt); font-weight: 600; }
+.giveaway-platform .gp-profile-tx-date { color: var(--muted); font-size: 11.5px; }
+.giveaway-platform .gp-profile-tx-amt {
+  font-family: var(--font-display), var(--font-rajdhani), sans-serif;
+  font-weight: 800;
+  font-size: 14px;
+}
+.giveaway-platform .gp-profile-tx-amt.pos { color: #4ade80; }
+.giveaway-platform .gp-profile-tx-amt.neg { color: #ff8fa1; }

--- a/src/app/sorteos/plataforma/platform-widgets.css
+++ b/src/app/sorteos/plataforma/platform-widgets.css
@@ -288,6 +288,24 @@
 .giveaway-platform .gp-rank-list .tix { color: var(--muted); font-size: 12px; }
 .giveaway-platform .gp-rank-list .tix b { color: var(--sp-pink); font-weight: 700; }
 
+/* Highlight del usuario actual dentro del ranking */
+.giveaway-platform .gp-rank-podium-card.me {
+  border-color: rgba(224, 48, 112, 0.65);
+  box-shadow: 0 0 22px rgba(224, 48, 112, 0.28);
+}
+.giveaway-platform .gp-rank-list li.me {
+  background: rgba(224, 48, 112, 0.10);
+  border-left: 3px solid var(--sp-pink);
+}
+.giveaway-platform .gp-rank-me-tag {
+  font-size: 10px;
+  letter-spacing: 1.2px;
+  text-transform: uppercase;
+  color: var(--sp-pink);
+  font-weight: 800;
+  margin-left: 4px;
+}
+
 /* ================ TIENDA / CANJEO ================ */
 .giveaway-platform .gp-shop-tabs {
   display: flex;
@@ -384,6 +402,103 @@
   box-shadow: 0 6px 20px rgba(245, 183, 61, 0.3);
 }
 .giveaway-platform .gp-shop-btn:disabled { opacity: 0.4; cursor: not-allowed; box-shadow: none; }
+
+/* ================ TIENDA · summary + progress + affordance ================ */
+.giveaway-platform .gp-shop-summary {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 16px;
+  margin-bottom: 16px;
+  border-radius: 14px;
+  background: rgba(11, 9, 23, 0.55);
+  border: 1px solid rgba(245, 183, 61, 0.22);
+  flex-wrap: wrap;
+}
+.giveaway-platform .gp-shop-balance {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.giveaway-platform .gp-shop-balance .l {
+  font-size: 11px;
+  letter-spacing: 1.3px;
+  color: var(--muted);
+  text-transform: uppercase;
+  font-weight: 700;
+}
+.giveaway-platform .gp-shop-balance b {
+  font-family: var(--font-display), var(--font-rajdhani), sans-serif;
+  font-size: 22px;
+  font-weight: 900;
+  color: var(--gold);
+}
+.giveaway-platform .gp-shop-next {
+  flex: 1;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.4;
+  min-width: 240px;
+}
+.giveaway-platform .gp-shop-next b { color: var(--txt); }
+.giveaway-platform .gp-shop-next-gap {
+  color: var(--sp-pink);
+  font-weight: 700;
+}
+.giveaway-platform .gp-shop-next.ok { color: #4ade80; font-weight: 700; }
+
+.giveaway-platform .gp-shop-tab-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  padding: 0 6px;
+  height: 18px;
+  margin-left: 8px;
+  border-radius: 999px;
+  background: rgba(11, 9, 23, 0.55);
+  font-size: 10.5px;
+  font-weight: 800;
+  color: var(--muted);
+}
+.giveaway-platform .gp-shop-tab.is-active .gp-shop-tab-count {
+  background: rgba(255, 255, 255, 0.18);
+  color: #fff;
+}
+
+.giveaway-platform .gp-shop-card { position: relative; }
+.giveaway-platform .gp-shop-card.affordable {
+  border-color: rgba(74, 222, 128, 0.5);
+  box-shadow: 0 0 22px rgba(74, 222, 128, 0.14);
+}
+.giveaway-platform .gp-shop-badge {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: rgba(74, 222, 128, 0.16);
+  border: 1px solid rgba(74, 222, 128, 0.42);
+  color: #4ade80;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+.giveaway-platform .gp-shop-progress {
+  width: 100%;
+  height: 4px;
+  border-radius: 2px;
+  background: rgba(11, 9, 23, 0.7);
+  margin: 4px 0 8px;
+  overflow: hidden;
+}
+.giveaway-platform .gp-shop-progress-fill {
+  display: block;
+  height: 100%;
+  background: linear-gradient(90deg, var(--sp-orange), var(--gold));
+  transition: width 0.4s ease-out;
+}
 
 /* Responsive: streak 7-col → apila en móvil. */
 @media (max-width: 720px) {

--- a/src/app/sorteos/plataforma/platform.css
+++ b/src/app/sorteos/plataforma/platform.css
@@ -194,6 +194,49 @@
 }
 .giveaway-platform .gp-dd-item span { font-size: 10.5px; color: var(--muted); }
 
+/* Scalable dropdown: search input + scrollable list + empty state */
+.giveaway-platform .gp-dd-search {
+  width: 100%;
+  padding: 8px 10px;
+  margin-bottom: 6px;
+  border-radius: 9px;
+  background: rgba(11, 9, 23, 0.6);
+  border: 1px solid rgba(196, 40, 128, 0.28);
+  color: var(--txt);
+  font-family: var(--font-body), sans-serif;
+  font-size: 12.5px;
+  outline: none;
+  transition: border-color 0.15s;
+}
+.giveaway-platform .gp-dd-search::placeholder { color: var(--muted); }
+.giveaway-platform .gp-dd-search:focus { border-color: rgba(224, 48, 112, 0.55); }
+.giveaway-platform .gp-dd-scroll {
+  max-height: 320px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(224, 48, 112, 0.45) transparent;
+}
+.giveaway-platform .gp-dd-scroll::-webkit-scrollbar { width: 6px; }
+.giveaway-platform .gp-dd-scroll::-webkit-scrollbar-thumb {
+  background: rgba(224, 48, 112, 0.45);
+  border-radius: 3px;
+}
+.giveaway-platform .gp-dd-empty {
+  padding: 14px 10px;
+  text-align: center;
+  font-size: 12px;
+  color: var(--muted);
+  font-style: italic;
+}
+/* Items en el nuevo dropdown son <button>, no <a>: normalizamos */
+.giveaway-platform button.gp-dd-item {
+  width: 100%;
+  border: 1px solid transparent;
+  background: transparent;
+  text-align: left;
+  font-family: inherit;
+}
+
 .giveaway-platform .gp-nav-links { display: flex; gap: 2px; margin: 0 auto; }
 .giveaway-platform .gp-nav-links a {
   color: var(--txt);

--- a/src/app/sorteos/plataforma/platform.css
+++ b/src/app/sorteos/plataforma/platform.css
@@ -286,6 +286,12 @@
   place-items: center;
   font-size: 14px;
   color: #fff;
+  flex-shrink: 0;
+}
+.giveaway-platform .gp-avatar-img {
+  padding: 0;
+  object-fit: cover;
+  border: 1px solid rgba(224, 48, 112, 0.4);
 }
 .giveaway-platform .gp-user-name { font-size: 12.5px; font-weight: 600; }
 .giveaway-platform .gp-balance {

--- a/src/features/giveaway-platform/actions/updateProfile.ts
+++ b/src/features/giveaway-platform/actions/updateProfile.ts
@@ -46,7 +46,17 @@ export async function updateProfile(formData: FormData): Promise<UpdateProfileRe
   const userId = session?.user?.id;
   if (!userId) return { ok: false, error: 'unauthenticated' };
 
-  const parsed = UpdateProfileSchema.safeParse(Object.fromEntries(formData));
+  // Normalización: los checkboxes HTML no envían el campo cuando están
+  // desmarcados. El form incluye un `hasPrivateField=1` para que podamos
+  // distinguir "el form NO tocó privacidad" (isPrivate ausente sin flag)
+  // de "el usuario desmarcó el toggle" (flag presente, isPrivate ausente).
+  const raw = Object.fromEntries(formData) as Record<string, unknown>;
+  if (raw.hasPrivateField === '1' && !('isPrivate' in raw)) {
+    raw.isPrivate = 'false';
+  }
+  delete raw.hasPrivateField;
+
+  const parsed = UpdateProfileSchema.safeParse(raw);
   if (!parsed.success) {
     return { ok: false, fieldErrors: parsed.error.flatten().fieldErrors };
   }

--- a/src/features/giveaway-platform/actions/updateProfile.ts
+++ b/src/features/giveaway-platform/actions/updateProfile.ts
@@ -1,0 +1,78 @@
+'use server';
+
+import { headers } from 'next/headers';
+import { revalidatePath } from 'next/cache';
+import { eq } from 'drizzle-orm';
+import { z } from 'zod';
+import { auth } from '@/lib/auth';
+import { db } from '@/lib/db';
+import { playerProfiles } from '@/db/schema';
+
+/**
+ * Ajustes de perfil que el propio usuario puede modificar. Todos los campos
+ * son opcionales — mandamos solo lo que cambia. Steam trade URL se sanea
+ * a `https://steamcommunity.com/tradeoffer/new/?partner=...&token=...`.
+ */
+const UpdateProfileSchema = z.object({
+  isPrivate: z
+    .union([z.enum(['true', 'false']), z.boolean()])
+    .transform((v) => (typeof v === 'boolean' ? v : v === 'true'))
+    .optional(),
+  steamTradeUrl: z
+    .string()
+    .trim()
+    .max(500)
+    .refine(
+      (v) => v === '' || /^https:\/\/steamcommunity\.com\/tradeoffer\/new\/\?partner=\d+&token=[A-Za-z0-9_-]+$/.test(v),
+      { message: 'URL de intercambio Steam inválida' },
+    )
+    .optional(),
+  kickUsername: z
+    .string()
+    .trim()
+    .max(100)
+    .regex(/^[a-zA-Z0-9_.-]*$/, { message: 'Solo letras, números, "_", "." o "-"' })
+    .optional(),
+});
+
+export type UpdateProfileResult =
+  | { ok: true }
+  | { ok: false; fieldErrors: Record<string, string[]> }
+  | { ok: false; error: 'unauthenticated' }
+  | { ok: false; error: 'no_profile' };
+
+export async function updateProfile(formData: FormData): Promise<UpdateProfileResult> {
+  const session = await auth.api.getSession({ headers: await headers() });
+  const userId = session?.user?.id;
+  if (!userId) return { ok: false, error: 'unauthenticated' };
+
+  const parsed = UpdateProfileSchema.safeParse(Object.fromEntries(formData));
+  if (!parsed.success) {
+    return { ok: false, fieldErrors: parsed.error.flatten().fieldErrors };
+  }
+
+  const patch: Partial<{
+    isPrivate: boolean;
+    steamTradeUrl: string | null;
+    kickUsername: string | null;
+    updatedAt: Date;
+  }> = { updatedAt: new Date() };
+
+  if (parsed.data.isPrivate !== undefined) patch.isPrivate = parsed.data.isPrivate;
+  if (parsed.data.steamTradeUrl !== undefined) {
+    patch.steamTradeUrl = parsed.data.steamTradeUrl === '' ? null : parsed.data.steamTradeUrl;
+  }
+  if (parsed.data.kickUsername !== undefined) {
+    patch.kickUsername = parsed.data.kickUsername === '' ? null : parsed.data.kickUsername;
+  }
+
+  const existing = await db.query.playerProfiles.findFirst({
+    where: eq(playerProfiles.userId, userId),
+  });
+  if (!existing) return { ok: false, error: 'no_profile' };
+
+  await db.update(playerProfiles).set(patch).where(eq(playerProfiles.userId, userId));
+
+  revalidatePath('/sorteos/plataforma/perfil');
+  return { ok: true };
+}

--- a/src/features/giveaway-platform/components/CreatorDropdown.tsx
+++ b/src/features/giveaway-platform/components/CreatorDropdown.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 
 interface CreatorOption {
@@ -17,6 +17,9 @@ interface Props {
   creators: CreatorOption[];
   activeSlug: string;
 }
+
+/** Umbral a partir del cual mostramos el input de búsqueda. */
+const SEARCH_THRESHOLD = 6;
 
 function CreatorAvatar({ creator, size }: { creator: CreatorOption; size: number }) {
   if (creator.photoUrl) {
@@ -40,6 +43,7 @@ function CreatorAvatar({ creator, size }: { creator: CreatorOption; size: number
 
 export function CreatorDropdown({ creators, activeSlug }: Props) {
   const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
   const router = useRouter();
   const searchParams = useSearchParams();
   const ref = useRef<HTMLDivElement>(null);
@@ -48,16 +52,32 @@ export function CreatorDropdown({ creators, activeSlug }: Props) {
   // Cierre por click fuera. Único useEffect y para una interacción imperativa real.
   useEffect(() => {
     function onDocClick(e: MouseEvent) {
-      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+        setQuery('');
+      }
     }
     document.addEventListener('click', onDocClick);
     return () => document.removeEventListener('click', onDocClick);
   }, []);
 
+  const filtered = useMemo(() => {
+    if (!query) return creators;
+    const q = query.toLowerCase().trim();
+    return creators.filter((c) =>
+      c.name.toLowerCase().includes(q) ||
+      c.slug.toLowerCase().includes(q) ||
+      c.sub.toLowerCase().includes(q)
+    );
+  }, [creators, query]);
+
+  const showSearch = creators.length >= SEARCH_THRESHOLD;
+
   function select(slug: string) {
     const params = new URLSearchParams(searchParams.toString());
     params.set('creador', slug);
     setOpen(false);
+    setQuery('');
     router.push(`/sorteos/plataforma?${params.toString()}`, { scroll: false });
   }
 
@@ -69,22 +89,39 @@ export function CreatorDropdown({ creators, activeSlug }: Props) {
         <CreatorAvatar creator={active} size={22} /> Creador: <span>{active.name}</span> ▾
       </button>
       <div className="gp-dd-menu" role="menu">
-        {creators.map((c) => (
-          <button
-            type="button"
-            key={c.slug}
-            role="menuitem"
-            className={`gp-dd-item${c.slug === activeSlug ? ' on' : ''}`}
-            style={{ ['--c' as string]: c.color }}
-            onClick={() => select(c.slug)}
-          >
-            <CreatorAvatar creator={c} size={30} />
-            <span>
-              <b>{c.name}</b>
-              <span>{c.sub}</span>
-            </span>
-          </button>
-        ))}
+        {showSearch ? (
+          <input
+            type="text"
+            className="gp-dd-search"
+            placeholder="Buscar creador…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            aria-label="Buscar creador"
+            autoFocus
+          />
+        ) : null}
+        <div className="gp-dd-scroll">
+          {filtered.length === 0 ? (
+            <div className="gp-dd-empty">Sin resultados</div>
+          ) : (
+            filtered.map((c) => (
+              <button
+                type="button"
+                key={c.slug}
+                role="menuitem"
+                className={`gp-dd-item${c.slug === activeSlug ? ' on' : ''}`}
+                style={{ ['--c' as string]: c.color }}
+                onClick={() => select(c.slug)}
+              >
+                <CreatorAvatar creator={c} size={30} />
+                <span>
+                  <b>{c.name}</b>
+                  <span>{c.sub}</span>
+                </span>
+              </button>
+            ))
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/features/giveaway-platform/components/ExternalGiveawayCard.tsx
+++ b/src/features/giveaway-platform/components/ExternalGiveawayCard.tsx
@@ -28,7 +28,7 @@ export function ExternalGiveawayCard({ card, finished = false, providerDisplayNa
             {statusLabel(card.status, finished)}
           </span>
         </div>
-        <div className="gp-sorteo-img">
+        <div className="gp-sorteo-img gp-external-img">
           {card.imageUrl ? (
             <Image
               src={card.imageUrl}
@@ -40,6 +40,24 @@ export function ExternalGiveawayCard({ card, finished = false, providerDisplayNa
           ) : (
             <div className="gp-sorteo-img-empty">📷 Sin imagen</div>
           )}
+          {card.prizeCount > 1 ? (
+            <div className="gp-external-prize-strip" aria-hidden>
+              {card.prizesPreview.slice(1, 5).map((p) => (
+                <div key={String(p.id)} className="gp-external-prize-thumb" title={p.title}>
+                  <Image
+                    src={p.imageUrl}
+                    alt=""
+                    width={44}
+                    height={32}
+                    unoptimized
+                  />
+                </div>
+              ))}
+              {card.prizeCount > 5 ? (
+                <div className="gp-external-prize-more">+{card.prizeCount - 5}</div>
+              ) : null}
+            </div>
+          ) : null}
         </div>
         <h3 className="gp-sorteo-title">
           ★ {card.title}
@@ -51,9 +69,38 @@ export function ExternalGiveawayCard({ card, finished = false, providerDisplayNa
             <span className="gp-external-multi">  · +{card.extraPrizeCount} premios</span>
           ) : null}
         </div>
-        <div className="gp-sorteo-meta">
-          👥 <b>{card.participantCount.toLocaleString('es-ES')}</b> participantes
-          {card.minUsers > 0 ? <> · <span>arranca en {card.minUsers}</span></> : null}
+        <div className="gp-external-participants">
+          <div className="gp-external-participants-row">
+            <span className="gp-external-participants-icon" aria-hidden>👥</span>
+            <b className="gp-external-participants-count">
+              {card.participantCount.toLocaleString('es-ES')}
+            </b>
+            <span className="gp-external-participants-label">participantes</span>
+          </div>
+          {card.minUsers > 0 && card.participantCount < card.minUsers ? (
+            <>
+              <div
+                className="gp-external-participants-bar"
+                role="progressbar"
+                aria-valuenow={card.participantCount}
+                aria-valuemin={0}
+                aria-valuemax={card.minUsers}
+                aria-label="Progreso hacia el mínimo para arrancar"
+              >
+                <span
+                  className="gp-external-participants-bar-fill"
+                  style={{
+                    width: `${Math.min(100, Math.round((card.participantCount / card.minUsers) * 100))}%`,
+                  }}
+                />
+              </div>
+              <span className="gp-external-participants-min">
+                Arranca en {(card.minUsers - card.participantCount).toLocaleString('es-ES')} más
+              </span>
+            </>
+          ) : card.minUsers > 0 ? (
+            <span className="gp-external-participants-ready">✓ Mínimo alcanzado — arranca ya</span>
+          ) : null}
         </div>
         <div className="gp-sorteo-reward">
           Depósito mín. <b>{formatCurrency(card.depositRequired, card.depositCurrency)}</b>

--- a/src/features/giveaway-platform/components/ExternalGiveawaysSection.tsx
+++ b/src/features/giveaway-platform/components/ExternalGiveawaysSection.tsx
@@ -1,5 +1,6 @@
 import Image from 'next/image';
 import { ExternalGiveawayCard } from './ExternalGiveawayCard';
+import { ProviderRankingPlaceholder } from './ProviderRankingPlaceholder';
 import { getProvider } from '@/lib/external-giveaways/providers';
 import type { ExternalGiveawaySections } from '@/lib/external-giveaways/types';
 
@@ -95,6 +96,11 @@ export function ExternalGiveawaysSection({ sections, creatorDisplayName }: Props
             </div>
           </details>
         ) : null}
+
+        <ProviderRankingPlaceholder
+          providerDisplayName={provider.displayName}
+          creatorDisplayName={creatorDisplayName}
+        />
       </div>
     </section>
   );

--- a/src/features/giveaway-platform/components/MonthlyRanking.tsx
+++ b/src/features/giveaway-platform/components/MonthlyRanking.tsx
@@ -2,6 +2,8 @@ import type { RankingRow } from '@/types/giveawayPlatform';
 
 interface Props {
   rows: RankingRow[];
+  totalPlayers: number;
+  currentUserId: string | null;
 }
 
 function initials(name: string): string {
@@ -16,8 +18,13 @@ function initials(name: string): string {
   return clean.slice(0, 2).toUpperCase();
 }
 
-/** Server Component. El ranking mide tickets de participación, nunca dinero. */
-export function MonthlyRanking({ rows }: Props) {
+/**
+ * Server Component. Ranking global de la plataforma (agrega participaciones
+ * en TODOS los creadores). Read-only: mide tickets, nunca dinero. Muestra
+ * el total de jugadores del mes como contexto y resalta al usuario actual
+ * si aparece en el top.
+ */
+export function MonthlyRanking({ rows, totalPlayers, currentUserId }: Props) {
   if (rows.length === 0) {
     return <p className="gp-rank-empty">Aún no hay participaciones este mes. ¡Sé el primero!</p>;
   }
@@ -33,17 +40,23 @@ export function MonthlyRanking({ rows }: Props) {
   return (
     <>
       <p className="gp-rank-note">
-        Mide participación (tickets), nunca dinero. Los perfiles privados aparecen enmascarados.
+        Ranking global de la plataforma · Top {rows.length} de{' '}
+        <b>{totalPlayers.toLocaleString('es-ES')}</b> jugadores este mes · mide
+        tickets, no dinero · read-only
       </p>
       <div className="gp-rank-podium">
         {podiumOrder.map((row) => {
           if (!row) return null;
           const pos = rows.indexOf(row) + 1;
+          const isMe = row.userId === currentUserId;
           return (
-            <div key={row.userId} className={`gp-rank-podium-card p${pos}`}>
+            <div key={row.userId} className={`gp-rank-podium-card p${pos}${isMe ? ' me' : ''}`}>
               <div className="gp-rank-avatar">{initials(row.displayName)}</div>
               <div className="gp-rank-pos">Puesto {pos}</div>
-              <div className="gp-rank-name">{row.displayName}</div>
+              <div className="gp-rank-name">
+                {row.displayName}
+                {isMe ? <span className="gp-rank-me-tag"> · tú</span> : null}
+              </div>
               <span className="gp-rank-tickets">
                 <b>{row.tickets.toLocaleString('es-ES')}</b> tickets
               </span>
@@ -53,13 +66,19 @@ export function MonthlyRanking({ rows }: Props) {
       </div>
       {rest.length > 0 ? (
         <ol className="gp-rank-list">
-          {rest.map((row, i) => (
-            <li key={row.userId}>
-              <span className="num">{i + 4}</span>
-              <span className="who">{row.displayName}</span>
-              <span className="tix"><b>{row.tickets.toLocaleString('es-ES')}</b> tickets</span>
-            </li>
-          ))}
+          {rest.map((row, i) => {
+            const isMe = row.userId === currentUserId;
+            return (
+              <li key={row.userId} className={isMe ? 'me' : undefined}>
+                <span className="num">{i + 4}</span>
+                <span className="who">
+                  {row.displayName}
+                  {isMe ? <span className="gp-rank-me-tag"> · tú</span> : null}
+                </span>
+                <span className="tix"><b>{row.tickets.toLocaleString('es-ES')}</b> tickets</span>
+              </li>
+            );
+          })}
         </ol>
       ) : null}
     </>

--- a/src/features/giveaway-platform/components/PlatformNav.tsx
+++ b/src/features/giveaway-platform/components/PlatformNav.tsx
@@ -16,6 +16,7 @@ interface Props {
   creators: CreatorOption[];
   activeSlug: string;
   userName: string | null;
+  userImage: string | null;
   balance: number;
   loggedIn: boolean;
 }
@@ -29,7 +30,7 @@ const NAV_ITEMS = [
   { href: '#tienda', label: 'Tienda' },
 ];
 
-export function PlatformNav({ creators, activeSlug, userName, balance, loggedIn }: Props) {
+export function PlatformNav({ creators, activeSlug, userName, userImage, balance, loggedIn }: Props) {
   return (
     <nav className="gp-nav" aria-label="Plataforma de sorteos">
       <div className="gp-nav-inner">
@@ -58,7 +59,7 @@ export function PlatformNav({ creators, activeSlug, userName, balance, loggedIn 
           ))}
         </div>
 
-        <UserPill userName={userName} balance={balance} loggedIn={loggedIn} />
+        <UserPill userName={userName} userImage={userImage} balance={balance} loggedIn={loggedIn} />
       </div>
     </nav>
   );

--- a/src/features/giveaway-platform/components/PlatformShop.tsx
+++ b/src/features/giveaway-platform/components/PlatformShop.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useTransition } from 'react';
+import { useMemo, useState, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
 import { redeemShopItem } from '@/app/sorteos/plataforma/actions';
 import type { ShopCategory, ShopItem } from '@/types/giveawayPlatform';
@@ -23,6 +23,18 @@ export function PlatformShop({ items, balance }: Props) {
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
 
+  const counts = useMemo<Record<string, number>>(() => {
+    const byCat: Record<string, number> = { all: items.length };
+    for (const it of items) byCat[it.category] = (byCat[it.category] ?? 0) + 1;
+    return byCat;
+  }, [items]);
+
+  const cheapestUnaffordable = useMemo(() => {
+    const stockPos = items.filter((i) => i.stock > 0 && i.costCoins > balance);
+    if (stockPos.length === 0) return null;
+    return stockPos.reduce((a, b) => (a.costCoins <= b.costCoins ? a : b));
+  }, [items, balance]);
+
   const visible = items.filter((i) => category === 'all' || i.category === category);
 
   function handleRedeem(shopItemId: number) {
@@ -36,6 +48,24 @@ export function PlatformShop({ items, balance }: Props) {
 
   return (
     <>
+      <div className="gp-shop-summary">
+        <div className="gp-shop-balance">
+          <span className="l">Tu saldo</span>
+          <b>🪙 {balance.toLocaleString('es-ES')}</b>
+        </div>
+        {cheapestUnaffordable ? (
+          <div className="gp-shop-next">
+            Siguiente premio a tu alcance:{' '}
+            <b>{cheapestUnaffordable.name}</b> — te faltan{' '}
+            <span className="gp-shop-next-gap">
+              {(cheapestUnaffordable.costCoins - balance).toLocaleString('es-ES')} 🪙
+            </span>
+          </div>
+        ) : items.length > 0 ? (
+          <div className="gp-shop-next ok">✓ Puedes canjear cualquier premio disponible.</div>
+        ) : null}
+      </div>
+
       <div className="gp-shop-tabs">
         {CATEGORIES.map((c) => (
           <button
@@ -45,42 +75,54 @@ export function PlatformShop({ items, balance }: Props) {
             className={`gp-shop-tab${category === c.key ? ' is-active' : ''}`}
           >
             {c.label}
+            <span className="gp-shop-tab-count">{counts[c.key] ?? 0}</span>
           </button>
         ))}
       </div>
       {error ? <p className="gp-shop-error">{error}</p> : null}
-      <div className="gp-shop-grid">
-        {visible.map((item) => {
-          const affordable = balance >= item.costCoins && item.stock > 0;
-          const stockClass = item.stock === 0 ? ' gone' : item.stock < 4 ? ' low' : '';
-          return (
-            <div key={item.id} className="gp-shop-card">
-              <div className="gp-shop-img">
-                {item.imageUrl ? (
-                  // eslint-disable-next-line @next/next/no-img-element
-                  <img src={item.imageUrl} alt={item.name} />
-                ) : (
-                  <div className="gp-shop-img-empty">Imagen pendiente</div>
-                )}
+      {visible.length === 0 ? (
+        <p className="gp-rank-empty">
+          No hay artículos en esta categoría. Prueba otra pestaña.
+        </p>
+      ) : (
+        <div className="gp-shop-grid">
+          {visible.map((item) => {
+            const affordable = balance >= item.costCoins && item.stock > 0;
+            const stockClass = item.stock === 0 ? ' gone' : item.stock < 4 ? ' low' : '';
+            const pct = Math.min(100, Math.round((balance / Math.max(1, item.costCoins)) * 100));
+            return (
+              <div key={item.id} className={`gp-shop-card${affordable ? ' affordable' : ''}`}>
+                <div className="gp-shop-img">
+                  {item.imageUrl ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img src={item.imageUrl} alt={item.name} />
+                  ) : (
+                    <div className="gp-shop-img-empty">Imagen pendiente</div>
+                  )}
+                  {affordable ? <span className="gp-shop-badge">Disponible</span> : null}
+                </div>
+                <h4 className="gp-shop-name">{item.name}</h4>
+                {item.description ? <p className="gp-shop-desc">{item.description}</p> : <p className="gp-shop-desc" />}
+                <div className="gp-shop-cost">🪙 {item.costCoins.toLocaleString('es-ES')}</div>
+                <div className="gp-shop-progress" aria-hidden>
+                  <span className="gp-shop-progress-fill" style={{ width: `${pct}%` }} />
+                </div>
+                <div className={`gp-shop-stock${stockClass}`}>
+                  {item.stock > 0 ? `${item.stock} en stock` : 'Agotado'}
+                </div>
+                <button
+                  type="button"
+                  onClick={() => handleRedeem(item.id)}
+                  disabled={!affordable || isPending}
+                  className="gp-shop-btn"
+                >
+                  {isPending ? 'Canjeando…' : affordable ? 'Canjear' : `Faltan ${(item.costCoins - balance).toLocaleString('es-ES')} 🪙`}
+                </button>
               </div>
-              <h4 className="gp-shop-name">{item.name}</h4>
-              {item.description ? <p className="gp-shop-desc">{item.description}</p> : <p className="gp-shop-desc" />}
-              <div className="gp-shop-cost">🪙 {item.costCoins.toLocaleString('es-ES')}</div>
-              <div className={`gp-shop-stock${stockClass}`}>
-                {item.stock > 0 ? `${item.stock} en stock` : 'Agotado'}
-              </div>
-              <button
-                type="button"
-                onClick={() => handleRedeem(item.id)}
-                disabled={!affordable || isPending}
-                className="gp-shop-btn"
-              >
-                Canjear
-              </button>
-            </div>
-          );
-        })}
-      </div>
+            );
+          })}
+        </div>
+      )}
     </>
   );
 }

--- a/src/features/giveaway-platform/components/ProfileSettingsForm.tsx
+++ b/src/features/giveaway-platform/components/ProfileSettingsForm.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { updateProfile, type UpdateProfileResult } from '@/features/giveaway-platform/actions/updateProfile';
+
+interface Props {
+  initialIsPrivate: boolean;
+  initialSteamTradeUrl: string | null;
+  initialKickUsername: string | null;
+}
+
+export function ProfileSettingsForm({ initialIsPrivate, initialSteamTradeUrl, initialKickUsername }: Props) {
+  const [isPending, startTransition] = useTransition();
+  const [result, setResult] = useState<UpdateProfileResult | null>(null);
+
+  function handleSubmit(formData: FormData) {
+    setResult(null);
+    startTransition(async () => {
+      const r = await updateProfile(formData);
+      setResult(r);
+    });
+  }
+
+  const errors = result && 'fieldErrors' in result ? result.fieldErrors : {};
+
+  return (
+    <form action={handleSubmit} className="gp-profile-form">
+      <div className="gp-profile-field">
+        <label htmlFor="pf-tradeurl">
+          <b>Steam Trade URL</b>
+          <span>Necesaria para enviar premios físicos digitales (skins).</span>
+        </label>
+        <input
+          id="pf-tradeurl"
+          name="steamTradeUrl"
+          type="url"
+          defaultValue={initialSteamTradeUrl ?? ''}
+          placeholder="https://steamcommunity.com/tradeoffer/new/?partner=…&token=…"
+          spellCheck={false}
+        />
+        {errors.steamTradeUrl?.[0] ? (
+          <span className="gp-profile-err">{errors.steamTradeUrl[0]}</span>
+        ) : null}
+      </div>
+
+      <div className="gp-profile-field">
+        <label htmlFor="pf-kick">
+          <b>Usuario de Kick</b>
+          <span>Vinculación opcional para misiones que requieren interacción en Kick.</span>
+        </label>
+        <input
+          id="pf-kick"
+          name="kickUsername"
+          type="text"
+          defaultValue={initialKickUsername ?? ''}
+          placeholder="tuUsuario"
+          spellCheck={false}
+        />
+        {errors.kickUsername?.[0] ? (
+          <span className="gp-profile-err">{errors.kickUsername[0]}</span>
+        ) : null}
+      </div>
+
+      <div className="gp-profile-field gp-profile-toggle">
+        <label htmlFor="pf-private">
+          <b>Perfil privado</b>
+          <span>Si está activo, tu nombre aparece enmascarado en el ranking global (k*****).</span>
+        </label>
+        <input
+          id="pf-private"
+          name="isPrivate"
+          type="checkbox"
+          defaultChecked={initialIsPrivate}
+          value="true"
+        />
+      </div>
+
+      <div className="gp-profile-actions">
+        <button type="submit" className="gp-btn gp-btn-primary" disabled={isPending}>
+          {isPending ? 'Guardando…' : 'Guardar cambios'}
+        </button>
+        {result?.ok ? <span className="gp-profile-ok">✔ Guardado</span> : null}
+        {result && !result.ok && 'error' in result ? (
+          <span className="gp-profile-err">
+            {result.error === 'unauthenticated' ? 'Sesión expirada, vuelve a entrar' : 'No hay perfil vinculado a esta cuenta'}
+          </span>
+        ) : null}
+      </div>
+    </form>
+  );
+}

--- a/src/features/giveaway-platform/components/ProfileSettingsForm.tsx
+++ b/src/features/giveaway-platform/components/ProfileSettingsForm.tsx
@@ -66,6 +66,10 @@ export function ProfileSettingsForm({ initialIsPrivate, initialSteamTradeUrl, in
           <b>Perfil privado</b>
           <span>Si está activo, tu nombre aparece enmascarado en el ranking global (k*****).</span>
         </label>
+        {/* Un checkbox HTML nativo no envía el campo cuando está desmarcado.
+            Marcamos con un flag "hasPrivateField" que el server usa para
+            interpretar la ausencia como false en lugar de "no tocar". */}
+        <input type="hidden" name="hasPrivateField" value="1" />
         <input
           id="pf-private"
           name="isPrivate"

--- a/src/features/giveaway-platform/components/ProviderRankingPlaceholder.tsx
+++ b/src/features/giveaway-platform/components/ProviderRankingPlaceholder.tsx
@@ -1,0 +1,38 @@
+interface Props {
+  providerDisplayName: string;
+  creatorDisplayName: string;
+}
+
+/**
+ * Placeholder read-only del ranking mensual por provider externo.
+ * Los providers (KeyDrop, CSGORoll, etc.) no exponen endpoints públicos de
+ * top-participantes de forma estable; hasta que llegue esa integración
+ * mostramos un skeleton de 5 puestos + copy claro de "próximamente".
+ *
+ * Renderiza dentro de la sección de ExternalGiveaways debajo de la
+ * collapsible de finalizados. Sin efectos, sin datos reales: solo shell.
+ */
+export function ProviderRankingPlaceholder({ providerDisplayName, creatorDisplayName }: Props) {
+  const rows = Array.from({ length: 5 }, (_, i) => i + 1);
+  return (
+    <section className="gp-provider-rank">
+      <h3 className="gp-provider-rank-title">
+        🏆 Top participantes en {providerDisplayName} · {creatorDisplayName}
+      </h3>
+      <p className="gp-provider-rank-note">
+        Próximamente. El ranking mensual por provider externo se activará cuando conectemos su
+        endpoint de participantes / ganadores. Este bloque quedará poblado con datos reales sin
+        cambiar la UI.
+      </p>
+      <ol className="gp-provider-rank-list">
+        {rows.map((n) => (
+          <li key={n} aria-hidden>
+            <span className="num">{n}</span>
+            <span className="skeleton skeleton-name" />
+            <span className="skeleton skeleton-value" />
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}

--- a/src/features/giveaway-platform/components/UserPill.tsx
+++ b/src/features/giveaway-platform/components/UserPill.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import { useEffect, useRef, useState, useTransition } from 'react';
 import { steamLogout } from '@/features/giveaway-platform/actions/steamLogout';
 
@@ -68,27 +69,27 @@ export function UserPill({ userName, balance, loggedIn }: Props) {
         <span className="gp-chev" aria-hidden>▾</span>
       </button>
       <div className="gp-user-menu" role="menu">
-        <button type="button" role="menuitem" className="gp-um-item" data-todo="profile-config">
+        <Link href="/sorteos/plataforma/perfil" role="menuitem" className="gp-um-item" onClick={() => setOpen(false)}>
           <span className="i" aria-hidden>⚙️</span>
           <span>
-            <b>Configuración</b>
-            <span>Ajusta tu perfil</span>
+            <b>Mi perfil</b>
+            <span>Ajustes, inventario y saldo</span>
           </span>
-        </button>
-        <button type="button" role="menuitem" className="gp-um-item" data-todo="profile-inv">
+        </Link>
+        <Link href="/sorteos/plataforma/perfil#inventario" role="menuitem" className="gp-um-item" onClick={() => setOpen(false)}>
           <span className="i" aria-hidden>🎒</span>
           <span>
             <b>Inventario</b>
             <span>Ver tu historial de premios</span>
           </span>
-        </button>
-        <button type="button" role="menuitem" className="gp-um-item" data-todo="profile-tx">
+        </Link>
+        <Link href="/sorteos/plataforma/perfil#transacciones" role="menuitem" className="gp-um-item" onClick={() => setOpen(false)}>
           <span className="i" aria-hidden>🧾</span>
           <span>
             <b>Transacciones</b>
             <span>Revisa tu historial de monedas</span>
           </span>
-        </button>
+        </Link>
         <button
           type="button"
           role="menuitem"

--- a/src/features/giveaway-platform/components/UserPill.tsx
+++ b/src/features/giveaway-platform/components/UserPill.tsx
@@ -6,6 +6,7 @@ import { steamLogout } from '@/features/giveaway-platform/actions/steamLogout';
 
 interface Props {
   userName: string | null;
+  userImage: string | null;
   balance: number;
   loggedIn: boolean;
 }
@@ -16,7 +17,7 @@ interface Props {
  * Logout = server action que llama a auth.api.signOut y redirige.
  * Perfil/Inventario/Transacciones siguen marcados como `data-todo` — PR3.
  */
-export function UserPill({ userName, balance, loggedIn }: Props) {
+export function UserPill({ userName, userImage, balance, loggedIn }: Props) {
   const [open, setOpen] = useState(false);
   const [isPending, startTransition] = useTransition();
   const ref = useRef<HTMLDivElement>(null);
@@ -60,7 +61,19 @@ export function UserPill({ userName, balance, loggedIn }: Props) {
   return (
     <div ref={ref} className={`gp-user-wrap${open ? ' open' : ''}`}>
       <button type="button" className="gp-user-pill" onClick={() => setOpen((v) => !v)}>
-        <span className="gp-avatar" aria-hidden>🐱</span>
+        {userImage ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={userImage}
+            alt=""
+            aria-hidden
+            className="gp-avatar gp-avatar-img"
+            width={26}
+            height={26}
+          />
+        ) : (
+          <span className="gp-avatar" aria-hidden>🎮</span>
+        )}
         <span className="gp-user-name">{userName ?? 'Jugador'}</span>
         <span className="gp-balance">
           <span>{balance.toLocaleString('es-ES')}</span>

--- a/src/lib/external-giveaways/providers/keydrop/fetch.ts
+++ b/src/lib/external-giveaways/providers/keydrop/fetch.ts
@@ -13,18 +13,10 @@ import { keydropItemToCard } from './mapper';
  */
 
 const KEYDROP_BASE_URL = 'https://ws-2071.socket-cs.com/v1/giveaway-user';
-const KEYDROP_LISTING_URL = 'https://key-drop.com/es/giveaways';
+// Listing público del provider (para el badge del registry). El deep link
+// por sorteo lo construye el mapper con `buildKeydropDeepLink(id, promoCode)`.
+const KEYDROP_LISTING_URL = 'https://keydrop.com/es/giveaways';
 const KEYDROP_REVALIDATE_SECONDS = 60;
-
-/**
- * URL destino del botón "Ver en KeyDrop". KeyDrop no expone URL pública
- * individual por giveaway (verificado 2026-07 — devuelve 404); apuntamos
- * al listing general. Si en el futuro KeyDrop publica URLs por id,
- * actualizar aquí y el argumento _id vuelve a interpolarse.
- */
-function buildKeydropExternalUrl(_id: string): string {
-  return KEYDROP_LISTING_URL;
-}
 
 /**
  * Fetch para un creador concreto: llama /api/list y mapea. Devuelve el
@@ -60,10 +52,10 @@ export async function fetchKeydropForCreator(input: {
   }
 
   const active = res.data.data.active.map((item) =>
-    keydropItemToCard({ item, creatorSlug, externalUrl: buildKeydropExternalUrl(item.id) })
+    keydropItemToCard({ item, creatorSlug })
   );
   const finished = res.data.data.finished.map((item) =>
-    keydropItemToCard({ item, creatorSlug, externalUrl: buildKeydropExternalUrl(item.id) })
+    keydropItemToCard({ item, creatorSlug })
   );
   return { ok: true, active, finished };
 }

--- a/src/lib/external-giveaways/providers/keydrop/mapper.ts
+++ b/src/lib/external-giveaways/providers/keydrop/mapper.ts
@@ -15,9 +15,15 @@ import type { KeydropListItem, KeydropRequirement } from './zod-schemas';
  *   - `totalValue = totalPrizes` si viene; si no, suma de `prizes[].price`.
  *   - `promoCode`: primer requirement con `promoCode`, o
  *     `organizer.promocode` como fallback.
- *   - `externalUrl` viene inyectado por el fetch (proviene del listing URL
- *     del provider registry). NO se construye desde `id` porque KeyDrop no
- *     expone URL individual pública.
+ *   - `externalUrl` se construye con `buildKeydropDeepLink(id, promoCode)`:
+ *     usamos el shortener oficial `kd.link` que aplica el promocode del
+ *     creador y deep-linkea al giveaway concreto. Diagnóstico HEAD/curl
+ *     (2026-07): `key-drop.com` con guión devuelve 403 (Cloudflare) para
+ *     todo path; `keydrop.com/es/giveaways/{id}` responde 200 con
+ *     `<link rel="alternate">` para los 12 locales del mismo path
+ *     (canónico); `kd.link/?code=X&giveaway=Y` redirige 301 →
+ *     `keydrop.com/?code=X&giveaway=Y` (200) — preferido porque preserva
+ *     el promocode del creador para affiliate tracking.
  *   - `imageUrl` = `prizes[0].itemImg` (primer premio como portada; el
  *     conteo total va en `prizeCount`; el resto en `prizesPreview`).
  *   - `status` mapeado a los 3 valores universales:
@@ -29,10 +35,39 @@ import type { KeydropListItem, KeydropRequirement } from './zod-schemas';
 interface MapInput {
   item: KeydropListItem;
   creatorSlug: string;
-  externalUrl: string;
 }
 
-export function keydropItemToCard({ item, creatorSlug, externalUrl }: MapInput): ExternalGiveawayCard {
+/** Fallback si por algún motivo llegamos sin promocode ni id — página de listado. */
+const KEYDROP_LISTING_FALLBACK = 'https://keydrop.com/es/giveaways';
+
+/**
+ * Construye la URL destino del CTA de la card para un giveaway KeyDrop.
+ *
+ * Prioridad:
+ *   1. `kd.link/?code={promo}&giveaway={id}` — shortener oficial. Aplica el
+ *      promocode del creador y deep-linkea al sorteo. Best-in-class.
+ *   2. `keydrop.com/es/giveaways/{id}` — path canónico (verificado en el
+ *      HTML shell, sirve `<link rel="alternate">` para 12 locales del
+ *      mismo path). No aplica promocode.
+ *   3. Listing genérico — solo si faltan ambos id y promocode (no debería
+ *      ocurrir con datos válidos).
+ *
+ * Los inputs se URL-encodean para no romper si un promocode contiene
+ * caracteres reservados en el futuro.
+ */
+export function buildKeydropDeepLink(id: string, promoCode: string | undefined): string {
+  const safeId = id ? encodeURIComponent(id) : '';
+  const safeCode = promoCode ? encodeURIComponent(promoCode) : '';
+  if (safeId && safeCode) {
+    return `https://kd.link/?code=${safeCode}&giveaway=${safeId}`;
+  }
+  if (safeId) {
+    return `https://keydrop.com/es/giveaways/${safeId}`;
+  }
+  return KEYDROP_LISTING_FALLBACK;
+}
+
+export function keydropItemToCard({ item, creatorSlug }: MapInput): ExternalGiveawayCard {
   const firstPrize = item.prizes[0];
 
   const totalFromSum = item.prizes.reduce((acc, p) => acc + (typeof p.price === 'number' ? p.price : 0), 0);
@@ -99,7 +134,7 @@ export function keydropItemToCard({ item, creatorSlug, externalUrl }: MapInput):
     startsAt: item.startDate ? new Date(item.startDate) : new Date(item.createdAt),
     endsAt: item.deadlineTimestamp !== null ? new Date(item.deadlineTimestamp) : null,
     promoCode,
-    externalUrl,
+    externalUrl: buildKeydropDeepLink(item.id, promoCode),
     prizesPreview,
     prizeCount,
     extraPrizeCount,

--- a/src/lib/queries/giveawayPlatform.ts
+++ b/src/lib/queries/giveawayPlatform.ts
@@ -135,6 +135,27 @@ export async function getMonthlyRanking(limit = 10): Promise<RankingRow[]> {
 }
 
 /**
+ * Total de jugadores distintos con participación este mes. Contexto para el
+ * ranking global — permite mostrar "top 10 de 1.234 jugadores".
+ *
+ * @cache none
+ * @visibility public
+ */
+export async function getMonthlyRankingTotal(): Promise<number> {
+  const monthStart = new Date();
+  monthStart.setUTCDate(1);
+  monthStart.setUTCHours(0, 0, 0, 0);
+
+  const [row] = await db
+    .select({
+      total: sql<number>`count(distinct ${giveawayEntries.userId})::int`,
+    })
+    .from(giveawayEntries)
+    .where(gte(giveawayEntries.createdAt, monthStart));
+  return row?.total ?? 0;
+}
+
+/**
  * Items de tienda activos con stock, por categoría opcional.
  *
  * @cache none
@@ -173,4 +194,65 @@ export async function getUserRedemptions(userId: string): Promise<(Redemption & 
     with: { shopItem: true },
     orderBy: (r, { desc: d }) => [d(r.createdAt)],
   }) as Promise<(Redemption & { shopItem: ShopItem })[]>;
+}
+
+/**
+ * Métricas agregadas del usuario para el perfil premium:
+ *  - entriesTotal: participaciones totales de por vida
+ *  - entriesMonth: participaciones del mes natural en curso
+ *  - distinctCreators: creadores distintos en los que ha entrado (all-time)
+ *  - redemptionsCount: canjes realizados en tienda (all-time)
+ *
+ * @cache none
+ * @visibility public (propio usuario)
+ */
+export async function getUserStats(userId: string): Promise<{
+  entriesTotal: number;
+  entriesMonth: number;
+  distinctCreators: number;
+  redemptionsCount: number;
+}> {
+  const monthStart = new Date();
+  monthStart.setUTCDate(1);
+  monthStart.setUTCHours(0, 0, 0, 0);
+
+  const [entriesTotalRow, entriesMonthRow, creatorsRow, redemptionsRow] = await Promise.all([
+    db
+      .select({ n: count(giveawayEntries.id) })
+      .from(giveawayEntries)
+      .where(eq(giveawayEntries.userId, userId)),
+    db
+      .select({ n: count(giveawayEntries.id) })
+      .from(giveawayEntries)
+      .where(and(eq(giveawayEntries.userId, userId), gte(giveawayEntries.createdAt, monthStart))),
+    db
+      .select({ n: sql<number>`count(distinct ${giveaways.talentId})::int` })
+      .from(giveawayEntries)
+      .innerJoin(giveaways, eq(giveaways.id, giveawayEntries.giveawayId))
+      .where(eq(giveawayEntries.userId, userId)),
+    db
+      .select({ n: count(redemptions.id) })
+      .from(redemptions)
+      .where(eq(redemptions.userId, userId)),
+  ]);
+
+  return {
+    entriesTotal: entriesTotalRow[0]?.n ?? 0,
+    entriesMonth: entriesMonthRow[0]?.n ?? 0,
+    distinctCreators: creatorsRow[0]?.n ?? 0,
+    redemptionsCount: redemptionsRow[0]?.n ?? 0,
+  };
+}
+
+/**
+ * Fila `player_profiles` del usuario. Puede ser `null` si aún no se generó
+ * (caso teórico: Steam OpenID crea la fila en el hook post-signup).
+ *
+ * @cache none
+ * @visibility public (propio usuario)
+ */
+export async function getPlayerProfile(userId: string) {
+  return db.query.playerProfiles.findFirst({
+    where: eq(playerProfiles.userId, userId),
+  });
 }


### PR DESCRIPTION
## Summary

Overnight autonomous execution de 9 prioridades sobre `/sorteos/plataforma`. 3 commits temáticos, +1200 líneas, 83 tests estructurales nuevos (todos verdes), 0 errores TS/ESLint en `src/`.

### Sorteos externos (KeyDrop) — 3 mejoras UI
- Multi-prize strip: miniaturas de premios adicionales superpuestas al pie de la imagen, badge "+N" si hay más de 5.
- Bloque de participantes rediseñado: count grande en `sp-pink`, progressbar accesible hacia `minUsers`, estado "Mínimo alcanzado" en verde.
- `ProviderRankingPlaceholder` debajo de finalizados: skeleton animado (respeta `prefers-reduced-motion`) + copy claro "Próximamente".

### Perfiles nuevos
- **`/sorteos/plataforma/perfil`** (noindex): server component con hero Steam, 4 stat cards (saldo, racha, participaciones totales/mes, creadores distintos), ajustes editables (Steam trade URL validado por regex, kick, toggle privado), inventario y últimas 10 transacciones. Server action con Zod safeParse + `revalidatePath`.
- **`/sorteos/plataforma/creadores/[slug]`** (noindex, placeholder-friendly): hero con gradient dinámico del talent, socials, 4 tarjetas "próximamente" con dashed border para estadísticas históricas.
- **`CreatorDropdown`** escalable a 15+ creadores: buscador condicional (`>=6`), filtrado por name/slug/sub con `useMemo`, wrapper `.gp-dd-scroll` + empty state.

### Ranking global + tienda enriquecida
- `MonthlyRanking`: copy explícito "Ranking global · mensual", muestra total de jugadores del mes, resalta al usuario actual con clase `.me`. Read-only (sin botones).
- `PlatformShop`: summary top con saldo + próximo canjeable a tu alcance, tabs con badge de count, cards `affordable` en verde, progress bar por card, botón "Faltan N 🪙" cuando no llega.

### Doc
- `docs/giveaway-coin-economy-plan.md`: plan técnico para monedas por click/participación — reglas de idempotencia (`ref_key` UNIQUE), caps por fuente, verificadores server-side, 5 fases sugeridas. Doc-only.

## Test plan
- [x] `npx tsc --noEmit` — 0 errores en `src/`
- [x] `npx jest src/__tests__/server/` — 2289 passing (incluye los 83 nuevos)
- [x] ESLint en los 12 archivos tocados — 0 warnings
- [ ] Smoke manual: /sorteos/plataforma, /perfil (con Steam login), /creadores/naow
- [ ] Verificar en mobile (grid stats colapsa a 2 columnas @ <900px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)