### PR TITLE
fix(sorteos): 8 skins CS2 reales visibles en Recompensas con imagen real

### DIFF
--- a/src/__tests__/server/rewards-catalog.test.ts
+++ b/src/__tests__/server/rewards-catalog.test.ts
@@ -233,9 +233,12 @@ describe('[rewards-catalog] script enrich-rewards detecta CI/prod', () => {
 describe('[rewards-catalog] UI PlatformShop consume el catálogo', () => {
   const src = read('src/features/giveaway-platform/components/PlatformShop.tsx');
 
-  it('importa PLANNED_TEAM_MERCH del catálogo (REAL_STEAM_REWARDS vive en DB tras seed)', () => {
+  it('importa PLANNED_TEAM_MERCH y REAL_STEAM_REWARDS del catálogo', () => {
+    // REAL_STEAM_REWARDS se importa para mostrar las 8 skins como
+    // "próximamente" (con imagen real) mientras el seed no las mueva a DB.
+    // Se filtran por `name` contra items ya en DB para no duplicar.
     expect(src).toMatch(/import\s*\{[^}]*PLANNED_TEAM_MERCH[^}]*\}\s*from\s*'@\/features\/giveaway-platform\/constants\/rewards-catalog'/);
-    expect(src).not.toMatch(/import\s*\{[^}]*REAL_STEAM_REWARDS/);
+    expect(src).toMatch(/import\s*\{[^}]*REAL_STEAM_REWARDS[^}]*\}\s*from\s*'@\/features\/giveaway-platform\/constants\/rewards-catalog'/);
   });
 
   it('YA no hay bloque separado "Próximas en tienda" — todo en un grid', () => {

--- a/src/features/giveaway-platform/components/PlatformShop.tsx
+++ b/src/features/giveaway-platform/components/PlatformShop.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation';
 import { redeemShopItem } from '@/app/sorteos/plataforma/actions';
 import {
   PLANNED_TEAM_MERCH,
+  REAL_STEAM_REWARDS,
   type CatalogReward,
 } from '@/features/giveaway-platform/constants/rewards-catalog';
 import type { ShopCategory, ShopItem } from '@/types/giveawayPlatform';
@@ -50,13 +51,25 @@ export function PlatformShop({ items, balance, hasSteamTradeUrl }: Props) {
   const [successMsg, setSuccessMsg] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
 
-  // Merch de equipos CS2 planificado — se mezcla con `items` (DB) para que
-  // el filtro por categoría funcione uniforme y no haya bloque aparte.
-  // Cuando un `PLANNED_TEAM_MERCH` tenga equivalente en DB (por `name`),
-  // se filtra fuera para no duplicar.
+  // Recompensas "próximamente" en el mismo grid — sin bloque separado.
+  // Combina dos fuentes:
+  //   1. `REAL_STEAM_REWARDS` — las 8 skins CS2 reales, mientras el seed
+  //      no las haya movido a DB. Renderizadas con su imagen real, nombre,
+  //      precio en puntos y stock — Canjear disabled hasta que se active.
+  //   2. `PLANNED_TEAM_MERCH` — camisetas de equipos planned, placeholder
+  //      visual sin logo oficial.
+  //
+  // Cuando el owner corre el seed (o activa un item manualmente), el mismo
+  // `name` aparece en `items` (DB) → esta lista lo filtra para no duplicar
+  // y la card canjeable de la grid principal es la única visible.
   const upcomingCards = useMemo(() => {
     const dbNames = new Set(items.map((i) => i.name));
-    return PLANNED_TEAM_MERCH.filter((m) => !dbNames.has(m.name));
+    const skinsPending = REAL_STEAM_REWARDS.filter(
+      (r) => r.status === 'active' && !dbNames.has(r.name),
+    );
+    const teamPending = PLANNED_TEAM_MERCH.filter((m) => !dbNames.has(m.name));
+    // Skins primero (más atractivas visualmente) — luego team merch.
+    return [...skinsPending, ...teamPending];
   }, [items]);
 
   const counts = useMemo<Record<string, number>>(() => {


### PR DESCRIPTION
Fix del bug reportado: las 8 skins CS2 reales no aparecían en Recompensas porque requerían ejecutar el seed manualmente contra DB. Ahora se ven inmediatamente con su imagen real como cards "Próximamente" — sin depender del seed.

## Antes

Solo aparecían las 3 skins antiguas de DB (Water Elemental, Kill Confirmed, Redline) con placeholder verde. Las 8 skins Steam reales del PR #191 no eran visibles porque el seed no se había ejecutado.

## Después

En el mismo grid unificado, las 8 skins aparecen con:
- **Imagen real** — `/images/rewards/*.png` descargadas del CDN Steam.
- Nombre real: "AWP | Atheris", "Glock-18 | Fully Tuned", etc.
- Precio real en puntos (⭐ 8.100 · 104.500 · etc.).
- Stock real (1 en stock).
- Descripción real (Envío por Steam Trade Offer · stock limitado · canje sujeto a revisión manual).
- Badge "Próximamente" superpuesto.
- Botón "Próximamente" disabled.

Cuando ejecutes el seed:

\`\`\`
CONFIRM_SEED_STEAM_REWARDS=I_ACCEPT_ADD_STEAM_REWARDS \
  npx tsx scripts/seed-socialpro-rewards-steam.ts
\`\`\`

Las skins pasan a DB → dedup por \`name\` las filtra del \`upcomingCards\` → aparecen en la grid principal como **canjeables reales** con botón Canjear activo. Sin duplicados. Sin bloque separado.

## Cambio técnico

- \`PlatformShop.tsx\` importa \`REAL_STEAM_REWARDS\` (además de PLANNED_TEAM_MERCH).
- \`upcomingCards\` = skins pendientes + team merch pendientes (skins primero por atractivo visual).
- Dedup por \`name\` sigue funcionando cuando el seed pasa.

## No cambia

Un solo grid · Trade URL gate en skins canjeables · email interno tras canje · naming Recompensas.

## Checks

- \`npx tsc --noEmit\` → 0 errores.
- \`npx jest\` → **152 suites / 2836 tests verdes**.
- ESLint → 0 errores.

Preview: al abrir el PR — Recompensas mostrará las 8 skins con imagen real inmediatamente.

**No mergear sin OK visual.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)