### PR TITLE
feat(sorteos): deals adaptativos por creador + roster actualizado

### DIFF
--- a/docs/external-giveaways-provider-onboarding.md
+++ b/docs/external-giveaways-provider-onboarding.md
@@ -285,10 +285,14 @@ Al mergear, memoria (`~/.claude/.../memory/`) recibe una entry
 
 | Creador (slug) | Provider | Código | Estado |
 |---|---|---|---|
-| zacketizor | KeyDrop | ZACKCSGO | ✅ En producción desde 2026-07-01. |
+| zacketizor | KeyDrop + CSGO-SKINS | ZACKCSGO | ✅ KeyDrop con API real; CSGO-SKINS como card promocional. |
 | naow | — | — | ⏸ Pendiente de deal + datos confirmados. |
 | huasopeek | — | — | ⏸ Pendiente de deal + datos confirmados. |
-| martinez | — | — | ⏸ Pendiente de deal + datos confirmados. |
+| todocs2 | — | — | ⏸ Pendiente de deal + datos confirmados. |
+| imantado | — | — | ⏸ Pendiente de deal + datos confirmados. |
+| jolu | — | — | ⏸ Pendiente de deal + datos confirmados. |
+
+*(martinez retirado del roster público 2026-07-03.)*
 
 Nada más está confirmado. Los comentarios `csgoroll` / `hellcase` que
 aparecen en `types.ts` son placeholders históricos y NO representan

--- a/src/__tests__/server/creator-deals-config.test.ts
+++ b/src/__tests__/server/creator-deals-config.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Config declarativa de deals por creador + rendering adaptativo.
+ *
+ * Regla dura del proyecto: nunca inventar partnerships. Un creador solo
+ * puede mostrar cards de partners si tiene deal REAL confirmado en
+ * `CREATOR_DEALS`. Los otros ven placeholder honesto.
+ *
+ * Estado real 2026-07-03:
+ *   zacketizor → keydrop + csgoskins   ✅ único con deals confirmados
+ *   huasopeek / naow / todocs2 / imantado / jolu → sin deals
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  CREATOR_DEALS,
+  getCreatorDeals,
+  hasAnyDeal,
+} from '@/features/giveaway-platform/constants/creator-deals';
+import { PLATFORM_CREATOR_SLUGS } from '@/lib/giveaway-platform/constants';
+
+const ROOT = path.resolve(__dirname, '..', '..', '..');
+const read = (rel: string) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');
+
+describe('[creator-deals-config] roster y datos', () => {
+  it('CREATOR_DEALS cubre exactamente los slugs de PLATFORM_CREATOR_SLUGS', () => {
+    const dealKeys = Object.keys(CREATOR_DEALS).sort();
+    const rosterKeys = [...PLATFORM_CREATOR_SLUGS].sort();
+    expect(dealKeys).toEqual(rosterKeys);
+  });
+
+  it('zacketizor tiene exactamente keydrop + csgoskins (nada de skinsmonkey ni skinclub)', () => {
+    expect([...CREATOR_DEALS.zacketizor].sort()).toEqual(['csgoskins', 'keydrop']);
+  });
+
+  it('huasopeek / naow / todocs2 / imantado / jolu → sin deals confirmados ([])', () => {
+    expect(CREATOR_DEALS.huasopeek).toEqual([]);
+    expect(CREATOR_DEALS.naow).toEqual([]);
+    expect(CREATOR_DEALS.todocs2).toEqual([]);
+    expect(CREATOR_DEALS.imantado).toEqual([]);
+    expect(CREATOR_DEALS.jolu).toEqual([]);
+  });
+
+  it('martinez retirado — no aparece ni en el roster ni en la config', () => {
+    expect([...PLATFORM_CREATOR_SLUGS]).not.toContain('martinez');
+    expect((CREATOR_DEALS as Record<string, unknown>).martinez).toBeUndefined();
+  });
+});
+
+describe('[creator-deals-config] helpers', () => {
+  it('getCreatorDeals devuelve la lista o array vacío defensivo', () => {
+    expect(getCreatorDeals('zacketizor').length).toBe(2);
+    expect(getCreatorDeals('huasopeek')).toEqual([]);
+    expect(getCreatorDeals('nonexistent-slug')).toEqual([]);
+  });
+
+  it('hasAnyDeal true solo para creadores con al menos un partner', () => {
+    expect(hasAnyDeal('zacketizor')).toBe(true);
+    for (const slug of ['huasopeek', 'naow', 'todocs2', 'imantado', 'jolu']) {
+      expect(hasAnyDeal(slug)).toBe(false);
+    }
+  });
+});
+
+describe('[creator-deals-config] BrandBonusesSection adaptativa', () => {
+  const src = read('src/features/giveaway-platform/components/BrandBonusesSection.tsx');
+
+  it('recibe creatorSlug además del creatorCode', () => {
+    expect(src).toMatch(/interface Props\s*\{[\s\S]{0,200}creatorSlug:\s*string/);
+    expect(src).toMatch(/interface Props\s*\{[\s\S]{0,200}creatorCode:\s*string/);
+  });
+
+  it('llama a getCreatorDeals para calcular las cards a renderizar', () => {
+    expect(src).toMatch(/const\s+deals\s*=\s*getCreatorDeals\(creatorSlug\)/);
+  });
+
+  it('renderiza placeholder honesto cuando deals.length === 0', () => {
+    expect(src).toMatch(/if\s*\(deals\.length\s*===\s*0\)/);
+    expect(src).toMatch(/gp-bonuses-empty/);
+    expect(src).toMatch(/Deals de partners próximamente/);
+  });
+
+  it('KeyDrop se renderiza aparte arriba solo si está en deals', () => {
+    expect(src).toMatch(/const\s+hasKeyDrop\s*=\s*deals\.includes\('keydrop'\)/);
+    expect(src).toMatch(/hasKeyDrop\s*\?\s*<BrandCardKeyDrop/);
+  });
+
+  it('resto de deals van en un grid adaptativo (.gp-grid-1 si 1, .gp-grid-2 si 2+)', () => {
+    expect(src).toMatch(/otherDeals\.length\s*===\s*1\s*\?\s*'gp-grid-1'\s*:\s*'gp-grid-2'/);
+  });
+
+  it('nunca renderiza cards que no estén en la config del creador', () => {
+    // El switch cubre las 4 BrandKey pero solo se llama con las que están
+    // en `otherDeals`. Verificamos que no hay hard-coded fallbacks a
+    // SkinsMonkey/Skin.Club fuera del switch.
+    expect(src).not.toMatch(/<BrandCardSkinsMonkey\s+code=[^\}]/); // no fuera del map
+    expect(src).not.toMatch(/<BrandCardSkinClub\s+code=[^\}]/);
+  });
+});
+
+describe('[creator-deals-config] wiring en PlatformCreatorLanding', () => {
+  const src = read('src/features/giveaway-platform/components/PlatformCreatorLanding.tsx');
+
+  it('pasa creatorSlug además del creatorCode al BrandBonusesSection', () => {
+    expect(src).toMatch(/<BrandBonusesSection\s+creatorSlug=\{active\.slug\}\s+creatorCode=\{activeVisual\.code\}/);
+  });
+});
+
+describe('[creator-deals-config] CSS del placeholder + grids adaptativos', () => {
+  const css = read('src/app/sorteos/plataforma/platform-brand-cards.css');
+
+  it('.gp-grid-1 es una columna full-width', () => {
+    expect(css).toMatch(/\.gp-grid-1\s*\{[\s\S]{0,200}grid-template-columns:\s*1fr\s*[;}]/);
+  });
+
+  it('.gp-grid-2 colapsa a 1 columna en <=720px (mobile)', () => {
+    expect(css).toMatch(/@media\s*\(max-width:\s*720px\)[\s\S]{0,300}\.gp-grid-2\s*\{[\s\S]{0,120}1fr/);
+  });
+
+  it('placeholder honesto con dashed border', () => {
+    expect(css).toMatch(/\.gp-bonuses-empty-inner\s*\{[\s\S]{0,400}border:\s*1px\s+dashed/);
+    expect(css).toMatch(/\.gp-bonuses-empty-body\s+b\s*\{[\s\S]{0,200}color:\s*var\(--gold\)/);
+  });
+});

--- a/src/__tests__/server/creator-zacketizor.test.ts
+++ b/src/__tests__/server/creator-zacketizor.test.ts
@@ -20,15 +20,16 @@ import {
 const ROOT = path.resolve(__dirname, '..', '..', '..');
 
 describe('[creator-zacketizor] server whitelist', () => {
-  it('PLATFORM_CREATOR_SLUGS incluye zacketizor en último lugar', () => {
+  it('PLATFORM_CREATOR_SLUGS incluye zacketizor', () => {
     expect([...PLATFORM_CREATOR_SLUGS]).toContain('zacketizor');
-    expect(PLATFORM_CREATOR_SLUGS[PLATFORM_CREATOR_SLUGS.length - 1]).toBe('zacketizor');
   });
 
-  it('los 4 creadores esperados están presentes sin duplicados', () => {
+  it('roster actual (2026-07-03): 6 slugs sin martinez, con todocs2/imantado/jolu', () => {
     expect([...PLATFORM_CREATOR_SLUGS].sort()).toEqual(
-      ['huasopeek', 'martinez', 'naow', 'zacketizor'],
+      ['huasopeek', 'imantado', 'jolu', 'naow', 'todocs2', 'zacketizor'],
     );
+    // martinez fue retirado.
+    expect([...PLATFORM_CREATOR_SLUGS]).not.toContain('martinez');
     const asSet = new Set(PLATFORM_CREATOR_SLUGS);
     expect(asSet.size).toBe(PLATFORM_CREATOR_SLUGS.length);
   });

--- a/src/__tests__/server/external-giveaways-common.test.ts
+++ b/src/__tests__/server/external-giveaways-common.test.ts
@@ -88,7 +88,9 @@ describe('[external-giveaways] CREATOR_PROVIDER_BINDINGS', () => {
     expect(isExternalCreator('zacketizor')).toBe(true);
     expect(isExternalCreator('naow')).toBe(false);
     expect(isExternalCreator('huasopeek')).toBe(false);
-    expect(isExternalCreator('martinez')).toBe(false);
+    expect(isExternalCreator('todocs2')).toBe(false);
+    expect(isExternalCreator('imantado')).toBe(false);
+    expect(isExternalCreator('jolu')).toBe(false);
     expect(isExternalCreator('unknown-slug')).toBe(false);
   });
 });

--- a/src/__tests__/server/external-providers-inventory.test.ts
+++ b/src/__tests__/server/external-providers-inventory.test.ts
@@ -43,7 +43,7 @@ describe('[external-providers-inventory] estado real 2026-07-03', () => {
     expect(src).toMatch(/zacketizor/);
     expect(src).toMatch(/provider:\s*'keydrop'/);
     // Ni bindings "de prueba" para otros creadores.
-    for (const slug of ['naow', 'huasopeek', 'martinez']) {
+    for (const slug of ['naow', 'huasopeek', 'todocs2', 'imantado', 'jolu']) {
       // Aparecer en un comentario o import está OK; aparecer como key de binding no.
       expect(src).not.toMatch(new RegExp(`^\\s*${slug}\\s*:`, 'm'));
     }
@@ -63,9 +63,9 @@ describe('[external-providers-inventory] estado real 2026-07-03', () => {
   it('doc de onboarding existe y refleja el estado real', () => {
     const doc = read('docs/external-giveaways-provider-onboarding.md');
     // Tabla de estado con zacketizor confirmado.
-    expect(doc).toMatch(/zacketizor[\s\S]{0,80}KeyDrop[\s\S]{0,80}ZACKCSGO[\s\S]{0,80}En producción/);
+    expect(doc).toMatch(/zacketizor[\s\S]{0,140}KeyDrop[\s\S]{0,140}ZACKCSGO/);
     // Los otros 3 creadores están explícitamente pendientes.
-    for (const slug of ['naow', 'huasopeek', 'martinez']) {
+    for (const slug of ['naow', 'huasopeek', 'todocs2', 'imantado', 'jolu']) {
       expect(doc).toMatch(new RegExp(`\\|\\s*${slug}\\s*\\|[^|]*\\|[^|]*\\|[^|]*Pendiente`, 'i'));
     }
     // Regla dura visible.

--- a/src/__tests__/server/sorteos-public-routes.test.ts
+++ b/src/__tests__/server/sorteos-public-routes.test.ts
@@ -82,10 +82,16 @@ describe('[sorteos-routes] /sorteos/[creatorSlug]', () => {
     expect(src).toMatch(/canonical:\s*`\/sorteos\/\$\{canonicalSlug\}`/);
     expect(src).toMatch(/robots:\s*\{\s*index:\s*true,\s*follow:\s*true/);
   });
-  it('redirect defensivo por typo (zackezitor → zacketizor)', () => {
+  it('redirect defensivo por typo (zackezitor → zacketizor) + target vacío al índice', () => {
     expect(src).toMatch(/SLUG_TYPO_REDIRECTS:\s*Record<string,\s*string>/);
     expect(src).toMatch(/zackezitor:\s*'zacketizor'/);
-    expect(src).toMatch(/redirect\(`\/sorteos\/\$\{typoTarget\}`\)/);
+    // Target='' (por ejemplo martinez retirado) → redirect al índice.
+    expect(src).toMatch(/redirect\(target\s*\?\s*`\/sorteos\/\$\{target\}`\s*:\s*'\/sorteos'\)/);
+  });
+  it('martinez retirado: redirect a /sorteos (no notFound ni landing)', () => {
+    expect(src).toMatch(/martinez:\s*''/);
+    // Y no aparece como slug canónico.
+    expect(src).not.toMatch(/martines:\s*'martinez'/);
   });
   it('slug no válido → notFound()', () => {
     expect(src).toMatch(/!PLATFORM_CREATOR_SLUGS\.includes\(slugLc[\s\S]{0,80}notFound\(\)/);
@@ -150,8 +156,8 @@ describe('[sorteos-routes] providers reales — no inventar bindings', () => {
     const src = read('src/lib/external-giveaways/creator-bindings.ts');
     expect(src).toMatch(/zacketizor/);
     expect(src).toMatch(/provider:\s*'keydrop'/);
-    // Los otros 3 creadores NO deben tener binding.
-    for (const slug of ['naow', 'huasopeek', 'martinez']) {
+    // Los otros creadores del roster NO deben tener binding.
+    for (const slug of ['naow', 'huasopeek', 'todocs2', 'imantado', 'jolu']) {
       expect(src).not.toMatch(new RegExp(`^\\s*${slug}\\s*:`, 'm'));
     }
   });

--- a/src/app/sorteos/[creatorSlug]/page.tsx
+++ b/src/app/sorteos/[creatorSlug]/page.tsx
@@ -17,8 +17,20 @@ const SLUG_TYPO_REDIRECTS: Record<string, string> = {
   zacketizador: 'zacketizor',
   huaso: 'huasopeek',
   huasopeak: 'huasopeek',
-  martines: 'martinez',
   naaw: 'naow',
+  // Roster nuevo (2026-07-03): defensivos para typos comunes.
+  todo: 'todocs2',
+  todocs: 'todocs2',
+  'todo-cs2': 'todocs2',
+  jolucs2: 'jolu',
+  jolucs: 'jolu',
+  'jolu-cs2': 'jolu',
+  imantao: 'imantado',
+  imanta: 'imantado',
+  // Roster antiguo (martinez retirado 2026-07-03): quien aterrice en la
+  // URL antigua va al índice, no a un notFound.
+  martinez: '',
+  martines: '',
 };
 
 export async function generateStaticParams() {
@@ -66,9 +78,12 @@ export default async function SorteosCreatorPage({
   const { creatorSlug } = await params;
   const slugLc = creatorSlug.toLowerCase();
 
-  // Redirect defensivo por typos conocidos.
-  const typoTarget = SLUG_TYPO_REDIRECTS[slugLc];
-  if (typoTarget) redirect(`/sorteos/${typoTarget}`);
+  // Redirect defensivo por typos conocidos. Target='' → índice /sorteos
+  // (útil para slugs retirados como martinez).
+  if (Object.prototype.hasOwnProperty.call(SLUG_TYPO_REDIRECTS, slugLc)) {
+    const target = SLUG_TYPO_REDIRECTS[slugLc];
+    redirect(target ? `/sorteos/${target}` : '/sorteos');
+  }
 
   // Guard duro contra slugs que no son creadores de la plataforma.
   if (!PLATFORM_CREATOR_SLUGS.includes(slugLc as (typeof PLATFORM_CREATOR_SLUGS)[number])) {

--- a/src/app/sorteos/plataforma/platform-brand-cards.css
+++ b/src/app/sorteos/plataforma/platform-brand-cards.css
@@ -157,8 +157,46 @@
   font-size: 12px;
 }
 
-/* ================ CLASH + MONKEY (gold cards) ================ */
+/* ================ GRIDS ADAPTATIVOS ================ */
+.giveaway-platform .gp-grid-1 { display: grid; grid-template-columns: 1fr; gap: 26px; }
 .giveaway-platform .gp-grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 26px; }
+@media (max-width: 720px) {
+  .giveaway-platform .gp-grid-2 { grid-template-columns: 1fr; }
+}
+
+/* ================ PLACEHOLDER — creador sin deals confirmados ================
+ * Regla del proyecto: nunca inventar partnerships. Cuando un creador no
+ * tiene deals reales confirmados, se muestra este banner honesto en vez
+ * de una fila vacía o cards falsas.
+ */
+.giveaway-platform .gp-bonuses-empty { margin-top: 6px; }
+.giveaway-platform .gp-bonuses-empty-inner {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  padding: 20px 26px;
+  border-radius: 16px;
+  background: rgba(11, 9, 23, 0.55);
+  border: 1px dashed rgba(196, 40, 128, 0.35);
+}
+.giveaway-platform .gp-bonuses-empty-icon { font-size: 32px; line-height: 1; flex-shrink: 0; }
+.giveaway-platform .gp-bonuses-empty-body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 13px;
+  line-height: 1.55;
+}
+.giveaway-platform .gp-bonuses-empty-body b {
+  font-family: var(--font-display), var(--font-rajdhani), sans-serif;
+  font-weight: 800;
+  letter-spacing: 0.6px;
+  font-size: 14px;
+  color: var(--gold);
+}
+.giveaway-platform .gp-bonuses-empty-body span { color: var(--muted); }
+
+/* ================ CLASH + MONKEY (gold cards) ================ */
 .giveaway-platform .p-gold {
   border-color: rgba(245, 183, 61, 0.4);
   padding: 32px 34px;

--- a/src/features/giveaway-platform/components/BrandBonusesSection.tsx
+++ b/src/features/giveaway-platform/components/BrandBonusesSection.tsx
@@ -2,28 +2,76 @@ import { BrandCardKeyDrop } from './BrandCardKeyDrop';
 import { BrandCardCsgoskins } from './BrandCardCsgoskins';
 import { BrandCardSkinsMonkey } from './BrandCardSkinsMonkey';
 import { BrandCardSkinClub } from './BrandCardSkinClub';
+import { getCreatorDeals } from '../constants/creator-deals';
+import type { BrandKey } from '../constants/brands';
 
 interface Props {
+  creatorSlug: string;
   creatorCode: string;
 }
 
 /**
- * Bloque estático de bonuses de partners.
- * Datos en src/features/giveaway-platform/constants/brands.ts.
+ * Bloque de bonuses adaptativo a los deals reales del creador.
+ *
+ * Reglas:
+ *   - 0 deals → placeholder honesto ("Deals de partners próximamente").
+ *   - 1 deal  → card sola full-width (no grid).
+ *   - 2 deals → grid 2 columnas (`.gp-grid-2`), sin dejar hueco.
+ *   - 3+ deals → misma grid + siguientes cards apiladas.
+ *
+ * Las cards que renderiza SIEMPRE están en `CREATOR_DEALS` para el
+ * creador activo — nunca aparecen partners fantasma. La lista canónica
+ * de partnerships vive en `creator-deals.ts`.
  */
-export function BrandBonusesSection({ creatorCode }: Props) {
-  return (
-    <>
-      <BrandCardKeyDrop code={creatorCode} />
+export function BrandBonusesSection({ creatorSlug, creatorCode }: Props) {
+  const deals = getCreatorDeals(creatorSlug);
 
-      <section aria-label="CSGO-SKINS y SkinsMonkey">
-        <div className="gp-grid-2">
-          <BrandCardCsgoskins code={creatorCode} />
-          <BrandCardSkinsMonkey code={creatorCode} />
+  if (deals.length === 0) {
+    return (
+      <section aria-label="Deals de partners" className="gp-bonuses-empty">
+        <div className="gp-bonuses-empty-inner" role="note">
+          <span className="gp-bonuses-empty-icon" aria-hidden>🤝</span>
+          <div className="gp-bonuses-empty-body">
+            <b>Deals de partners próximamente.</b>
+            <span>
+              Este creador aún no tiene partnerships confirmados en la
+              plataforma. Vuelve pronto — anunciaremos aquí cada nuevo deal.
+            </span>
+          </div>
         </div>
       </section>
+    );
+  }
 
-      <BrandCardSkinClub code={creatorCode} />
+  // KeyDrop es siempre la card grande arriba; el resto va en la fila.
+  const hasKeyDrop = deals.includes('keydrop');
+  const otherDeals = deals.filter((d) => d !== 'keydrop');
+
+  return (
+    <>
+      {hasKeyDrop ? <BrandCardKeyDrop code={creatorCode} /> : null}
+
+      {otherDeals.length > 0 ? (
+        <section aria-label="Deals de partners">
+          <div className={otherDeals.length === 1 ? 'gp-grid-1' : 'gp-grid-2'}>
+            {otherDeals.map((brand) => renderBrandCard(brand, creatorCode))}
+          </div>
+        </section>
+      ) : null}
     </>
   );
+}
+
+function renderBrandCard(brand: BrandKey, code: string) {
+  switch (brand) {
+    case 'keydrop':
+      // KeyDrop se renderiza aparte arriba — no debería llegar aquí.
+      return <BrandCardKeyDrop key={brand} code={code} />;
+    case 'csgoskins':
+      return <BrandCardCsgoskins key={brand} code={code} />;
+    case 'skinsmonkey':
+      return <BrandCardSkinsMonkey key={brand} code={code} />;
+    case 'skinclub':
+      return <BrandCardSkinClub key={brand} code={code} />;
+  }
 }

--- a/src/features/giveaway-platform/components/PlatformCreatorLanding.tsx
+++ b/src/features/giveaway-platform/components/PlatformCreatorLanding.tsx
@@ -125,7 +125,7 @@ export async function PlatformCreatorLanding({ slug }: Props) {
 
       <main className="gp-wrap">
         <PlatformHero code={activeVisual.code} creatorName={active.name} />
-        <BrandBonusesSection creatorCode={activeVisual.code} />
+        <BrandBonusesSection creatorSlug={active.slug} creatorCode={activeVisual.code} />
 
         {userId ? (
           <>

--- a/src/features/giveaway-platform/constants/creator-deals.ts
+++ b/src/features/giveaway-platform/constants/creator-deals.ts
@@ -1,0 +1,41 @@
+import type { BrandKey } from './brands';
+import { PLATFORM_CREATOR_SLUGS } from '@/lib/giveaway-platform/constants';
+
+/**
+ * Config declarativa: qué partners/deals tiene cada creador confirmados.
+ *
+ * Regla dura: solo aparecen aquí partnerships REALES. Si un creador no
+ * tiene deal confirmado, su entry es `[]` y su landing muestra un
+ * placeholder honesto ("Deals de partners próximamente"). Nunca inventar
+ * partnerships para llenar espacio.
+ *
+ * `BrandKey` corresponde con las cards estáticas de
+ * `PLATFORM_BRANDS` en `./brands.ts`. Añadir un partner aquí implica
+ * tener la card visual creada; añadir un provider externo con API real
+ * implica además ver `docs/external-giveaways-provider-onboarding.md`.
+ */
+
+export type PlatformCreatorSlug = (typeof PLATFORM_CREATOR_SLUGS)[number];
+
+export const CREATOR_DEALS: Record<PlatformCreatorSlug, readonly BrandKey[]> = {
+  zacketizor: ['keydrop', 'csgoskins'],
+  huasopeek:  [],
+  naow:       [],
+  todocs2:    [],
+  imantado:   [],
+  jolu:       [],
+};
+
+/**
+ * Partners activos de un creador. Devuelve `[]` si el slug no está en el
+ * roster público (defensivo — el caller debería haber validado antes).
+ */
+export function getCreatorDeals(slug: string): readonly BrandKey[] {
+  const key = slug as PlatformCreatorSlug;
+  return CREATOR_DEALS[key] ?? [];
+}
+
+/** True si el creador tiene al menos un deal confirmado. */
+export function hasAnyDeal(slug: string): boolean {
+  return getCreatorDeals(slug).length > 0;
+}

--- a/src/features/giveaway-platform/constants/creators.ts
+++ b/src/features/giveaway-platform/constants/creators.ts
@@ -15,12 +15,15 @@ export interface PlatformCreatorVisual {
 }
 
 export const PLATFORM_CREATOR_VISUALS: Record<string, PlatformCreatorVisual> = {
-  naow: { emoji: '🎯', color: '#28d7ff', code: 'NAOW', sub: 'Creador de CS · SocialPro' },
-  huasopeek: { emoji: '🔥', color: '#ff9d2e', code: 'HUASOPEEK', sub: 'Creador de CS · SocialPro' },
-  martinez: { emoji: '⚔️', color: '#4ade80', code: 'MARTINEZ', sub: 'Creador de CS · SocialPro' },
   // ZACKETIZOR: display name en KeyDrop es "zack", código promocional real
-  // es ZACKCSGO (no ZACKETIZOR — descubierto en el probe de la API KeyDrop).
+  // es ZACKCSGO (descubierto en el probe de la API KeyDrop).
   zacketizor: { emoji: '🎬', color: '#e03070', code: 'ZACKCSGO', sub: 'Creador CS2 · SocialPro' },
+  huasopeek:  { emoji: '🔥', color: '#ff9d2e', code: 'HUASOPEEK', sub: 'Creador de CS · SocialPro' },
+  naow:       { emoji: '🎯', color: '#28d7ff', code: 'NAOW',      sub: 'Creador de CS · SocialPro' },
+  todocs2:    { emoji: '🎮', color: '#f5b73d', code: 'TODOCS2',   sub: 'Creador CS2 · SocialPro' },
+  imantado:   { emoji: '🧲', color: '#8b3dff', code: 'IMANTADO',  sub: 'Creador CS2 · SocialPro' },
+  // Slug DB real: `jolu`; el display público es "JoluCS2".
+  jolu:       { emoji: '💎', color: '#4ade80', code: 'JOLUCS2',   sub: 'Trading CS2 · SocialPro' },
 };
 
 export function getCreatorVisual(slug: string): PlatformCreatorVisual {

--- a/src/lib/giveaway-platform/constants.ts
+++ b/src/lib/giveaway-platform/constants.ts
@@ -10,8 +10,23 @@ export const ENTRY_COIN_REWARD = 20;
 /** Recompensa fija por día de racha (índice 0 = día 1). */
 export const STREAK_REWARDS = [10, 15, 20, 25, 30, 40, 60] as const;
 
-/** Slugs de talents visibles en el selector de creador de la plataforma. */
-export const PLATFORM_CREATOR_SLUGS = ['naow', 'huasopeek', 'martinez', 'zacketizor'] as const;
+/**
+ * Slugs de talents visibles en el selector de creador de la plataforma.
+ *
+ * Actualizado 2026-07-03: sale `martinez`, entran `todocs2`, `imantado`,
+ * `jolu` (slug DB real; display "JoluCS2"). Los partners de cada creador
+ * viven en `src/features/giveaway-platform/constants/creator-deals.ts`
+ * — un creador puede aparecer aquí (roster público) y aún no tener deals
+ * confirmados; en ese caso su landing muestra el placeholder honesto.
+ */
+export const PLATFORM_CREATOR_SLUGS = [
+  'zacketizor',
+  'huasopeek',
+  'naow',
+  'todocs2',
+  'imantado',
+  'jolu',
+] as const;
 
 /** Zona horaria para el corte del día de la racha y el mes del ranking. */
 export const PLATFORM_TZ = 'Europe/Madrid';


### PR DESCRIPTION
Landing por creador solo muestra cards de partners **reales**. Antes se renderizaban las 4 (KeyDrop + CSGO-SKINS + SkinsMonkey + Skin.Club) para cualquier creador, mostrando deals inventados a NAOW/HUASOPEEK/MARTINEZ. **No mergear sin OK.**

## Roster público — cambios detectados

⚠️ **Slug real de "jolucs2":** en DB el slug es \`jolu\` (display "JoluCS2"). Uso el slug canónico y añado \`jolucs2 → jolu\` como redirect defensivo. Confírmame si prefieres al revés (renombrar en DB) — sería otro PR.

| Slug pedido | Slug canónico | Status |
|---|---|---|
| \`zacketizor\` | \`zacketizor\` | ✅ ya existía |
| \`huasopeek\` | \`huasopeek\` | ✅ ya existía |
| \`naow\` | \`naow\` | ✅ ya existía |
| \`todocs2\` | \`todocs2\` | ✅ añadido al roster |
| \`imantado\` | \`imantado\` | ✅ añadido al roster |
| **\`jolucs2\`** | ⚠️ **\`jolu\`** | ✅ añadido al roster (slug DB); \`jolucs2\` redirige |
| \`martinez\` | — | ❌ retirado del roster público |

## Config declarativa nueva

\`\`\`ts
// src/features/giveaway-platform/constants/creator-deals.ts
export const CREATOR_DEALS = {
  zacketizor: ['keydrop', 'csgoskins'],
  huasopeek:  [],
  naow:       [],
  todocs2:    [],
  imantado:   [],
  jolu:       [],
};
\`\`\`

Cuando confirmes un deal para cualquier otro creador, se añade su \`BrandKey\` a este array y la UI se adapta automáticamente. **Nunca inventar partnerships.**

## BrandBonusesSection adaptativa

Recibe \`creatorSlug\` (además del \`creatorCode\`) y filtra por deals reales:

- **0 deals** → placeholder honesto:
  > 🤝 **Deals de partners próximamente.**
  > Este creador aún no tiene partnerships confirmados en la plataforma.
- **1 deal secundario** → \`.gp-grid-1\` (full-width, no fila con hueco).
- **2+ deals** → \`.gp-grid-2\` (colapsa a 1 col ≤720px).
- KeyDrop siempre va aparte arriba si está en la lista.
- Ya **NO renderiza** SkinsMonkey ni Skin.Club fuera del switch — nunca aparecen para creadores que no las tienen.

## ZACKETIZOR

Antes: KeyDrop grande arriba + fila CSGO-SKINS + SkinsMonkey + Skin.Club abajo (los dos últimos inventados).
Ahora: KeyDrop grande arriba + CSGO-SKINS en \`.gp-grid-1\` (full-width). SkinsMonkey y Skin.Club desaparecen.

- \`ZACKCSGO\` intacto como código promocional.
- KeyDrop sigue siendo provider real (API activa).
- CSGO-SKINS queda como card promocional visual (sin API, tal como estaba).

## Redirects legacy

Añadido en \`SLUG_TYPO_REDIRECTS\` para captar aterrizajes en URLs antiguas o mal escritas:

- \`martinez\`, \`martines\` → \`/sorteos\` (índice; retirado del roster).
- \`todo\`, \`todocs\`, \`todo-cs2\` → \`todocs2\`.
- \`jolucs2\`, \`jolucs\`, \`jolu-cs2\` → \`jolu\`.
- \`imantao\`, \`imanta\` → \`imantado\`.
- \`zackezitor\`, \`zacketizador\` → \`zacketizor\` (ya estaba).

Cualquier slug no reconocido → \`notFound()\`.

## Rutas esperadas post-merge

| URL | Behavior |
|---|---|
| \`/sorteos/zacketizor\` | KeyDrop + CSGO-SKINS |
| \`/sorteos/huasopeek\` | Placeholder honesto |
| \`/sorteos/naow\` | Placeholder honesto |
| \`/sorteos/todocs2\` | Placeholder honesto |
| \`/sorteos/imantado\` | Placeholder honesto |
| \`/sorteos/jolu\` | Placeholder honesto (display "JoluCS2") |
| \`/sorteos/jolucs2\` | 302 → \`/sorteos/jolu\` |
| \`/sorteos/martinez\` | 302 → \`/sorteos\` |

## API keys

Este PR NO integra APIs nuevas. Cuando decidas activar deals reales de los otros creadores:
1. Me dices el nombre exacto de la env var: \`<PROVIDER>_<CREATOR>_API_KEY\`.
2. Tú la añades en Vercel (Production).
3. Yo declaro la key en \`src/lib/env.ts\` como \`.optional()\` server-only.
4. Yo añado el binding en \`creator-bindings.ts\` y el partner en \`CREATOR_DEALS[creador]\`.
5. Nunca la logueamos ni imprimimos.

## Sin cambios prohibidos
- 0 migraciones · 0 cambios en \`.env*\` · 0 cambios en \`next.config.ts\`.
- 0 nuevos providers en enum ni registry.
- 0 nuevas keys ni bindings.
- 0 escrituras a \`coin_transactions\` / \`giveaway_entries\` / \`mission_claims\` por externos.

## Test plan
- [x] \`npx tsc --noEmit\` → 0 errores en \`src/\`.
- [x] \`npx jest src/__tests__/server/\` → **123 suites / 2473 tests passing** (+ nuevas assertions \`creator-deals-config\`; tests existentes actualizados para el nuevo roster).
- [x] \`npx eslint\` → 0 warnings en \`src/\`.
- [ ] Smoke visual en preview:
  - \`/sorteos\` → índice con los 6 creadores; \`martinez\` fuera.
  - \`/sorteos/zacketizor\` → KeyDrop grande + CSGO-SKINS. Sin SkinsMonkey ni Skin.Club.
  - \`/sorteos/huasopeek\`, \`/sorteos/naow\`, \`/sorteos/todocs2\`, \`/sorteos/imantado\`, \`/sorteos/jolu\` → placeholder honesto en lugar de partners falsos.
  - \`/sorteos/jolucs2\` → redirige a \`/sorteos/jolu\`.
  - \`/sorteos/martinez\` → redirige al índice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)