### PR TITLE
feat(sorteos): Recompensas unificadas + canje skin con email interno + team merch planned

### DIFF
--- a/src/__tests__/server/rewards-catalog.test.ts
+++ b/src/__tests__/server/rewards-catalog.test.ts
@@ -233,31 +233,39 @@ describe('[rewards-catalog] script enrich-rewards detecta CI/prod', () => {
 describe('[rewards-catalog] UI PlatformShop consume el catálogo', () => {
   const src = read('src/features/giveaway-platform/components/PlatformShop.tsx');
 
-  it('importa REAL_STEAM_REWARDS del catálogo', () => {
-    expect(src).toMatch(/import\s*\{[^}]*REAL_STEAM_REWARDS[^}]*\}\s*from\s*'@\/features\/giveaway-platform\/constants\/rewards-catalog'/);
+  it('importa PLANNED_TEAM_MERCH del catálogo (REAL_STEAM_REWARDS vive en DB tras seed)', () => {
+    expect(src).toMatch(/import\s*\{[^}]*PLANNED_TEAM_MERCH[^}]*\}\s*from\s*'@\/features\/giveaway-platform\/constants\/rewards-catalog'/);
+    expect(src).not.toMatch(/import\s*\{[^}]*REAL_STEAM_REWARDS/);
   });
 
-  it('vitrina dedupica contra items ya en DB (por name)', () => {
-    // Cuando el seed pasa, el mismo `name` está en DB → la vitrina lo filtra.
+  it('YA no hay bloque separado "Próximas en tienda" — todo en un grid', () => {
+    // Regresión: el bloque separado "Próximas en tienda · Skins CS2" está
+    // eliminado. Ahora es un solo grid con `PLANNED_TEAM_MERCH` mezclado.
+    expect(src).not.toMatch(/Próximas en tienda/);
+    expect(src).not.toMatch(/rewards-showcase-title/);
+    expect(src).not.toMatch(/gp-rewards-upcoming/);
+    expect(src).not.toMatch(/function ShowcaseCard/);
+  });
+
+  it('team merch dedupica contra items ya en DB (por name)', () => {
+    // Cuando el owner active un item equivalente en DB, se filtra fuera.
     expect(src).toMatch(/dbNames\s*=\s*new Set\(items\.map\(\(i\)\s*=>\s*i\.name\)\)/);
-    expect(src).toMatch(/!dbNames\.has\(r\.name\)/);
+    expect(src).toMatch(/PLANNED_TEAM_MERCH\.filter\([\s\S]{0,120}!dbNames\.has\(m\.name\)/);
   });
 
-  it('cards de vitrina muestran precio en puntos, no en €/$', () => {
-    // Vitrina renderiza costPoints con símbolo ⭐, nunca €/$.
-    // (⭐ puede ir antes o después de {costPoints} en el JSX.)
+  it('cards planned muestran precio en puntos, no en €/$', () => {
     expect(src).toMatch(/⭐[\s\S]{0,80}reward\.costPoints|reward\.costPoints[\s\S]{0,80}⭐/);
     expect(src).not.toMatch(/reward\.costPoints[\s\S]{0,20}€/);
     expect(src).not.toMatch(/reward\.costPoints[\s\S]{0,20}\$\D/);
   });
 
-  it('cards de vitrina NO tienen botón Canjear — solo "Ver en Steam Market"', () => {
-    // ShowcaseCard usa un anchor a Steam Market, no un botón de canje.
-    expect(src).toMatch(/function ShowcaseCard/);
-    expect(src).toMatch(/Ver en Steam Market/);
-    // El componente ShowcaseCard no debería llamar handleRedeem.
-    const showcaseFn = src.match(/function ShowcaseCard[\s\S]*?^}$/m)?.[0] ?? '';
-    expect(showcaseFn).not.toMatch(/handleRedeem/);
+  it('cards de team merch tienen botón "Próximamente" (deshabilitado), no Canjear', () => {
+    // UpcomingCard renderiza un botón disabled con label "Próximamente".
+    expect(src).toMatch(/function UpcomingCard/);
+    expect(src).toMatch(/Próximamente/);
+    const upcomingFn = src.match(/function UpcomingCard[\s\S]*?^}$/m)?.[0] ?? '';
+    expect(upcomingFn).not.toMatch(/handleRedeem/);
+    expect(upcomingFn).toMatch(/disabled/);
   });
 });
 

--- a/src/__tests__/server/rewards-unified-canjeable.test.ts
+++ b/src/__tests__/server/rewards-unified-canjeable.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Estructura unificada de la sección Recompensas + flujo de canje de skin.
+ *
+ * Contrato:
+ *  - Un solo grid — sin bloque separado "Próximas en tienda".
+ *  - Team merch (`PLANNED_TEAM_MERCH`) se mezcla en el grid como cards
+ *    disabled con label "Próximamente".
+ *  - Skins requieren Steam Trade URL — la card muestra CTA a
+ *    `/sorteos/perfil` cuando el usuario aún no la tiene.
+ *  - `redeemShopItem` devuelve `code: 'trade_url_required'` para skins
+ *    sin trade URL — el cliente lo mapea a la CTA.
+ *  - Al canje exitoso, la UI muestra "Solicitud recibida..." — no un
+ *    revalidatePath silencioso.
+ *  - Email interno a `info@socialpro.es` se dispara desde la action.
+ *  - No se usan logos oficiales de equipos.
+ *  - Naming Recompensas + puntos preservado.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(__dirname, '..', '..', '..');
+const read = (rel: string) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');
+
+describe('[rewards-unified] un solo grid — sin bloque separado', () => {
+  const src = read('src/features/giveaway-platform/components/PlatformShop.tsx');
+
+  it('YA no existe la sección "Próximas en tienda"', () => {
+    expect(src).not.toMatch(/Próximas en tienda/);
+    expect(src).not.toMatch(/gp-rewards-upcoming/);
+    expect(src).not.toMatch(/rewards-showcase-title/);
+    expect(src).not.toMatch(/ShowcaseCard/);
+  });
+
+  it('UpcomingCard sustituye a ShowcaseCard y se renderiza inline en el grid', () => {
+    expect(src).toMatch(/function UpcomingCard/);
+    // Las cards planned se pintan dentro del mismo `<div className="gp-shop-grid">`.
+    // Verificamos que UpcomingCard se referencia dentro del mapper del grid.
+    expect(src).toMatch(/visibleUpcoming\.map\([\s\S]{0,120}<UpcomingCard/);
+  });
+
+  it('tabs incluyen nueva categoría "Merch equipos CS2" (team)', () => {
+    expect(src).toMatch(/key:\s*'team',\s*label:\s*'🏆 Merch equipos CS2'/);
+  });
+});
+
+describe('[rewards-unified] PLANNED_TEAM_MERCH — 11 camisetas sin logos oficiales', () => {
+  const src = read('src/features/giveaway-platform/constants/rewards-catalog.ts');
+
+  const teams = [
+    'Camiseta Team Vitality',
+    'Camiseta Team Spirit',
+    'Camiseta FURIA',
+    'Camiseta NAVI',
+    'Camiseta Aurora',
+    'Camiseta G2 Esports',
+    'Camiseta 9z',
+    'Camiseta MOUZ',
+    'Camiseta BetBoom',
+    'Camiseta Legacy',
+    'Camiseta Fnatic',
+  ] as const;
+
+  it('exporta PLANNED_TEAM_MERCH con 11 entradas', () => {
+    expect(src).toMatch(/export const PLANNED_TEAM_MERCH:\s*readonly\s+CatalogReward\[\]/);
+    for (const team of teams) {
+      expect(src).toContain(team);
+    }
+  });
+
+  it('todas planned + team + null costPoints/stock', () => {
+    // El factory `createPlannedTeamMerch` fija todos estos defaults.
+    expect(src).toMatch(/function createPlannedTeamMerch/);
+    expect(src).toMatch(/status:\s*'planned'/);
+    expect(src).toMatch(/costPoints:\s*null/);
+    expect(src).toMatch(/stock:\s*null/);
+    expect(src).toMatch(/category:\s*'team'/);
+  });
+
+  it('description honesta — "Diseño pendiente de confirmación"', () => {
+    expect(src).toMatch(/Diseño pendiente de confirmación/);
+  });
+
+  it('cada camiseta tiene slug único vía createPlannedTeamMerch', () => {
+    // El factory `createPlannedTeamMerch(slug, name)` construye
+    // `team-shirt-${slug}` — verificamos que se llame 11 veces con slugs
+    // distintos como primer argumento.
+    const factoryCalls = src.match(/createPlannedTeamMerch\(\s*'([^']+)'/g) ?? [];
+    expect(factoryCalls.length).toBeGreaterThanOrEqual(11);
+    const slugs = factoryCalls.map((s) => s.match(/'([^']+)'/)?.[1] ?? '');
+    const uniq = new Set(slugs);
+    expect(uniq.size).toBeGreaterThanOrEqual(11);
+    // Y el prefijo team-shirt- se aplica dentro del factory.
+    expect(src).toMatch(/slug:\s*`team-shirt-\$\{slug\}`/);
+  });
+});
+
+describe('[rewards-unified] Steam Trade URL gate', () => {
+  const shopSrc = read('src/features/giveaway-platform/components/PlatformShop.tsx');
+  const landingSrc = read('src/features/giveaway-platform/components/PlatformCreatorLanding.tsx');
+
+  it('PlatformShop acepta prop hasSteamTradeUrl: boolean', () => {
+    expect(shopSrc).toMatch(/hasSteamTradeUrl:\s*boolean/);
+  });
+
+  it('para skins sin trade URL, muestra Link a /sorteos/perfil en lugar de Canjear', () => {
+    expect(shopSrc).toMatch(/const\s+needsTradeUrl\s*=\s*isSkin\s*&&\s*!hasSteamTradeUrl/);
+    expect(shopSrc).toMatch(/needsTradeUrl\s*&&\s*affordable\s*\?[\s\S]{0,300}<Link\s+href="\/sorteos\/perfil"/);
+    expect(shopSrc).toMatch(/Añadir Steam Trade URL/);
+  });
+
+  it('PlatformCreatorLanding lee steamTradeUrl del perfil y lo pasa al shop', () => {
+    expect(landingSrc).toMatch(/db\.query\.playerProfiles\.findFirst\({[\s\S]{0,300}steamTradeUrl:\s*true/);
+    expect(landingSrc).toMatch(/const hasSteamTradeUrl\s*=\s*Boolean\(playerProfile\?\.steamTradeUrl/);
+    expect(landingSrc).toMatch(/<PlatformShop[\s\S]{0,150}hasSteamTradeUrl=\{hasSteamTradeUrl\}/);
+  });
+});
+
+describe('[rewards-unified] redeemShopItem action', () => {
+  const actionsSrc = read('src/app/sorteos/plataforma/actions.ts');
+
+  it('devuelve códigos de error tipados (no strings sueltos)', () => {
+    expect(actionsSrc).toMatch(/type RedeemErrorCode\s*=/);
+    expect(actionsSrc).toMatch(/'trade_url_required'/);
+    expect(actionsSrc).toMatch(/'insufficient_balance'/);
+    expect(actionsSrc).toMatch(/'out_of_stock'/);
+  });
+
+  it('para skin sin Steam Trade URL devuelve code "trade_url_required"', () => {
+    expect(actionsSrc).toMatch(
+      /category === 'skin'[\s\S]{0,120}!profile\?\.steamTradeUrl[\s\S]{0,300}code:\s*'trade_url_required'/,
+    );
+  });
+
+  it('en éxito devuelve requiresManualReview para skin/merch', () => {
+    expect(actionsSrc).toMatch(/requiresManualReview:\s*item\.category === 'skin'\s*\|\|\s*item\.category === 'merch'/);
+  });
+
+  it('dispara email interno a info@socialpro.es para category=skin', () => {
+    expect(actionsSrc).toMatch(/sendRewardRedemptionEmail/);
+    expect(actionsSrc).toMatch(/if\s*\(item\.category === 'skin'\)\s*\{[\s\S]{0,600}sendRewardRedemptionEmail/);
+  });
+
+  it('el envío del email es fire-and-forget (try/catch, no revierte canje)', () => {
+    expect(actionsSrc).toMatch(/try\s*\{[\s\S]{0,600}sendRewardRedemptionEmail[\s\S]{0,600}\}\s*catch/);
+  });
+});
+
+describe('[rewards-unified] email interno a info@socialpro.es', () => {
+  const src = read('src/lib/email.ts');
+
+  it('exporta sendRewardRedemptionEmail', () => {
+    expect(src).toMatch(/export async function sendRewardRedemptionEmail/);
+  });
+
+  it('el destinatario es info@socialpro.es', () => {
+    expect(src).toMatch(/sendRewardRedemptionEmail[\s\S]{0,1200}to:\s*'info@socialpro\.es'/);
+  });
+
+  it('subject menciona la recompensa solicitada', () => {
+    expect(src).toMatch(/sendRewardRedemptionEmail[\s\S]{0,1500}subject[\s\S]{0,200}Nueva recompensa solicitada/);
+  });
+
+  it('el cuerpo incluye Steam ID, Trade URL, Redemption ID, precio en puntos', () => {
+    expect(src).toMatch(/sendRewardRedemptionEmail[\s\S]{0,3000}Steam ID/);
+    expect(src).toMatch(/sendRewardRedemptionEmail[\s\S]{0,3000}Steam Trade URL/);
+    expect(src).toMatch(/sendRewardRedemptionEmail[\s\S]{0,3000}Redemption ID/);
+    expect(src).toMatch(/sendRewardRedemptionEmail[\s\S]{0,3000}Precio en puntos/);
+  });
+
+  it('los datos PII se escapan con escapeHtml', () => {
+    // Verificamos que se usa la utilidad de escape para userEmail, steamName,
+    // steamId, tradeUrl dentro del template.
+    expect(src).toMatch(/sendRewardRedemptionEmail[\s\S]{0,2500}escapeHtml\(payload\.userEmail\)/);
+    expect(src).toMatch(/sendRewardRedemptionEmail[\s\S]{0,2500}escapeHtml\(payload\.steamName\)/);
+    expect(src).toMatch(/sendRewardRedemptionEmail[\s\S]{0,2500}escapeHtml\(payload\.steamTradeUrl\)/);
+  });
+});
+
+describe('[rewards-unified] UI mensaje éxito post-canje', () => {
+  const src = read('src/features/giveaway-platform/components/PlatformShop.tsx');
+
+  it('setSuccessMsg tras canje exitoso muestra copy de revisión manual', () => {
+    expect(src).toMatch(
+      /Solicitud recibida\. Revisaremos el canje y enviaremos la recompensa manualmente por Steam Trade Offer/,
+    );
+  });
+
+  it('no muestra silenciosamente — hay un banner .gp-shop-success', () => {
+    expect(src).toMatch(/gp-shop-success/);
+  });
+
+  it('CSS del banner success existe', () => {
+    const css = read('src/app/sorteos/plataforma/platform-widgets.css');
+    expect(css).toMatch(/\.gp-shop-success\s*\{[\s\S]{0,600}rgba\(74,\s*222,\s*128/);
+  });
+
+  it('CSS del CTA "Añadir Steam Trade URL" existe', () => {
+    const css = read('src/app/sorteos/plataforma/platform-widgets.css');
+    expect(css).toMatch(/\.gp-shop-error-cta\s*\{/);
+  });
+});
+
+describe('[rewards-unified] no logos oficiales de equipos', () => {
+  it('imágenes de team merch no referencian assets oficiales de equipos', () => {
+    const catalogSrc = read('src/features/giveaway-platform/constants/rewards-catalog.ts');
+    // Ningún path de imagen con nombres tipo "team-vitality-logo" etc.
+    // El factory usa imageUrl:'' — placeholder visual renderiza tipo team.
+    expect(catalogSrc).toMatch(/imageUrl:\s*''/);
+    // Y explícitamente NO referencia archivos con nombre de equipo.
+    expect(catalogSrc).not.toMatch(/\/images\/rewards\/vitality-logo/);
+    expect(catalogSrc).not.toMatch(/\/images\/rewards\/navi-logo/);
+    expect(catalogSrc).not.toMatch(/\/images\/rewards\/fnatic-logo/);
+  });
+});
+
+describe('[rewards-unified] naming Recompensas + puntos preservado', () => {
+  const src = read('src/features/giveaway-platform/components/PlatformShop.tsx');
+  // Comentarios JSDoc de contexto pueden mencionar "Tienda" (antes) — filtramos.
+  const codeOnly = src
+    .split('\n')
+    .filter((l) => !/^\s*\*/.test(l) && !/^\s*\/\/\s/.test(l))
+    .join('\n');
+
+  it('copy visible no dice "Tienda" ni "monedas"', () => {
+    expect(codeOnly).not.toMatch(/\bTienda\b|\btienda\b/);
+    expect(codeOnly).not.toMatch(/\bmonedas?\b|\bcoins?\b/i);
+  });
+
+  it('sigue mostrando ⭐ como icono de puntos', () => {
+    expect(src).toContain('⭐');
+  });
+});

--- a/src/__tests__/server/shop-enhancement.test.ts
+++ b/src/__tests__/server/shop-enhancement.test.ts
@@ -39,7 +39,9 @@ describe('[shop-enhancement] componente', () => {
 
   it('card marca affordable cuando balance >= cost && stock > 0', () => {
     expect(src).toMatch(/const\s+affordable\s*=\s*balance\s*>=\s*item\.costCoins\s*&&\s*item\.stock\s*>\s*0/);
-    expect(src).toMatch(/gp-shop-card\$\{affordable\s*\?\s*' affordable'\s*:\s*''\}/);
+    // Post-refactor: la card marca affordable solo si además no requiere
+    // Steam Trade URL (skin sin trade URL configurada → no affordable UX).
+    expect(src).toMatch(/gp-shop-card\$\{affordable\s*&&\s*!needsTradeUrl\s*\?\s*' affordable'\s*:\s*''\}/);
   });
 
   it('barra de progreso clamped a 100 usando Math.max(1, cost) para evitar /0', () => {
@@ -50,10 +52,9 @@ describe('[shop-enhancement] componente', () => {
     expect(src).toMatch(/Faltan\s*\$\{\(item\.costCoins\s*-\s*balance\)/);
   });
 
-  it('empty state cuando visible.length === 0', () => {
-    // Post-rebrand: "No hay recompensas en esta categoría" reemplaza al
-    // "No hay artículos" original.
-    expect(src).toMatch(/visible\.length\s*===\s*0\s*\?[\s\S]{0,200}No hay recompensas/);
+  it('empty state cuando no hay ni items ni team merch en la categoría', () => {
+    // Post-refactor: la variable es `nothing` (combina visibleItems + visibleUpcoming).
+    expect(src).toMatch(/nothing\s*\?[\s\S]{0,200}No hay recompensas/);
   });
 });
 

--- a/src/app/sorteos/plataforma/actions.ts
+++ b/src/app/sorteos/plataforma/actions.ts
@@ -145,23 +145,45 @@ export async function claimDailyReward(): Promise<ActionResult<{ coinsEarned: nu
   return { ok: true, data: { coinsEarned, day } };
 }
 
+/**
+ * Códigos de error del canje. Permiten al cliente diferenciar la falta
+ * de Trade URL (que muestra una CTA a /sorteos/perfil) de otros errores.
+ */
+type RedeemErrorCode =
+  | 'unauthenticated'
+  | 'invalid_input'
+  | 'item_unavailable'
+  | 'insufficient_balance'
+  | 'trade_url_required'
+  | 'shipping_required'
+  | 'out_of_stock'
+  | 'internal';
+
+/**
+ * Resultado del canje. En éxito devuelve `redemptionId` + copy amistoso
+ * para que el cliente muestre "Solicitud recibida. Revisaremos el canje…".
+ */
+export type RedeemResult =
+  | { ok: true; data: { redemptionId: number; requiresManualReview: boolean } }
+  | { ok: false; code: RedeemErrorCode; error: string };
+
 /** Canjea un item de tienda: valida saldo, decrementa stock condicionalmente y registra el canje. */
-export async function redeemShopItem(input: unknown): Promise<ActionResult<{ redemptionId: number }>> {
+export async function redeemShopItem(input: unknown): Promise<RedeemResult> {
   const sessionUser = await requirePlayerSession();
-  if (!sessionUser) return { ok: false, error: 'Inicia sesión con Steam' };
+  if (!sessionUser) return { ok: false, code: 'unauthenticated', error: 'Inicia sesión con Steam' };
 
   const parsed = redeemSchema.safeParse(input);
-  if (!parsed.success) return { ok: false, error: 'Item no válido' };
+  if (!parsed.success) return { ok: false, code: 'invalid_input', error: 'Item no válido' };
   const { shopItemId } = parsed.data;
 
   const item = await db.query.shopItems.findFirst({
     where: and(eq(shopItems.id, shopItemId), eq(shopItems.isActive, true)),
   });
-  if (!item) return { ok: false, error: 'El item no está disponible' };
+  if (!item) return { ok: false, code: 'item_unavailable', error: 'El item no está disponible' };
 
   const balance = await getCoinBalance(sessionUser.id);
   if (balance < item.costCoins) {
-    return { ok: false, error: 'No tienes puntos suficientes' };
+    return { ok: false, code: 'insufficient_balance', error: 'No tienes puntos suficientes' };
   }
 
   // Snapshot de entrega según categoría.
@@ -169,10 +191,18 @@ export async function redeemShopItem(input: unknown): Promise<ActionResult<{ red
     where: eq(playerProfiles.userId, sessionUser.id),
   });
   if (item.category === 'skin' && !profile?.steamTradeUrl) {
-    return { ok: false, error: 'Añade tu Steam Trade URL en tu perfil antes de canjear skins' };
+    return {
+      ok: false,
+      code: 'trade_url_required',
+      error: 'Para canjear esta recompensa necesitas añadir tu Steam Trade URL en tu perfil.',
+    };
   }
   if (item.category === 'merch' && !profile?.shippingAddress) {
-    return { ok: false, error: 'Añade tu dirección de envío antes de canjear merchandising' };
+    return {
+      ok: false,
+      code: 'shipping_required',
+      error: 'Añade tu dirección de envío antes de canjear merchandising',
+    };
   }
   const deliveryInfo =
     item.category === 'skin' ? profile?.steamTradeUrl
@@ -185,7 +215,7 @@ export async function redeemShopItem(input: unknown): Promise<ActionResult<{ red
     .set({ stock: sql`${shopItems.stock} - 1`, updatedAt: new Date() })
     .where(and(eq(shopItems.id, shopItemId), gt(shopItems.stock, 0)))
     .returning({ id: shopItems.id });
-  if (stockUpdated.length === 0) return { ok: false, error: 'Item agotado' };
+  if (stockUpdated.length === 0) return { ok: false, code: 'out_of_stock', error: 'Item agotado' };
 
   await db.insert(coinTransactions).values({
     userId: sessionUser.id,
@@ -203,13 +233,46 @@ export async function redeemShopItem(input: unknown): Promise<ActionResult<{ red
       deliveryInfo: deliveryInfo ?? null,
     })
     .returning({ id: redemptions.id });
-  if (!redemption) return { ok: false, error: 'No se pudo crear el canje' };
+  if (!redemption) return { ok: false, code: 'internal', error: 'No se pudo crear el canje' };
 
   // Trigger para misiones basadas en redemptions_total (p.ej. "Primer canje").
   await evaluateAndClaimMissions(sessionUser.id);
 
+  // Notificación al equipo interno — solo para categorías que requieren
+  // envío/revisión manual (skins hoy; merch cuando aplique). Fire-and-forget:
+  // si Resend falla no revertimos el canje.
+  if (item.category === 'skin') {
+    try {
+      const { sendRewardRedemptionEmail } = await import('@/lib/email');
+      await sendRewardRedemptionEmail({
+        redemptionId: redemption.id,
+        rewardName: item.name,
+        rewardCategory: item.category,
+        costPoints: item.costCoins,
+        userEmail: sessionUser.email ?? null,
+        steamName: sessionUser.name ?? null,
+        steamId: profile?.steamId ?? null,
+        steamTradeUrl: profile?.steamTradeUrl ?? null,
+        createdAtIso: new Date().toISOString(),
+      });
+    } catch {
+      // No revertimos el canje si el email falla. Log seguro (sin PII —
+      // el motivo del fallo lo veremos en el dashboard de Resend).
+      console.warn('[redeem] internal notification failed', {
+        redemptionId: redemption.id,
+        category: item.category,
+      });
+    }
+  }
+
   revalidatePath('/sorteos', 'layout');
-  return { ok: true, data: { redemptionId: redemption.id } };
+  return {
+    ok: true,
+    data: {
+      redemptionId: redemption.id,
+      requiresManualReview: item.category === 'skin' || item.category === 'merch',
+    },
+  };
 }
 
 /** Guarda la Steam Trade URL del perfil. */

--- a/src/app/sorteos/plataforma/platform-widgets.css
+++ b/src/app/sorteos/plataforma/platform-widgets.css
@@ -341,6 +341,29 @@
   color: #ff5d7d;
   font-size: 13px;
   margin: 0 0 10px;
+  padding: 10px 14px;
+  border-radius: 10px;
+  background: rgba(255, 93, 125, 0.08);
+  border: 1px solid rgba(255, 93, 125, 0.35);
+}
+.giveaway-platform .gp-shop-error p { margin: 0 0 6px; }
+.giveaway-platform .gp-shop-error-cta {
+  display: inline-block;
+  color: var(--cyan);
+  font-weight: 700;
+  text-decoration: none;
+  font-size: 12.5px;
+  letter-spacing: 0.5px;
+}
+.giveaway-platform .gp-shop-error-cta:hover { text-decoration: underline; }
+.giveaway-platform .gp-shop-success {
+  color: #4ade80;
+  font-size: 13px;
+  margin: 0 0 10px;
+  padding: 12px 16px;
+  border-radius: 10px;
+  background: rgba(74, 222, 128, 0.10);
+  border: 1px solid rgba(74, 222, 128, 0.35);
 }
 .giveaway-platform .gp-shop-grid {
   display: grid;

--- a/src/features/giveaway-platform/components/PlatformCreatorLanding.tsx
+++ b/src/features/giveaway-platform/components/PlatformCreatorLanding.tsx
@@ -3,7 +3,7 @@ import { eq, inArray } from 'drizzle-orm';
 import { notFound } from 'next/navigation';
 import { auth } from '@/lib/auth';
 import { db } from '@/lib/db';
-import { dailyStreaks, talents } from '@/db/schema';
+import { dailyStreaks, playerProfiles, talents } from '@/db/schema';
 import {
   getActiveShopItems,
   getCoinBalance,
@@ -87,13 +87,19 @@ export async function PlatformCreatorLanding({ slug }: Props) {
     ? []
     : await getGiveawaysWithEntryData(active.id, userId);
 
-  const [balance, missions, streak] = userId
+  const [balance, missions, streak, playerProfile] = userId
     ? await Promise.all([
         getCoinBalance(userId),
         getMissionsWithProgress(userId),
         db.query.dailyStreaks.findFirst({ where: eq(dailyStreaks.userId, userId) }),
+        db.query.playerProfiles.findFirst({
+          where: eq(playerProfiles.userId, userId),
+          columns: { steamTradeUrl: true },
+        }),
       ])
-    : [0, [], undefined];
+    : [0, [], undefined, undefined];
+
+  const hasSteamTradeUrl = Boolean(playerProfile?.steamTradeUrl && playerProfile.steamTradeUrl.trim().length > 0);
 
   const [ranking, rankingTotal, shopItemsData, externalSections] = await Promise.all([
     getMonthlyRanking(10),
@@ -208,7 +214,7 @@ export async function PlatformCreatorLanding({ slug }: Props) {
         <section id="recompensas">
           <div className="gp-legacy-block">
             <h2>Recompensas · canjea tus puntos</h2>
-            <PlatformShop items={shopItemsData} balance={balance} />
+            <PlatformShop items={shopItemsData} balance={balance} hasSteamTradeUrl={hasSteamTradeUrl} />
           </div>
         </section>
 

--- a/src/features/giveaway-platform/components/PlatformShop.tsx
+++ b/src/features/giveaway-platform/components/PlatformShop.tsx
@@ -1,54 +1,70 @@
 'use client';
 
 import { useMemo, useState, useTransition } from 'react';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { redeemShopItem } from '@/app/sorteos/plataforma/actions';
-import { REAL_STEAM_REWARDS, type CatalogReward } from '@/features/giveaway-platform/constants/rewards-catalog';
+import {
+  PLANNED_TEAM_MERCH,
+  type CatalogReward,
+} from '@/features/giveaway-platform/constants/rewards-catalog';
 import type { ShopCategory, ShopItem } from '@/types/giveawayPlatform';
 
 interface Props {
   items: ShopItem[];
   balance: number;
+  /** True si el usuario ya tiene Steam Trade URL configurada. */
+  hasSteamTradeUrl: boolean;
 }
 
 const CATEGORIES: { key: ShopCategory | 'all'; label: string }[] = [
   { key: 'all',     label: 'Todo' },
   { key: 'skin',    label: '🔫 Skins CS2' },
   { key: 'merch',   label: '👕 Merch SocialPro' },
+  { key: 'team',    label: '🏆 Merch equipos CS2' },
   { key: 'gift',    label: '🎁 Tarjetas regalo' },
-  // Nuevas categorías cosméticas (2026-07-03) — se muestran solo si hay
-  // items canjeables en cada una. Ver docs/sorteos-coin-economy.md §4.
   { key: 'profile', label: '🎨 Profile Cards' },
   { key: 'frame',   label: '🖼️ Avatar Frames' },
   { key: 'badge',   label: '🏅 Badges' },
 ];
 
 /**
- * Componente "Recompensas" (antes "Tienda"). Renombrado 2026-07-03 por
- * compliance — no queremos que parezca una tienda donde se compra con
- * dinero. Nomenclatura: el usuario canjea puntos por recompensas.
+ * Sección "Recompensas" (antes "Tienda"). Un solo grid unificado.
  *
- * Estructura:
- *  1. Resumen de saldo + próximo canjeable.
- *  2. Disclaimer compliance.
- *  3. Tabs por categoría.
- *  4. Grid de recompensas activas (fuente: `items` — DB).
- *  5. Bloque "Vitrina · próximamente en tienda" con recompensas del
- *     catálogo `REAL_STEAM_REWARDS` que aún no están en DB. Se
- *     deduplican por `name` para no aparecer dos veces cuando el seed
- *     las mueva a `shop_items`.
+ * Contenido de la grid:
+ *  1. Items reales de DB (`items`) — canjeables si hay saldo y stock.
+ *  2. Cards "próximamente" (`PLANNED_TEAM_MERCH`) — no canjeables,
+ *     placeholder visual, sin logo oficial de equipo. Se filtran del
+ *     grid cuando el owner active un item equivalente en DB.
+ *
+ * No hay bloque separado. Todo pasa por el mismo grid + filtros por
+ * categoría. Los items de tipo skin requieren Steam Trade URL — la
+ * card muestra un gate visual con CTA a `/sorteos/perfil` cuando el
+ * usuario aún no la tiene configurada.
  */
-export function PlatformShop({ items, balance }: Props) {
+export function PlatformShop({ items, balance, hasSteamTradeUrl }: Props) {
   const router = useRouter();
   const [category, setCategory] = useState<ShopCategory | 'all'>('all');
   const [error, setError] = useState<string | null>(null);
+  const [errorCode, setErrorCode] = useState<string | null>(null);
+  const [successMsg, setSuccessMsg] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
 
-  const counts = useMemo<Record<string, number>>(() => {
-    const byCat: Record<string, number> = { all: items.length };
-    for (const it of items) byCat[it.category] = (byCat[it.category] ?? 0) + 1;
-    return byCat;
+  // Merch de equipos CS2 planificado — se mezcla con `items` (DB) para que
+  // el filtro por categoría funcione uniforme y no haya bloque aparte.
+  // Cuando un `PLANNED_TEAM_MERCH` tenga equivalente en DB (por `name`),
+  // se filtra fuera para no duplicar.
+  const upcomingCards = useMemo(() => {
+    const dbNames = new Set(items.map((i) => i.name));
+    return PLANNED_TEAM_MERCH.filter((m) => !dbNames.has(m.name));
   }, [items]);
+
+  const counts = useMemo<Record<string, number>>(() => {
+    const byCat: Record<string, number> = { all: items.length + upcomingCards.length };
+    for (const it of items) byCat[it.category] = (byCat[it.category] ?? 0) + 1;
+    for (const u of upcomingCards) byCat[u.category] = (byCat[u.category] ?? 0) + 1;
+    return byCat;
+  }, [items, upcomingCards]);
 
   const cheapestUnaffordable = useMemo(() => {
     const stockPos = items.filter((i) => i.stock > 0 && i.costCoins > balance);
@@ -56,27 +72,27 @@ export function PlatformShop({ items, balance }: Props) {
     return stockPos.reduce((a, b) => (a.costCoins <= b.costCoins ? a : b));
   }, [items, balance]);
 
-  const visible = items.filter((i) => category === 'all' || i.category === category);
-
-  // Vitrina · items del catálogo que NO estén ya en DB. Cuando el seed
-  // pase, los mismos `name` se filtrarán de aquí y aparecerán en la grid
-  // principal como canjeables. Sin dup visual.
-  const showcase = useMemo(() => {
-    const dbNames = new Set(items.map((i) => i.name));
-    return REAL_STEAM_REWARDS.filter(
-      (r) =>
-        r.status === 'active' &&
-        !dbNames.has(r.name) &&
-        (category === 'all' || r.category === category),
-    );
-  }, [items, category]);
+  const visibleItems = items.filter((i) => category === 'all' || i.category === category);
+  const visibleUpcoming = upcomingCards.filter((u) => category === 'all' || u.category === category);
+  const nothing = visibleItems.length === 0 && visibleUpcoming.length === 0;
 
   function handleRedeem(shopItemId: number) {
     setError(null);
+    setErrorCode(null);
+    setSuccessMsg(null);
     startTransition(async () => {
       const result = await redeemShopItem({ shopItemId });
-      if (result.ok) router.refresh();
-      else setError(result.error);
+      if (result.ok) {
+        setSuccessMsg(
+          result.data.requiresManualReview
+            ? 'Solicitud recibida. Revisaremos el canje y enviaremos la recompensa manualmente por Steam Trade Offer.'
+            : '¡Canje registrado! Revisa tu perfil para el estado del envío.',
+        );
+        router.refresh();
+      } else {
+        setError(result.error);
+        setErrorCode(result.code);
+      }
     });
   }
 
@@ -120,20 +136,35 @@ export function PlatformShop({ items, balance }: Props) {
           </button>
         ))}
       </div>
-      {error ? <p className="gp-shop-error">{error}</p> : null}
-      {visible.length === 0 ? (
-        <p className="gp-rank-empty">
-          No hay recompensas en esta categoría.{' '}
-          {showcase.length > 0 ? 'Mira las próximas más abajo.' : 'Prueba otra pestaña.'}
+
+      {successMsg ? (
+        <p className="gp-shop-success" role="status">
+          {successMsg}
         </p>
+      ) : null}
+      {error ? (
+        <div className="gp-shop-error" role="alert">
+          <p>{error}</p>
+          {errorCode === 'trade_url_required' ? (
+            <Link href="/sorteos/perfil" className="gp-shop-error-cta">
+              Añadir Steam Trade URL →
+            </Link>
+          ) : null}
+        </div>
+      ) : null}
+
+      {nothing ? (
+        <p className="gp-rank-empty">No hay recompensas en esta categoría. Prueba otra pestaña.</p>
       ) : (
         <div className="gp-shop-grid">
-          {visible.map((item) => {
+          {visibleItems.map((item) => {
             const affordable = balance >= item.costCoins && item.stock > 0;
+            const isSkin = item.category === 'skin';
+            const needsTradeUrl = isSkin && !hasSteamTradeUrl;
             const stockClass = item.stock === 0 ? ' gone' : item.stock < 4 ? ' low' : '';
             const pct = Math.min(100, Math.round((balance / Math.max(1, item.costCoins)) * 100));
             return (
-              <div key={item.id} className={`gp-shop-card${affordable ? ' affordable' : ''}`}>
+              <div key={`db-${item.id}`} className={`gp-shop-card${affordable && !needsTradeUrl ? ' affordable' : ''}`}>
                 <div className="gp-shop-img">
                   {item.imageUrl ? (
                     // eslint-disable-next-line @next/next/no-img-element
@@ -141,7 +172,7 @@ export function PlatformShop({ items, balance }: Props) {
                   ) : (
                     <RewardPlaceholder category={item.category as ShopCategory} />
                   )}
-                  {affordable ? <span className="gp-shop-badge">Disponible</span> : null}
+                  {affordable && !needsTradeUrl ? <span className="gp-shop-badge">Disponible</span> : null}
                 </div>
                 <h4 className="gp-shop-name">{item.name}</h4>
                 {item.description ? <p className="gp-shop-desc">{item.description}</p> : <p className="gp-shop-desc" />}
@@ -152,90 +183,73 @@ export function PlatformShop({ items, balance }: Props) {
                 <div className={`gp-shop-stock${stockClass}`}>
                   {item.stock > 0 ? `${item.stock} en stock` : 'Agotado'}
                 </div>
-                <button
-                  type="button"
-                  onClick={() => handleRedeem(item.id)}
-                  disabled={!affordable || isPending}
-                  className="gp-shop-btn"
-                >
-                  {isPending ? 'Canjeando…' : affordable ? 'Canjear' : `Faltan ${(item.costCoins - balance).toLocaleString('es-ES')} ⭐`}
-                </button>
+
+                {needsTradeUrl && affordable ? (
+                  <Link href="/sorteos/perfil" className="gp-shop-btn gp-shop-btn-outline">
+                    Añadir Steam Trade URL →
+                  </Link>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => handleRedeem(item.id)}
+                    disabled={!affordable || isPending}
+                    className="gp-shop-btn"
+                  >
+                    {isPending ? 'Canjeando…' : affordable ? 'Canjear' : `Faltan ${(item.costCoins - balance).toLocaleString('es-ES')} ⭐`}
+                  </button>
+                )}
               </div>
             );
           })}
+
+          {visibleUpcoming.map((r) => (
+            <UpcomingCard key={`upcoming-${r.slug}`} reward={r} />
+          ))}
         </div>
       )}
-
-      {/* Vitrina · recompensas del catálogo aún no en DB. */}
-      {showcase.length > 0 ? (
-        <section className="gp-rewards-upcoming" aria-labelledby="rewards-showcase-title">
-          <div className="gp-rewards-upcoming-head">
-            <h3 id="rewards-showcase-title" className="gp-rewards-upcoming-title">
-              Próximas en tienda · Skins CS2
-            </h3>
-            <p className="gp-rewards-upcoming-sub">
-              Confirmadas en catálogo · disponibles para canjear tras el próximo update de tienda
-            </p>
-          </div>
-          <div className="gp-shop-grid">
-            {showcase.map((r) => (
-              <ShowcaseCard key={r.slug} reward={r} />
-            ))}
-          </div>
-        </section>
-      ) : null}
     </>
   );
 }
 
 /**
- * Card de vitrina — se usa para recompensas ya definidas en el catálogo
- * (`REAL_STEAM_REWARDS`) pero que aún no han pasado por seed al DB.
- * Muestra la misma info que una card canjeable (imagen local, nombre,
- * precio en puntos, stock, rareza) pero SIN botón Canjear — en su lugar
- * indica "Próximamente disponible" y ofrece "Ver en Steam Market".
- *
- * Cuando el seed corra, DB tendrá el mismo `name`, la vitrina la filtra
- * fuera automáticamente y la card canjeable de la grid principal es la
- * única que renderiza.
+ * Card "Próximamente" para recompensas planificadas del catálogo que aún
+ * no viven en DB (típicamente `PLANNED_TEAM_MERCH`). Sin logo oficial de
+ * equipo — placeholder + copy honesto "Diseño pendiente de confirmación".
+ * Sin botón Canjear.
  */
-function ShowcaseCard({ reward }: { reward: CatalogReward }) {
+function UpcomingCard({ reward }: { reward: CatalogReward }) {
   return (
     <article className="gp-shop-card gp-shop-card-planned">
       <div className="gp-shop-img">
-        {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img src={reward.imageUrl} alt={reward.name} />
+        {reward.imageUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={reward.imageUrl} alt={reward.name} />
+        ) : (
+          <RewardPlaceholder category={reward.category} />
+        )}
         <span className="gp-shop-badge gp-shop-badge-soon">Próximamente</span>
       </div>
       <h4 className="gp-shop-name">{reward.name}</h4>
       <p className="gp-shop-desc">{reward.description}</p>
-      <div className="gp-shop-cost">⭐ {reward.costPoints.toLocaleString('es-ES')}</div>
-      <div className="gp-shop-stock">
-        {reward.stock > 0 ? `${reward.stock} en stock` : 'Agotado'}
+      <div className="gp-shop-cost gp-shop-cost-pending">
+        {reward.costPoints === null ? 'Precio pendiente' : `⭐ ${reward.costPoints.toLocaleString('es-ES')}`}
       </div>
-      <a
-        href={reward.steamMarketUrl}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="gp-shop-btn gp-shop-btn-outline"
-        aria-label={`Ver ${reward.name} en Steam Market`}
-      >
-        Ver en Steam Market
-      </a>
+      <div className="gp-shop-stock">
+        {reward.stock === null ? 'Stock pendiente' : `${reward.stock} en stock`}
+      </div>
+      <button type="button" disabled className="gp-shop-btn" aria-label="Próximamente disponible">
+        Próximamente
+      </button>
     </article>
   );
 }
 
 /**
- * Placeholder premium para recompensas sin `imageUrl`. Reemplaza al
- * fallback plano anterior — poco profesional en una sección de
- * recompensas. Muestra:
- *   - Fondo oscuro tipo CS2 con textura sutil.
- *   - Badge de categoría arriba a la izquierda.
- *   - Icono grande centrado.
- *   - Etiqueta legible del tipo de recompensa.
+ * Placeholder visual premium para recompensas sin `imageUrl`. Fondo tipo
+ * CS2 + badge de categoría + icono + label. Usado tanto por items DB sin
+ * imagen como por planificados de catálogo.
  */
-function RewardPlaceholder({ category }: { category: ShopCategory }) {
+function RewardPlaceholder({ category }: { category: ShopCategory | 'team' }) {
   const config = PLACEHOLDER_BY_CATEGORY[category] ?? PLACEHOLDER_BY_CATEGORY.skin;
   return (
     <div className={`gp-reward-placeholder gp-reward-placeholder-${category}`} aria-hidden>
@@ -246,9 +260,10 @@ function RewardPlaceholder({ category }: { category: ShopCategory }) {
   );
 }
 
-const PLACEHOLDER_BY_CATEGORY: Record<ShopCategory, { badge: string; icon: string; label: string }> = {
+const PLACEHOLDER_BY_CATEGORY: Record<ShopCategory | 'team', { badge: string; icon: string; label: string }> = {
   skin:    { badge: 'CS2',   icon: '🔫', label: 'Skin CS2' },
   merch:   { badge: 'MERCH', icon: '👕', label: 'Merch SocialPro' },
+  team:    { badge: 'TEAM',  icon: '🏆', label: 'Merch equipos CS2' },
   gift:    { badge: 'GIFT',  icon: '🎁', label: 'Tarjeta regalo' },
   profile: { badge: 'CARD',  icon: '🎨', label: 'Profile Card' },
   frame:   { badge: 'FRAME', icon: '🖼️', label: 'Avatar Frame' },

--- a/src/features/giveaway-platform/constants/rewards-catalog.ts
+++ b/src/features/giveaway-platform/constants/rewards-catalog.ts
@@ -42,15 +42,15 @@ export interface CatalogReward {
   /** Rareza tal como Steam la reporta (Restricted, Classified, Covert, etc.). */
   rarity: string | null;
   /** Categoría — coincide con `shop_items.category`. */
-  category: 'skin' | 'gift' | 'merch' | 'profile' | 'frame' | 'badge';
+  category: 'skin' | 'gift' | 'merch' | 'team' | 'profile' | 'frame' | 'badge';
   /** Juego asociado. */
   game: 'CS2' | null;
   /** Ruta al PNG en el repo (relativa a /public). Debe existir. */
   imageUrl: string;
-  /** Precio final en puntos SocialPro. */
-  costPoints: number;
-  /** Stock actual — el seed lo aplica en DB. */
-  stock: number;
+  /** Precio final en puntos SocialPro. `null` = pendiente de definir. */
+  costPoints: number | null;
+  /** Stock actual — el seed lo aplica en DB. `null` = pendiente de definir. */
+  stock: number | null;
   /** Estado. `active` → aparece canjeable en la tienda una vez seedeado. */
   status: RewardStatus;
   /** URL del listing en Steam Market — solo interno / trazabilidad. */
@@ -217,3 +217,55 @@ export const REAL_STEAM_REWARDS: readonly CatalogReward[] = [
  * que ningún componente lo consume.
  */
 export const PLANNED_REWARDS: readonly CatalogReward[] = [];
+
+/**
+ * Camisetas de equipos CS2 top — planificadas, no canjeables.
+ *
+ * Estado: cada card se muestra con placeholder visual + copy "Diseño
+ * pendiente de confirmación". Sin imagen fiable → placeholder premium.
+ * Sin logos oficiales de equipos ni diseños oficiales — dependemos de
+ * mockups SocialPro o de permisos oficiales antes de activarlos.
+ *
+ * Cuando se apruebe cada camiseta, se aporta imagen local + precio en
+ * puntos + stock, se mueve a `shop_items` vía seed y se retira de este
+ * array.
+ *
+ * Ver `docs/sorteos-rewards-catalog.md` §Team merch para el flujo de
+ * activación.
+ */
+export const PLANNED_TEAM_MERCH: readonly CatalogReward[] = [
+  createPlannedTeamMerch('vitality', 'Camiseta Team Vitality'),
+  createPlannedTeamMerch('spirit', 'Camiseta Team Spirit'),
+  createPlannedTeamMerch('furia', 'Camiseta FURIA'),
+  createPlannedTeamMerch('navi', 'Camiseta NAVI'),
+  createPlannedTeamMerch('aurora', 'Camiseta Aurora'),
+  createPlannedTeamMerch('g2', 'Camiseta G2 Esports'),
+  createPlannedTeamMerch('9z', 'Camiseta 9z'),
+  createPlannedTeamMerch('mouz', 'Camiseta MOUZ'),
+  createPlannedTeamMerch('betboom', 'Camiseta BetBoom'),
+  createPlannedTeamMerch('legacy', 'Camiseta Legacy'),
+  createPlannedTeamMerch('fnatic', 'Camiseta Fnatic'),
+] as const;
+
+/**
+ * Factory helper — mantiene los defaults consistentes y evita duplicar
+ * `null`/`'planned'`/`description` en cada entrada.
+ */
+function createPlannedTeamMerch(slug: string, name: string): CatalogReward {
+  return {
+    slug: `team-shirt-${slug}`,
+    name,
+    wear: null,
+    rarity: null,
+    category: 'team',
+    game: 'CS2',
+    imageUrl: '',
+    costPoints: null,
+    stock: null,
+    status: 'planned',
+    steamMarketUrl: '',
+    delivery: 'physical_shipping',
+    requiresManualReview: true,
+    description: 'Merch CS2 · Próximamente · Diseño pendiente de confirmación.',
+  };
+}

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -296,6 +296,62 @@ export async function sendInvoiceEmail(payload: {
   });
 }
 
+/**
+ * Notifica al equipo interno que un usuario ha canjeado una recompensa que
+ * requiere envío/revisión manual (típicamente skins CS2 vía Steam Trade
+ * Offer). Se dispara desde `redeemShopItem` en fire-and-forget — si el
+ * email falla no revierte el canje. Los datos sensibles (Steam Trade URL,
+ * email) NO se loguean, se envían directo por Resend.
+ */
+export async function sendRewardRedemptionEmail(payload: {
+  redemptionId: number;
+  rewardName: string;
+  rewardCategory: string;
+  costPoints: number;
+  userEmail: string | null;
+  steamName: string | null;
+  steamId: string | null;
+  steamTradeUrl: string | null;
+  createdAtIso: string;
+}): Promise<void> {
+  const name = escapeHtml(payload.rewardName);
+  const category = escapeHtml(payload.rewardCategory);
+  const userEmail = payload.userEmail ? escapeHtml(payload.userEmail) : '—';
+  const steamName = payload.steamName ? escapeHtml(payload.steamName) : '—';
+  const steamId = payload.steamId ? escapeHtml(payload.steamId) : '—';
+  const tradeUrl = payload.steamTradeUrl ? escapeHtml(payload.steamTradeUrl) : '—';
+  const subject = payload.rewardCategory === 'skin'
+    ? `Nueva recompensa solicitada · Skin CS2 — ${payload.rewardName}`
+    : `Nueva recompensa solicitada — ${payload.rewardName}`;
+
+  await resend.emails.send({
+    from: 'SocialPro Giveaways <noreply@socialpro.es>',
+    to: 'info@socialpro.es',
+    subject,
+    html: `
+      <div style="font-family:Inter,sans-serif;max-width:560px;color:#16161f;">
+        <h2 style="font-family:'Barlow Condensed',sans-serif;text-transform:uppercase;">
+          Nueva recompensa solicitada
+        </h2>
+        <p><strong>Recompensa:</strong> ${name}</p>
+        <p><strong>Categoría:</strong> ${category}</p>
+        <p><strong>Precio en puntos:</strong> ${payload.costPoints.toLocaleString('es-ES')}</p>
+        <hr style="margin:16px 0;border:none;border-top:1px solid #e5e7eb;"/>
+        <p><strong>Usuario:</strong> ${steamName}</p>
+        <p><strong>Steam ID:</strong> ${steamId}</p>
+        <p><strong>Email:</strong> ${userEmail}</p>
+        <p><strong>Steam Trade URL:</strong> <a href="${tradeUrl}" style="color:#f5632a;">${tradeUrl}</a></p>
+        <hr style="margin:16px 0;border:none;border-top:1px solid #e5e7eb;"/>
+        <p><strong>Redemption ID:</strong> ${payload.redemptionId}</p>
+        <p><strong>Fecha:</strong> ${escapeHtml(payload.createdAtIso)}</p>
+        <p style="color:#6b6864;font-size:12px;margin-top:24px;">
+          Revisa el canje en el panel de admin y envía la recompensa manualmente.
+        </p>
+      </div>
+    `,
+  });
+}
+
 export async function sendBrandInviteEmail(payload: {
   brandEmail: string;
   brandName: string;

--- a/src/types/giveawayPlatform.ts
+++ b/src/types/giveawayPlatform.ts
@@ -34,7 +34,7 @@ export type Redemption = InferSelectModel<typeof redemptions>;
  * del usuario) sí hace falta migración — ver `docs/sorteos-coin-economy.md`
  * §4.2. Mientras tanto se pueden canjear y quedan en `redemptions`.
  */
-export type ShopCategory = 'skin' | 'merch' | 'gift' | 'profile' | 'frame' | 'badge';
+export type ShopCategory = 'skin' | 'merch' | 'team' | 'gift' | 'profile' | 'frame' | 'badge';
 export type RedemptionStatus = 'pendiente' | 'enviado' | 'cancelado';
 export type MissionConditionType = 'entries_total' | 'distinct_creators' | 'streak_days';
 export type CoinSource = 'racha' | 'mision' | 'sorteo' | 'tienda' | 'admin';


### PR DESCRIPTION
Unifica la sección Recompensas en un solo grid, activa el gate de Steam Trade URL para skins CS2, y notifica por email interno a \`info@socialpro.es\` en cada canje de skin.

## Auditoría — todo verde, sin migración

| Ítem | Estado |
|------|--------|
| \`player_profiles.steam_trade_url\` | ✅ Existe (text nullable). |
| /sorteos/perfil edita Trade URL | ✅ \`ProfileSettingsForm\` input \`steamTradeUrl\`. |
| \`redemptions.status = 'pendiente'\` cubre manual review | ✅ Default. varchar(15). |
| \`redeemShopItem\` deducía puntos transaccional | ✅ Balance check → stock atómico → coin_transactions → redemption. |
| Resend/email interno | ✅ Configurado. \`env.RESEND_API_KEY\` ya requerido. |
| Env vars nuevas | ❌ **Ninguna**. |

## Qué hice para unificar Recompensas

- **Eliminé** el bloque separado "Próximas en tienda · Skins CS2".
- **Un solo grid** que mezcla items DB + \`PLANNED_TEAM_MERCH\`. Dedup por \`name\` para no duplicar cuando el owner active.
- **Nueva pestaña** "🏆 Merch equipos CS2" (\`category: 'team'\`, cabe en varchar(10) sin migración).
- **Card planned**: placeholder visual + copy honesto + botón "Próximamente" disabled.

## Cómo quedan las 8 skins CS2

Sin cambio del PR #191: viven en \`REAL_STEAM_REWARDS\`. Aparecen como canjeables en el grid principal una vez ejecutado el seed:

\`\`\`
CONFIRM_SEED_STEAM_REWARDS=I_ACCEPT_ADD_STEAM_REWARDS \
  npx tsx scripts/seed-socialpro-rewards-steam.ts
\`\`\`

**No lo he ejecutado** — decides tú y contra qué DB. Sin seed corrido, el grid solo muestra items previos + las 11 camisetas planned.

## Cómo quedan las camisetas de equipos

11 entradas en \`PLANNED_TEAM_MERCH\`:

Vitality, Spirit, FURIA, NAVI, Aurora, G2 Esports, 9z, MOUZ, BetBoom, Legacy, **Fnatic** (añadida a petición).

**Todas planned, no canjeables, sin logos oficiales.**

- \`category: 'team'\`
- \`imageUrl: ''\` → placeholder premium con badge "TEAM", icono 🏆, label "Merch equipos CS2"
- \`costPoints: null\` → UI muestra "Precio pendiente"
- \`stock: null\` → UI muestra "Stock pendiente"
- Copy: *"Merch CS2 · Próximamente · Diseño pendiente de confirmación."*
- Botón: **"Próximamente"** disabled

Cuando tengas mockups SocialPro o permisos oficiales, se activan una a una en PR separado con imagen local + precio + seed.

## Flujo de canje skin CS2

**Sin Steam Trade URL**:
- La card muestra directamente **"Añadir Steam Trade URL →"** como link a \`/sorteos/perfil\` (en lugar del botón Canjear).
- Si el usuario intenta canjear igualmente (por manipulación JS), la action devuelve \`code: 'trade_url_required'\` y el cliente pinta el error con el mismo CTA.

**Con Steam Trade URL**:
1. Se descuentan los puntos (transaccional — patrón existente).
2. Se crea \`redemptions\` con \`status: 'pendiente'\` (default DB).
3. Se dispara email interno a **info@socialpro.es** (fire-and-forget, try/catch — si Resend falla no revierte el canje).
4. UI muestra banner verde:
   > *"Solicitud recibida. Revisaremos el canje y enviaremos la recompensa manualmente por Steam Trade Offer."*

**Contenido del email interno**:
- Recompensa solicitada + categoría + precio en puntos
- Usuario (nombre Steam) + Steam ID + email + Steam Trade URL
- Redemption ID + fecha ISO
- Todos los datos PII escapados con \`escapeHtml\`

## Naming preservado

- **Recompensas** (no Tienda).
- **⭐ puntos** (no monedas / coins / 🪙).

Interno sin cambio: \`shop_items\`, \`coin_transactions\`, \`getCoinBalance\`, etc.

## Comando de seed (opcional, tuyo)

\`\`\`bash
CONFIRM_SEED_STEAM_REWARDS=I_ACCEPT_ADD_STEAM_REWARDS \
  npx tsx scripts/seed-socialpro-rewards-steam.ts
\`\`\`

**Sin ejecutarlo**, el preview solo muestra las 11 camisetas planned y los items previos. **Con seed ejecutado**, aparecen también las 8 skins CS2 como canjeables reales.

## Archivos tocados

**Modificados**:
- \`src/features/giveaway-platform/components/PlatformShop.tsx\` — grid unificado, UpcomingCard, Trade URL gate.
- \`src/features/giveaway-platform/components/PlatformCreatorLanding.tsx\` — pasa \`hasSteamTradeUrl\`.
- \`src/features/giveaway-platform/constants/rewards-catalog.ts\` — PLANNED_TEAM_MERCH + factory.
- \`src/types/giveawayPlatform.ts\` — \`ShopCategory\` amplía a 'team'.
- \`src/app/sorteos/plataforma/actions.ts\` — códigos tipados + email interno.
- \`src/lib/email.ts\` — \`sendRewardRedemptionEmail\`.
- \`src/app/sorteos/plataforma/platform-widgets.css\` — banner success + CTA error.

**Tests**:
- Nuevo \`rewards-unified-canjeable.test.ts\` (27 asserts).
- Actualizados: \`rewards-catalog.test.ts\`, \`shop-enhancement.test.ts\`.

## Qué NO cambia

migraciones DB · balances · precios existentes · providers · KeyDrop/CSGO-SKINS API · auth · ranking externo · marketplace P2P · logos oficiales de equipos.

## Checks locales

- \`npx tsc --noEmit\` → 0 errores en src/.
- \`npx jest\` → **152 suites / 2836 tests verdes** (+27 nuevos).
- ESLint archivos tocados → 0 errores.

Preview: se despliega al abrir el PR. Ir a \`/sorteos/zacketizor\` → sección Recompensas.

**No mergear sin OK visual.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)