### PR TITLE
fix(sorteos): card SkinsMonkey — patrón hero-top con banner cover

### DIFF
--- a/src/__tests__/server/brand-card-skinsmonkey.test.ts
+++ b/src/__tests__/server/brand-card-skinsmonkey.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Rediseño de la card SkinsMonkey (2026-07-03).
+ *
+ * Motivación: `constants/brands.ts` documenta que el `agentAsset` de
+ * SkinsMonkey viene de gstatic en baja resolución. En el patrón "agente
+ * flotante" que usan las otras cards la miniatura queda pequeña y
+ * recortada. Se rediseña a patrón "hero-top": banner ancho completo
+ * arriba con object-fit cover y overlay + contenido debajo.
+ *
+ * Contratos verificados:
+ *  - La card usa `.p-monkey` (modificadora de `.p-gold`), no la anterior
+ *    combinación de `.p-gold` sola con `<div className="gp-brand-agent-wrap">`.
+ *  - El hero usa <Image fill> + sizes responsive.
+ *  - CSS del hero fuerza aspect-ratio, overflow hidden, object-fit cover
+ *    y object-position que centra bien pese al thumbnail de baja calidad.
+ *  - Overlay gradient garantiza legibilidad al pasar de imagen a fondo.
+ *  - Las otras cards (KeyDrop, CSGO-SKINS, Skin.Club) mantienen el patrón
+ *    agente-flotante — no se tocan.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(__dirname, '..', '..', '..');
+const read = (rel: string) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');
+
+describe('[brand-card-skinsmonkey] hero-top layout', () => {
+  const src = read('src/features/giveaway-platform/components/BrandCardSkinsMonkey.tsx');
+
+  it('la card usa la modificadora .p-monkey junto a .p-gold', () => {
+    expect(src).toMatch(/className="gp-card\s+p-gold\s+p-monkey"/);
+  });
+
+  it('YA NO usa el patrón agente-flotante `.gp-brand-agent-wrap`', () => {
+    expect(src).not.toMatch(/gp-brand-agent-wrap/);
+    expect(src).not.toMatch(/gp-brand-agent\b/);
+  });
+
+  it('monta el hero como <div class="gp-monkey-hero"> con <Image fill>', () => {
+    expect(src).toMatch(/<div className="gp-monkey-hero"[\s\S]{0,120}aria-hidden/);
+    expect(src).toMatch(/<Image[\s\S]{0,200}fill[\s\S]{0,200}gp-monkey-hero-img/);
+  });
+
+  it('sizes responsive (banner mobile, ancho fijo desktop)', () => {
+    expect(src).toMatch(/sizes="\(max-width:\s*720px\)\s*100vw,\s*520px"/);
+  });
+
+  it('renderiza el overlay como <span class="gp-monkey-hero-overlay">', () => {
+    expect(src).toMatch(/gp-monkey-hero-overlay/);
+  });
+
+  it('separa el contenido en `.gp-monkey-body` (padding controlado)', () => {
+    expect(src).toMatch(/<div className="gp-monkey-body">/);
+  });
+
+  it('mantiene logo + oferta + código + CTA "Reclamar"', () => {
+    expect(src).toMatch(/gp-brand-logo/);
+    expect(src).toMatch(/pill-offer/);
+    expect(src).toMatch(/35% Bonus \+ hasta 5\$ Gratis/);
+    expect(src).toMatch(/Reclamar/);
+  });
+});
+
+describe('[brand-card-skinsmonkey] CSS del hero-top', () => {
+  const css = read('src/app/sorteos/plataforma/platform-brand-cards.css');
+
+  it('.p-monkey elimina el padding para dejar el hero a full-width', () => {
+    expect(css).toMatch(/\.p-monkey\s*\{[\s\S]{0,200}padding:\s*0/);
+    expect(css).toMatch(/\.p-monkey\s*\{[\s\S]{0,200}overflow:\s*hidden/);
+  });
+
+  it('.gp-monkey-hero fuerza aspect-ratio + overflow hidden + fallback bg', () => {
+    expect(css).toMatch(/\.gp-monkey-hero\s*\{[\s\S]{0,400}aspect-ratio:\s*16\s*\/\s*8/);
+    expect(css).toMatch(/\.gp-monkey-hero\s*\{[\s\S]{0,400}overflow:\s*hidden/);
+    expect(css).toMatch(/\.gp-monkey-hero\s*\{[\s\S]{0,400}background:\s*linear-gradient/);
+  });
+
+  it('.gp-monkey-hero-img usa object-fit cover + object-position que evita cortes malos', () => {
+    expect(css).toMatch(/\.gp-monkey-hero-img\s*\{[\s\S]{0,200}object-fit:\s*cover/);
+    expect(css).toMatch(/\.gp-monkey-hero-img\s*\{[\s\S]{0,200}object-position:\s*center\s+\d+%/);
+  });
+
+  it('.gp-monkey-hero-overlay define gradient de abajo hacia arriba para legibilidad', () => {
+    expect(css).toMatch(/\.gp-monkey-hero-overlay\s*\{[\s\S]{0,500}linear-gradient\(180deg/);
+  });
+
+  it('mobile responsive: aspect-ratio 16/9 en <=720px', () => {
+    expect(css).toMatch(/@media\s*\(max-width:\s*720px\)[\s\S]{0,300}\.gp-monkey-hero\s*\{[\s\S]{0,120}aspect-ratio:\s*16\s*\/\s*9/);
+  });
+});
+
+describe('[brand-card-skinsmonkey] otras cards intactas', () => {
+  it('KeyDrop sigue usando .p-keydrop con .gp-brand-keydrop-banner', () => {
+    const src = read('src/features/giveaway-platform/components/BrandCardKeyDrop.tsx');
+    expect(src).toMatch(/p-keydrop/);
+  });
+
+  it('CSGO-SKINS sigue usando .p-red', () => {
+    const src = read('src/features/giveaway-platform/components/BrandCardCsgoskins.tsx');
+    expect(src).toMatch(/p-red/);
+    // No lleva la modificadora .p-monkey por error.
+    expect(src).not.toMatch(/p-monkey/);
+  });
+
+  it('Skin.Club sigue usando .p-skinclub', () => {
+    const src = read('src/features/giveaway-platform/components/BrandCardSkinClub.tsx');
+    expect(src).toMatch(/p-skinclub/);
+    expect(src).not.toMatch(/p-monkey/);
+  });
+});

--- a/src/app/sorteos/plataforma/platform-brand-cards.css
+++ b/src/app/sorteos/plataforma/platform-brand-cards.css
@@ -189,6 +189,64 @@
   box-shadow: 0 6px 22px rgba(245, 183, 61, 0.35);
 }
 
+/* ================ SKINSMONKEY (hero-top variant of .p-gold) ================
+ * Rediseño 2026-07-03: la card de SkinsMonkey usa una imagen hero a ancho
+ * completo arriba en lugar del "agente flotante" que usan las demás. Esto
+ * disimula la baja calidad del thumbnail actual (marcado como TODO en
+ * constants/brands.ts) y le da más protagonismo visual.
+ */
+.giveaway-platform .p-monkey {
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.giveaway-platform .gp-monkey-hero {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 8;
+  min-height: 190px;
+  overflow: hidden;
+  background: linear-gradient(160deg, #2b1e40, #0d0a18);
+}
+.giveaway-platform .gp-monkey-hero-img {
+  object-fit: cover;
+  object-position: center 35%;
+  filter: saturate(1.05) contrast(1.02);
+}
+.giveaway-platform .gp-monkey-hero-overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    linear-gradient(180deg,
+      transparent 45%,
+      rgba(11, 8, 20, 0.55) 78%,
+      rgba(11, 8, 20, 0.92) 100%
+    ),
+    radial-gradient(600px 300px at 82% 20%, rgba(245, 183, 61, 0.16), transparent 70%);
+}
+.giveaway-platform .gp-monkey-body {
+  padding: 24px 30px 30px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  flex: 1;
+}
+.giveaway-platform .gp-monkey-body .gp-logo-slot { margin-bottom: 2px; }
+.giveaway-platform .gp-monkey-lead {
+  font-size: 14px;
+  color: var(--txt);
+  margin: 0;
+  line-height: 1.45;
+}
+.giveaway-platform .gp-monkey-body .pill-offer { margin: 4px 0 0; }
+.giveaway-platform .gp-monkey-body .btn-gold { margin-top: 8px; }
+@media (max-width: 720px) {
+  .giveaway-platform .gp-monkey-hero { aspect-ratio: 16 / 9; min-height: 160px; }
+  .giveaway-platform .gp-monkey-body { padding: 20px 22px 24px; }
+}
+
 /* ================ CSGO-SKINS (red variant of .p-gold) ================ */
 .giveaway-platform .p-red {
   border-color: rgba(220, 38, 60, 0.42);

--- a/src/features/giveaway-platform/components/BrandCardSkinsMonkey.tsx
+++ b/src/features/giveaway-platform/components/BrandCardSkinsMonkey.tsx
@@ -5,46 +5,69 @@ interface Props {
   code: string;
 }
 
+/**
+ * Card de SkinsMonkey rediseñada en patrón "hero-top":
+ *   ┌───────────────────────┐
+ *   │      HERO BANNER      │  — imagen ancho completo, altura fija
+ *   ├───────────────────────┤
+ *   │  Logo · texto · oferta │
+ *   │  CTA                  │
+ *   └───────────────────────┘
+ *
+ * Motivación: el patrón "agente flotante en esquina" que usan las otras
+ * cards no encaja con SkinsMonkey porque la fuente del asset es una
+ * thumbnail de baja resolución (comentario en constants/brands.ts). Con
+ * un banner cover + object-position center + gradient overlay se
+ * disimula el defecto y se le da más protagonismo visual.
+ *
+ * Reutiliza los tokens gold de `.p-gold` mediante la modificadora
+ * `.p-monkey` (que además override el padding para permitir hero a full
+ * ancho).
+ */
 export function BrandCardSkinsMonkey({ code }: Props) {
   const brand = PLATFORM_BRANDS.skinsmonkey;
   return (
-    <div className="gp-card p-gold">
+    <div className="gp-card p-gold p-monkey">
       <div className="glow" aria-hidden />
-      <div className="gp-logo-slot">
-        {brand.logoAsset ? (
-          <Image
-            src={brand.logoAsset}
-            alt={brand.displayName}
-            width={190}
-            height={44}
-            className="gp-brand-logo"
-          />
-        ) : (
-          <div className="gp-brand-logo-fallback">{brand.displayName}</div>
-        )}
-      </div>
-      <p style={{ fontSize: 14, margin: '12px 0 10px' }}>
-        Compra e intercambia skins de forma rápida y segura
-      </p>
-      <span className="pill-offer">
-        <b>35% Bonus + hasta 5$ Gratis</b> con el código <span>{code}</span>
-      </span>
-      <br />
-      <button type="button" className="gp-btn btn-gold" data-todo="claim-code">
-        Reclamar
-      </button>
       {brand.agentAsset ? (
-        <div className="gp-brand-agent-wrap" aria-hidden>
+        <div className="gp-monkey-hero" aria-hidden>
           <Image
             src={brand.agentAsset}
             alt=""
-            width={220}
-            height={280}
-            className="gp-brand-agent"
+            fill
+            sizes="(max-width: 720px) 100vw, 520px"
+            className="gp-monkey-hero-img"
             unoptimized
           />
+          <span className="gp-monkey-hero-overlay" aria-hidden />
         </div>
       ) : null}
+      <div className="gp-monkey-body">
+        <div className="gp-logo-slot">
+          {brand.logoAsset ? (
+            <Image
+              src={brand.logoAsset}
+              alt={brand.displayName}
+              width={190}
+              height={44}
+              className="gp-brand-logo"
+            />
+          ) : (
+            <div className="gp-brand-logo-fallback">{brand.displayName}</div>
+          )}
+        </div>
+        <p className="gp-monkey-lead">
+          Compra e intercambia skins de forma rápida y segura
+        </p>
+        <span className="pill-offer">
+          <b>35% Bonus + hasta 5$ Gratis</b> con el código <span>{code}</span>
+        </span>
+        <div>
+          <button type="button" className="gp-btn btn-gold" data-todo="claim-code">
+            Reclamar
+          </button>
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Bug reportado: la imagen de la card SkinsMonkey se ve pequeña y recortada, "muy cuadrada", parece thumbnail metida a la fuerza.

## Diagnóstico
La card mostraba el \`agentAsset\` en la esquina inferior derecha como agente flotante (patrón \`.gp-brand-agent-wrap\` de 220px con \`object-fit: contain\`). El propio comentario en \`constants/brands.ts\` documenta que ese asset viene de gstatic en baja resolución. En un contenedor pequeño sin cover, se ve peor.

## Fix: rediseño a patrón hero-top
```
┌─────────────────────────────┐
│                             │
│      HERO BANNER            │  ← ancho completo, aspect 16:8, object-fit cover
│                             │
├─────────────────────────────┤
│  [SkinsMonkey logo]         │
│  Compra e intercambia...    │
│  ┌──────────────────────┐   │
│  │ 35% Bonus + 5$ CODE  │   │
│  └──────────────────────┘   │
│  [Reclamar]                 │
└─────────────────────────────┘
```

- Nueva modificadora **\`.p-monkey\`** sobre \`.p-gold\` (mantiene tokens gold).
- **\`.gp-monkey-hero\`** ancho completo con \`aspect-ratio 16/8\` (desktop) / \`16/9\` (mobile ≤720px), \`min-height 190/160\`.
- \`<Image fill>\` con \`object-fit: cover\` + \`object-position: center 35%\` — centra bien pese al thumbnail de baja calidad.
- \`sizes="(max-width: 720px) 100vw, 520px"\` para servir la variante correcta.
- **Overlay gradient** transparente → oscuro 92% para transición limpia al body.
- **Fallback bg** morado/violeta si la imagen no carga.
- **\`.gp-monkey-body\`** con padding controlado (24/30 desktop, 20/22 mobile). Contenido igual: logo + lead + pill oferta + CTA "Reclamar".

## Otras cards intactas
- KeyDrop → \`.p-keydrop\` (banner-right, no se toca).
- CSGO-SKINS → \`.p-red\` (agente flotante, no se toca).
- Skin.Club → \`.p-skinclub\` (no se toca).

Solo SkinsMonkey estrena el patrón hero-top. Su asset de baja calidad justifica el rediseño; los otros brands tienen agentes PNG de alta resolución que funcionan bien flotando.

## Sin cambios prohibidos
- 0 migraciones · 0 cambios en \`.env*\` · 0 cambios en \`next.config.ts\` · 0 cambios en \`package.json\`.
- 0 cambios en lógica de negocio (auth, monedas, providers).
- El \`agentAsset\` en \`constants/brands.ts\` **no** cambia — sigue apuntando al mismo JPEG. El TODO documentado de reemplazarlo por PNG oficial sigue en pie.

## Test plan
- [x] \`npx tsc --noEmit\` → 0 errores en \`src/\`
- [x] \`npx jest src/__tests__/server/\` → **122 suites / 2456 tests passing** (+15 assertions nuevas)
- [x] \`npx eslint\` → 0 warnings en \`src/\`
- [ ] Smoke visual en preview: card SkinsMonkey (comparar antes/después), desktop + mobile ≤720px, verificar que las otras 3 cards (KeyDrop, CSGO-SKINS, Skin.Club) no se han tocado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)