### PR TITLE
feat(sorteos): rebrand público monedas/coins/🪙 → puntos/points/⭐

### DIFF
--- a/docs/socialpro-prizes-catalog.md
+++ b/docs/socialpro-prizes-catalog.md
@@ -93,19 +93,19 @@ Cualquiera de las 3 vías debe:
 
 ---
 
-## Conversión coste → monedas (interno, no publicar)
+## Conversión coste → puntos (interno, no publicar)
 
 Regla propuesta:
 
 ```txt
-1 USD coste interno  ≈ 1_000 monedas
-1 EUR coste interno  ≈ 1_100 monedas
+1 USD coste interno  ≈ 1_000 puntos
+1 EUR coste interno  ≈ 1_100 puntos
 ```
 
 **Estos valores se calculan solo en este documento** — no aparecen en
 `shop_items`, ni en `platform-shop.tsx`, ni en ningún endpoint público.
 Cuando se apruebe activar un premio, el owner define el precio final en
-monedas y lo escribe manualmente en el seed / migración.
+puntos y lo escribe manualmente en el seed / migración.
 
 Hasta entonces, cada item tiene `suggested_coin_price: pending`.
 
@@ -146,8 +146,8 @@ siguientes fuentes/categorías:
 - ❌ No hay scraping runtime. Ningún módulo en `src/` hace `fetch` a
   `steamcommunity.com/market`.
 - ❌ No hay conversión monetaria expuesta a usuario. La regla de 1$≈1000
-  monedas queda encerrada en este `.md`.
-- ❌ No hay marketplace P2P, ni compra de monedas, ni transferencias.
+  puntos queda encerrada en este `.md`.
+- ❌ No hay marketplace P2P, ni compra de puntos, ni transferencias.
 
 ---
 
@@ -159,7 +159,7 @@ siguientes fuentes/categorías:
   - Cada premio se marca como `planned` / `is_active: false`.
   - No hay seed script que inserte estos 8 URLs.
   - No hay código de producción que haga `fetch` a Steam Market.
-  - La conversión coste → monedas no aparece en ningún componente UI.
+  - La conversión coste → puntos no aparece en ningún componente UI.
 - ✅ Compatibilidad futura con más categorías (documentada).
 
 ---
@@ -169,7 +169,7 @@ siguientes fuentes/categorías:
 1. **Metadata real fase 1** — capturar título + imagen de los 8 items
    manualmente y actualizar la tabla arriba. Requiere OK del owner
    antes de tocar imagen assets.
-2. **Precios en monedas** — owner define coin-price por item cuando
+2. **Precios en puntos** — owner define coin-price por item cuando
    decida activarlos.
 3. **Sección "Próximamente" en la tienda** — cuando haya OK visual del
    owner, mostrar en `PlatformShop.tsx` bloque claramente marcado

--- a/docs/sorteos-coin-economy.md
+++ b/docs/sorteos-coin-economy.md
@@ -1,27 +1,32 @@
-# Economía de monedas — SocialPro Giveaways
+# Economía de puntos — SocialPro Giveaways
 
 **Estado:** Fase 1 — política aprobada por producto, pendiente de revisión legal para textos públicos.
 **Alcance:** `/sorteos/plataforma`, misiones, tienda, rankings, perfil.
 **Autor:** producto (2026-07-03).
 
-Este documento fija la regla interna de balance para la economía de monedas 🪙 de la plataforma. La regla NO se expone al usuario ni se comunica como conversión monetaria — es una guía interna para calibrar rewards y precios.
+> **Nota de naming (2026-07-03)**: el sistema se llama **puntos SocialPro (SP)** en la UI pública. Internamente (DB, código, tests) se mantienen los identificadores heredados `coin_transactions`, `getCoinBalance`, `ENTRY_COIN_REWARD`, etc. porque renombrarlos implicaría migraciones de DB — se hará en un PR separado si se aprueba. El nombre del propio archivo `sorteos-coin-economy.md` se mantiene por retrocompatibilidad con las referencias en `src/`; el contenido habla siempre de puntos.
+
+Este documento fija la regla interna de balance para la economía de puntos ⭐ de la plataforma. La regla NO se expone al usuario ni se comunica como conversión monetaria — es una guía interna para calibrar rewards y precios.
 
 ---
 
 ## 1. Regla interna de valoración
 
-- **1 USD de coste interno ≈ 1.000 monedas.**
-- **1 EUR de coste interno ≈ 1.100 monedas.**
+- **1 USD de coste interno ≈ 1.000 puntos.**
+- **1 EUR de coste interno ≈ 1.100 puntos.**
 
 Uso: cuando un artículo cueste al proveedor (SocialPro) X€, su precio interno base es `X × 1.100`. Se ajusta a la baja para incentivar canjes menores y al alza para artículos premium (fricción, uso de stock limitado, marca).
 
-**Importante — nunca exponer al usuario:**
-- No mostrar "1.000 monedas = 1$" en la UI.
-- No permitir comprar monedas con dinero.
-- No permitir transferir monedas entre usuarios.
+Esta referencia **no se muestra al usuario y no implica valor monetario de los puntos**.
+
+**Prohibido exponer al usuario:**
+- No mostrar "1.000 puntos = 1$" ni conversión equivalente en la UI.
+- No permitir comprar puntos con dinero.
+- No permitir transferir puntos entre usuarios.
 - No permitir marketplace usuario↔usuario.
-- No decir que las monedas tienen valor monetario.
-- Copy público estable: *"Las monedas son puntos internos sin valor monetario, no transferibles y no canjeables por dinero."*
+- No decir que los puntos tienen valor monetario.
+- Copy público estable — literal en tienda/FAQ/legales:
+  > *"Los puntos son un sistema interno de fidelización y recompensas dentro de SocialPro Giveaways. No son dinero, no son criptomonedas, no tienen valor monetario, no son transferibles y no pueden canjearse por efectivo."*
 
 Ver también `docs/giveaway-coin-economy-plan.md` (plan técnico futuro de expansión), `docs/sorteos-*` legales.
 
@@ -33,8 +38,8 @@ Ver también `docs/giveaway-coin-economy-plan.md` (plan técnico futuro de expan
 
 | Fuente | Valor |
 |---|---|
-| Racha diaria días 1-7 | `[10, 15, 20, 25, 30, 40, 60]` → total semana **200 monedas** |
-| Participar en sorteo interno (`ENTRY_COIN_REWARD`) | 20 monedas |
+| Racha diaria días 1-7 | `[10, 15, 20, 25, 30, 40, 60]` → total semana **200 puntos** |
+| Participar en sorteo interno (`ENTRY_COIN_REWARD`) | 20 puntos |
 | Misión "Primera participación" | 50 |
 | Misión "Participa en +5 sorteos" | 250 |
 | Misión "Participa en +50 sorteos" | 1.500 |
@@ -56,7 +61,7 @@ Ver también `docs/giveaway-coin-economy-plan.md` (plan técnico futuro de expan
 | PSN Plus 1 mes (~5€) | 900 |
 | Riot Points 10€ | 1.000 |
 
-Ratio actual = ~100 monedas/€. Propuesta = ~1.100 monedas/€. **Factor de reajuste ≈ 11×.**
+Ratio actual = ~100 puntos/€. Propuesta = ~1.100 puntos/€. **Factor de reajuste ≈ 11×.**
 
 ---
 
@@ -66,21 +71,21 @@ Ratio actual = ~100 monedas/€. Propuesta = ~1.100 monedas/€. **Factor de rea
 
 | Fuente | Rango objetivo |
 |---|---|
-| Login diario (racha día 1) | 20 monedas |
-| Racha 3 días completada | +75 monedas |
-| Racha 7 días completada | +250 monedas |
-| Misión básica | 50 monedas |
-| Misión media | 250 monedas |
-| Misión premium (verificada) | 1.000 monedas |
-| Participar en sorteo interno | 50 monedas |
-| Completar perfil | 150 monedas (una vez) |
-| Conectar Discord/YouTube (futuro) | 250-750 monedas (una vez cada canal) |
+| Login diario (racha día 1) | 20 puntos |
+| Racha 3 días completada | +75 puntos |
+| Racha 7 días completada | +250 puntos |
+| Misión básica | 50 puntos |
+| Misión media | 250 puntos |
+| Misión premium (verificada) | 1.000 puntos |
+| Participar en sorteo interno | 50 puntos |
+| Completar perfil | 150 puntos (una vez) |
+| Conectar Discord/YouTube (futuro) | 250-750 puntos (una vez cada canal) |
 | Ranking mensual — Top 3 | premio especial (ver §6) |
 
 **Ganancia esperada por perfil:**
-- **Casual** (login diario + 1 sorteo/semana): ~150 mon/semana → ~600/mes.
-- **Activo** (racha completa + 3 misiones básicas/mes): ~1.200 mon/mes.
-- **Grinder** (racha + misiones media + participaciones semanales): ~3.500-5.000 mon/mes.
+- **Casual** (login diario + 1 sorteo/semana): ~150 puntos/semana → ~600/mes.
+- **Activo** (racha completa + 3 misiones básicas/mes): ~1.200 puntos/mes.
+- **Grinder** (racha + misiones media + participaciones semanales): ~3.500-5.000 puntos/mes.
 
 ### 3.2 Precios de tienda
 
@@ -97,7 +102,7 @@ Ratio actual = ~100 monedas/€. Propuesta = ~1.100 monedas/€. **Factor de rea
 | Skin CS2 pequeña | 3.000-8.000 | Glock, USP-S básicas |
 | Skin CS2 media | 10.000-25.000 | AK-47 · Redline y similares |
 | Skin CS2 premium | 40.000+ | knife, gloves, top-tier factory new |
-| Merch físico (T-shirt) | coste-interno × 1.3 → ~15.000 mon si T-shirt cuesta ~11€ |
+| Merch físico (T-shirt) | coste-interno × 1.3 → ~15.000 puntos si T-shirt cuesta ~11€ |
 
 ### 3.3 Política de dificultad
 
@@ -106,19 +111,23 @@ Ratio actual = ~100 monedas/€. Propuesta = ~1.100 monedas/€. **Factor de rea
 - **Grinder** → skin media o gift card 25$ en 2-3 meses.
 - **Premio grande** (skin premium, knife/gloves) requiere constancia + ranking + campañas especiales — NO farmeable con solo login diario.
 
-Regla dura: **con solo login diario 30 días** el usuario acumula ~600 monedas → una profile card básica. No permite skin ni gift card. Hace falta misiones + participación.
+Regla dura: **con solo login diario 30 días** el usuario acumula ~600 puntos → una profile card básica. No permite skin ni gift card. Hace falta misiones + participación.
 
 ### 3.4 Reglas legales / disclaimers públicos
 
 Estas frases deben aparecer literales o equivalentes en tienda/FAQ/perfil (borrador; validar con gestoría antes de definitivas):
 
-- "Las monedas son puntos internos sin valor monetario."
+- "Los puntos son recompensas internas sin valor monetario."
 - "No son criptomonedas."
 - "No son transferibles entre usuarios."
 - "No pueden venderse."
 - "No son canjeables por dinero en efectivo."
 - "Los precios y disponibilidad pueden cambiar."
 - "Los canjes pueden requerir revisión antes del envío."
+
+**Disclaimer largo (recomendado en Términos y FAQ):**
+
+> Los puntos son un sistema interno de fidelización y recompensas dentro de SocialPro Giveaways. No son dinero, no son criptomonedas, no tienen valor monetario, no son transferibles y no pueden canjearse por efectivo.
 
 ---
 
@@ -193,9 +202,9 @@ Ampliación en `src/features/giveaway-platform/components/PlatformShop.tsx`:
 - `ENTRY_COIN_REWARD`: 20 → 50 (antes también incluía "por sorteo", ahora "por participación").
 
 **Misiones** — mantener rango 50-3.000, pero clarificar tiers:
-- Básica: 50 mon (una tarea puntual).
-- Media: 250 mon (semanal o "5 acciones").
-- Premium: 1.000-1.500 mon (mensual, verificada).
+- Básica: 50 puntos (una tarea puntual).
+- Media: 250 puntos (semanal o "5 acciones").
+- Premium: 1.000-1.500 puntos (mensual, verificada).
 
 **Precios shop** — factor ~11×:
 - Steam 10€: 1.000 → 11.000.
@@ -218,8 +227,8 @@ Recomiendo **B**. Documentar el cambio con fecha en un mensaje interno.
 
 Espacio reservado para expansiones futuras:
 
-- **Ranking mensual** — top 3 recibe bonus one-shot (2.500 / 1.500 / 1.000 monedas + badge exclusivo). Ver `getMonthlyRanking` en `src/lib/queries/giveawayPlatform.ts`.
-- **Campañas de creador** — un partner (KeyDrop, futuros) puede lanzar campaña con multiplicador de monedas por participar (ej. ×2 durante 1 semana). Implementación pendiente.
+- **Ranking mensual** — top 3 recibe bonus one-shot (2.500 / 1.500 / 1.000 puntos + badge exclusivo). Ver `getMonthlyRanking` en `src/lib/queries/giveawayPlatform.ts`.
+- **Campañas de creador** — un partner (KeyDrop, futuros) puede lanzar campaña con multiplicador de puntos por participar (ej. ×2 durante 1 semana). Implementación pendiente.
 - **Season pass** — badge premium mensual desbloqueable con actividad.
 
 Cada expansión requiere PR propio + revisión legal si hay premio en dinero equivalente.
@@ -245,5 +254,6 @@ Cada expansión requiere PR propio + revisión legal si hay premio en dinero equ
 | Fase 4 — reajuste económico | Cambio de constantes rewards + `costCoins` en seed. Aplicar a producción con seed idempotente | No (solo re-seed) |
 | Fase 5 — ranking mensual bonus | Cron end-of-month que distribuye premios | Posible tabla `monthly_bonuses` |
 | Fase 6 — campañas creador | Tabla `coin_campaigns` con multiplicadores temporales | Sí |
+| Fase X — rename interno DB | `coin_transactions` → `points_transactions`, `getCoinBalance` → `getPointsBalance`, `ENTRY_COIN_REWARD` → `ENTRY_POINTS_REWARD` | **Sí** — pedir OK antes |
 
 **Este PR se limita a Fase 1 + Fase 2 sin ejecutar el reseed.** Los cambios de precios reales en producción los aplicas tú corriendo `npx tsx scripts/seed-giveaway-platform.ts` cuando decidas.

--- a/src/__tests__/server/coin-economy.test.ts
+++ b/src/__tests__/server/coin-economy.test.ts
@@ -1,10 +1,15 @@
 /**
- * Contratos estructurales de la Fase 1+2 de la economía de monedas.
+ * Contratos estructurales de la Fase 1+2 de la economía de puntos.
+ *
+ * Naming (2026-07-03): al usuario público se le habla siempre de "puntos".
+ * Internamente (DB, código, tests) se conservan los identificadores
+ * heredados (`coin_transactions`, `getCoinBalance`, `ENTRY_COIN_REWARD`,
+ * `costCoins`...) porque renombrarlos requeriría migración DB.
  *
  * Regla interna (docs/sorteos-coin-economy.md):
- *   1 USD ≈ 1.000 monedas · 1 EUR ≈ 1.100 monedas.
+ *   1 USD ≈ 1.000 puntos · 1 EUR ≈ 1.100 puntos.
  *   Nunca exponer esta conversión al usuario ni permitir
- *   comprar/transferir monedas.
+ *   comprar/transferir puntos.
  *
  * Este test verifica:
  *  - Doc existe con las tablas y reglas.
@@ -12,8 +17,8 @@
  *  - PlatformShop muestra las nuevas categorías + disclaimer legal.
  *  - Seed script actualizado con nueva economía + profile cards demo
  *    (NO se ejecuta desde este PR).
- *  - Sin fugas: nadie expone "1$ = 1000 monedas" en UI pública ni existe
- *    endpoint de "comprar monedas" o "transferir monedas".
+ *  - Sin fugas: nadie expone "1$ = 1000 puntos" en UI pública ni existe
+ *    endpoint de "comprar puntos" o "transferir puntos".
  */
 
 import * as fs from 'fs';
@@ -25,14 +30,14 @@ const read = (rel: string) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');
 describe('[coin-economy] doc de política', () => {
   const doc = read('docs/sorteos-coin-economy.md');
 
-  it('existe y cita la regla interna 1$ ≈ 1.000 monedas', () => {
-    expect(doc).toMatch(/1 USD de coste interno\s*≈\s*1\.?000 monedas/i);
-    expect(doc).toMatch(/1 EUR de coste interno\s*≈\s*1\.?100 monedas/i);
+  it('existe y cita la regla interna 1$ ≈ 1.000 puntos', () => {
+    expect(doc).toMatch(/1 USD de coste interno\s*≈\s*1\.?000 puntos/i);
+    expect(doc).toMatch(/1 EUR de coste interno\s*≈\s*1\.?100 puntos/i);
   });
 
   it('deja claro que la regla NUNCA se expone al usuario', () => {
-    expect(doc).toMatch(/nunca exponer al usuario/i);
-    expect(doc).toMatch(/No mostrar "1\.000 monedas\s*=\s*1\$" en la UI/);
+    expect(doc).toMatch(/Prohibido exponer al usuario/i);
+    expect(doc).toMatch(/No mostrar "1\.000 puntos\s*=\s*1\$"/);
   });
 
   it('reglas legales completas de "no valor monetario"', () => {
@@ -43,8 +48,15 @@ describe('[coin-economy] doc de política', () => {
     expect(doc).toMatch(/No son canjeables por dinero/i);
   });
 
+  it('disclaimer largo con el copy compliance completo', () => {
+    // Frase canónica que se copiará literal en Términos + FAQ.
+    expect(doc).toMatch(
+      /Los puntos son un sistema interno de fidelización y recompensas[\s\S]{0,200}No son dinero, no son criptomonedas, no tienen valor monetario, no son transferibles y no pueden canjearse por efectivo/,
+    );
+  });
+
   it('incluye tabla de rewards y precios objetivo', () => {
-    expect(doc).toMatch(/Racha 7 días completada[\s\S]{0,80}250 monedas/i);
+    expect(doc).toMatch(/Racha 7 días completada[\s\S]{0,80}250 puntos/i);
     expect(doc).toMatch(/Gift card 10€[\s\S]{0,120}11\.?000-15\.?000/i);
     expect(doc).toMatch(/Skin CS2 premium/i);
   });
@@ -102,8 +114,8 @@ describe('[coin-economy] PlatformShop UI', () => {
   });
 
   it('el disclaimer NUNCA cita la conversión interna (fuga bloqueada)', () => {
-    expect(src).not.toMatch(/1\.?000 monedas\s*=\s*1\s*\$/i);
-    expect(src).not.toMatch(/1\.?100 monedas\s*=\s*1\s*€/i);
+    expect(src).not.toMatch(/1\.?000 puntos\s*=\s*1\s*\$/i);
+    expect(src).not.toMatch(/1\.?100 puntos\s*=\s*1\s*€/i);
     expect(src).not.toMatch(/1\s*USD.*1\.?000/i);
     expect(src).not.toMatch(/valor.*€|valor.*USD/i);
   });
@@ -160,20 +172,23 @@ describe('[coin-economy] safeguards — ningún vector prohibido en código', ()
     'src/features/giveaway-platform/components/PlatformCreatorLanding.tsx',
   ];
 
-  it('ningún componente/action ofrece "comprar monedas" con dinero', () => {
+  it('ningún componente/action ofrece "comprar puntos/monedas" con dinero', () => {
     for (const p of SRC_PATHS) {
       const src = read(p);
+      expect(src).not.toMatch(/comprar puntos/i);
       expect(src).not.toMatch(/comprar monedas/i);
       expect(src).not.toMatch(/purchase coins/i);
       expect(src).not.toMatch(/buy coins/i);
     }
   });
 
-  it('ningún componente/action ofrece "transferir monedas" entre usuarios', () => {
+  it('ningún componente/action ofrece "transferir puntos/monedas" entre usuarios', () => {
     for (const p of SRC_PATHS) {
       const src = read(p);
+      expect(src).not.toMatch(/transferir puntos/i);
       expect(src).not.toMatch(/transferir monedas/i);
       expect(src).not.toMatch(/transfer coins/i);
+      expect(src).not.toMatch(/enviar puntos/i);
       expect(src).not.toMatch(/enviar monedas/i);
     }
   });
@@ -182,6 +197,7 @@ describe('[coin-economy] safeguards — ningún vector prohibido en código', ()
     for (const p of SRC_PATHS) {
       const src = read(p);
       expect(src).not.toMatch(/marketplace/i);
+      expect(src).not.toMatch(/vender puntos/i);
       expect(src).not.toMatch(/vender monedas/i);
     }
   });

--- a/src/__tests__/server/post-170-fixes.test.ts
+++ b/src/__tests__/server/post-170-fixes.test.ts
@@ -93,7 +93,7 @@ describe('[post-170] SteamAvatar fallback premium', () => {
     expect(pill).toMatch(/<SteamAvatar\s+imageUrl=\{userImage\}\s+name=\{userName\}\s+size=\{26\}/);
     // El avatar antiguo era `<span className="gp-avatar" aria-hidden>🐱|🎮</span>`.
     // Comprobamos que ese patrón concreto ya no existe (el emoji 🎮 del botón de
-    // login y el 🪙 de las monedas son legítimos y siguen).
+    // login y el ⭐ de los puntos son legítimos y siguen).
     expect(pill).not.toMatch(/<span\s+className="gp-avatar"[^>]*>\s*(🐱|🎮)/);
   });
 

--- a/src/__tests__/server/public-copy-points-rebrand.test.ts
+++ b/src/__tests__/server/public-copy-points-rebrand.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Rebrand compliance — el usuario público solo ve "puntos", nunca "monedas".
+ *
+ * Motivo: por prevención legal/compliance (2026-07-03) evitamos que el
+ * sistema interno de fidelización parezca una moneda, token, cripto o
+ * valor económico. En UI pública se habla siempre de **puntos SocialPro**.
+ *
+ * Internamente se conservan los identificadores heredados por evitar
+ * migración de DB en este PR:
+ *   - Tabla `coin_transactions`
+ *   - Funciones `getCoinBalance`, `awardCoins`
+ *   - Constantes `ENTRY_COIN_REWARD`, `STREAK_REWARDS`, `costCoins`
+ *   - Props/fields `coinsEarned`, `rewardCoins`, `costCoins`
+ *
+ * Este test verifica que ninguna string visible al usuario contenga
+ * "monedas" (o su plural) ni "coins" ni el emoji 🪙 en los archivos de
+ * UI pública de `/sorteos`.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(__dirname, '..', '..', '..');
+const read = (rel: string) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');
+
+/**
+ * Archivos de UI pública de la plataforma de sorteos.
+ * NO incluye admin/facturacion (allí "monedas" se refiere a currency
+ * financiera USD/EUR, no al sistema de puntos).
+ */
+const PUBLIC_UI_FILES = [
+  'src/app/sorteos/page.tsx',
+  'src/app/sorteos/[creatorSlug]/page.tsx',
+  'src/app/sorteos/perfil/page.tsx',
+  'src/app/sorteos/(legal)/terminos/page.tsx',
+  'src/app/sorteos/(legal)/privacidad/page.tsx',
+  'src/app/sorteos/(legal)/juego-responsable/page.tsx',
+  'src/app/sorteos/(legal)/faq/page.tsx',
+  'src/features/giveaway-platform/components/UserPill.tsx',
+  'src/features/giveaway-platform/components/PlatformShop.tsx',
+  'src/features/giveaway-platform/components/PlatformCreatorLanding.tsx',
+  'src/features/giveaway-platform/components/MissionsGrid.tsx',
+  'src/features/giveaway-platform/components/DailyStreakCard.tsx',
+] as const;
+
+/**
+ * Extrae las partes de un fuente TSX/TS que pueden acabar en pantalla
+ * del usuario:
+ *   - Contenido dentro de string literals ('...', "...", `...`).
+ *   - Contenido de texto en JSX (entre `>` y `<`).
+ * Excluye:
+ *   - Comentarios `//` y `/* ... *​/`.
+ *   - Nombres de clase CSS y de identificadores.
+ * Es una heurística — no un parser AST — suficiente para bloquear las
+ * strings visibles obvias sin ser demasiado ruidosa.
+ */
+function extractUserVisibleText(src: string): string {
+  // 1. Quitar comentarios de bloque y de línea.
+  let s = src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+  // 2. Quitar `className="..."` completas — son clases CSS, no visible text.
+  s = s.replace(/className\s*=\s*"[^"]*"/g, '');
+  s = s.replace(/className\s*=\s*\{[^}]*\}/g, '');
+  // 3. Quitar bloques CSS-like en style={{...}}.
+  s = s.replace(/style\s*=\s*\{\{[^}]*\}\}/g, '');
+  return s;
+}
+
+describe('[points-rebrand] UI pública no muestra "monedas"', () => {
+  for (const rel of PUBLIC_UI_FILES) {
+    it(`${rel} no contiene la palabra "monedas" en texto visible`, () => {
+      const src = read(rel);
+      const visible = extractUserVisibleText(src);
+      // Case-insensitive por seguridad. Buscamos "moneda" o "monedas".
+      expect(visible).not.toMatch(/\bmonedas?\b/i);
+    });
+  }
+});
+
+describe('[points-rebrand] UI pública no muestra "coins/coin"', () => {
+  for (const rel of PUBLIC_UI_FILES) {
+    it(`${rel} no contiene "coins"/"coin" como palabra visible al usuario`, () => {
+      const src = read(rel);
+      const visible = extractUserVisibleText(src);
+      // Solo bloqueamos "coin"/"coins" como palabra suelta (aria-label,
+      // texto JSX, string literal). Nombres internos como costCoins,
+      // rewardCoins, ENTRY_COIN_REWARD siguen permitidos porque no
+      // aparecen como palabra suelta en el texto visible.
+      expect(visible).not.toMatch(/\bcoins?\b/i);
+    });
+  }
+});
+
+describe('[points-rebrand] UI pública no muestra el emoji 🪙', () => {
+  for (const rel of PUBLIC_UI_FILES) {
+    it(`${rel} no contiene 🪙`, () => {
+      const src = read(rel);
+      expect(src).not.toContain('🪙');
+    });
+  }
+});
+
+describe('[points-rebrand] icono nuevo ⭐ en su lugar', () => {
+  const withStarIcon = [
+    'src/features/giveaway-platform/components/UserPill.tsx',
+    'src/features/giveaway-platform/components/PlatformShop.tsx',
+    'src/features/giveaway-platform/components/PlatformCreatorLanding.tsx',
+    'src/features/giveaway-platform/components/MissionsGrid.tsx',
+    'src/features/giveaway-platform/components/DailyStreakCard.tsx',
+    'src/app/sorteos/perfil/page.tsx',
+    'src/app/sorteos/page.tsx',
+  ];
+
+  for (const rel of withStarIcon) {
+    it(`${rel} usa ⭐ como icono de puntos`, () => {
+      const src = read(rel);
+      expect(src).toContain('⭐');
+    });
+  }
+});
+
+describe('[points-rebrand] copy legal compliance', () => {
+  it('Términos: "Puntos SocialPro" reemplaza a "Monedas virtuales"', () => {
+    const src = read('src/app/sorteos/(legal)/terminos/page.tsx');
+    // La sección 5 debe titularse con "Puntos SocialPro".
+    expect(src).toMatch(/Puntos SocialPro/);
+    // Copy canónico de compliance debe estar presente (permite saltos
+    // de línea y etiquetas <b> entre partes).
+    expect(src).toMatch(/Los puntos son un sistema interno de fidelización y recompensas/);
+    expect(src).toMatch(
+      /No son dinero, no son criptomonedas, no tienen valor monetario, no son\s+transferibles y no pueden canjearse por efectivo/,
+    );
+  });
+
+  it('FAQ: sección "Puntos y tienda" reemplaza a "Monedas y tienda"', () => {
+    const src = read('src/app/sorteos/(legal)/faq/page.tsx');
+    expect(src).toMatch(/title:\s*'Puntos y tienda'/);
+    expect(src).toMatch(/¿Qué son los puntos ⭐\?/);
+  });
+
+  it('Juego responsable: aclara que los puntos no tienen valor monetario', () => {
+    const src = read('src/app/sorteos/(legal)/juego-responsable\/page.tsx');
+    expect(src).toMatch(/puntos ⭐ son recompensas internas sin valor monetario/);
+  });
+
+  it('PlatformShop disclaimer: "Los puntos son recompensas internas sin valor monetario"', () => {
+    const src = read('src/features/giveaway-platform/components/PlatformShop.tsx');
+    expect(src).toMatch(/Los puntos son recompensas internas.*sin valor monetario/);
+    // Y NO menciona "las monedas".
+    expect(src).not.toMatch(/[Ll]as monedas/);
+  });
+});
+
+describe('[points-rebrand] identificadores internos preservados (no requiere migración)', () => {
+  it('DB schema coin_transactions sigue existiendo (no se toca)', () => {
+    const src = read('src/db/schema/coinTransactions.ts');
+    expect(src).toMatch(/coin_transactions/);
+  });
+
+  it('getCoinBalance sigue exportado desde queries', () => {
+    const src = read('src/lib/queries/giveawayPlatform.ts');
+    expect(src).toMatch(/export\s+async\s+function\s+getCoinBalance/);
+  });
+
+  it('ENTRY_COIN_REWARD sigue en constants', () => {
+    const src = read('src/lib/giveaway-platform/constants.ts');
+    expect(src).toMatch(/ENTRY_COIN_REWARD/);
+  });
+
+  it('costCoins sigue en el schema de shop_items', () => {
+    const src = read('src/db/schema/shopItems.ts');
+    expect(src).toMatch(/costCoins/);
+  });
+});

--- a/src/__tests__/server/shop-enhancement.test.ts
+++ b/src/__tests__/server/shop-enhancement.test.ts
@@ -6,7 +6,7 @@
  *  - Category tabs con badge de count.
  *  - Card marca "affordable" cuando balance >= cost && stock > 0.
  *  - Barra de progreso por card (% balance/cost, clamped 100).
- *  - Botón muestra "Faltan N 🪙" cuando no alcanza.
+ *  - Botón muestra "Faltan N ⭐" cuando no alcanza.
  *  - Empty state cuando el filtro no devuelve items.
  *  - CSS para summary, badges y progress-fill.
  */

--- a/src/__tests__/server/socialpro-prizes-catalog.test.ts
+++ b/src/__tests__/server/socialpro-prizes-catalog.test.ts
@@ -9,7 +9,7 @@
  *  - Cada premio queda como `planned` / `is_active: false`.
  *  - Ningún seed script inserta estos 8 URLs.
  *  - Ningún módulo de `src/` hace fetch runtime a `steamcommunity.com/market`.
- *  - La regla de conversión coste → monedas NO aparece en ningún componente UI
+ *  - La regla de conversión coste → puntos NO aparece en ningún componente UI
  *    (solo en el .md).
  *
  * Objetivo: bloquear activación accidental de premios sin OK explícito.
@@ -170,12 +170,12 @@ describe('[prizes-catalog] no hay scraping runtime de Steam Market', () => {
   });
 });
 
-describe('[prizes-catalog] regla de conversión coste→monedas queda solo en el .md', () => {
+describe('[prizes-catalog] regla de conversión coste→puntos queda solo en el .md', () => {
   const doc = read(DOC_PATH);
 
-  it('la regla 1 USD ≈ 1.000 monedas está documentada en el .md', () => {
-    expect(doc).toMatch(/1\s*USD\s*coste\s*interno\s*≈\s*1_?000\s*monedas/);
-    expect(doc).toMatch(/1\s*EUR\s*coste\s*interno\s*≈\s*1_?100\s*monedas/);
+  it('la regla 1 USD ≈ 1.000 puntos está documentada en el .md', () => {
+    expect(doc).toMatch(/1\s*USD\s*coste\s*interno\s*≈\s*1_?000\s*puntos/);
+    expect(doc).toMatch(/1\s*EUR\s*coste\s*interno\s*≈\s*1_?100\s*puntos/);
   });
 
   it('la regla NO aparece en el componente PlatformShop ni en la tienda pública', () => {
@@ -196,8 +196,8 @@ describe('[prizes-catalog] regla de conversión coste→monedas queda solo en el
     const files = walk(srcDir);
     for (const f of files) {
       const src = fs.readFileSync(f, 'utf-8');
-      expect(src).not.toMatch(/1\s*USD\s*[^.]{0,40}1_?000\s*monedas/);
-      expect(src).not.toMatch(/1\s*EUR\s*[^.]{0,40}1_?100\s*monedas/);
+      expect(src).not.toMatch(/1\s*USD\s*[^.]{0,40}1_?000\s*puntos/);
+      expect(src).not.toMatch(/1\s*EUR\s*[^.]{0,40}1_?100\s*puntos/);
     }
   });
 });

--- a/src/__tests__/server/ui-dropdown-steam-fixes.test.ts
+++ b/src/__tests__/server/ui-dropdown-steam-fixes.test.ts
@@ -84,7 +84,7 @@ describe('[ui] UserPill usa SteamLoginButton cuando !loggedIn', () => {
 
   it('el emoji 🎮 hardcoded ya no aparece en el CTA', () => {
     // 🎮 solo aparecía en el botón antiguo "🎮 Iniciar sesión con Steam".
-    // Otros emojis del pill (🪙 monedas) siguen siendo legítimos.
+    // Otros emojis del pill (⭐ puntos) siguen siendo legítimos.
     expect(src).not.toMatch(/🎮\s+Iniciar sesión con Steam/);
   });
 });

--- a/src/app/sorteos/(legal)/faq/page.tsx
+++ b/src/app/sorteos/(legal)/faq/page.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 export const metadata: Metadata = {
   title: 'FAQ · SocialPro Giveaways',
   description:
-    'Preguntas frecuentes sobre la plataforma de sorteos gratuitos de SocialPro: cómo participar, monedas, canjeo, providers externos y Steam login. Borrador.',
+    'Preguntas frecuentes sobre la plataforma de sorteos gratuitos de SocialPro: cómo participar, puntos, canjeo, providers externos y Steam login. Borrador.',
   alternates: { canonical: '/sorteos/faq' },
   robots: { index: false, follow: false },
 };
@@ -24,8 +24,8 @@ const SECTIONS: { title: string; items: QA[] }[] = [
           <p>
             SocialPro Giveaways es una plataforma web operada por SocialPro donde los creadores de
             contenido asociados a la agencia publican sorteos <b>gratuitos</b> dirigidos a su
-            comunidad. Los participantes ganan tickets sin coste y pueden acumular monedas
-            virtuales (🪙) que se canjean por objetos físicos, digitales o tarjetas regalo en la
+            comunidad. Los participantes ganan tickets sin coste y pueden acumular puntos
+            internos (⭐) que se canjean por objetos físicos, digitales o tarjetas regalo en la
             tienda interna. La plataforma no acepta ni gestiona dinero real de los participantes.
           </p>
         ),
@@ -85,7 +85,7 @@ const SECTIONS: { title: string; items: QA[] }[] = [
         q: '¿Qué es una racha diaria?',
         a: (
           <p>
-            Es una recompensa diaria de 🪙 que puedes reclamar una vez cada 24 horas si mantienes
+            Es una recompensa diaria de puntos ⭐ que puedes reclamar una vez cada 24 horas si mantienes
             el login diario. Si te saltas un día, la racha se reinicia al día 1. Es solo un bono
             de fidelidad, no una obligación.
           </p>
@@ -94,16 +94,16 @@ const SECTIONS: { title: string; items: QA[] }[] = [
     ],
   },
   {
-    title: 'Monedas y tienda',
+    title: 'Puntos y tienda',
     items: [
       {
-        q: '¿Qué son las monedas 🪙?',
+        q: '¿Qué son los puntos ⭐?',
         a: (
           <p>
-            Son puntos internos, sin valor monetario y sin capacidad de conversión a euros o
-            cualquier moneda de curso legal. Se ganan participando, completando misiones o
-            manteniendo la racha diaria. Se gastan canjeando premios en la tienda. No se pueden
-            comprar, transferir entre cuentas ni retirar.
+            Los puntos son un sistema interno de fidelización y recompensas dentro de SocialPro
+            Giveaways. <b>No son dinero, no son criptomonedas, no tienen valor monetario, no son
+            transferibles y no pueden canjearse por efectivo.</b> Se ganan participando, completando
+            misiones o manteniendo la racha diaria. Se gastan canjeando premios en la tienda.
           </p>
         ),
       },
@@ -112,7 +112,7 @@ const SECTIONS: { title: string; items: QA[] }[] = [
         a: (
           <p>
             En <code>/sorteos#tienda</code> eliges un artículo cuyo coste sea igual o
-            menor que tu saldo. Al pulsar &quot;Canjear&quot; se descuentan las monedas y el
+            menor que tu saldo. Al pulsar &quot;Canjear&quot; se descuentan los puntos y el
             equipo de SocialPro contacta contigo para coordinar el envío o la entrega digital,
             según el tipo de artículo. Una vez procesado o entregado un canje puede no ser
             posible cancelarlo, sin perjuicio de los derechos que correspondan al usuario según
@@ -122,7 +122,7 @@ const SECTIONS: { title: string; items: QA[] }[] = [
         ),
       },
       {
-        q: '¿Puedo perder monedas?',
+        q: '¿Puedo perder puntos?',
         a: (
           <p>
             Solo si canjeas (gasto voluntario) o si tu cuenta es suspendida por incumplir
@@ -172,7 +172,7 @@ const SECTIONS: { title: string; items: QA[] }[] = [
         a: (
           <p>
             Steam ID, nombre público de Steam, avatar público de Steam, participaciones en
-            sorteos, transacciones de monedas, misiones completadas y canjeos. Detalle completo
+            sorteos, historial de puntos, misiones completadas y canjeos. Detalle completo
             en <Link href="/sorteos/privacidad">/sorteos/privacidad</Link>.
           </p>
         ),

--- a/src/app/sorteos/(legal)/juego-responsable/page.tsx
+++ b/src/app/sorteos/(legal)/juego-responsable/page.tsx
@@ -26,7 +26,7 @@ export default function JuegoResponsablePage() {
         <p>
           Los sorteos internos publicados en <code>/sorteos</code> son{' '}
           <b>gratuitos</b>, no requieren depósito ni ninguna forma de pago y no reparten dinero
-          en metálico. Las monedas 🪙 son puntos internos sin valor monetario. Este servicio,
+          en metálico. Los puntos ⭐ son recompensas internas sin valor monetario. Este servicio,
           en su parte interna, <b>no es una actividad de juego regulado</b> conforme a la Ley
           13/2011.
         </p>

--- a/src/app/sorteos/(legal)/privacidad/page.tsx
+++ b/src/app/sorteos/(legal)/privacidad/page.tsx
@@ -48,7 +48,7 @@ export default function PrivacidadPage() {
           </li>
           <li>
             <b>Datos de participación en la plataforma:</b> sorteos en los que participas,
-            transacciones de monedas 🪙, misiones completadas, racha diaria, canjeos en tienda.
+            historial de puntos ⭐, misiones completadas, racha diaria, canjeos en tienda.
           </li>
           <li>
             <b>Datos de sesión:</b> cookies estrictamente necesarias para mantener la sesión
@@ -73,7 +73,7 @@ export default function PrivacidadPage() {
         <ul>
           <li>
             <b>Ejecución del servicio (art. 6.1.b):</b> gestión de tu cuenta, participaciones,
-            saldo de monedas y canjeos.
+            saldo de puntos y canjeos.
           </li>
           <li>
             <b>Consentimiento (art. 6.1.a):</b> para funcionalidades opcionales (vincular tu
@@ -82,7 +82,7 @@ export default function PrivacidadPage() {
           <li>
             <b>Interés legítimo (art. 6.1.f):</b> aplicar medidas para prevenir abusos o
             uso indebido, revisar posibles incumplimientos y auditar el registro interno de
-            monedas.
+            puntos.
           </li>
         </ul>
         <p>
@@ -140,7 +140,7 @@ export default function PrivacidadPage() {
         <ul>
           <li>Datos de cuenta: mientras la cuenta permanezca activa.</li>
           <li>
-            Historial de monedas y canjeos: durante el plazo estrictamente necesario
+            Historial de puntos y canjeos: durante el plazo estrictamente necesario
             para gestionar la cuenta, resolver incidencias, prevenir abusos y cumplir,
             en su caso, con las obligaciones legales aplicables.
           </li>

--- a/src/app/sorteos/(legal)/terminos/page.tsx
+++ b/src/app/sorteos/(legal)/terminos/page.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 export const metadata: Metadata = {
   title: 'Términos de uso · SocialPro Giveaways',
   description:
-    'Condiciones de uso de la plataforma SocialPro Giveaways: elegibilidad, gratuidad, monedas virtuales, canjeos, partners externos y limitación de responsabilidad. Borrador.',
+    'Condiciones de uso de la plataforma SocialPro Giveaways: elegibilidad, gratuidad, puntos internos, canjeos, partners externos y limitación de responsabilidad. Borrador.',
   alternates: { canonical: '/sorteos/terminos' },
   robots: { index: false, follow: false },
 };
@@ -27,7 +27,7 @@ export default function TerminosPage() {
           Estos términos regulan el uso de la plataforma <b>SocialPro Giveaways</b>, disponible en{' '}
           <code>/sorteos</code>, operada por SocialPro. La plataforma permite a los
           usuarios participar gratuitamente en sorteos publicados por creadores de contenido
-          asociados a la agencia, acumular puntos virtuales sin valor monetario (🪙) y canjearlos
+          asociados a la agencia, acumular puntos internos sin valor monetario (⭐) y canjearlos
           por artículos ofertados en la tienda interna.
         </p>
       </section>
@@ -65,10 +65,13 @@ export default function TerminosPage() {
       </section>
 
       <section className="gp-legal-section">
-        <h2>5. Monedas virtuales (🪙)</h2>
+        <h2>5. Puntos SocialPro (⭐)</h2>
         <ul>
-          <li>Son puntos internos <b>sin valor monetario</b> y sin convertibilidad a moneda
-              de curso legal.</li>
+          <li>
+            Los puntos son un sistema interno de fidelización y recompensas dentro de SocialPro
+            Giveaways. <b>No son dinero, no son criptomonedas, no tienen valor monetario, no son
+            transferibles y no pueden canjearse por efectivo.</b>
+          </li>
           <li>Se obtienen participando en sorteos, completando misiones o manteniendo la racha
               diaria. No se compran.</li>
           <li>Se gastan canjeando artículos de la tienda.</li>
@@ -86,7 +89,7 @@ export default function TerminosPage() {
       <section className="gp-legal-section">
         <h2>6. Canjeos en la tienda</h2>
         <p>
-          El canjeo descuenta monedas del saldo y genera una solicitud de entrega. SocialPro
+          El canjeo descuenta puntos del saldo y genera una solicitud de entrega. SocialPro
           coordinará contigo la entrega según el tipo de artículo (skin CS2 vía trade offer,
           merchandising físico o tarjeta regalo digital). Una vez procesado o entregado un
           canje puede no ser posible cancelarlo. Lo anterior se aplicará <b>sin perjuicio de
@@ -117,7 +120,7 @@ export default function TerminosPage() {
         <h2>8. Conducta prohibida</h2>
         <ul>
           <li>Crear varias cuentas para el mismo participante.</li>
-          <li>Usar bots o automatismos para acumular monedas o participaciones.</li>
+          <li>Usar bots o automatismos para acumular puntos o participaciones.</li>
           <li>Suplantar la identidad de otra persona o creador.</li>
           <li>Intentar vulnerar la seguridad de la plataforma, sus proveedores o los partners.</li>
           <li>
@@ -134,7 +137,7 @@ export default function TerminosPage() {
       <section className="gp-legal-section">
         <h2>9. Modificaciones y disponibilidad</h2>
         <p>
-          Podemos actualizar estos términos, la mecánica de monedas, el catálogo de la tienda o
+          Podemos actualizar estos términos, la mecánica de puntos, el catálogo de la tienda o
           la lista de creadores participantes en cualquier momento. Los cambios sustanciales se
           comunicarán desde la propia plataforma con antelación razonable. No garantizamos la
           disponibilidad continua del servicio; podemos suspenderlo temporalmente por

--- a/src/app/sorteos/[creatorSlug]/page.tsx
+++ b/src/app/sorteos/[creatorSlug]/page.tsx
@@ -64,7 +64,7 @@ export async function generateMetadata({
     robots: { index: true, follow: true },
     openGraph: {
       title: `Sorteos de ${name} · SocialPro Giveaways`,
-      description: `Sorteos gratis con tus creadores favoritos de SocialPro. Participa con Steam, gana 🪙 y canjea recompensas.`,
+      description: `Sorteos gratis con tus creadores favoritos de SocialPro. Participa con Steam, gana puntos y canjea recompensas.`,
       url: absoluteUrl(`/sorteos/${canonicalSlug}`),
     },
   };

--- a/src/app/sorteos/layout.tsx
+++ b/src/app/sorteos/layout.tsx
@@ -38,7 +38,7 @@ const chakra = Chakra_Petch({
 export const metadata: Metadata = {
   title: 'Sorteos y recompensas de creadores | SocialPro',
   description:
-    'Índice público de SocialPro Giveaways. Elige un creador y participa gratis en sus sorteos, gana monedas y canjea recompensas.',
+    'Índice público de SocialPro Giveaways. Elige un creador y participa gratis en sus sorteos, gana puntos y canjea recompensas.',
   robots: { index: true, follow: true },
   alternates: { canonical: absoluteUrl('/sorteos') },
 };

--- a/src/app/sorteos/page.tsx
+++ b/src/app/sorteos/page.tsx
@@ -15,13 +15,13 @@ import { absoluteUrl } from '@/lib/site-url';
 export const metadata: Metadata = {
   title: 'Sorteos y recompensas de creadores | SocialPro',
   description:
-    'Índice público de SocialPro Giveaways. Elige un creador y participa gratis en sus sorteos, gana monedas y canjea recompensas. Login con Steam, sin depósitos, +18.',
+    'Índice público de SocialPro Giveaways. Elige un creador y participa gratis en sus sorteos, gana puntos y canjea recompensas. Login con Steam, sin depósitos, +18.',
   alternates: { canonical: '/sorteos' },
   robots: { index: true, follow: true },
   openGraph: {
     title: 'SocialPro Giveaways · sorteos gratuitos de creadores',
     description:
-      'Elige tu creador favorito, participa gratis, gana 🪙 y canjea recompensas. Login con Steam, sin depósitos, +18.',
+      'Elige tu creador favorito, participa gratis, gana puntos y canjea recompensas. Login con Steam, sin depósitos, +18.',
     url: absoluteUrl('/sorteos'),
   },
 };
@@ -71,8 +71,8 @@ export default async function SorteosIndexPage() {
           </h1>
           <p className="gp-index-lead">
             Elige un creador, inicia sesión con Steam y participa <b>gratis</b> en sus sorteos.
-            Gana monedas <b>🪙</b> por participar, completar misiones y mantener la racha diaria,
-            y cánjealas por skins, merchandising o tarjetas regalo. Sin depósitos, sin apuestas, +18.
+            Gana puntos <b>⭐</b> por participar, completar misiones y mantener la racha diaria,
+            y cánjealos por skins, merchandising o tarjetas regalo. Sin depósitos, sin apuestas, +18.
           </p>
           <div className="gp-index-hero-cta">
             <Link href="/sorteos/faq" className="gp-btn gp-btn-ghost">¿Cómo funciona?</Link>
@@ -150,16 +150,16 @@ export default async function SorteosIndexPage() {
               nombre, avatar y Steam ID. Ni tarjeta ni contraseñas.
             </li>
             <li>
-              <b>Participa gratis.</b> Cada participación cuenta un ticket + ganas 🪙 monedas.
+              <b>Participa gratis.</b> Cada participación cuenta un ticket + ganas puntos ⭐.
               La racha diaria y las misiones te suman más.
             </li>
             <li>
-              <b>Canjea recompensas.</b> Con tus 🪙 puedes canjear skins CS2, merchandising o
-              tarjetas regalo en la tienda interna.
+              <b>Canjea recompensas.</b> Con tus puntos ⭐ puedes canjear skins CS2, merchandising
+              o tarjetas regalo en la tienda interna.
             </li>
           </ol>
           <p className="gp-index-explainer-note">
-            SocialPro Giveaways no acepta depósitos, no cobra comisiones y las monedas no
+            SocialPro Giveaways no acepta depósitos, no cobra comisiones y los puntos no
             tienen valor monetario. Los sorteos internos son <b>gratuitos</b>. Algunos
             creadores enlazan partners externos con sus propios términos.
           </p>

--- a/src/app/sorteos/perfil/page.tsx
+++ b/src/app/sorteos/perfil/page.tsx
@@ -114,9 +114,9 @@ export default async function PerfilPage() {
 
         <section className="gp-profile-stats">
           <div className="gp-profile-stat">
-            <span className="l">🪙 Saldo</span>
+            <span className="l">⭐ Saldo</span>
             <b>{balance.toLocaleString('es-ES')}</b>
-            <span className="s">monedas disponibles</span>
+            <span className="s">puntos disponibles</span>
           </div>
           <div className="gp-profile-stat">
             <span className="l">🔥 Racha</span>
@@ -148,7 +148,7 @@ export default async function PerfilPage() {
           <h2>🎒 Inventario</h2>
           {userRedemptions.length === 0 ? (
             <p className="gp-rank-empty">
-              Aún no has canjeado nada en la tienda. Consigue monedas con misiones y sorteos.
+              Aún no has canjeado nada en la tienda. Consigue puntos con misiones y sorteos.
             </p>
           ) : (
             <ul className="gp-profile-inv">
@@ -178,7 +178,7 @@ export default async function PerfilPage() {
         <section className="gp-legacy-block">
           <h2>🧾 Últimas transacciones</h2>
           {transactions.length === 0 ? (
-            <p className="gp-rank-empty">Aún no tienes movimientos de monedas.</p>
+            <p className="gp-rank-empty">Aún no tienes movimientos de puntos.</p>
           ) : (
             <ul className="gp-profile-tx">
               {transactions.map((t) => (
@@ -186,7 +186,7 @@ export default async function PerfilPage() {
                   <span className="gp-profile-tx-src">{SOURCE_LABEL[t.source] ?? t.source}</span>
                   <span className="gp-profile-tx-date">{formatDate(t.createdAt)}</span>
                   <span className={`gp-profile-tx-amt ${t.amount >= 0 ? 'pos' : 'neg'}`}>
-                    {t.amount > 0 ? '+' : ''}{t.amount.toLocaleString('es-ES')} 🪙
+                    {t.amount > 0 ? '+' : ''}{t.amount.toLocaleString('es-ES')} ⭐
                   </span>
                 </li>
               ))}

--- a/src/app/sorteos/plataforma/actions.ts
+++ b/src/app/sorteos/plataforma/actions.ts
@@ -161,7 +161,7 @@ export async function redeemShopItem(input: unknown): Promise<ActionResult<{ red
 
   const balance = await getCoinBalance(sessionUser.id);
   if (balance < item.costCoins) {
-    return { ok: false, error: 'No tienes monedas suficientes' };
+    return { ok: false, error: 'No tienes puntos suficientes' };
   }
 
   // Snapshot de entrega según categoría.

--- a/src/features/giveaway-platform/components/DailyStreakCard.tsx
+++ b/src/features/giveaway-platform/components/DailyStreakCard.tsx
@@ -40,7 +40,7 @@ export function DailyStreakCard({ currentDay, claimedToday }: Props) {
             >
               {isClaimed ? <span className="gp-streak-check">✓</span> : null}
               <div className="gp-streak-label">Día {day}</div>
-              <div className="gp-streak-amount">🪙 {reward}</div>
+              <div className="gp-streak-amount">⭐ {reward}</div>
               {isToday ? (
                 <button
                   type="button"

--- a/src/features/giveaway-platform/components/MissionsGrid.tsx
+++ b/src/features/giveaway-platform/components/MissionsGrid.tsx
@@ -30,7 +30,7 @@ export function MissionsGrid({ missions }: Props) {
 
   return (
     <>
-      <p className="gp-mission-head">Las monedas de todos los creadores se suman al mismo saldo.</p>
+      <p className="gp-mission-head">Los puntos de todos los creadores se suman al mismo saldo.</p>
       <div className="gp-missions-grid">
         {visible.map((m) => {
           const pct = m.goal > 0 ? Math.min(100, Math.round((m.current / m.goal) * 100)) : 0;
@@ -39,7 +39,7 @@ export function MissionsGrid({ missions }: Props) {
               <div className="gp-mission-row">
                 <h3 className="gp-mission-title">{m.claimed ? '✓ ' : ''}{m.title}</h3>
                 <span className={`gp-mission-reward${m.claimed ? ' is-done' : ''}`}>
-                  {m.claimed ? 'Cobrado' : `+${m.rewardCoins} 🪙`}
+                  {m.claimed ? 'Cobrado' : `+${m.rewardCoins} ⭐`}
                 </span>
               </div>
               <p className="gp-mission-desc">{m.description}</p>

--- a/src/features/giveaway-platform/components/PlatformCreatorLanding.tsx
+++ b/src/features/giveaway-platform/components/PlatformCreatorLanding.tsx
@@ -138,7 +138,7 @@ export async function PlatformCreatorLanding({ slug }: Props) {
 
             <section id="misiones">
               <div className="gp-legacy-block">
-                <h2>Misiones · gana monedas</h2>
+                <h2>Misiones · gana puntos</h2>
                 <MissionsGrid missions={missions} />
               </div>
             </section>
@@ -146,7 +146,7 @@ export async function PlatformCreatorLanding({ slug }: Props) {
         ) : (
           <section>
             <div className="gp-legacy-block gp-login-prompt">
-              <p>Inicia sesión con Steam para participar en los sorteos, completar misiones y ganar monedas.</p>
+              <p>Inicia sesión con Steam para participar en los sorteos, completar misiones y ganar puntos.</p>
               <SteamLoginButton size="lg" />
             </div>
           </section>
@@ -157,7 +157,7 @@ export async function PlatformCreatorLanding({ slug }: Props) {
             <div className="gp-legacy-block">
               <h2>Sorteos de {active.name}</h2>
               <p className="gp-rank-note">
-                Participación gratuita · ganas +{ENTRY_COIN_REWARD} 🪙 por sorteo · fotos reales de las skins
+                Participación gratuita · ganas +{ENTRY_COIN_REWARD} ⭐ por sorteo · fotos reales de las skins
               </p>
               <div className="gp-sorteos-grid">
                 {giveawaysData.map((g) => (
@@ -178,7 +178,7 @@ export async function PlatformCreatorLanding({ slug }: Props) {
                         👥 <b>{g.entryCount.toLocaleString('es-ES')}</b> participantes
                       </div>
                       <div className="gp-sorteo-reward">
-                        Gratis · +{ENTRY_COIN_REWARD} 🪙
+                        Gratis · +{ENTRY_COIN_REWARD} ⭐
                       </div>
                       <div className="gp-sorteo-cta">
                         {userId ? (
@@ -207,7 +207,7 @@ export async function PlatformCreatorLanding({ slug }: Props) {
 
         <section id="tienda">
           <div className="gp-legacy-block">
-            <h2>Tienda · canjea tus monedas</h2>
+            <h2>Tienda · canjea tus puntos</h2>
             <PlatformShop items={shopItemsData} balance={balance} />
           </div>
         </section>

--- a/src/features/giveaway-platform/components/PlatformShop.tsx
+++ b/src/features/giveaway-platform/components/PlatformShop.tsx
@@ -56,14 +56,14 @@ export function PlatformShop({ items, balance }: Props) {
       <div className="gp-shop-summary">
         <div className="gp-shop-balance">
           <span className="l">Tu saldo</span>
-          <b>🪙 {balance.toLocaleString('es-ES')}</b>
+          <b>⭐ {balance.toLocaleString('es-ES')}</b>
         </div>
         {cheapestUnaffordable ? (
           <div className="gp-shop-next">
             Siguiente premio a tu alcance:{' '}
             <b>{cheapestUnaffordable.name}</b> — te faltan{' '}
             <span className="gp-shop-next-gap">
-              {(cheapestUnaffordable.costCoins - balance).toLocaleString('es-ES')} 🪙
+              {(cheapestUnaffordable.costCoins - balance).toLocaleString('es-ES')} ⭐
             </span>
           </div>
         ) : items.length > 0 ? (
@@ -72,7 +72,7 @@ export function PlatformShop({ items, balance }: Props) {
       </div>
 
       <p className="gp-shop-disclaimer" role="note">
-        Las monedas son puntos internos <b>sin valor monetario</b>, no
+        Los puntos son recompensas internas <b>sin valor monetario</b>, no
         transferibles y no canjeables por dinero. Los precios y la
         disponibilidad pueden cambiar. Los canjes pueden requerir revisión
         antes del envío.
@@ -115,7 +115,7 @@ export function PlatformShop({ items, balance }: Props) {
                 </div>
                 <h4 className="gp-shop-name">{item.name}</h4>
                 {item.description ? <p className="gp-shop-desc">{item.description}</p> : <p className="gp-shop-desc" />}
-                <div className="gp-shop-cost">🪙 {item.costCoins.toLocaleString('es-ES')}</div>
+                <div className="gp-shop-cost">⭐ {item.costCoins.toLocaleString('es-ES')}</div>
                 <div className="gp-shop-progress" aria-hidden>
                   <span className="gp-shop-progress-fill" style={{ width: `${pct}%` }} />
                 </div>
@@ -128,7 +128,7 @@ export function PlatformShop({ items, balance }: Props) {
                   disabled={!affordable || isPending}
                   className="gp-shop-btn"
                 >
-                  {isPending ? 'Canjeando…' : affordable ? 'Canjear' : `Faltan ${(item.costCoins - balance).toLocaleString('es-ES')} 🪙`}
+                  {isPending ? 'Canjeando…' : affordable ? 'Canjear' : `Faltan ${(item.costCoins - balance).toLocaleString('es-ES')} ⭐`}
                 </button>
               </div>
             );

--- a/src/features/giveaway-platform/components/UserPill.tsx
+++ b/src/features/giveaway-platform/components/UserPill.tsx
@@ -53,7 +53,7 @@ export function UserPill({ userName, userImage, balance, loggedIn }: Props) {
         <span className="gp-user-name">{userName ?? 'Jugador'}</span>
         <span className="gp-balance">
           <span>{balance.toLocaleString('es-ES')}</span>
-          <span className="coin" aria-hidden>🪙</span>
+          <span className="coin" aria-hidden>⭐</span>
         </span>
         <span className="gp-chev" aria-hidden>▾</span>
       </button>
@@ -76,7 +76,7 @@ export function UserPill({ userName, userImage, balance, loggedIn }: Props) {
           <span className="i" aria-hidden>🧾</span>
           <span>
             <b>Transacciones</b>
-            <span>Revisa tu historial de monedas</span>
+            <span>Revisa tu historial de puntos</span>
           </span>
         </Link>
         <button


### PR DESCRIPTION
Rebrand por prevención legal/compliance. El sistema interno de fidelización se llama en UI pública **puntos SocialPro (SP)** con icono ⭐. Elimina cualquier lenguaje que pueda sugerir moneda, token, cripto o saldo económico.

## Icono nuevo

**⭐** (estrella). Reemplaza 🪙 en 7 componentes/páginas. Sin librería nueva ni SVG custom — un solo caracter Unicode universal, sin connotación monetaria, alineado con la preferencia del brief ("estrella/spark").

## Textos cambiados (públicos)

| Antes | Después |
| --- | --- |
| monedas | puntos |
| coins | points |
| coin balance | saldo de puntos |
| ganar monedas | ganar puntos |
| canjear monedas | canjear puntos |
| transacciones de monedas | historial de puntos |
| 🪙 | ⭐ |

## Copy compliance canónico

En Términos §5, FAQ, Juego responsable y disclaimer de la tienda:

> Los puntos son un sistema interno de fidelización y recompensas dentro de SocialPro Giveaways. **No son dinero, no son criptomonedas, no tienen valor monetario, no son transferibles y no pueden canjearse por efectivo.**

## Interno preservado (sin migración)

Se mantienen tal cual porque cambiarlos requiere migración DB. Un test verifica que siguen intactos:
- Tabla \`coin_transactions\`
- Funciones \`getCoinBalance\`, \`awardCoins\`
- Constantes \`ENTRY_COIN_REWARD\`, \`STREAK_REWARDS\`, \`costCoins\`
- Props \`coinsEarned\`, \`rewardCoins\`, \`costCoins\`
- Clase CSS \`.coin\` (no visible al usuario)

Rename interno queda documentado como **Fase X** en \`docs/sorteos-coin-economy.md\` — cuando lo apruebes se hace en PR separado con migración Drizzle.

## Archivos tocados

**UI pública (14)**: layout, page, [creatorSlug]/page, perfil, 4 legales, UserPill, PlatformShop, PlatformCreatorLanding, MissionsGrid, DailyStreakCard, actions.ts (error msg).

**Docs (2)**: \`sorteos-coin-economy.md\` (rewrite con nota naming + Fase X), \`socialpro-prizes-catalog.md\` (regla conversión).

**Tests (6)**: nuevo \`public-copy-points-rebrand.test.ts\` (51 asserts) + 5 actualizados con nuevo naming.

## Sin cambios

- No hay migraciones.
- No hay renombrado de tablas/columnas DB.
- No hay reset de balances.
- No hay cambios de rewards ni precios.
- No hay cambios de providers ni APIs.
- No hay cambios de auth.

## Checks locales

- \`npx tsc --noEmit\` → 0 errores en \`src/\`.
- \`npx jest\` → **150 suites / 2776 tests verdes** (+51 nuevos).
- ESLint archivos tocados → 0 errores.

Preview: se despliega al abrir el PR — visita \`/sorteos\`, \`/sorteos/zacketizor\`, \`/sorteos/perfil\`, y las 4 páginas legales para confirmar el rebrand end-to-end.

**No mergear sin OK visual.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)