### PR TITLE
fix(sorteos): CTA sorteo abre el sorteo real + fallback visible en preview

### DIFF
--- a/src/__tests__/server/external-giveaways-integration.test.ts
+++ b/src/__tests__/server/external-giveaways-integration.test.ts
@@ -101,16 +101,37 @@ describe('[external-giveaways] UI del ExternalGiveawaysSection + Card', () => {
   const sectionSrc = read('src/features/giveaway-platform/components/ExternalGiveawaysSection.tsx');
   const cardSrc = read('src/features/giveaway-platform/components/ExternalGiveawayCard.tsx');
 
-  it('Section devuelve null si status !== "ok"', () => {
-    expect(sectionSrc).toMatch(/if\s*\(sections\.status\s*!==\s*'ok'\)\s*return\s*null/);
-  });
-
-  it('Section devuelve null si no hay providerKey', () => {
+  it('Section devuelve null si no hay providerKey (creador sin binding)', () => {
+    // Sin binding externo el creador usa sorteos internos — la sección
+    // externa queda silenciosa. Único caso donde devolvemos null.
     expect(sectionSrc).toMatch(/if\s*\(!sections\.providerKey\)\s*return\s*null/);
   });
 
-  it('Section devuelve null si no hay sorteos', () => {
-    expect(sectionSrc).toMatch(/sections\.active\.length\s*===\s*0\s*&&\s*sections\.finished\.length\s*===\s*0[\s\S]{0,40}return\s*null/);
+  it('Section renderiza fallback visible si status !== "ok" (ya no null silencioso)', () => {
+    // Con binding pero fetch failed → fallback visible, no null.
+    // (`no_binding` excluido explícitamente para satisfacer al type checker,
+    // aunque ya se filtra arriba por `!sections.providerKey`.)
+    expect(sectionSrc).toMatch(/sections\.status\s*!==\s*'ok'[\s\S]{0,300}<FallbackShell/);
+    expect(sectionSrc).toMatch(/function\s+FallbackShell/);
+  });
+
+  it('Fallback usa el copy del usuario para status `not_configured` (preview)', () => {
+    expect(sectionSrc).toMatch(/Sorteos\s\$\{providerDisplayName\}\sno\sdisponibles\sen\seste\sentorno/);
+    expect(sectionSrc).toMatch(/este\sentorno\sde\spreview\sno\stiene\sla\sAPI\skey\sconfigurada/);
+  });
+
+  it('Fallback usa copy genérico para errores runtime (no menciona preview/key)', () => {
+    // Para `error`/`timeout`/`network`/`http`/`parse` mostramos otra
+    // frase — no mencionamos preview ni API key porque podría ser
+    // producción durante una incidencia.
+    expect(sectionSrc).toMatch(/La\sconexi[oó]n\sha\sfallado\stemporalmente/);
+  });
+
+  it('Section shell muestra empty-state (no null) si status ok pero sin sorteos', () => {
+    // Antes: return null. Ahora: renderiza shell con "No hay sorteos ahora mismo".
+    expect(sectionSrc).toMatch(/No\shay\ssorteos\sahora\smismo/);
+    // Y NO tenemos ya el early-return por listas vacías.
+    expect(sectionSrc).not.toMatch(/sections\.active\.length\s*===\s*0\s*&&\s*sections\.finished\.length\s*===\s*0[\s\S]{0,40}return\s*null/);
   });
 
   it('Section resuelve badge/CTA/displayName vía getProvider (dinámico, no hardcoded)', () => {

--- a/src/__tests__/server/keydrop-provider-mapper.test.ts
+++ b/src/__tests__/server/keydrop-provider-mapper.test.ts
@@ -92,10 +92,12 @@ describe('[keydrop-mapper] activo → ExternalGiveawayCard', () => {
     expect(map(baseItem).promoCode).toBe('ZACKCSGO');
   });
 
-  it('externalUrl usa kd.link con code + giveaway id (deep link con promocode)', () => {
-    // baseItem.organizer.promocode = 'ZACKCSGO', item.id = 'o3S8gi66000'
+  it('externalUrl usa el path canónico /es/giveaways/user/{id} + ?code=', () => {
+    // Nueva regla post-QA: el shortener `kd.link/?code=X&giveaway=Y`
+    // redirigía a home en vez de abrir el sorteo. Ahora usamos la URL
+    // directa que el partner confirma como válida — con code query.
     expect(map(baseItem).externalUrl).toBe(
-      'https://kd.link/?code=ZACKCSGO&giveaway=o3S8gi66000',
+      'https://keydrop.com/es/giveaways/user/o3S8gi66000?code=ZACKCSGO',
     );
   });
 
@@ -260,10 +262,12 @@ describe('[keydrop-mapper] Zod schemas parsean el shape real', () => {
   });
 });
 
-describe('[keydrop-mapper] buildKeydropDeepLink — deep link con promocode', () => {
-  it('id + promoCode → shortener kd.link con ambos parámetros', () => {
+describe('[keydrop-mapper] buildKeydropDeepLink — URL directa al sorteo concreto', () => {
+  it('id + promoCode → keydrop.com/es/giveaways/user/{id}?code={code}', () => {
+    // Path oficial confirmado por partner. `?code=` propaga tracking sin
+    // romper si KeyDrop ignora el param.
     expect(buildKeydropDeepLink('o3S8gi66000', 'ZACKCSGO')).toBe(
-      'https://kd.link/?code=ZACKCSGO&giveaway=o3S8gi66000',
+      'https://keydrop.com/es/giveaways/user/o3S8gi66000?code=ZACKCSGO',
     );
   });
 
@@ -271,33 +275,42 @@ describe('[keydrop-mapper] buildKeydropDeepLink — deep link con promocode', ()
     // Caso extremo: promocode con guion o espacios NO debería llegar, pero
     // si llegara, se sanea para no romper la URL.
     expect(buildKeydropDeepLink('id/with slash', 'CODE 1')).toBe(
-      'https://kd.link/?code=CODE%201&giveaway=id%2Fwith%20slash',
+      'https://keydrop.com/es/giveaways/user/id%2Fwith%20slash?code=CODE%201',
     );
   });
 
-  it('sin promoCode → path canónico keydrop.com/es/giveaways/{id}', () => {
+  it('sin promoCode → path canónico sin query', () => {
     expect(buildKeydropDeepLink('o3S8gi66000', undefined)).toBe(
-      'https://keydrop.com/es/giveaways/o3S8gi66000',
+      'https://keydrop.com/es/giveaways/user/o3S8gi66000',
     );
     expect(buildKeydropDeepLink('o3S8gi66000', '')).toBe(
-      'https://keydrop.com/es/giveaways/o3S8gi66000',
+      'https://keydrop.com/es/giveaways/user/o3S8gi66000',
     );
   });
 
-  it('sin id ni promoCode → listing genérico (nunca URL rota /giveaway/ vacío)', () => {
+  it('sin id → listing genérico (nunca URL rota)', () => {
     expect(buildKeydropDeepLink('', undefined)).toBe('https://keydrop.com/es/giveaways');
     expect(buildKeydropDeepLink('', '')).toBe('https://keydrop.com/es/giveaways');
+    expect(buildKeydropDeepLink('', 'ZACKCSGO')).toBe('https://keydrop.com/es/giveaways');
+  });
+
+  it('YA no usa el shortener kd.link — redirigía a home en vez de al sorteo', () => {
+    // Regresión: `kd.link/?code=X&giveaway=Y` aterrizaba en la home con
+    // el código aplicado, sin abrir el sorteo. Ya no lo usamos aquí; el
+    // banner de marca (`buildKeydropClaimUrl`) sí lo mantiene.
+    expect(buildKeydropDeepLink('any', 'ANY')).not.toMatch(/kd\.link/);
+    expect(buildKeydropDeepLink('any', undefined)).not.toMatch(/kd\.link/);
+  });
+
+  it('siempre incluye el segmento /user/ del path oficial', () => {
+    expect(buildKeydropDeepLink('any', 'ANY')).toMatch(/\/es\/giveaways\/user\//);
+    expect(buildKeydropDeepLink('any', undefined)).toMatch(/\/es\/giveaways\/user\//);
   });
 
   it('nunca produce URL sobre el dominio legacy key-drop.com (403 Cloudflare)', () => {
     expect(buildKeydropDeepLink('any', 'ANY')).not.toMatch(/key-drop\.com/);
     expect(buildKeydropDeepLink('any', undefined)).not.toMatch(/key-drop\.com/);
     expect(buildKeydropDeepLink('', undefined)).not.toMatch(/key-drop\.com/);
-  });
-
-  it('nunca genera /giveaway/ (singular) — devuelve 404 en keydrop.com', () => {
-    expect(buildKeydropDeepLink('any', 'ANY')).not.toMatch(/\/giveaway\//);
-    expect(buildKeydropDeepLink('any', undefined)).not.toMatch(/\/giveaway\//);
   });
 
   it('no pierde el id del giveaway cuando lo tiene', () => {

--- a/src/app/sorteos/plataforma/platform-external-giveaways.css
+++ b/src/app/sorteos/plataforma/platform-external-giveaways.css
@@ -274,3 +274,47 @@
   font-size: 12.5px;
 }
 .giveaway-platform .gp-provider-rank-mini-body span { color: var(--muted); }
+
+/*
+ * Fallback informativo — se muestra cuando el creador tiene binding
+ * con un provider externo pero la API no devuelve datos (env sin key
+ * en preview, o error controlado de fetch en producción).
+ *
+ * Diseño: tarjeta ligera con icono ⚠️ a la izquierda y texto a la
+ * derecha. Sin colores agresivos — es informativo, no error.
+ */
+.giveaway-platform .gp-external-fallback {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  padding: 18px 20px;
+  border-radius: 14px;
+  background: rgba(11, 8, 20, 0.55);
+  border: 1px dashed rgba(255, 210, 100, 0.35);
+  margin: 10px 0 6px;
+}
+.giveaway-platform .gp-external-fallback-icon {
+  font-size: 24px;
+  line-height: 1;
+  flex-shrink: 0;
+}
+.giveaway-platform .gp-external-fallback-body {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  line-height: 1.5;
+}
+.giveaway-platform .gp-external-fallback-title {
+  margin: 0;
+  font-family: var(--font-display), var(--font-rajdhani), sans-serif;
+  font-weight: 800;
+  font-size: 15px;
+  letter-spacing: 0.5px;
+  color: #ffd77a;
+}
+.giveaway-platform .gp-external-fallback-text {
+  margin: 0;
+  font-size: 13.5px;
+  color: var(--muted);
+  max-width: 720px;
+}

--- a/src/features/giveaway-platform/components/ExternalGiveawaysSection.tsx
+++ b/src/features/giveaway-platform/components/ExternalGiveawaysSection.tsx
@@ -19,20 +19,40 @@ interface Props {
  *   - Solo lectura. Botón CTA abre en nueva pestaña.
  *   - Sin monedas ni tickets internos — este bloque no interactúa con
  *     coin_transactions ni giveaway_entries.
- *   - Si `status !== 'ok'` o no hay sorteos → no renderiza nada (degradación
- *     silenciosa).
+ *   - Sin binding externo → no renderiza (creador usa sorteos internos).
+ *   - Con binding pero API no disponible (`not_configured` en preview,
+ *     `error`/`timeout`/`network`/`http`/`parse` en producción) →
+ *     renderiza fallback visible informativo, no null silencioso.
  *   - Activos arriba; finalizados en <details> colapsable debajo.
  */
 export function ExternalGiveawaysSection({ sections, creatorDisplayName }: Props) {
-  if (sections.status !== 'ok') return null;
-  if (sections.active.length === 0 && sections.finished.length === 0) return null;
+  // Sin binding externo → creador usa sorteos internos, section silenciosa.
   if (!sections.providerKey) return null;
 
   const provider = getProvider(sections.providerKey);
   if (!provider) return null;
 
+  // Con binding pero fetch falló o falta la key: fallback visible.
+  // (`no_binding` es imposible aquí — arriba ya retornamos si no hay
+  // providerKey — pero lo excluimos del cast para satisfacer al type
+  // checker.)
+  if (sections.status !== 'ok' && sections.status !== 'no_binding') {
+    return (
+      <FallbackShell
+        providerDisplayName={provider.displayName}
+        providerLogo={provider.logoAsset}
+        creatorDisplayName={creatorDisplayName}
+        status={sections.status}
+      />
+    );
+  }
+
   const promoCode = sections.active[0]?.promoCode ?? sections.finished[0]?.promoCode ?? '';
   const ctaLabel = `Ver en ${provider.displayName}`;
+
+  // Estado OK pero sin sorteos — poco frecuente. Renderizamos shell con
+  // "no hay sorteos ahora mismo" en lugar de null silencioso.
+  const isEmpty = sections.active.length === 0 && sections.finished.length === 0;
 
   return (
     <section aria-labelledby="external-section" className="gp-external-section">
@@ -62,7 +82,9 @@ export function ExternalGiveawaysSection({ sections, creatorDisplayName }: Props
           </div>
         </div>
 
-        {sections.active.length > 0 ? (
+        {isEmpty ? (
+          <p className="gp-mission-head">No hay sorteos ahora mismo.</p>
+        ) : sections.active.length > 0 ? (
           <div className="gp-sorteos-grid">
             {sections.active.map((g) => (
               <ExternalGiveawayCard
@@ -101,6 +123,62 @@ export function ExternalGiveawaysSection({ sections, creatorDisplayName }: Props
           providerDisplayName={provider.displayName}
           creatorDisplayName={creatorDisplayName}
         />
+      </div>
+    </section>
+  );
+}
+
+/**
+ * Shell del fallback informativo — se muestra cuando el creador tiene
+ * binding con un provider externo pero la API no responde con datos.
+ *
+ * Casos cubiertos:
+ *   - `not_configured` — la env var con la API key no está en este
+ *     entorno (típicamente Preview de Vercel). Copy explica que la
+ *     integración está montada y en producción se ven los sorteos.
+ *   - `error` / `timeout` / `network` / `http` / `parse` — la API falló
+ *     en runtime. Copy genérico "temporalmente no disponibles".
+ *
+ * Nunca inventa sorteos ni datos — solo comunica estado del provider.
+ */
+function FallbackShell({
+  providerDisplayName,
+  providerLogo,
+  creatorDisplayName,
+  status,
+}: {
+  providerDisplayName: string;
+  providerLogo: string;
+  creatorDisplayName: string;
+  status: Exclude<ExternalGiveawaySections['status'], 'ok' | 'no_binding'>;
+}) {
+  const title = `Sorteos ${providerDisplayName} no disponibles en este entorno`;
+  const body =
+    status === 'not_configured'
+      ? `Los sorteos se cargan automáticamente desde la API del partner. En producción están activos, pero este entorno de preview no tiene la API key configurada.`
+      : `Los sorteos se cargan automáticamente desde la API del partner. La conexión ha fallado temporalmente — vuelve en unos minutos.`;
+
+  return (
+    <section aria-labelledby="external-section" className="gp-external-section">
+      <div className="gp-legacy-block">
+        <div className="gp-external-head">
+          <div>
+            <h2 id="external-section">
+              Sorteos {providerDisplayName} de {creatorDisplayName}
+            </h2>
+            <p className="gp-mission-head">Datos en directo desde {providerDisplayName}</p>
+          </div>
+          <div className="gp-external-badge">
+            <Image src={providerLogo} alt={providerDisplayName} width={110} height={26} />
+          </div>
+        </div>
+        <div className="gp-external-fallback" role="status">
+          <div className="gp-external-fallback-icon" aria-hidden>⚠️</div>
+          <div className="gp-external-fallback-body">
+            <p className="gp-external-fallback-title">{title}</p>
+            <p className="gp-external-fallback-text">{body}</p>
+          </div>
+        </div>
       </div>
     </section>
   );

--- a/src/lib/external-giveaways/providers/keydrop/mapper.ts
+++ b/src/lib/external-giveaways/providers/keydrop/mapper.ts
@@ -41,30 +41,31 @@ interface MapInput {
 const KEYDROP_LISTING_FALLBACK = 'https://keydrop.com/es/giveaways';
 
 /**
- * Construye la URL destino del CTA de la card para un giveaway KeyDrop.
+ * Construye la URL destino del CTA de la card para un giveaway KeyDrop
+ * concreto.
  *
- * Prioridad:
- *   1. `kd.link/?code={promo}&giveaway={id}` — shortener oficial. Aplica el
- *      promocode del creador y deep-linkea al sorteo. Best-in-class.
- *   2. `keydrop.com/es/giveaways/{id}` — path canónico (verificado en el
- *      HTML shell, sirve `<link rel="alternate">` para 12 locales del
- *      mismo path). No aplica promocode.
- *   3. Listing genérico — solo si faltan ambos id y promocode (no debería
- *      ocurrir con datos válidos).
+ * Path oficial verificado con los 5 sorteos activos de ZACKETIZOR
+ * (2026-07): `https://keydrop.com/es/giveaways/user/{id}` — abre la
+ * página del sorteo concreto en el SPA de KeyDrop.
  *
- * Los inputs se URL-encodean para no romper si un promocode contiene
- * caracteres reservados en el futuro.
+ * El shortener `kd.link/?code=X&giveaway=Y` NO se usa aquí porque en
+ * la práctica redirige a la home con el código aplicado en vez de
+ * abrir el sorteo — falla el objetivo del CTA. Queda reservado para
+ * el banner de marca (`buildKeydropClaimUrl` — sin sorteo concreto).
+ *
+ * El promocode se propaga como query param `?code=X` para preservar
+ * affiliate tracking cuando aterriza el usuario. Params desconocidos
+ * son ignorados por KeyDrop sin romper el routing.
+ *
+ * Fallback si falta id: página de listado (nunca URL rota).
  */
 export function buildKeydropDeepLink(id: string, promoCode: string | undefined): string {
   const safeId = id ? encodeURIComponent(id) : '';
   const safeCode = promoCode ? encodeURIComponent(promoCode) : '';
-  if (safeId && safeCode) {
-    return `https://kd.link/?code=${safeCode}&giveaway=${safeId}`;
-  }
-  if (safeId) {
-    return `https://keydrop.com/es/giveaways/${safeId}`;
-  }
-  return KEYDROP_LISTING_FALLBACK;
+  if (!safeId) return KEYDROP_LISTING_FALLBACK;
+
+  const base = `https://keydrop.com/es/giveaways/user/${safeId}`;
+  return safeCode ? `${base}?code=${safeCode}` : base;
 }
 
 /**


### PR DESCRIPTION
Dos bugs UX del bloque KeyDrop en \`/sorteos/[creatorSlug]\`:

## Bug 1 — CTA sorteo llevaba a la home

\`buildKeydropDeepLink(id, code)\` construía \`kd.link/?code=X&giveaway=Y\`. El shortener aplica el código pero redirige a la home; no abre el sorteo concreto — el CTA "Ver en KeyDrop" fallaba su objetivo.

**Fix**: usar el path oficial \`keydrop.com/es/giveaways/user/{id}\` (confirmado por los 5 URLs reales de ZACKETIZOR). El promocode se propaga como \`?code=X\` para preservar tracking.

Nueva prioridad:
- \`id + code\` → \`keydrop.com/es/giveaways/user/{id}?code={code}\`
- \`id\`       → \`keydrop.com/es/giveaways/user/{id}\`
- sin id     → listado genérico (fallback seguro)

El shortener \`kd.link\` se mantiene solo para \`buildKeydropClaimUrl\` (banner de marca — no necesita apuntar a sorteo concreto).

## Bug 2 — sin API key en preview la sección era invisible

\`ExternalGiveawaysSection\` devolvía \`null\` cuando \`status !== 'ok'\`. En Preview sin \`KEYDROP_ZACKETIZOR_API_KEY\` el fetch retornaba \`not_configured\` → sección invisible → el usuario veía layout roto/vacío sin explicación.

**Fix**: \`<FallbackShell>\` con el copy propuesto:

- **\`not_configured\`** (típicamente preview):
  > Sorteos KeyDrop no disponibles en este entorno
  > Los sorteos se cargan automáticamente desde la API del partner. En producción están activos, pero este entorno de preview no tiene la API key configurada.

- **\`error\`** (fallos runtime en producción):
  > Sorteos KeyDrop no disponibles en este entorno
  > Los sorteos se cargan automáticamente desde la API del partner. La conexión ha fallado temporalmente.

- **\`no_binding\`** — sigue silencioso (creador sin partner, usa sorteos internos).
- **\`ok\` sin sorteos** — shell con "No hay sorteos ahora mismo".
- **\`ok\` con datos** — como siempre.

Estilos en \`platform-external-giveaways.css\` (\`.gp-external-fallback*\`). Tarjeta ligera dashed border tono ámbar suave — informativo, no error alarmante.

## Cuándo aparece el fallback

| Entorno | Estado real | Qué ve el usuario |
| --- | --- | --- |
| Producción con key | \`ok\` + datos | 5 sorteos activos de ZACKETIZOR — sin cambio |
| Producción con key + API abajo | \`error\` | Fallback "conexión fallada temporalmente" |
| Preview sin key | \`not_configured\` | Fallback "preview no tiene la API key" |
| Cualquiera, creador sin binding | \`no_binding\` | Nada (usa sorteos internos del CRM) |

## Archivos tocados

- \`src/lib/external-giveaways/providers/keydrop/mapper.ts\` — \`buildKeydropDeepLink\` refactorizado.
- \`src/features/giveaway-platform/components/ExternalGiveawaysSection.tsx\` — \`<FallbackShell>\`, empty-state visible.
- \`src/app/sorteos/plataforma/platform-external-giveaways.css\` — \`.gp-external-fallback\` + subcomponentes.
- \`src/__tests__/server/keydrop-provider-mapper.test.ts\` — regex y asserts al nuevo formato de URL.
- \`src/__tests__/server/external-giveaways-integration.test.ts\` — asserts a la nueva UI (fallback visible en vez de null silencioso).

## Qué NO cambia

lógica de monedas · ranking externo · participantes externos · depósitos externos · misiones externas · DB · migraciones · auth · legales · banner CTAs (kd.link/?code=X sigue funcionando).

## Checks locales

- \`npx tsc --noEmit\` → 0 errores en \`src/\`.
- \`npx jest\` → 148 suites / 2698 tests verdes.
- ESLint archivos tocados → 0 errores.

Preview: se despliega al abrir el PR — visita \`/sorteos/zacketizor\` en el preview URL para ver el fallback (en producción los 5 sorteos siguen visibles).

**No mergear sin OK visual.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)