### PR TITLE
feat(sorteos): política de economía de monedas + Fase 2 UI/config sin migración

### DIFF
--- a/docs/sorteos-coin-economy.md
+++ b/docs/sorteos-coin-economy.md
@@ -1,0 +1,249 @@
+# Economía de monedas — SocialPro Giveaways
+
+**Estado:** Fase 1 — política aprobada por producto, pendiente de revisión legal para textos públicos.
+**Alcance:** `/sorteos/plataforma`, misiones, tienda, rankings, perfil.
+**Autor:** producto (2026-07-03).
+
+Este documento fija la regla interna de balance para la economía de monedas 🪙 de la plataforma. La regla NO se expone al usuario ni se comunica como conversión monetaria — es una guía interna para calibrar rewards y precios.
+
+---
+
+## 1. Regla interna de valoración
+
+- **1 USD de coste interno ≈ 1.000 monedas.**
+- **1 EUR de coste interno ≈ 1.100 monedas.**
+
+Uso: cuando un artículo cueste al proveedor (SocialPro) X€, su precio interno base es `X × 1.100`. Se ajusta a la baja para incentivar canjes menores y al alza para artículos premium (fricción, uso de stock limitado, marca).
+
+**Importante — nunca exponer al usuario:**
+- No mostrar "1.000 monedas = 1$" en la UI.
+- No permitir comprar monedas con dinero.
+- No permitir transferir monedas entre usuarios.
+- No permitir marketplace usuario↔usuario.
+- No decir que las monedas tienen valor monetario.
+- Copy público estable: *"Las monedas son puntos internos sin valor monetario, no transferibles y no canjeables por dinero."*
+
+Ver también `docs/giveaway-coin-economy-plan.md` (plan técnico futuro de expansión), `docs/sorteos-*` legales.
+
+---
+
+## 2. Diagnóstico del estado actual (2026-07-03)
+
+### Rewards actuales (`src/lib/giveaway-platform/constants.ts` + `scripts/seed-giveaway-platform.ts`)
+
+| Fuente | Valor |
+|---|---|
+| Racha diaria días 1-7 | `[10, 15, 20, 25, 30, 40, 60]` → total semana **200 monedas** |
+| Participar en sorteo interno (`ENTRY_COIN_REWARD`) | 20 monedas |
+| Misión "Primera participación" | 50 |
+| Misión "Participa en +5 sorteos" | 250 |
+| Misión "Participa en +50 sorteos" | 1.500 |
+| Misión "Participa en +100 sorteos" | 3.000 |
+| Misión "Racha 7 días" | 400 |
+
+### Precios actuales de tienda
+
+| Item | Precio actual |
+|---|---|
+| Glock-18 · Water Elemental | 150 |
+| USP-S · Kill Confirmed | 450 |
+| AK-47 · Redline | 800 |
+| Camiseta SocialPro | 300 |
+| Gorra SocialPro | 220 |
+| Tarjeta Steam 10€ | **1.000** |
+| Tarjeta Steam 20€ | 1.900 |
+| Tarjeta Steam 50€ | 4.500 |
+| PSN Plus 1 mes (~5€) | 900 |
+| Riot Points 10€ | 1.000 |
+
+Ratio actual = ~100 monedas/€. Propuesta = ~1.100 monedas/€. **Factor de reajuste ≈ 11×.**
+
+---
+
+## 3. Nueva economía objetivo
+
+### 3.1 Ganancia (rewards)
+
+| Fuente | Rango objetivo |
+|---|---|
+| Login diario (racha día 1) | 20 monedas |
+| Racha 3 días completada | +75 monedas |
+| Racha 7 días completada | +250 monedas |
+| Misión básica | 50 monedas |
+| Misión media | 250 monedas |
+| Misión premium (verificada) | 1.000 monedas |
+| Participar en sorteo interno | 50 monedas |
+| Completar perfil | 150 monedas (una vez) |
+| Conectar Discord/YouTube (futuro) | 250-750 monedas (una vez cada canal) |
+| Ranking mensual — Top 3 | premio especial (ver §6) |
+
+**Ganancia esperada por perfil:**
+- **Casual** (login diario + 1 sorteo/semana): ~150 mon/semana → ~600/mes.
+- **Activo** (racha completa + 3 misiones básicas/mes): ~1.200 mon/mes.
+- **Grinder** (racha + misiones media + participaciones semanales): ~3.500-5.000 mon/mes.
+
+### 3.2 Precios de tienda
+
+| Categoría | Rango | Ejemplo |
+|---|---|---|
+| Profile card básica | 1.500-3.000 | Neon Pink, Cyber Blue |
+| Profile card premium | 5.000-10.000 | Gold Elite, Inferno |
+| Avatar frame básico | 2.000-4.000 | Cyan glow, Basic gold |
+| Avatar frame premium | 7.500-15.000 | Legendary flame |
+| Badge premium | 3.000-10.000 | OG Member, Top Grinder |
+| Gift card 5$ | 5.500-7.500 | Steam, Riot, PSN |
+| Gift card 10€ | 11.000-15.000 | Steam, PSN Plus |
+| Gift card 25$ | 25.000-40.000 | Steam / Riot Points |
+| Skin CS2 pequeña | 3.000-8.000 | Glock, USP-S básicas |
+| Skin CS2 media | 10.000-25.000 | AK-47 · Redline y similares |
+| Skin CS2 premium | 40.000+ | knife, gloves, top-tier factory new |
+| Merch físico (T-shirt) | coste-interno × 1.3 → ~15.000 mon si T-shirt cuesta ~11€ |
+
+### 3.3 Política de dificultad
+
+- **Casual** (login diario) → alcanza recompensa pequeña (Profile card básica) en ~2 semanas.
+- **Activo** → gift card 10€ o skin pequeña en ~1 mes.
+- **Grinder** → skin media o gift card 25$ en 2-3 meses.
+- **Premio grande** (skin premium, knife/gloves) requiere constancia + ranking + campañas especiales — NO farmeable con solo login diario.
+
+Regla dura: **con solo login diario 30 días** el usuario acumula ~600 monedas → una profile card básica. No permite skin ni gift card. Hace falta misiones + participación.
+
+### 3.4 Reglas legales / disclaimers públicos
+
+Estas frases deben aparecer literales o equivalentes en tienda/FAQ/perfil (borrador; validar con gestoría antes de definitivas):
+
+- "Las monedas son puntos internos sin valor monetario."
+- "No son criptomonedas."
+- "No son transferibles entre usuarios."
+- "No pueden venderse."
+- "No son canjeables por dinero en efectivo."
+- "Los precios y disponibilidad pueden cambiar."
+- "Los canjes pueden requerir revisión antes del envío."
+
+---
+
+## 4. Sistema de personalización de perfil (nuevo)
+
+### 4.1 MVP inicial — items visuales
+
+Los siguientes items entran como categorías nuevas en `shop_items`:
+
+| Item | Categoría | Precio inicial | Notas |
+|---|---|---|---|
+| Profile Card — Neon Pink | `profile` | 1.500 | Básica |
+| Profile Card — Cyber Blue | `profile` | 2.500 | Básica |
+| Profile Card — Gold Elite | `profile` | 5.000 | Premium |
+| Profile Card — Inferno | `profile` | 8.000 | Premium |
+| Avatar Frame — Cyan | `frame` | 2.000 | Básico |
+| Avatar Frame — Gold | `frame` | 7.500 | Premium |
+| Badge — OG Member | `badge` | 3.000 | Exclusivo pre-registro |
+| Badge — Top Grinder | `badge` | 5.000 | Constancia |
+
+**Categorías nuevas** (`profile`, `frame`, `badge`) caben en el `varchar(10)` actual de `shop_items.category` — no requiere migración de esquema.
+
+**Estado del rendering visual:** hasta que exista soporte de equipamiento (§4.2), los items aparecen en tienda como "Próximamente disponible para equipar". Se canjean, se registran en `redemptions`, pero el efecto visual queda pendiente.
+
+### 4.2 Qué falta para "equipar" cosméticos
+
+Para que el usuario pueda equipar y ver su cosmético en el perfil hace falta:
+
+**Migración pendiente (requiere confirmación de Pablo antes de generar):**
+
+Opción A — columnas por tipo en `player_profiles`:
+```sql
+ALTER TABLE player_profiles
+  ADD COLUMN equipped_profile_card_id INTEGER REFERENCES shop_items(id),
+  ADD COLUMN equipped_frame_id        INTEGER REFERENCES shop_items(id),
+  ADD COLUMN equipped_badge_id        INTEGER REFERENCES shop_items(id);
+```
+
+Opción B — tabla dedicada `user_cosmetics`:
+```sql
+CREATE TABLE user_cosmetics (
+  user_id TEXT REFERENCES "user"(id) ON DELETE CASCADE,
+  shop_item_id INTEGER REFERENCES shop_items(id),
+  equipped BOOLEAN NOT NULL DEFAULT false,
+  acquired_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (user_id, shop_item_id)
+);
+```
+
+**Recomendación:** Opción B es más flexible (permite múltiples cosméticos del mismo tipo, historial, etc.) pero también requiere más código de UI. Opción A es más rápida.
+
+Cuando Pablo apruebe, se hace en un PR separado con migración Drizzle (`npx drizzle-kit generate` → `npm run migrate`).
+
+### 4.3 Categorías de tienda visibles en UI
+
+Ampliación en `src/features/giveaway-platform/components/PlatformShop.tsx`:
+
+- Todo (`all`)
+- 🔫 Skins CS2 (`skin`)
+- 👕 Merch SocialPro (`merch`)
+- 🎁 Tarjetas regalo (`gift`)
+- 🎨 Profile Cards (`profile`) *(nueva)*
+- 🖼️ Avatar Frames (`frame`) *(nueva)*
+- 🏅 Badges (`badge`) *(nueva)*
+
+---
+
+## 5. Reajuste de la economía existente
+
+**Rewards** — cambio recomendado:
+- `STREAK_REWARDS`: `[20, 25, 30, 40, 50, 60, 75]` → total semana **300** (antes 200).
+- `ENTRY_COIN_REWARD`: 20 → 50 (antes también incluía "por sorteo", ahora "por participación").
+
+**Misiones** — mantener rango 50-3.000, pero clarificar tiers:
+- Básica: 50 mon (una tarea puntual).
+- Media: 250 mon (semanal o "5 acciones").
+- Premium: 1.000-1.500 mon (mensual, verificada).
+
+**Precios shop** — factor ~11×:
+- Steam 10€: 1.000 → 11.000.
+- Steam 20€: 1.900 → 22.000.
+- Steam 50€: 4.500 → 55.000.
+- Skins pequeñas (Glock/USP): 150-450 → 3.000-6.000.
+- Skin media (AK Redline): 800 → 12.000-15.000.
+- T-shirt: 300 → 12.000-15.000 (coste ~11€ × 1.3 ratio).
+- Gorra: 220 → 9.000.
+
+**Riesgo:** si aplicamos el reajuste de golpe, los balances actuales de usuarios existentes quedarán muy bajos vs la nueva escala. Dos opciones:
+- **A.** Aplicar rebase 1:11 a todos los balances (`UPDATE coin_transactions SET amount = amount * 11 WHERE created_at < NOW()`). Complejo y auditable.
+- **B.** No reescalar el pasado; los usuarios existentes conservan su saldo y ganan al ritmo nuevo. Puede parecer inflación pero es la opción honesta y auditable.
+
+Recomiendo **B**. Documentar el cambio con fecha en un mensaje interno.
+
+---
+
+## 6. Ranking y campañas especiales
+
+Espacio reservado para expansiones futuras:
+
+- **Ranking mensual** — top 3 recibe bonus one-shot (2.500 / 1.500 / 1.000 monedas + badge exclusivo). Ver `getMonthlyRanking` en `src/lib/queries/giveawayPlatform.ts`.
+- **Campañas de creador** — un partner (KeyDrop, futuros) puede lanzar campaña con multiplicador de monedas por participar (ej. ×2 durante 1 semana). Implementación pendiente.
+- **Season pass** — badge premium mensual desbloqueable con actividad.
+
+Cada expansión requiere PR propio + revisión legal si hay premio en dinero equivalente.
+
+---
+
+## 7. Contras / vectores de fraude
+
+- **Multi-account** — riesgo mitigable con verificación Steam ID único (ya implementado en `player_profiles.steamId UNIQUE`).
+- **Bots** — actualmente no hay CAPTCHA en la participación. Coste bajo por bot → riesgo de vaciar stock de gift cards. Mitigable con rate limit + revisión manual antes de canjear items caros.
+- **Trade offers Steam** — para canjear skins CS2 hace falta que el usuario tenga configurada su URL de trade. Ya existe en `player_profiles.steamTradeUrl` (opcional).
+- **Refunds** — los canjes son firmes. Ver disclaimer del apartado legal.
+
+---
+
+## 8. Roadmap
+
+| Fase | Alcance | Requiere migración |
+|---|---|---|
+| Fase 1 — este doc | Política, tablas, disclaimers | No |
+| Fase 2 — UI adaptada | Nuevas categorías tienda, disclaimer, seeds actualizados (no ejecutados) | No |
+| Fase 3 — equipar cosméticos | `equipped_*` en `player_profiles` o `user_cosmetics` | **Sí** — pedir OK antes |
+| Fase 4 — reajuste económico | Cambio de constantes rewards + `costCoins` en seed. Aplicar a producción con seed idempotente | No (solo re-seed) |
+| Fase 5 — ranking mensual bonus | Cron end-of-month que distribuye premios | Posible tabla `monthly_bonuses` |
+| Fase 6 — campañas creador | Tabla `coin_campaigns` con multiplicadores temporales | Sí |
+
+**Este PR se limita a Fase 1 + Fase 2 sin ejecutar el reseed.** Los cambios de precios reales en producción los aplicas tú corriendo `npx tsx scripts/seed-giveaway-platform.ts` cuando decidas.

--- a/scripts/seed-giveaway-platform.ts
+++ b/scripts/seed-giveaway-platform.ts
@@ -30,17 +30,51 @@ const MISSIONS = [
 /** Títulos legacy a desactivar (se conservan filas + claims históricos). */
 const DEACTIVATE_TITLES = ['Coleccionista', 'Racha de 7 días'];
 
+/**
+ * Precios reajustados 2026-07-03 según la nueva economía objetivo
+ * (docs/sorteos-coin-economy.md). Factor ~11× vs valores previos para
+ * alinear con la regla interna "1$ ≈ 1.000 monedas".
+ *
+ * NO se ejecuta automáticamente. Correr `npx tsx scripts/seed-giveaway-platform.ts`
+ * cuando decidamos aplicar los cambios en producción. Ver también
+ * §5 del doc para el riesgo de reescalado del pasado.
+ *
+ * Las 3 nuevas categorías (`profile`, `frame`, `badge`) caben en el
+ * `varchar(10)` actual de `shop_items.category` — sin migración de esquema.
+ * Para EQUIPAR estos cosméticos hace falta migración adicional (§4.2 del doc).
+ */
 const SHOP_ITEMS = [
-  { category: 'skin', name: '★ Glock-18 · Water Elemental', description: 'Stock propio · envío por trade offer', costCoins: 150, stock: 4, sortOrder: 1 },
-  { category: 'skin', name: '★ USP-S · Kill Confirmed',      description: 'Stock propio · envío por trade offer', costCoins: 450, stock: 2, sortOrder: 2 },
-  { category: 'skin', name: '★ AK-47 · Redline',             description: 'Stock propio · envío por trade offer', costCoins: 800, stock: 3, sortOrder: 3 },
-  { category: 'merch', name: 'Camiseta SocialPro',            description: 'Edición 2026 · envío incluido',         costCoins: 300, stock: 25, sortOrder: 10 },
-  { category: 'merch', name: 'Gorra SocialPro',               description: 'Bordado · envío incluido',              costCoins: 220, stock: 18, sortOrder: 11 },
-  { category: 'gift', name: 'Tarjeta Steam 10€',              description: 'Código digital por email',              costCoins: 1000, stock: 10, sortOrder: 20 },
-  { category: 'gift', name: 'Tarjeta Steam 20€',              description: 'Código digital por email',              costCoins: 1900, stock: 6, sortOrder: 21 },
-  { category: 'gift', name: 'Tarjeta Steam 50€',              description: 'Código digital por email',              costCoins: 4500, stock: 3, sortOrder: 22 },
-  { category: 'gift', name: 'PSN Plus · 1 mes',               description: 'Código digital por email',              costCoins: 900, stock: 8, sortOrder: 23 },
-  { category: 'gift', name: 'Riot Points 10€',                description: 'Código digital por email',              costCoins: 1000, stock: 8, sortOrder: 24 },
+  // Skins CS2 — stock propio, envío por trade offer.
+  { category: 'skin',  name: '★ Glock-18 · Water Elemental', description: 'Stock propio · envío por trade offer', costCoins: 3000,  stock: 4,  sortOrder: 1 },
+  { category: 'skin',  name: '★ USP-S · Kill Confirmed',     description: 'Stock propio · envío por trade offer', costCoins: 6000,  stock: 2,  sortOrder: 2 },
+  { category: 'skin',  name: '★ AK-47 · Redline',            description: 'Stock propio · envío por trade offer', costCoins: 15000, stock: 3,  sortOrder: 3 },
+
+  // Merch físico SocialPro.
+  { category: 'merch', name: 'Camiseta SocialPro',           description: 'Edición 2026 · envío incluido',        costCoins: 15000, stock: 25, sortOrder: 10 },
+  { category: 'merch', name: 'Gorra SocialPro',              description: 'Bordado · envío incluido',             costCoins: 9000,  stock: 18, sortOrder: 11 },
+
+  // Tarjetas regalo (códigos digitales por email).
+  { category: 'gift',  name: 'Tarjeta Steam 10€',            description: 'Código digital por email',             costCoins: 11000, stock: 10, sortOrder: 20 },
+  { category: 'gift',  name: 'Tarjeta Steam 20€',            description: 'Código digital por email',             costCoins: 22000, stock: 6,  sortOrder: 21 },
+  { category: 'gift',  name: 'Tarjeta Steam 50€',            description: 'Código digital por email',             costCoins: 55000, stock: 3,  sortOrder: 22 },
+  { category: 'gift',  name: 'PSN Plus · 1 mes',             description: 'Código digital por email',             costCoins: 8500,  stock: 8,  sortOrder: 23 },
+  { category: 'gift',  name: 'Riot Points 10€',              description: 'Código digital por email',             costCoins: 11000, stock: 8,  sortOrder: 24 },
+
+  // Profile Cards — cosméticos de perfil. Efecto visual pendiente de
+  // migración (equipped_profile_card_id o user_cosmetics). El canje ya
+  // funciona: se registra en redemptions y se marca "próximamente".
+  { category: 'profile', name: 'Profile Card — Neon Pink',   description: 'Cosmético digital · próximamente equipable', costCoins: 1500, stock: 500, sortOrder: 30 },
+  { category: 'profile', name: 'Profile Card — Cyber Blue',  description: 'Cosmético digital · próximamente equipable', costCoins: 2500, stock: 500, sortOrder: 31 },
+  { category: 'profile', name: 'Profile Card — Gold Elite',  description: 'Cosmético digital premium · próximamente equipable', costCoins: 5000, stock: 200, sortOrder: 32 },
+  { category: 'profile', name: 'Profile Card — Inferno',     description: 'Cosmético digital premium · próximamente equipable', costCoins: 8000, stock: 100, sortOrder: 33 },
+
+  // Avatar Frames.
+  { category: 'frame',   name: 'Avatar Frame — Cyan',        description: 'Marco alrededor del avatar · próximamente equipable', costCoins: 2000, stock: 500, sortOrder: 40 },
+  { category: 'frame',   name: 'Avatar Frame — Gold',        description: 'Marco alrededor del avatar · próximamente equipable', costCoins: 7500, stock: 150, sortOrder: 41 },
+
+  // Badges.
+  { category: 'badge',   name: 'Badge — OG Member',          description: 'Reconocimiento pre-registro · próximamente equipable', costCoins: 3000, stock: 300, sortOrder: 50 },
+  { category: 'badge',   name: 'Badge — Top Grinder',        description: 'Reconocimiento por constancia · próximamente equipable', costCoins: 5000, stock: 200, sortOrder: 51 },
 ];
 
 async function main() {

--- a/src/__tests__/server/coin-economy.test.ts
+++ b/src/__tests__/server/coin-economy.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Contratos estructurales de la Fase 1+2 de la economía de monedas.
+ *
+ * Regla interna (docs/sorteos-coin-economy.md):
+ *   1 USD ≈ 1.000 monedas · 1 EUR ≈ 1.100 monedas.
+ *   Nunca exponer esta conversión al usuario ni permitir
+ *   comprar/transferir monedas.
+ *
+ * Este test verifica:
+ *  - Doc existe con las tablas y reglas.
+ *  - Tipo ShopCategory ampliado (profile/frame/badge) sin migración.
+ *  - PlatformShop muestra las nuevas categorías + disclaimer legal.
+ *  - Seed script actualizado con nueva economía + profile cards demo
+ *    (NO se ejecuta desde este PR).
+ *  - Sin fugas: nadie expone "1$ = 1000 monedas" en UI pública ni existe
+ *    endpoint de "comprar monedas" o "transferir monedas".
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(__dirname, '..', '..', '..');
+const read = (rel: string) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');
+
+describe('[coin-economy] doc de política', () => {
+  const doc = read('docs/sorteos-coin-economy.md');
+
+  it('existe y cita la regla interna 1$ ≈ 1.000 monedas', () => {
+    expect(doc).toMatch(/1 USD de coste interno\s*≈\s*1\.?000 monedas/i);
+    expect(doc).toMatch(/1 EUR de coste interno\s*≈\s*1\.?100 monedas/i);
+  });
+
+  it('deja claro que la regla NUNCA se expone al usuario', () => {
+    expect(doc).toMatch(/nunca exponer al usuario/i);
+    expect(doc).toMatch(/No mostrar "1\.000 monedas\s*=\s*1\$" en la UI/);
+  });
+
+  it('reglas legales completas de "no valor monetario"', () => {
+    expect(doc).toMatch(/sin valor monetario/i);
+    expect(doc).toMatch(/No son criptomonedas/i);
+    expect(doc).toMatch(/No son transferibles/i);
+    expect(doc).toMatch(/No pueden venderse/i);
+    expect(doc).toMatch(/No son canjeables por dinero/i);
+  });
+
+  it('incluye tabla de rewards y precios objetivo', () => {
+    expect(doc).toMatch(/Racha 7 días completada[\s\S]{0,80}250 monedas/i);
+    expect(doc).toMatch(/Gift card 10€[\s\S]{0,120}11\.?000-15\.?000/i);
+    expect(doc).toMatch(/Skin CS2 premium/i);
+  });
+
+  it('sección profile cards MVP + qué falta para equipar', () => {
+    expect(doc).toMatch(/Profile Card\s*—\s*Neon Pink/);
+    expect(doc).toMatch(/Profile Card\s*—\s*Gold Elite/);
+    expect(doc).toMatch(/qué falta para "equipar" cosméticos/i);
+    // Deja constancia de que hace falta migración.
+    expect(doc).toMatch(/Migración pendiente/i);
+    expect(doc).toMatch(/ALTER TABLE player_profiles/);
+  });
+
+  it('roadmap con fases claras y qué requiere migración', () => {
+    expect(doc).toMatch(/Fase 1[\s\S]{0,80}\| No/);
+    expect(doc).toMatch(/Fase 2[\s\S]{0,120}\| No/);
+    expect(doc).toMatch(/Fase 3[\s\S]{0,120}\| \*\*Sí\*\*/);
+  });
+});
+
+describe('[coin-economy] tipos + DB (sin migración)', () => {
+  it('ShopCategory amplía a profile/frame/badge en TypeScript', () => {
+    const src = read('src/types/giveawayPlatform.ts');
+    expect(src).toMatch(/type ShopCategory\s*=[\s\S]{0,120}'profile'/);
+    expect(src).toMatch(/type ShopCategory\s*=[\s\S]{0,120}'frame'/);
+    expect(src).toMatch(/type ShopCategory\s*=[\s\S]{0,120}'badge'/);
+  });
+
+  it('los strings nuevos caben en el varchar(10) actual (sin migración)', () => {
+    for (const cat of ['profile', 'frame', 'badge'] as const) {
+      expect(cat.length).toBeLessThanOrEqual(10);
+    }
+  });
+
+  it('el schema shop_items sigue con category varchar length 10 — no se toca', () => {
+    const src = read('src/db/schema/shopItems.ts');
+    expect(src).toMatch(/category:\s*varchar\('category',\s*\{\s*length:\s*10\s*\}\)/);
+  });
+});
+
+describe('[coin-economy] PlatformShop UI', () => {
+  const src = read('src/features/giveaway-platform/components/PlatformShop.tsx');
+
+  it('CATEGORIES incluye las 3 nuevas cosméticas', () => {
+    expect(src).toMatch(/key:\s*'profile',\s*label:\s*'🎨 Profile Cards'/);
+    expect(src).toMatch(/key:\s*'frame',\s*label:\s*'🖼️ Avatar Frames'/);
+    expect(src).toMatch(/key:\s*'badge',\s*label:\s*'🏅 Badges'/);
+  });
+
+  it('renderiza disclaimer legal público — sin valor monetario', () => {
+    expect(src).toMatch(/gp-shop-disclaimer/);
+    expect(src).toMatch(/sin valor monetario/);
+    expect(src).toMatch(/no\s+transferibles/i);
+    expect(src).toMatch(/no canjeables por dinero/i);
+  });
+
+  it('el disclaimer NUNCA cita la conversión interna (fuga bloqueada)', () => {
+    expect(src).not.toMatch(/1\.?000 monedas\s*=\s*1\s*\$/i);
+    expect(src).not.toMatch(/1\.?100 monedas\s*=\s*1\s*€/i);
+    expect(src).not.toMatch(/1\s*USD.*1\.?000/i);
+    expect(src).not.toMatch(/valor.*€|valor.*USD/i);
+  });
+
+  it('CSS del disclaimer existe con dashed border', () => {
+    const css = read('src/app/sorteos/plataforma/platform-widgets.css');
+    expect(css).toMatch(/\.gp-shop-disclaimer\s*\{[\s\S]{0,400}border:\s*1px\s+dashed/);
+  });
+});
+
+describe('[coin-economy] seed script actualizado — NO ejecutado desde el PR', () => {
+  const src = read('scripts/seed-giveaway-platform.ts');
+
+  it('cita el doc y advierte que no se ejecuta automáticamente', () => {
+    expect(src).toMatch(/docs\/sorteos-coin-economy\.md/);
+    expect(src).toMatch(/NO se ejecuta automáticamente/);
+  });
+
+  it('precios reajustados a la nueva economía', () => {
+    expect(src).toMatch(/Tarjeta Steam 10€[\s\S]{0,200}costCoins:\s*11000/);
+    expect(src).toMatch(/Tarjeta Steam 20€[\s\S]{0,200}costCoins:\s*22000/);
+    expect(src).toMatch(/Tarjeta Steam 50€[\s\S]{0,200}costCoins:\s*55000/);
+    expect(src).toMatch(/AK-47 · Redline[\s\S]{0,200}costCoins:\s*15000/);
+  });
+
+  it('los 4 Profile Cards MVP existen con precios en rango del doc', () => {
+    expect(src).toMatch(/Profile Card — Neon Pink[\s\S]{0,200}costCoins:\s*1500/);
+    expect(src).toMatch(/Profile Card — Cyber Blue[\s\S]{0,200}costCoins:\s*2500/);
+    expect(src).toMatch(/Profile Card — Gold Elite[\s\S]{0,200}costCoins:\s*5000/);
+    expect(src).toMatch(/Profile Card — Inferno[\s\S]{0,200}costCoins:\s*8000/);
+  });
+
+  it('todos los precios de profile card están en rango 1.500-10.000', () => {
+    const matches = Array.from(src.matchAll(/category:\s*'profile'[\s\S]{0,200}costCoins:\s*(\d+)/g));
+    expect(matches.length).toBeGreaterThanOrEqual(4);
+    for (const m of matches) {
+      const cost = Number(m[1]);
+      expect(cost).toBeGreaterThanOrEqual(1500);
+      expect(cost).toBeLessThanOrEqual(10000);
+    }
+  });
+
+  it('avatar frames + badges añadidos también', () => {
+    expect(src).toMatch(/category:\s*'frame'[\s\S]{0,80}Avatar Frame — Cyan/);
+    expect(src).toMatch(/category:\s*'badge'[\s\S]{0,80}Badge — OG Member/);
+  });
+});
+
+describe('[coin-economy] safeguards — ningún vector prohibido en código', () => {
+  const SRC_PATHS = [
+    'src/features/giveaway-platform/components/PlatformShop.tsx',
+    'src/app/sorteos/plataforma/actions.ts',
+    'src/app/sorteos/page.tsx',
+    'src/features/giveaway-platform/components/PlatformCreatorLanding.tsx',
+  ];
+
+  it('ningún componente/action ofrece "comprar monedas" con dinero', () => {
+    for (const p of SRC_PATHS) {
+      const src = read(p);
+      expect(src).not.toMatch(/comprar monedas/i);
+      expect(src).not.toMatch(/purchase coins/i);
+      expect(src).not.toMatch(/buy coins/i);
+    }
+  });
+
+  it('ningún componente/action ofrece "transferir monedas" entre usuarios', () => {
+    for (const p of SRC_PATHS) {
+      const src = read(p);
+      expect(src).not.toMatch(/transferir monedas/i);
+      expect(src).not.toMatch(/transfer coins/i);
+      expect(src).not.toMatch(/enviar monedas/i);
+    }
+  });
+
+  it('ningún componente/action ofrece "marketplace" P2P', () => {
+    for (const p of SRC_PATHS) {
+      const src = read(p);
+      expect(src).not.toMatch(/marketplace/i);
+      expect(src).not.toMatch(/vender monedas/i);
+    }
+  });
+
+  it('las Server Actions no aceptan money-in por externos (sin depósitos)', () => {
+    const actions = read('src/app/sorteos/plataforma/actions.ts');
+    // El fetch de sorteos externos no debe usar awardCoins ni insertar
+    // en coin_transactions con source distinto a los internos.
+    expect(actions).not.toMatch(/keydrop.*insert.*coin_transactions/i);
+    expect(actions).not.toMatch(/external.*award/i);
+  });
+});

--- a/src/app/sorteos/plataforma/platform-widgets.css
+++ b/src/app/sorteos/plataforma/platform-widgets.css
@@ -452,6 +452,19 @@
 }
 .giveaway-platform .gp-shop-next.ok { color: #4ade80; font-weight: 700; }
 
+/* Disclaimer legal — sin valor monetario. Copy en docs/sorteos-coin-economy.md §3.4 */
+.giveaway-platform .gp-shop-disclaimer {
+  margin: 10px 0 16px;
+  padding: 10px 14px;
+  border-radius: 10px;
+  background: rgba(11, 9, 23, 0.55);
+  border: 1px dashed rgba(196, 40, 128, 0.28);
+  color: var(--muted);
+  font-size: 11.5px;
+  line-height: 1.55;
+}
+.giveaway-platform .gp-shop-disclaimer b { color: var(--txt); font-weight: 700; }
+
 .giveaway-platform .gp-shop-tab-count {
   display: inline-flex;
   align-items: center;

--- a/src/features/giveaway-platform/components/PlatformShop.tsx
+++ b/src/features/giveaway-platform/components/PlatformShop.tsx
@@ -11,10 +11,15 @@ interface Props {
 }
 
 const CATEGORIES: { key: ShopCategory | 'all'; label: string }[] = [
-  { key: 'all', label: 'Todo' },
-  { key: 'skin', label: '🔫 Skins CS2' },
-  { key: 'merch', label: '👕 Merch SocialPro' },
-  { key: 'gift', label: '🎁 Tarjetas regalo' },
+  { key: 'all',     label: 'Todo' },
+  { key: 'skin',    label: '🔫 Skins CS2' },
+  { key: 'merch',   label: '👕 Merch SocialPro' },
+  { key: 'gift',    label: '🎁 Tarjetas regalo' },
+  // Nuevas categorías cosméticas (2026-07-03) — se muestran solo si hay
+  // items canjeables en cada una. Ver docs/sorteos-coin-economy.md §4.
+  { key: 'profile', label: '🎨 Profile Cards' },
+  { key: 'frame',   label: '🖼️ Avatar Frames' },
+  { key: 'badge',   label: '🏅 Badges' },
 ];
 
 export function PlatformShop({ items, balance }: Props) {
@@ -65,6 +70,13 @@ export function PlatformShop({ items, balance }: Props) {
           <div className="gp-shop-next ok">✓ Puedes canjear cualquier premio disponible.</div>
         ) : null}
       </div>
+
+      <p className="gp-shop-disclaimer" role="note">
+        Las monedas son puntos internos <b>sin valor monetario</b>, no
+        transferibles y no canjeables por dinero. Los precios y la
+        disponibilidad pueden cambiar. Los canjes pueden requerir revisión
+        antes del envío.
+      </p>
 
       <div className="gp-shop-tabs">
         {CATEGORIES.map((c) => (

--- a/src/types/giveawayPlatform.ts
+++ b/src/types/giveawayPlatform.ts
@@ -19,7 +19,22 @@ export type DailyStreak = InferSelectModel<typeof dailyStreaks>;
 export type ShopItem = InferSelectModel<typeof shopItems>;
 export type Redemption = InferSelectModel<typeof redemptions>;
 
-export type ShopCategory = 'skin' | 'merch' | 'gift';
+/**
+ * Categorías de items canjeables en tienda.
+ *
+ * Se amplió el 2026-07-03 con las 3 categorías cosméticas (profile, frame,
+ * badge) — todas caben en el `varchar(10)` actual de `shop_items.category`,
+ * por lo que NO se necesita migración de esquema para admitirlas.
+ *
+ * `profile` — profile cards de fondo del perfil.
+ * `frame`   — marcos animados alrededor del avatar.
+ * `badge`   — badges premium visibles en pill/perfil.
+ *
+ * NOTA: para EQUIPAR estos cosméticos (aplicarlos visualmente al perfil
+ * del usuario) sí hace falta migración — ver `docs/sorteos-coin-economy.md`
+ * §4.2. Mientras tanto se pueden canjear y quedan en `redemptions`.
+ */
+export type ShopCategory = 'skin' | 'merch' | 'gift' | 'profile' | 'frame' | 'badge';
 export type RedemptionStatus = 'pendiente' | 'enviado' | 'cancelado';
 export type MissionConditionType = 'entries_total' | 'distinct_creators' | 'streak_days';
 export type CoinSource = 'racha' | 'mision' | 'sorteo' | 'tienda' | 'admin';


### PR DESCRIPTION
Primera fase controlada de la economía de monedas de SocialPro Giveaways. **No mergear sin OK.**

## Auditoría del estado actual

| Fuente | Valor actual |
|---|---|
| Balance del user | \`getCoinBalance\` en \`src/lib/queries/giveawayPlatform.ts\` = SUM(coin_transactions.amount) por userId |
| Misiones y rewards | \`platform_missions\` (DB) + seed \`scripts/seed-giveaway-platform.ts\`; **50-3.000 monedas** por misión |
| Racha | \`STREAK_REWARDS = [10, 15, 20, 25, 30, 40, 60]\` (200/semana) |
| Participación | \`ENTRY_COIN_REWARD = 20\` |
| shop_items | tabla DB con \`category varchar(10)\` — enum \`skin / merch / gift\` |
| \`ShopCategory\` en TS | Literal cerrado — hay que ampliar |
| Cosméticos de perfil | **NO existen**; no hay columna para equipar |
| Precios actuales | ~100 mon/€ (Steam 10€ = 1.000 mon) |
| Precios propuestos | ~1.100 mon/€ → **factor de reajuste ×11** |

## ⚠️ Migración requerida para EQUIPAR cosméticos

Para que el usuario pueda **equipar** una profile card y verla en su perfil hace falta migración adicional. No la he hecho — te pregunto antes:

**Opción A** — columnas por tipo en \`player_profiles\`:
\`\`\`sql
ALTER TABLE player_profiles
  ADD COLUMN equipped_profile_card_id INTEGER REFERENCES shop_items(id),
  ADD COLUMN equipped_frame_id        INTEGER REFERENCES shop_items(id),
  ADD COLUMN equipped_badge_id        INTEGER REFERENCES shop_items(id);
\`\`\`

**Opción B** — tabla dedicada \`user_cosmetics\`:
\`\`\`sql
CREATE TABLE user_cosmetics (
  user_id TEXT REFERENCES "user"(id) ON DELETE CASCADE,
  shop_item_id INTEGER REFERENCES shop_items(id),
  equipped BOOLEAN NOT NULL DEFAULT false,
  acquired_at TIMESTAMP NOT NULL DEFAULT NOW(),
  PRIMARY KEY (user_id, shop_item_id)
);
\`\`\`

Cuando elijas, hago un PR separado con Drizzle migration.

Mientras tanto los items se pueden **canjear** (se registra en \`redemptions\`) pero el efecto visual queda "Próximamente equipable".

## Qué incluye este PR

### Fase 1 — Documento (docs/sorteos-coin-economy.md)
1. Regla interna 1 USD ≈ 1.000 monedas / 1 EUR ≈ 1.100 monedas + política de NO exponerla.
2. Tabla de rewards objetivo (login/racha/misiones/completar perfil/rankings).
3. Tabla de precios por categoría con rangos.
4. Política de dificultad (casual → activo → grinder).
5. 7 reglas legales de "no valor monetario" para textos públicos.
6. Propuesta profile cards MVP + qué falta para equipar.
7. Roadmap 6 fases con flag por fase de "requiere migración".
8. Riesgos y vectores de fraude.

### Fase 2 — UI/config sin migración
1. **\`ShopCategory\`** ampliado en TS a \`skin | merch | gift | profile | frame | badge\` — cabe en el \`varchar(10)\` actual, cero migración.
2. **PlatformShop** con 3 categorías nuevas: 🎨 Profile Cards, 🖼️ Avatar Frames, 🏅 Badges.
3. **Disclaimer legal visible** en la tienda: *"Las monedas son puntos internos sin valor monetario, no transferibles y no canjeables por dinero. Los precios y la disponibilidad pueden cambiar. Los canjes pueden requerir revisión antes del envío."*
4. **Seed script actualizado** con nueva economía + 8 items MVP (4 profile cards, 2 frames, 2 badges). **NO se ejecuta desde el PR.** Cuando decidas aplicar, corres:
   \`\`\`
   npx tsx scripts/seed-giveaway-platform.ts
   \`\`\`

## Items MVP en el seed (no ejecutado)

| Item | Categoría | Precio | Stock |
|---|---|---|---|
| Profile Card — Neon Pink | profile | 1.500 | 500 |
| Profile Card — Cyber Blue | profile | 2.500 | 500 |
| Profile Card — Gold Elite | profile | 5.000 | 200 |
| Profile Card — Inferno | profile | 8.000 | 100 |
| Avatar Frame — Cyan | frame | 2.000 | 500 |
| Avatar Frame — Gold | frame | 7.500 | 150 |
| Badge — OG Member | badge | 3.000 | 300 |
| Badge — Top Grinder | badge | 5.000 | 200 |

Precios en el rango del §3.2 del doc.

## Reajuste de precios existentes (en el seed, no ejecutado)

| Item | Antes | Ahora |
|---|---|---|
| Steam 10€ | 1.000 | **11.000** |
| Steam 20€ | 1.900 | **22.000** |
| Steam 50€ | 4.500 | **55.000** |
| AK-47 Redline | 800 | **15.000** |
| Camiseta SocialPro | 300 | **15.000** |

## Riesgos de balance/economía

1. **Reescalar el pasado.** Los usuarios existentes tienen saldos calibrados a la escala vieja. Si aplicas los precios nuevos sin reescalar sus saldos, se sentirán empobrecidos. Recomendación (§5 del doc): **no reescalar**; comunicar el cambio de escala. Alternativa: `UPDATE coin_transactions SET amount = amount * 11 WHERE created_at < <fecha>` — más laborioso y auditable.
2. **Inflación futura.** Si añadimos rewards por acciones micro sin sink equivalente, los saldos crecerán sin control. Ya está previsto en `docs/giveaway-coin-economy-plan.md` (fases futuras).
3. **Fraude multi-account** — mitigable con `player_profiles.steamId UNIQUE` (ya presente). No hay bot mitigation activa; para artículos caros (skins CS2 premium) conviene revisión manual antes de enviar trade offer.
4. **Marketplace P2P.** El PR bloquea explícitamente por tests que no exista compra/transferencia/marketplace en el código.

## Test plan
- [x] \`npx tsc --noEmit\` → 0 errores en \`src/\`.
- [x] \`npx jest src/__tests__/server/\` → **125 suites / 2514 tests passing** (+22 assertions).
- [x] \`npx eslint\` → 0 warnings en \`src/\`.
- [ ] Smoke visual en preview: tienda con 7 pestañas (Todo, 4 antiguas + 3 nuevas), disclaimer visible bajo el summary.

## Sin cambios prohibidos
- 0 migraciones (todo respetando el varchar(10)).
- 0 cambios en \`.env*\`.
- 0 nuevos providers / bindings / API keys.
- 0 endpoints de comprar monedas.
- 0 endpoints de transferir monedas entre usuarios.
- 0 marketplace P2P.
- 0 monedas por depósitos externos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)