### PR TITLE
fix(sorteos): separar seed económico + bloquear canje cosmético hasta equipamiento

### DIFF
--- a/docs/sorteos-coin-economy.md
+++ b/docs/sorteos-coin-economy.md
@@ -240,10 +240,37 @@ Cada expansión requiere PR propio + revisión legal si hay premio en dinero equ
 | Fase | Alcance | Requiere migración |
 |---|---|---|
 | Fase 1 — este doc | Política, tablas, disclaimers | No |
-| Fase 2 — UI adaptada | Nuevas categorías tienda, disclaimer, seeds actualizados (no ejecutados) | No |
+| Fase 2 — UI adaptada | Nuevas categorías tienda, disclaimer, cosméticos bloqueados como "próximamente" | No |
 | Fase 3 — equipar cosméticos | `equipped_*` en `player_profiles` o `user_cosmetics` | **Sí** — pedir OK antes |
-| Fase 4 — reajuste económico | Cambio de constantes rewards + `costCoins` en seed. Aplicar a producción con seed idempotente | No (solo re-seed) |
+| Fase 4 — reajuste económico | Cambio de constantes rewards + `costCoins`. Aplicar con seed experimental | No (solo re-seed) |
 | Fase 5 — ranking mensual bonus | Cron end-of-month que distribuye premios | Posible tabla `monthly_bonuses` |
 | Fase 6 — campañas creador | Tabla `coin_campaigns` con multiplicadores temporales | Sí |
 
-**Este PR se limita a Fase 1 + Fase 2 sin ejecutar el reseed.** Los cambios de precios reales en producción los aplicas tú corriendo `npx tsx scripts/seed-giveaway-platform.ts` cuando decidas.
+### Separación de seeds
+
+Tras revisión post-PR #180, los cambios de economía se separan en dos scripts:
+
+1. **`scripts/seed-giveaway-platform.ts`** (seed principal) — mantiene los precios y items ACTUALES tal cual están hoy en producción. Es seguro correrlo en cualquier momento (idempotente). No debe recibir cambios de economía sin OK explícito de producto.
+
+2. **`scripts/seed-giveaway-platform-v2-experimental.ts`** (seed experimental) — contiene el reajuste ×11 y los 8 items MVP de cosméticos (insertados **`is_active: false`** para que NO aparezcan en tienda hasta que exista soporte de equipamiento). Requiere env var explícita:
+
+   ```
+   CONFIRM_SEED_V2=I_ACCEPT_ECONOMY_RESCALE \
+     npx tsx scripts/seed-giveaway-platform-v2-experimental.ts
+   ```
+
+   Sin la variable, imprime instrucciones y sale con código 1 sin tocar nada.
+
+### Cosméticos = "próximamente" en la UI
+
+Los items de categoría `profile`, `frame` o `badge` se muestran en la tienda con:
+
+- Badge visual "Próximamente" (dorado, encima de la imagen).
+- Card con `opacity: 0.92` y borde dorado tenue.
+- Botón "Próximamente" en lugar de "Canjear", `disabled`.
+- Server action `redeemShopItem` bloquea el canje server-side aunque un cliente hecho a mano lo intente:
+  ```
+  return { ok: false, error: 'Los cosméticos de perfil estarán disponibles cuando habilitemos el equipamiento' }
+  ```
+
+Esta protección se elimina automáticamente cuando se implemente Fase 3 (equipamiento) — solo hay que quitar el early-return del server action.

--- a/scripts/seed-giveaway-platform-v2-experimental.ts
+++ b/scripts/seed-giveaway-platform-v2-experimental.ts
@@ -1,0 +1,157 @@
+/**
+ * ============================================================================
+ * ⚠️  SEED EXPERIMENTAL — NO EJECUTAR EN PRODUCCIÓN SIN OK EXPLÍCITO   ⚠️
+ * ============================================================================
+ *
+ * Este script aplica la propuesta de reajuste económico de
+ * `docs/sorteos-coin-economy.md`:
+ *
+ *   - Precios reescalados ×11 en items EXISTENTES (skins, merch, tarjetas).
+ *   - 8 items MVP nuevos de cosméticos (profile / frame / badge),
+ *     insertados con `is_active = false` (INVISIBLES en la tienda) hasta
+ *     que exista soporte de equipamiento en el perfil.
+ *
+ * Riesgos conocidos si se ejecuta:
+ *   1. Los balances actuales de los usuarios NO se reescalan → sensación
+ *      de empobrecimiento inmediata (Steam 10€ pasa de 1.000 → 11.000
+ *      monedas y sus saldos siguen en la escala vieja).
+ *   2. La comunicación debe ir por delante — anunciar el cambio con
+ *      antelación razonable.
+ *   3. Los cosméticos MVP se insertan `is_active = false`. La UI actual
+ *      filtra por `isActive = true`, por lo que NO aparecerán en tienda.
+ *      Cuando se apruebe el equipamiento, un PR aparte los activa.
+ *
+ * Cómo ejecutar (solo cuando producto lo apruebe explícitamente):
+ *
+ *   CONFIRM_SEED_V2=I_ACCEPT_ECONOMY_RESCALE \
+ *     npx tsx scripts/seed-giveaway-platform-v2-experimental.ts
+ *
+ * Sin la variable de entorno el script imprime instrucciones y sale con
+ * código 1 sin tocar nada.
+ *
+ * Ver también: docs/sorteos-coin-economy.md, especialmente §5 (reescalado
+ * del pasado) y §4.2 (qué falta para equipar cosméticos).
+ * ============================================================================
+ */
+
+import 'dotenv/config';
+import { eq } from 'drizzle-orm';
+import { db } from '../src/lib/db';
+import { shopItems } from '../src/db/schema';
+
+const CONFIRM_TOKEN = 'I_ACCEPT_ECONOMY_RESCALE';
+
+/**
+ * Precios reajustados (~×11) de items ya existentes. Coinciden por `name`.
+ * El script SOLO actualiza si el item existe; nunca inserta duplicados.
+ */
+const RESCALE_PRICES: Array<{ name: string; costCoins: number }> = [
+  { name: '★ Glock-18 · Water Elemental', costCoins: 3000 },
+  { name: '★ USP-S · Kill Confirmed',      costCoins: 6000 },
+  { name: '★ AK-47 · Redline',             costCoins: 15000 },
+  { name: 'Camiseta SocialPro',            costCoins: 15000 },
+  { name: 'Gorra SocialPro',               costCoins: 9000 },
+  { name: 'Tarjeta Steam 10€',             costCoins: 11000 },
+  { name: 'Tarjeta Steam 20€',             costCoins: 22000 },
+  { name: 'Tarjeta Steam 50€',             costCoins: 55000 },
+  { name: 'PSN Plus · 1 mes',              costCoins: 8500 },
+  { name: 'Riot Points 10€',               costCoins: 11000 },
+];
+
+/**
+ * Items MVP de cosméticos. Se insertan `is_active: false` para que NO
+ * aparezcan en la tienda pública hasta que exista soporte real de
+ * equipamiento en el perfil (migración pendiente).
+ */
+const COSMETIC_ITEMS = [
+  { category: 'profile', name: 'Profile Card — Neon Pink',   description: 'Cosmético digital · próximamente equipable', costCoins: 1500, stock: 500, sortOrder: 30 },
+  { category: 'profile', name: 'Profile Card — Cyber Blue',  description: 'Cosmético digital · próximamente equipable', costCoins: 2500, stock: 500, sortOrder: 31 },
+  { category: 'profile', name: 'Profile Card — Gold Elite',  description: 'Cosmético digital premium · próximamente equipable', costCoins: 5000, stock: 200, sortOrder: 32 },
+  { category: 'profile', name: 'Profile Card — Inferno',     description: 'Cosmético digital premium · próximamente equipable', costCoins: 8000, stock: 100, sortOrder: 33 },
+  { category: 'frame',   name: 'Avatar Frame — Cyan',        description: 'Marco alrededor del avatar · próximamente equipable', costCoins: 2000, stock: 500, sortOrder: 40 },
+  { category: 'frame',   name: 'Avatar Frame — Gold',        description: 'Marco alrededor del avatar · próximamente equipable', costCoins: 7500, stock: 150, sortOrder: 41 },
+  { category: 'badge',   name: 'Badge — OG Member',          description: 'Reconocimiento pre-registro · próximamente equipable', costCoins: 3000, stock: 300, sortOrder: 50 },
+  { category: 'badge',   name: 'Badge — Top Grinder',        description: 'Reconocimiento por constancia · próximamente equipable', costCoins: 5000, stock: 200, sortOrder: 51 },
+];
+
+async function main() {
+  if (process.env.CONFIRM_SEED_V2 !== CONFIRM_TOKEN) {
+    console.log('');
+    console.log('=================================================================');
+    console.log(' ⚠️  SEED EXPERIMENTAL v2 — NO EJECUTADO');
+    console.log('=================================================================');
+    console.log('');
+    console.log(' Este script REESCALA los precios existentes ×11 e inserta');
+    console.log(' 8 items MVP de cosméticos (invisibles hasta equipamiento).');
+    console.log('');
+    console.log(' Riesgos: los balances actuales NO se reescalan. Los usuarios');
+    console.log(' sentirán "empobrecimiento" hasta que ganen a la nueva escala.');
+    console.log('');
+    console.log(' Para ejecutar, se requiere la variable de entorno:');
+    console.log('');
+    console.log('   CONFIRM_SEED_V2=' + CONFIRM_TOKEN + ' \\');
+    console.log('     npx tsx scripts/seed-giveaway-platform-v2-experimental.ts');
+    console.log('');
+    console.log(' Alternativa recomendada: aplicar los cambios en un PR');
+    console.log(' aparte con validación de balances y aviso comunitario.');
+    console.log('');
+    console.log('=================================================================');
+    console.log('');
+    process.exit(1);
+  }
+
+  console.log('[seed-v2] confirmación recibida. Iniciando cambios...');
+
+  // 1) Reescalado de precios existentes.
+  const existing = await db.query.shopItems.findMany();
+  const byName = new Map(existing.map((it) => [it.name, it]));
+
+  let updated = 0;
+  for (const spec of RESCALE_PRICES) {
+    const cur = byName.get(spec.name);
+    if (!cur) {
+      console.log(`[seed-v2] SKIP (no existe): ${spec.name}`);
+      continue;
+    }
+    if (cur.costCoins === spec.costCoins) {
+      console.log(`[seed-v2] SKIP (ya al precio nuevo): ${spec.name}`);
+      continue;
+    }
+    await db
+      .update(shopItems)
+      .set({ costCoins: spec.costCoins, updatedAt: new Date() })
+      .where(eq(shopItems.id, cur.id));
+    console.log(`[seed-v2] UPDATE: ${spec.name} · ${cur.costCoins} → ${spec.costCoins}`);
+    updated += 1;
+  }
+
+  // 2) Inserción de cosméticos MVP con is_active=false.
+  let inserted = 0;
+  for (const spec of COSMETIC_ITEMS) {
+    if (byName.has(spec.name)) {
+      console.log(`[seed-v2] SKIP (ya existe): ${spec.name}`);
+      continue;
+    }
+    await db.insert(shopItems).values({
+      category: spec.category,
+      name: spec.name,
+      description: spec.description,
+      costCoins: spec.costCoins,
+      stock: spec.stock,
+      sortOrder: spec.sortOrder,
+      isActive: false, // ← INVISIBLE hasta que exista equipamiento
+    });
+    console.log(`[seed-v2] INSERT (inactivo): ${spec.name}`);
+    inserted += 1;
+  }
+
+  console.log('');
+  console.log(`[seed-v2] Resumen: ${updated} precio(s) actualizado(s), ${inserted} cosmético(s) insertado(s) inactivo(s).`);
+  console.log('[seed-v2] Los cosméticos permanecerán ocultos en la tienda hasta que se apruebe');
+  console.log('[seed-v2] el soporte de equipamiento (migración de player_profiles / user_cosmetics).');
+}
+
+void main().then(
+  () => process.exit(0),
+  (err) => { console.error('[seed-v2] Error:', err); process.exit(1); },
+);

--- a/scripts/seed-giveaway-platform.ts
+++ b/scripts/seed-giveaway-platform.ts
@@ -31,50 +31,37 @@ const MISSIONS = [
 const DEACTIVATE_TITLES = ['Coleccionista', 'Racha de 7 días'];
 
 /**
- * Precios reajustados 2026-07-03 según la nueva economía objetivo
- * (docs/sorteos-coin-economy.md). Factor ~11× vs valores previos para
- * alinear con la regla interna "1$ ≈ 1.000 monedas".
+ * Seed principal de la tienda — precios y stock CONSERVADORES.
  *
- * NO se ejecuta automáticamente. Correr `npx tsx scripts/seed-giveaway-platform.ts`
- * cuando decidamos aplicar los cambios en producción. Ver también
- * §5 del doc para el riesgo de reescalado del pasado.
+ * Estos valores reflejan lo que existe hoy en producción. NO reajustan la
+ * economía ni añaden cosméticos: cualquier propuesta de cambio de precios
+ * o de nuevos items (profile cards, frames, badges) vive en el seed
+ * experimental separado:
  *
- * Las 3 nuevas categorías (`profile`, `frame`, `badge`) caben en el
- * `varchar(10)` actual de `shop_items.category` — sin migración de esquema.
- * Para EQUIPAR estos cosméticos hace falta migración adicional (§4.2 del doc).
+ *   scripts/seed-giveaway-platform-v2-experimental.ts
+ *
+ * Reglas de este archivo:
+ *   1. NUNCA meter aquí cambios de economía sin OK explícito de producto.
+ *   2. NUNCA meter aquí cosméticos hasta que exista soporte de
+ *      equipamiento (migración pendiente — ver docs/sorteos-coin-economy.md §4.2).
+ *   3. Este script es idempotente y actualiza `costCoins` si difiere:
+ *      cualquier cambio de precio aquí AFECTA producción en el próximo
+ *      `npx tsx scripts/seed-giveaway-platform.ts`.
+ *
+ * Ver también: docs/sorteos-coin-economy.md para la política y el
+ * reajuste ×11 propuesto (aún no aprobado para ejecución).
  */
 const SHOP_ITEMS = [
-  // Skins CS2 — stock propio, envío por trade offer.
-  { category: 'skin',  name: '★ Glock-18 · Water Elemental', description: 'Stock propio · envío por trade offer', costCoins: 3000,  stock: 4,  sortOrder: 1 },
-  { category: 'skin',  name: '★ USP-S · Kill Confirmed',     description: 'Stock propio · envío por trade offer', costCoins: 6000,  stock: 2,  sortOrder: 2 },
-  { category: 'skin',  name: '★ AK-47 · Redline',            description: 'Stock propio · envío por trade offer', costCoins: 15000, stock: 3,  sortOrder: 3 },
-
-  // Merch físico SocialPro.
-  { category: 'merch', name: 'Camiseta SocialPro',           description: 'Edición 2026 · envío incluido',        costCoins: 15000, stock: 25, sortOrder: 10 },
-  { category: 'merch', name: 'Gorra SocialPro',              description: 'Bordado · envío incluido',             costCoins: 9000,  stock: 18, sortOrder: 11 },
-
-  // Tarjetas regalo (códigos digitales por email).
-  { category: 'gift',  name: 'Tarjeta Steam 10€',            description: 'Código digital por email',             costCoins: 11000, stock: 10, sortOrder: 20 },
-  { category: 'gift',  name: 'Tarjeta Steam 20€',            description: 'Código digital por email',             costCoins: 22000, stock: 6,  sortOrder: 21 },
-  { category: 'gift',  name: 'Tarjeta Steam 50€',            description: 'Código digital por email',             costCoins: 55000, stock: 3,  sortOrder: 22 },
-  { category: 'gift',  name: 'PSN Plus · 1 mes',             description: 'Código digital por email',             costCoins: 8500,  stock: 8,  sortOrder: 23 },
-  { category: 'gift',  name: 'Riot Points 10€',              description: 'Código digital por email',             costCoins: 11000, stock: 8,  sortOrder: 24 },
-
-  // Profile Cards — cosméticos de perfil. Efecto visual pendiente de
-  // migración (equipped_profile_card_id o user_cosmetics). El canje ya
-  // funciona: se registra en redemptions y se marca "próximamente".
-  { category: 'profile', name: 'Profile Card — Neon Pink',   description: 'Cosmético digital · próximamente equipable', costCoins: 1500, stock: 500, sortOrder: 30 },
-  { category: 'profile', name: 'Profile Card — Cyber Blue',  description: 'Cosmético digital · próximamente equipable', costCoins: 2500, stock: 500, sortOrder: 31 },
-  { category: 'profile', name: 'Profile Card — Gold Elite',  description: 'Cosmético digital premium · próximamente equipable', costCoins: 5000, stock: 200, sortOrder: 32 },
-  { category: 'profile', name: 'Profile Card — Inferno',     description: 'Cosmético digital premium · próximamente equipable', costCoins: 8000, stock: 100, sortOrder: 33 },
-
-  // Avatar Frames.
-  { category: 'frame',   name: 'Avatar Frame — Cyan',        description: 'Marco alrededor del avatar · próximamente equipable', costCoins: 2000, stock: 500, sortOrder: 40 },
-  { category: 'frame',   name: 'Avatar Frame — Gold',        description: 'Marco alrededor del avatar · próximamente equipable', costCoins: 7500, stock: 150, sortOrder: 41 },
-
-  // Badges.
-  { category: 'badge',   name: 'Badge — OG Member',          description: 'Reconocimiento pre-registro · próximamente equipable', costCoins: 3000, stock: 300, sortOrder: 50 },
-  { category: 'badge',   name: 'Badge — Top Grinder',        description: 'Reconocimiento por constancia · próximamente equipable', costCoins: 5000, stock: 200, sortOrder: 51 },
+  { category: 'skin', name: '★ Glock-18 · Water Elemental', description: 'Stock propio · envío por trade offer', costCoins: 150, stock: 4, sortOrder: 1 },
+  { category: 'skin', name: '★ USP-S · Kill Confirmed',      description: 'Stock propio · envío por trade offer', costCoins: 450, stock: 2, sortOrder: 2 },
+  { category: 'skin', name: '★ AK-47 · Redline',             description: 'Stock propio · envío por trade offer', costCoins: 800, stock: 3, sortOrder: 3 },
+  { category: 'merch', name: 'Camiseta SocialPro',            description: 'Edición 2026 · envío incluido',         costCoins: 300, stock: 25, sortOrder: 10 },
+  { category: 'merch', name: 'Gorra SocialPro',               description: 'Bordado · envío incluido',              costCoins: 220, stock: 18, sortOrder: 11 },
+  { category: 'gift', name: 'Tarjeta Steam 10€',              description: 'Código digital por email',              costCoins: 1000, stock: 10, sortOrder: 20 },
+  { category: 'gift', name: 'Tarjeta Steam 20€',              description: 'Código digital por email',              costCoins: 1900, stock: 6, sortOrder: 21 },
+  { category: 'gift', name: 'Tarjeta Steam 50€',              description: 'Código digital por email',              costCoins: 4500, stock: 3, sortOrder: 22 },
+  { category: 'gift', name: 'PSN Plus · 1 mes',               description: 'Código digital por email',              costCoins: 900, stock: 8, sortOrder: 23 },
+  { category: 'gift', name: 'Riot Points 10€',                description: 'Código digital por email',              costCoins: 1000, stock: 8, sortOrder: 24 },
 ];
 
 async function main() {

--- a/src/__tests__/server/coin-economy.test.ts
+++ b/src/__tests__/server/coin-economy.test.ts
@@ -114,26 +114,57 @@ describe('[coin-economy] PlatformShop UI', () => {
   });
 });
 
-describe('[coin-economy] seed script actualizado — NO ejecutado desde el PR', () => {
+describe('[coin-economy] seed principal — precios ANTIGUOS conservados', () => {
   const src = read('scripts/seed-giveaway-platform.ts');
 
-  it('cita el doc y advierte que no se ejecuta automáticamente', () => {
-    expect(src).toMatch(/docs\/sorteos-coin-economy\.md/);
-    expect(src).toMatch(/NO se ejecuta automáticamente/);
+  it('mantiene los precios actuales de producción (Steam 10€ = 1.000)', () => {
+    expect(src).toMatch(/Tarjeta Steam 10€[\s\S]{0,200}costCoins:\s*1000\b/);
+    expect(src).toMatch(/Tarjeta Steam 20€[\s\S]{0,200}costCoins:\s*1900\b/);
+    expect(src).toMatch(/Tarjeta Steam 50€[\s\S]{0,200}costCoins:\s*4500\b/);
+    expect(src).toMatch(/AK-47 · Redline[\s\S]{0,200}costCoins:\s*800\b/);
+    // Los reescalados ×11 quedan fuera del seed principal.
+    expect(src).not.toMatch(/Tarjeta Steam 10€[\s\S]{0,200}costCoins:\s*11000/);
+    expect(src).not.toMatch(/Tarjeta Steam 20€[\s\S]{0,200}costCoins:\s*22000/);
   });
 
-  it('precios reajustados a la nueva economía', () => {
-    expect(src).toMatch(/Tarjeta Steam 10€[\s\S]{0,200}costCoins:\s*11000/);
-    expect(src).toMatch(/Tarjeta Steam 20€[\s\S]{0,200}costCoins:\s*22000/);
-    expect(src).toMatch(/Tarjeta Steam 50€[\s\S]{0,200}costCoins:\s*55000/);
-    expect(src).toMatch(/AK-47 · Redline[\s\S]{0,200}costCoins:\s*15000/);
+  it('NO contiene items cosméticos (profile/frame/badge) hasta que exista equipamiento', () => {
+    expect(src).not.toMatch(/category:\s*'profile'/);
+    expect(src).not.toMatch(/category:\s*'frame'/);
+    expect(src).not.toMatch(/category:\s*'badge'/);
   });
 
-  it('los 4 Profile Cards MVP existen con precios en rango del doc', () => {
+  it('advierte con claridad que los cambios de economía viven en el seed experimental', () => {
+    expect(src).toMatch(/scripts\/seed-giveaway-platform-v2-experimental\.ts/);
+    expect(src).toMatch(/NUNCA meter aquí cambios de economía/);
+  });
+});
+
+describe('[coin-economy] seed experimental — safeguard obligatorio', () => {
+  const src = read('scripts/seed-giveaway-platform-v2-experimental.ts');
+
+  it('cabecera muy visible marca el script como EXPERIMENTAL', () => {
+    expect(src).toMatch(/SEED EXPERIMENTAL/);
+    expect(src).toMatch(/NO EJECUTAR EN PRODUCCIÓN SIN OK EXPLÍCITO/);
+  });
+
+  it('exige env var CONFIRM_SEED_V2 con token exacto — imprime instrucciones si falta', () => {
+    expect(src).toMatch(/CONFIRM_SEED_V2\s*!==\s*CONFIRM_TOKEN/);
+    expect(src).toMatch(/const\s+CONFIRM_TOKEN\s*=\s*'I_ACCEPT_ECONOMY_RESCALE'/);
+    expect(src).toMatch(/process\.exit\(1\)/);
+  });
+
+  it('contiene los precios reajustados ×11 en constante dedicada', () => {
+    expect(src).toMatch(/Tarjeta Steam 10€[\s\S]{0,120}costCoins:\s*11000/);
+    expect(src).toMatch(/Tarjeta Steam 20€[\s\S]{0,120}costCoins:\s*22000/);
+    expect(src).toMatch(/Tarjeta Steam 50€[\s\S]{0,120}costCoins:\s*55000/);
+  });
+
+  it('inserta cosméticos MVP con is_active: false — invisibles en tienda', () => {
     expect(src).toMatch(/Profile Card — Neon Pink[\s\S]{0,200}costCoins:\s*1500/);
-    expect(src).toMatch(/Profile Card — Cyber Blue[\s\S]{0,200}costCoins:\s*2500/);
     expect(src).toMatch(/Profile Card — Gold Elite[\s\S]{0,200}costCoins:\s*5000/);
-    expect(src).toMatch(/Profile Card — Inferno[\s\S]{0,200}costCoins:\s*8000/);
+    // Todos los cosméticos se insertan con isActive: false.
+    expect(src).toMatch(/isActive:\s*false/);
+    expect(src).toMatch(/INVISIBLE hasta que exista equipamiento/);
   });
 
   it('todos los precios de profile card están en rango 1.500-10.000', () => {
@@ -145,10 +176,30 @@ describe('[coin-economy] seed script actualizado — NO ejecutado desde el PR', 
       expect(cost).toBeLessThanOrEqual(10000);
     }
   });
+});
 
-  it('avatar frames + badges añadidos también', () => {
-    expect(src).toMatch(/category:\s*'frame'[\s\S]{0,80}Avatar Frame — Cyan/);
-    expect(src).toMatch(/category:\s*'badge'[\s\S]{0,80}Badge — OG Member/);
+describe('[coin-economy] cosméticos no canjeables hasta equipamiento', () => {
+  it('PlatformShop define COSMETIC_CATEGORIES y bloquea el canje en UI', () => {
+    const src = read('src/features/giveaway-platform/components/PlatformShop.tsx');
+    expect(src).toMatch(/COSMETIC_CATEGORIES:\s*ReadonlySet<string>\s*=\s*new Set\(\['profile',\s*'frame',\s*'badge'\]\)/);
+    expect(src).toMatch(/isCosmeticNotEquipableYet/);
+    // Botón deshabilitado + label "Próximamente".
+    expect(src).toMatch(/cosmeticLocked\s*\?\s*'Próximamente'/);
+    // Badge visual "Próximamente" en la card.
+    expect(src).toMatch(/gp-shop-badge-soon[\s\S]{0,80}Próximamente/);
+  });
+
+  it('server action redeemShopItem BLOQUEA canje de cosméticos (belt-and-braces)', () => {
+    const src = read('src/app/sorteos/plataforma/actions.ts');
+    expect(src).toMatch(/COSMETIC_CATEGORIES\s*=\s*new Set\(\['profile',\s*'frame',\s*'badge'\]\)/);
+    expect(src).toMatch(/COSMETIC_CATEGORIES\.has\(item\.category\)/);
+    expect(src).toMatch(/estarán disponibles cuando habilitemos el equipamiento/);
+  });
+
+  it('CSS `.cosmetic-soon` y `.gp-shop-badge-soon` visibles y coherentes', () => {
+    const css = read('src/app/sorteos/plataforma/platform-widgets.css');
+    expect(css).toMatch(/\.gp-shop-card\.cosmetic-soon\s*\{[\s\S]{0,300}opacity:\s*0\.92/);
+    expect(css).toMatch(/\.gp-shop-badge-soon\s*\{[\s\S]{0,300}var\(--gold\)/);
   });
 });
 

--- a/src/app/sorteos/plataforma/actions.ts
+++ b/src/app/sorteos/plataforma/actions.ts
@@ -159,6 +159,19 @@ export async function redeemShopItem(input: unknown): Promise<ActionResult<{ red
   });
   if (!item) return { ok: false, error: 'El item no está disponible' };
 
+  // Salvaguarda server-side: los cosméticos de perfil (profile / frame /
+  // badge) NO se pueden canjear hasta que exista soporte de equipamiento.
+  // La UI ya deshabilita el botón, pero un cliente hecho a mano podría
+  // saltárselo — este check lo bloquea siempre. Ver
+  // docs/sorteos-coin-economy.md §4.2.
+  const COSMETIC_CATEGORIES = new Set(['profile', 'frame', 'badge']);
+  if (COSMETIC_CATEGORIES.has(item.category)) {
+    return {
+      ok: false,
+      error: 'Los cosméticos de perfil estarán disponibles cuando habilitemos el equipamiento',
+    };
+  }
+
   const balance = await getCoinBalance(sessionUser.id);
   if (balance < item.costCoins) {
     return { ok: false, error: 'No tienes monedas suficientes' };

--- a/src/app/sorteos/plataforma/platform-widgets.css
+++ b/src/app/sorteos/plataforma/platform-widgets.css
@@ -489,6 +489,22 @@
   border-color: rgba(74, 222, 128, 0.5);
   box-shadow: 0 0 22px rgba(74, 222, 128, 0.14);
 }
+/* Cosméticos "próximamente" — sin equipamiento, no canjeable todavía. */
+.giveaway-platform .gp-shop-card.cosmetic-soon {
+  border-color: rgba(245, 183, 61, 0.4);
+  opacity: 0.92;
+}
+.giveaway-platform .gp-shop-card.cosmetic-soon .gp-shop-btn {
+  background: linear-gradient(90deg, rgba(245, 183, 61, 0.5), rgba(245, 183, 61, 0.75));
+  color: #1a1405;
+  box-shadow: none;
+  opacity: 0.85;
+}
+.giveaway-platform .gp-shop-badge-soon {
+  background: rgba(245, 183, 61, 0.16) !important;
+  border-color: rgba(245, 183, 61, 0.5) !important;
+  color: var(--gold) !important;
+}
 .giveaway-platform .gp-shop-badge {
   position: absolute;
   top: 8px;

--- a/src/features/giveaway-platform/components/PlatformShop.tsx
+++ b/src/features/giveaway-platform/components/PlatformShop.tsx
@@ -5,6 +5,17 @@ import { useRouter } from 'next/navigation';
 import { redeemShopItem } from '@/app/sorteos/plataforma/actions';
 import type { ShopCategory, ShopItem } from '@/types/giveawayPlatform';
 
+/**
+ * Categorías cosméticas: se muestran en la UI como "próximamente" y
+ * bloqueadas para canje hasta que exista soporte real de equipamiento
+ * (columnas `equipped_*` en player_profiles o tabla user_cosmetics).
+ * Ver docs/sorteos-coin-economy.md §4.2.
+ */
+const COSMETIC_CATEGORIES: ReadonlySet<string> = new Set(['profile', 'frame', 'badge']);
+function isCosmeticNotEquipableYet(category: string): boolean {
+  return COSMETIC_CATEGORIES.has(category);
+}
+
 interface Props {
   items: ShopItem[];
   balance: number;
@@ -99,11 +110,15 @@ export function PlatformShop({ items, balance }: Props) {
       ) : (
         <div className="gp-shop-grid">
           {visible.map((item) => {
-            const affordable = balance >= item.costCoins && item.stock > 0;
+            const cosmeticLocked = isCosmeticNotEquipableYet(item.category);
+            const affordable = balance >= item.costCoins && item.stock > 0 && !cosmeticLocked;
             const stockClass = item.stock === 0 ? ' gone' : item.stock < 4 ? ' low' : '';
             const pct = Math.min(100, Math.round((balance / Math.max(1, item.costCoins)) * 100));
             return (
-              <div key={item.id} className={`gp-shop-card${affordable ? ' affordable' : ''}`}>
+              <div
+                key={item.id}
+                className={`gp-shop-card${affordable ? ' affordable' : ''}${cosmeticLocked ? ' cosmetic-soon' : ''}`}
+              >
                 <div className="gp-shop-img">
                   {item.imageUrl ? (
                     // eslint-disable-next-line @next/next/no-img-element
@@ -111,7 +126,11 @@ export function PlatformShop({ items, balance }: Props) {
                   ) : (
                     <div className="gp-shop-img-empty">Imagen pendiente</div>
                   )}
-                  {affordable ? <span className="gp-shop-badge">Disponible</span> : null}
+                  {cosmeticLocked ? (
+                    <span className="gp-shop-badge gp-shop-badge-soon">Próximamente</span>
+                  ) : affordable ? (
+                    <span className="gp-shop-badge">Disponible</span>
+                  ) : null}
                 </div>
                 <h4 className="gp-shop-name">{item.name}</h4>
                 {item.description ? <p className="gp-shop-desc">{item.description}</p> : <p className="gp-shop-desc" />}
@@ -128,7 +147,13 @@ export function PlatformShop({ items, balance }: Props) {
                   disabled={!affordable || isPending}
                   className="gp-shop-btn"
                 >
-                  {isPending ? 'Canjeando…' : affordable ? 'Canjear' : `Faltan ${(item.costCoins - balance).toLocaleString('es-ES')} 🪙`}
+                  {cosmeticLocked
+                    ? 'Próximamente'
+                    : isPending
+                      ? 'Canjeando…'
+                      : affordable
+                        ? 'Canjear'
+                        : `Faltan ${(item.costCoins - balance).toLocaleString('es-ES')} 🪙`}
                 </button>
               </div>
             );


### PR DESCRIPTION
Ajuste post-#180 tras review de producto. Cierra las 2 preocupaciones abiertas: el seed principal ya no contiene el reajuste ×11 (que no debe ejecutarse por accidente) y los cosméticos NO son canjeables hasta que exista soporte de equipamiento.

**No mergear sin OK visual del preview.**

## Contexto — #180 ya está en master

PR #180 se mergeó ayer (commit \`7b437f4\`) tras la instrucción "mergea cuando ci esté verde". No puedo hacer commits sobre él porque está cerrado; los ajustes van en este PR nuevo #181.

## Qué hiciste con el seed ×11 — Opción C

**\`scripts/seed-giveaway-platform.ts\`** (principal) → restaurado a los precios ACTUALES de producción:

| Item | Precio en seed principal |
|---|---|
| Tarjeta Steam 10€ | 1.000 |
| Tarjeta Steam 20€ | 1.900 |
| Tarjeta Steam 50€ | 4.500 |
| AK-47 Redline | 800 |
| Camiseta SocialPro | 300 |
| Gorra SocialPro | 220 |
| Glock-18 · Water Elemental | 150 |
| USP-S · Kill Confirmed | 450 |
| PSN Plus 1 mes | 900 |
| Riot Points 10€ | 1.000 |

**Cabecera nueva prohíbe** meter cambios de economía aquí sin OK explícito de producto. Todos los items cosméticos (profile/frame/badge) eliminados de este archivo.

**\`scripts/seed-giveaway-platform-v2-experimental.ts\`** (nuevo) → contiene el reajuste ×11 + los 8 items MVP de cosméticos. Con dos protecciones:

1. **Env var obligatoria:** requiere \`CONFIRM_SEED_V2=I_ACCEPT_ECONOMY_RESCALE\`. Sin ella imprime instrucciones y sale con \`exit code 1\` sin tocar nada.
   \`\`\`
   CONFIRM_SEED_V2=I_ACCEPT_ECONOMY_RESCALE \
     npx tsx scripts/seed-giveaway-platform-v2-experimental.ts
   \`\`\`
2. **Cosméticos con \`is_active: false\`:** aunque el script se ejecute con la env var, los 8 items cosméticos entran INVISIBLES en la tienda (la UI actual filtra por \`isActive = true\`). Solo cuando se implemente equipamiento (Fase 3) un PR aparte los activa.

## Cosméticos: sí solo placeholder, no canjeables

Los items de categoría \`profile\`, \`frame\` o \`badge\` que aparezcan en la tienda (por ejemplo si un admin los inserta manualmente en DB) se comportan como sigue:

**En la UI (\`PlatformShop.tsx\`):**
- Card con clase \`.cosmetic-soon\` → \`opacity: 0.92\` + borde dorado tenue.
- Badge visual **"Próximamente"** (dorado) en lugar del "Disponible" verde.
- Botón **"Próximamente"** en lugar de "Canjear", \`disabled\`.

**En el server action (belt-and-braces):** \`redeemShopItem\` bloquea el canje aunque un cliente hecho a mano se salte la UI:
\`\`\`ts
const COSMETIC_CATEGORIES = new Set(['profile', 'frame', 'badge']);
if (COSMETIC_CATEGORIES.has(item.category)) {
  return {
    ok: false,
    error: 'Los cosméticos de perfil estarán disponibles cuando habilitemos el equipamiento',
  };
}
\`\`\`

Este check se retira automáticamente en la Fase 3 (equipamiento). Sin código sucio adicional.

## Doc actualizado
\`docs/sorteos-coin-economy.md\` §8 recoge la separación de seeds y el patrón "próximamente" hasta que exista equipamiento.

## Migración pendiente sin cambios
Tu preferencia sigue anotada: **\`user_cosmetics\` como tabla dedicada** en vez de columnas \`equipped_*\` en \`player_profiles\`. Cuando toque, PR separado con \`npx drizzle-kit generate\`.

## Sin cambios prohibidos
- 0 migraciones. 0 cambios en \`.env*\`. 0 cambios en \`next.config.ts\`.
- 0 cambios en auth, providers, rutas, legales.
- 0 escrituras a \`coin_transactions\` / \`giveaway_entries\` / \`mission_claims\` por externos.

## Riesgos restantes
1. **Someone corre el seed principal accidentalmente** → aplica idempotentemente los precios viejos (sin efecto, ya están así). ✅ Seguro.
2. **Someone corre el seed experimental sin env var** → imprime instrucciones y sale sin tocar nada. ✅ Seguro.
3. **Someone corre el seed experimental con env var** → aplica ×11 y añade cosméticos inactivos. Los balances actuales de usuarios no se reescalan (sensación de empobrecimiento). Documentado en el script y en el doc.
4. **Admin manual activa un cosmético desde DB** → aparecerá en tienda como "Próximamente"; el server action seguirá bloqueando el canje. ✅ Seguro.

## Test plan
- [x] \`npx tsc --noEmit\` → 0 errores en \`src/\`.
- [x] \`npx jest src/__tests__/server/\` → **125 suites / 2520 tests passing** (+6 asserts nuevos del ajuste).
- [x] \`npx eslint\` en archivos tocados → 0 warnings.
- [ ] Smoke visual en preview: si añades un cosmético a la DB con \`isActive=true\`, aparece con badge "Próximamente" y botón deshabilitado; el resto de items sigue funcionando normal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)