### PR TITLE
feat(sorteos): bordes LED por marca en las cards de partners

### DIFF
--- a/src/__tests__/server/brand-card-leds.test.ts
+++ b/src/__tests__/server/brand-card-leds.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Bordes LED por marca en las cards de partners.
+ *
+ * Mecanismo:
+ *  - `.gp-card-led` (pseudo-elemento ::before) pinta el aro exterior con
+ *    un `linear-gradient` bajo máscara "gradient border via mask-composite".
+ *  - Cada modificadora `.p-*` declara sus propios tokens
+ *    (--brand-border, --brand-glow, --brand-accent, --brand-gradient).
+ *  - Animación 5s ease-in-out infinite del `background-position`.
+ *  - `@media (prefers-reduced-motion: reduce)` desactiva la animación.
+ *
+ * Además verifica:
+ *  - KeyDrop y CSGO-SKINS ya no usan sus tokens antiguos (azul + rojo).
+ *    Ahora KeyDrop es dorado y CSGO-SKINS cyan.
+ *  - Las 4 BrandCard*.tsx llevan la clase `.gp-card-led`.
+ *  - El layout raíz `/sorteos` carga `platform-brand-leds.css`.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(__dirname, '..', '..', '..');
+const read = (rel: string) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');
+
+describe('[brand-leds] mecanismo compartido `.gp-card-led`', () => {
+  const css = read('src/app/sorteos/plataforma/platform-brand-leds.css');
+
+  it('define tokens fallback por si una marca no declara todos', () => {
+    expect(css).toMatch(/\.gp-card-led\s*\{[\s\S]{0,600}--brand-border:/);
+    expect(css).toMatch(/\.gp-card-led\s*\{[\s\S]{0,600}--brand-glow:/);
+    expect(css).toMatch(/\.gp-card-led\s*\{[\s\S]{0,600}--brand-accent:/);
+    expect(css).toMatch(/\.gp-card-led\s*\{[\s\S]{0,800}--brand-gradient:/);
+  });
+
+  it('aplica los tokens a border-color + box-shadow (halo externo)', () => {
+    expect(css).toMatch(/\.gp-card-led\s*\{[\s\S]{0,800}border-color:\s*var\(--brand-border\)/);
+    expect(css).toMatch(/\.gp-card-led\s*\{[\s\S]{0,800}box-shadow:[\s\S]{0,200}var\(--brand-glow\)/);
+  });
+
+  it('borde LED con pseudo-elemento ::before + mask-composite exclude', () => {
+    expect(css).toMatch(/\.gp-card-led::before\s*\{[\s\S]{0,500}background:\s*var\(--brand-gradient\)/);
+    expect(css).toMatch(/\.gp-card-led::before\s*\{[\s\S]{0,800}mask-composite:\s*exclude/);
+    expect(css).toMatch(/\.gp-card-led::before\s*\{[\s\S]{0,800}pointer-events:\s*none/);
+  });
+
+  it('animación 5s ease-in-out infinite del gradient (sutil, sin parpadeo)', () => {
+    expect(css).toMatch(/animation:\s*gp-brand-led-shift\s+5s\s+ease-in-out\s+infinite/);
+    expect(css).toMatch(/@keyframes\s+gp-brand-led-shift/);
+  });
+
+  it('respeta prefers-reduced-motion desactivando la animación', () => {
+    expect(css).toMatch(/@media\s*\(prefers-reduced-motion:\s*reduce\)[\s\S]{0,400}animation:\s*none/);
+    // Mantiene color estático (no desactiva el color).
+    expect(css).toMatch(/@media\s*\(prefers-reduced-motion:\s*reduce\)[\s\S]{0,400}background-position:\s*50%\s+50%/);
+  });
+});
+
+describe('[brand-leds] tokens por marca en platform-brand-cards.css', () => {
+  const css = read('src/app/sorteos/plataforma/platform-brand-cards.css');
+
+  it('KeyDrop tiene tokens dorados (ya no azules)', () => {
+    // `.p-keydrop` declara los 4 tokens de marca.
+    expect(css).toMatch(/\.p-keydrop\s*\{[\s\S]{0,900}--brand-border:\s*rgba\(245,\s*200,\s*75/);
+    expect(css).toMatch(/\.p-keydrop\s*\{[\s\S]{0,900}--brand-accent:\s*#f5c84b/);
+    expect(css).toMatch(/\.p-keydrop\s*\{[\s\S]{0,900}--brand-gradient:\s*linear-gradient/);
+    // Ya NO usa el azul viejo `rgba(30, 155, 255, 0.35)`.
+    expect(css).not.toMatch(/\.p-keydrop\s*\{[\s\S]{0,900}border-color:\s*rgba\(30,\s*155,\s*255/);
+  });
+
+  it('CSGO-SKINS (.p-red legacy) tiene tokens cyan (ya no rojos)', () => {
+    expect(css).toMatch(/\.p-red\s*\{[\s\S]{0,900}--brand-border:\s*rgba\(40,\s*215,\s*255/);
+    expect(css).toMatch(/\.p-red\s*\{[\s\S]{0,900}--brand-accent:\s*#28d7ff/);
+    // Su glow interno también pasa a cyan.
+    expect(css).toMatch(/\.p-red\s+\.glow\s*\{[\s\S]{0,400}rgba\(40,\s*215,\s*255/);
+    // Ya no usa el rojo viejo.
+    expect(css).not.toMatch(/\.p-red\s*\{[\s\S]{0,900}border-color:\s*rgba\(220,\s*38,\s*60/);
+  });
+
+  it('pill-offer y btn-red heredan cyan para casar con el border', () => {
+    expect(css).toMatch(/\.pill-offer\.red\s*\{[\s\S]{0,200}rgba\(40,\s*215,\s*255/);
+    expect(css).toMatch(/\.btn-red\s*\{[\s\S]{0,300}linear-gradient\([^)]*#0077ff[^)]*#28d7ff/);
+  });
+
+  it('SkinsMonkey/.p-gold conserva tokens dorados (misma familia visual)', () => {
+    expect(css).toMatch(/\.p-gold\s*\{[\s\S]{0,900}--brand-accent:\s*#f5b73d/);
+  });
+
+  it('SkinClub tiene tokens purple/pink coherentes con el logo', () => {
+    expect(css).toMatch(/\.p-skinclub\s*\{[\s\S]{0,900}--brand-accent:\s*#ff4bd8/);
+    expect(css).toMatch(/\.p-skinclub\s*\{[\s\S]{0,900}--brand-gradient:\s*linear-gradient/);
+  });
+});
+
+describe('[brand-leds] las 4 BrandCard*.tsx aplican `.gp-card-led`', () => {
+  const files = [
+    ['KeyDrop',      'BrandCardKeyDrop.tsx',      /p-keydrop/],
+    ['CSGO-SKINS',   'BrandCardCsgoskins.tsx',    /p-red/],
+    ['SkinsMonkey',  'BrandCardSkinsMonkey.tsx',  /p-monkey-v2/],
+    ['Skin.Club',    'BrandCardSkinClub.tsx',     /p-skinclub/],
+  ] as const;
+  for (const [label, file, brandModifier] of files) {
+    it(`${label}: className incluye \`gp-card-led\` + su modificadora`, () => {
+      const src = read(`src/features/giveaway-platform/components/${file}`);
+      expect(src).toMatch(/className="[^"]*\bgp-card-led\b[^"]*"/);
+      expect(src).toMatch(brandModifier);
+    });
+  }
+});
+
+describe('[brand-leds] layout raíz carga el CSS', () => {
+  const src = read('src/app/sorteos/layout.tsx');
+  it("importa './plataforma/platform-brand-leds.css'", () => {
+    expect(src).toMatch(/import\s+'\.\/plataforma\/platform-brand-leds\.css'/);
+  });
+});
+
+describe('[brand-leds] contrato del CSS — sin regresiones bloqueantes', () => {
+  const css = read('src/app/sorteos/plataforma/platform-brand-leds.css');
+
+  it('el ::before no bloquea clicks (pointer-events: none)', () => {
+    expect(css).toMatch(/\.gp-card-led::before\s*\{[\s\S]{0,600}pointer-events:\s*none/);
+  });
+
+  it('padding pequeño (~1.5px) para que el aro no coma el contenido', () => {
+    expect(css).toMatch(/\.gp-card-led::before\s*\{[\s\S]{0,600}padding:\s*1\.5px/);
+  });
+
+  it('border-radius: inherit — el aro sigue las esquinas de la card', () => {
+    expect(css).toMatch(/\.gp-card-led::before\s*\{[\s\S]{0,600}border-radius:\s*inherit/);
+  });
+});

--- a/src/__tests__/server/brand-card-skinsmonkey.test.ts
+++ b/src/__tests__/server/brand-card-skinsmonkey.test.ts
@@ -30,10 +30,15 @@ const read = (rel: string) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');
 describe('[brand-card-skinsmonkey v2] revert de hero-top y patrón compacto', () => {
   const src = read('src/features/giveaway-platform/components/BrandCardSkinsMonkey.tsx');
 
-  it('la card usa `.p-monkey-v2` (no `.p-monkey` ni hero-top)', () => {
-    expect(src).toMatch(/className="gp-card\s+p-gold\s+p-monkey-v2"/);
-    // La modificadora v1 debe estar fuera.
+  it('la card usa `.p-monkey-v2` (no `.p-monkey` ni hero-top) y hereda `.gp-card-led`', () => {
+    // La lista de clases incluye .gp-card, .gp-card-led (borde LED
+    // por marca), .p-gold y .p-monkey-v2. Toleramos cualquier orden.
+    expect(src).toMatch(/className="[^"]*\bp-monkey-v2\b[^"]*"/);
+    expect(src).toMatch(/className="[^"]*\bp-gold\b[^"]*"/);
+    expect(src).toMatch(/className="[^"]*\bgp-card-led\b[^"]*"/);
+    // La modificadora v1 (hero-top) debe estar fuera.
     expect(src).not.toMatch(/className="gp-card\s+p-gold\s+p-monkey"/);
+    expect(src).not.toMatch(/\bp-monkey\b(?!-v2)/);
   });
 
   it('YA NO existe el bloque hero-top `.gp-monkey-hero`', () => {

--- a/src/app/sorteos/layout.tsx
+++ b/src/app/sorteos/layout.tsx
@@ -8,6 +8,7 @@ import './plataforma/platform.css';
 import './plataforma/platform-dropdown.css';
 import './plataforma/platform-hero.css';
 import './plataforma/platform-brand-cards.css';
+import './plataforma/platform-brand-leds.css';
 import './plataforma/platform-fx.css';
 import './plataforma/platform-widgets.css';
 import './plataforma/platform-external-giveaways.css';

--- a/src/app/sorteos/plataforma/platform-brand-cards.css
+++ b/src/app/sorteos/plataforma/platform-brand-cards.css
@@ -55,12 +55,26 @@
   right: 20px;
 }
 
-/* ================ TARJETA KEYDROP (grande, arriba) ================ */
+/* ================ TARJETA KEYDROP (grande, arriba) ================
+ * Border/glow dorados coherentes con el logo oficial (naranja/amarillo).
+ * El interior del panel derecho sigue siendo morado por el banner. */
 .giveaway-platform .p-keydrop {
+  --brand-border: rgba(245, 200, 75, 0.55);
+  --brand-glow:   rgba(245, 200, 75, 0.28);
+  --brand-accent: #f5c84b;
+  --brand-gradient: linear-gradient(
+    90deg,
+    #b88a1e 0%,
+    #ffd766 20%,
+    #f5c84b 50%,
+    #ffd766 80%,
+    #b88a1e 100%
+  );
+
   display: grid;
   grid-template-columns: 1.12fr 0.88fr;
   min-height: 330px;
-  border-color: rgba(30, 155, 255, 0.35);
+  border-color: var(--brand-border);
 }
 .giveaway-platform .p-keydrop .pad { padding: 34px 38px; }
 .giveaway-platform .p-keydrop .claim { font-size: 19px; line-height: 1.55; max-width: 720px; margin-top: 16px; }
@@ -196,9 +210,24 @@
 }
 .giveaway-platform .gp-bonuses-empty-body span { color: var(--muted); }
 
-/* ================ CLASH + MONKEY (gold cards) ================ */
+/* ================ CLASH + MONKEY (gold cards) ================
+ * `.p-gold` es el look base dorado; SkinsMonkey (.p-monkey-v2) hereda
+ * de aquí, por lo que sus tokens LED también son gold.
+ */
 .giveaway-platform .p-gold {
-  border-color: rgba(245, 183, 61, 0.4);
+  --brand-border: rgba(245, 183, 61, 0.55);
+  --brand-glow:   rgba(245, 183, 61, 0.28);
+  --brand-accent: #f5b73d;
+  --brand-gradient: linear-gradient(
+    90deg,
+    #b88a1e 0%,
+    #f5b73d 30%,
+    #ffe27a 50%,
+    #f5b73d 70%,
+    #b88a1e 100%
+  );
+
+  border-color: var(--brand-border);
   padding: 32px 34px;
   min-height: 300px;
   overflow: hidden;
@@ -296,9 +325,25 @@
   .giveaway-platform .gp-monkey-media-img { object-position: center bottom; }
 }
 
-/* ================ CSGO-SKINS (red variant of .p-gold) ================ */
+/* ================ CSGO-SKINS (cyan variant, coherente con logo) ================
+ * La clase `.p-red` es legacy — el nombre queda por compatibilidad, pero
+ * los tokens ahora son cyan celeste para casar con el logo real de
+ * CSGO-SKINS. Antes usaba rojo/rosa.
+ */
 .giveaway-platform .p-red {
-  border-color: rgba(220, 38, 60, 0.42);
+  --brand-border: rgba(40, 215, 255, 0.55);
+  --brand-glow:   rgba(40, 215, 255, 0.28);
+  --brand-accent: #28d7ff;
+  --brand-gradient: linear-gradient(
+    90deg,
+    #0077ff 0%,
+    #28d7ff 30%,
+    #7ff0ff 50%,
+    #28d7ff 70%,
+    #0077ff 100%
+  );
+
+  border-color: var(--brand-border);
   padding: 32px 34px;
   min-height: 300px;
   overflow: hidden;
@@ -306,25 +351,41 @@
 .giveaway-platform .p-red .glow {
   position: absolute;
   inset: 0;
-  background: radial-gradient(420px 260px at 82% 60%, rgba(220, 38, 60, 0.14), transparent 70%);
+  background: radial-gradient(420px 260px at 82% 60%, rgba(40, 215, 255, 0.14), transparent 70%);
   pointer-events: none;
 }
 .giveaway-platform .pill-offer.red {
-  border-color: rgba(220, 38, 60, 0.55);
-  background: rgba(220, 38, 60, 0.08);
+  border-color: rgba(40, 215, 255, 0.55);
+  background: rgba(40, 215, 255, 0.08);
 }
-.giveaway-platform .pill-offer.red b { color: #ff5d7d; }
+.giveaway-platform .pill-offer.red b { color: #7ff0ff; }
 .giveaway-platform .btn-red {
   margin-top: 14px;
   padding: 13px 42px;
-  background: linear-gradient(90deg, #8b1526, #dc263c);
-  color: #fff;
-  box-shadow: 0 6px 22px rgba(220, 38, 60, 0.35);
+  background: linear-gradient(90deg, #0077ff, #28d7ff);
+  color: #0a1420;
+  box-shadow: 0 6px 22px rgba(40, 215, 255, 0.35);
+  font-weight: 800;
 }
 
-/* ================ SKIN.CLUB ================ */
+/* ================ SKIN.CLUB ================
+ * Border/glow rosa+morado coherentes con el logo. Los tokens LED
+ * unifican los dos matices (purple → pink → purple) en el gradient.
+ */
 .giveaway-platform .p-skinclub {
-  border-color: rgba(255, 61, 216, 0.45);
+  --brand-border: rgba(255, 61, 216, 0.55);
+  --brand-glow:   rgba(139, 61, 255, 0.28);
+  --brand-accent: #ff4bd8;
+  --brand-gradient: linear-gradient(
+    90deg,
+    #6a1bd8 0%,
+    #9b5cff 30%,
+    #ff4bd8 50%,
+    #9b5cff 70%,
+    #6a1bd8 100%
+  );
+
+  border-color: var(--brand-border);
   padding: 32px 36px;
   min-height: 330px;
   overflow: hidden;

--- a/src/app/sorteos/plataforma/platform-brand-leds.css
+++ b/src/app/sorteos/plataforma/platform-brand-leds.css
@@ -1,0 +1,81 @@
+/*
+ * LED borders para las cards de partners (KeyDrop, CSGO-SKINS,
+ * SkinsMonkey, Skin.Club).
+ *
+ * Mecanismo:
+ *   .gp-card-led ganada por cualquier .gp-card + modificadora .p-*
+ *   consume 4 variables definidas por cada marca:
+ *     --brand-border    color del borde estático (rgba)
+ *     --brand-glow      halo externo (rgba)
+ *     --brand-accent    color puro para highlights (#hex)
+ *     --brand-gradient  linear-gradient para el borde LED animado
+ *
+ *   El borde LED se pinta con un pseudo-elemento ::before usando la
+ *   técnica "gradient border via mask-composite": el ::before ocupa la
+ *   caja completa con el gradient, y una máscara con content-box
+ *   descarta el interior — queda solo el aro exterior.
+ *
+ *   La animación desplaza el background-position para simular un LED
+ *   progresivo, sutil (5s ease-in-out, sin parpadeo).
+ *
+ * Accesibilidad:
+ *   - prefers-reduced-motion desactiva la animación (el gradient queda
+ *     estático, no se pierde el color de marca).
+ *   - El ::before es `pointer-events: none` — nunca bloquea clicks.
+ *   - z-index del ::before por encima del glow interno pero por debajo
+ *     del contenido, para no tapar CTAs ni imágenes.
+ */
+
+.giveaway-platform .gp-card-led {
+  /* Fallbacks defensivos por si una marca no declara sus tokens. */
+  --brand-border: rgba(196, 40, 128, 0.35);
+  --brand-glow: rgba(224, 48, 112, 0.20);
+  --brand-accent: #e03070;
+  --brand-gradient: linear-gradient(
+    90deg,
+    var(--brand-accent) 0%,
+    color-mix(in srgb, var(--brand-accent) 40%, transparent) 45%,
+    var(--brand-accent) 100%
+  );
+
+  border-color: var(--brand-border);
+  box-shadow: 0 0 0 1px var(--brand-border), 0 12px 42px -18px var(--brand-glow);
+}
+
+.giveaway-platform .gp-card-led::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: 1.5px;
+  background: var(--brand-gradient);
+  background-size: 220% 100%;
+  background-position: 0% 50%;
+  -webkit-mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  pointer-events: none;
+  z-index: 1;
+  opacity: 0.9;
+  animation: gp-brand-led-shift 5s ease-in-out infinite;
+}
+
+/* Highlight animado adicional muy sutil — barrido lento del borde. */
+@keyframes gp-brand-led-shift {
+  0%   { background-position: 0%   50%; }
+  50%  { background-position: 100% 50%; }
+  100% { background-position: 0%   50%; }
+}
+
+/* Reduce motion — desactiva animación, mantiene color estático. */
+@media (prefers-reduced-motion: reduce) {
+  .giveaway-platform .gp-card-led::before {
+    animation: none;
+    background-position: 50% 50%;
+  }
+}

--- a/src/features/giveaway-platform/components/BrandCardCsgoskins.tsx
+++ b/src/features/giveaway-platform/components/BrandCardCsgoskins.tsx
@@ -8,7 +8,7 @@ interface Props {
 export function BrandCardCsgoskins({ code }: Props) {
   const brand = PLATFORM_BRANDS.csgoskins;
   return (
-    <div className="gp-card p-red">
+    <div className="gp-card gp-card-led p-red">
       <div className="glow" aria-hidden />
       <div className="gp-logo-slot">
         {brand.logoAsset ? (

--- a/src/features/giveaway-platform/components/BrandCardKeyDrop.tsx
+++ b/src/features/giveaway-platform/components/BrandCardKeyDrop.tsx
@@ -9,7 +9,7 @@ export function BrandCardKeyDrop({ code }: Props) {
   const brand = PLATFORM_BRANDS.keydrop;
   return (
     <section aria-labelledby="brand-keydrop">
-      <div className="gp-card p-keydrop">
+      <div className="gp-card gp-card-led p-keydrop">
         <div className="pad">
           <div className="gp-logo-slot">
             {brand.logoAsset ? (

--- a/src/features/giveaway-platform/components/BrandCardSkinClub.tsx
+++ b/src/features/giveaway-platform/components/BrandCardSkinClub.tsx
@@ -9,7 +9,7 @@ export function BrandCardSkinClub({ code }: Props) {
   const brand = PLATFORM_BRANDS.skinclub;
   return (
     <section aria-labelledby="brand-skinclub">
-      <div className="gp-card p-skinclub">
+      <div className="gp-card gp-card-led p-skinclub">
         <div className="glow" aria-hidden />
         <div className="ufo" aria-hidden>🛸</div>
         <div className="gp-logo-slot">

--- a/src/features/giveaway-platform/components/BrandCardSkinsMonkey.tsx
+++ b/src/features/giveaway-platform/components/BrandCardSkinsMonkey.tsx
@@ -22,7 +22,7 @@ interface Props {
 export function BrandCardSkinsMonkey({ code }: Props) {
   const brand = PLATFORM_BRANDS.skinsmonkey;
   return (
-    <div className="gp-card p-gold p-monkey-v2">
+    <div className="gp-card gp-card-led p-gold p-monkey-v2">
       <div className="glow" aria-hidden />
       {brand.agentAsset ? (
         <div className="gp-monkey-media" aria-hidden>


### PR DESCRIPTION
Cada card de partner tiene ahora borde + glow del color de su marca con efecto LED progresivo sutil. **No mergear sin OK visual.**

## Archivos tocados

- ➕ \`src/app/sorteos/plataforma/platform-brand-leds.css\` (mecanismo compartido).
- 🔧 \`src/app/sorteos/plataforma/platform-brand-cards.css\` (tokens por marca).
- 🔧 \`src/features/giveaway-platform/components/BrandCardKeyDrop.tsx\` (+ \`gp-card-led\`).
- 🔧 \`src/features/giveaway-platform/components/BrandCardCsgoskins.tsx\` (+ \`gp-card-led\`).
- 🔧 \`src/features/giveaway-platform/components/BrandCardSkinsMonkey.tsx\` (+ \`gp-card-led\`).
- 🔧 \`src/features/giveaway-platform/components/BrandCardSkinClub.tsx\` (+ \`gp-card-led\`).
- 🔧 \`src/app/sorteos/layout.tsx\` (importa el CSS nuevo).
- ➕ \`src/__tests__/server/brand-card-leds.test.ts\` (19 asserts).
- 🔧 \`src/__tests__/server/brand-card-skinsmonkey.test.ts\` (assert de className tolerante al orden).

## Descripción visual del efecto LED

**Mecanismo:** pseudo-elemento \`::before\` sobre \`.gp-card-led\` con la técnica **"gradient border via mask-composite: exclude"** — el ::before ocupa la caja completa con un \`linear-gradient\` de la marca, y una máscara con \`content-box\` descarta el interior. Queda solo el aro exterior de 1.5px pintado con el gradient.

**Animación:** \`background-position\` shift 0% → 100% → 0% en 5s ease-in-out infinite. El resultado es un barrido suave del color a lo largo del borde — tipo LED progresivo, no parpadea.

**Glow:** \`box-shadow\` externo con el \`--brand-glow\` para halo suave.

**Tokens por marca:**

| Marca | Antes | Ahora | Accent |
|---|---|---|---|
| KeyDrop | Azul (30,155,255) ❌ chocaba con logo | **Dorado** ✅ | \`#f5c84b\` |
| CSGO-SKINS | Rojo (220,38,60) ❌ chocaba con logo | **Cyan celeste** ✅ | \`#28d7ff\` |
| SkinsMonkey | Gold — ok | **Gold** (unificado) | \`#f5b73d\` |
| Skin.Club | Purple/pink — ok | **Purple/pink** (unificado) | \`#ff4bd8\` |

Además de \`--brand-border\`, \`--brand-glow\` y \`--brand-accent\`, cada marca define un \`--brand-gradient\` de 5 stops (dark → mid → light → mid → dark) para el barrido.

Para CSGO-SKINS también se pasan a cyan el \`pill-offer.red\`, el \`btn-red\` (background + shadow) y el \`.p-red .glow\` interno, para que la card entera esté coherente. La clase \`.p-red\` queda por compatibilidad, pero ya no es "roja" — solo un nombre legacy.

## Accesibilidad / performance

- \`prefers-reduced-motion: reduce\` → \`animation: none\` + \`background-position: 50% 50%\` (mantiene el color estático, no se pierde la identidad de marca).
- \`pointer-events: none\` en el ::before → jamás bloquea CTAs ni imágenes.
- \`padding: 1.5px\` → aro delgado, no come el contenido.
- \`border-radius: inherit\` → sigue las esquinas 16px de la card.
- 1 sola animación por card, sobre un pseudo-elemento. Muy barato en render.

## Casos actuales (post-#178)

Con la config adaptativa mergeada en #178, en \`/sorteos/zacketizor\` solo aparecen KeyDrop + CSGO-SKINS. Ambos ahora con sus colores correctos.

- \`/sorteos/huasopeek\`, \`/naow\`, \`/todocs2\`, \`/imantado\`, \`/jolu\` → siguen viendo el placeholder honesto ("Deals de partners próximamente"). Los LEDs solo aparecen cuando hay cards que renderizar.

## Sin cambios prohibidos
- 0 migraciones · 0 cambios en \`.env*\` · 0 cambios en \`next.config.ts\`.
- 0 cambios en lógica de negocio, providers, auth, monedas, rutas, legales.
- 0 nuevos partners ni bindings.
- 0 escrituras a coin/entry/mission.

## Test plan
- [x] \`npx tsc --noEmit\` → 0 errores en \`src/\`.
- [x] \`npx jest src/__tests__/server/\` → **124 suites / 2492 tests passing** (+19 assertions nuevas + brand-card-skinsmonkey ajustado).
- [x] \`npx eslint\` → 0 warnings en \`src/\`.
- [ ] Smoke visual en preview:
  - \`/sorteos/zacketizor\` → KeyDrop con borde dorado; CSGO-SKINS con borde cyan. Barrido suave visible.
  - Reduce motion activado (en macOS: Sistema → Accesibilidad → Motion) → borde estático con el color, sin animación.
  - Mobile: LED no rompe layout, no mete overflow horizontal, CTAs siguen alineados.
  - Otras rutas de creadores sin deals → siguen con placeholder honesto, sin LED (no hay cards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)