### PR TITLE
feat(sorteos): cleanup skins legacy + subir precio merch SocialPro

### DIFF
--- a/scripts/cleanup-legacy-shop-items.ts
+++ b/scripts/cleanup-legacy-shop-items.ts
@@ -1,0 +1,112 @@
+/**
+ * Limpieza legacy + repricing merch SocialPro — 2026-07-03.
+ *
+ * ============================================================
+ * NUNCA se ejecuta automáticamente. Requiere env var explícita:
+ *   CONFIRM_CLEANUP_LEGACY_SHOP=I_ACCEPT_CLEANUP
+ *
+ * Comando real:
+ *   CONFIRM_CLEANUP_LEGACY_SHOP=I_ACCEPT_CLEANUP \
+ *     npx tsx scripts/cleanup-legacy-shop-items.ts
+ * ============================================================
+ *
+ * Motivación:
+ *  - Las 3 skins legacy de seed inicial (Water Elemental, Kill Confirmed,
+ *    Redline) tienen precios obsoletos y ya han sido reemplazadas por
+ *    las 8 skins reales de `REAL_STEAM_REWARDS` (PR #191). El owner
+ *    pidió retirarlas de la UI.
+ *  - Merch SocialPro (Camiseta, Gorra) tenía precios en puntos demasiado
+ *    bajos (300 y 220). Se sube al menos 2× a valores razonables.
+ *
+ * Qué hace:
+ *  1. Retira (soft-delete via `isActive: false`) las 3 skins legacy.
+ *     NO borra la fila — `redemptions.shopItemId` es ON DELETE RESTRICT,
+ *     y cualquier canje histórico rompería. El item queda inactivo y no
+ *     aparece en `getActiveShopItems`.
+ *  2. Sube el precio en puntos de Camiseta SocialPro (300 → 750, 2.5×)
+ *     y Gorra SocialPro (220 → 500, ~2.3×).
+ *
+ * Qué NO hace:
+ *  - No borra filas. No mueve saldos. No revierte redemptions.
+ *  - No toca otros items (skins Steam nuevas, gift cards, cosméticos,
+ *    team merch planned).
+ *  - No modifica el schema.
+ *
+ * Idempotente: correr N veces produce el mismo resultado.
+ */
+
+import { eq, inArray } from 'drizzle-orm';
+import { db } from '../src/lib/db';
+import { shopItems } from '../src/db/schema';
+
+const CONFIRM_TOKEN = 'I_ACCEPT_CLEANUP';
+
+/** Nombres exactos de las skins legacy a retirar. */
+const LEGACY_SKIN_NAMES = [
+  '★ Glock-18 · Water Elemental',
+  '★ USP-S · Kill Confirmed',
+  '★ AK-47 · Redline',
+] as const;
+
+/** Nuevos precios de merch SocialPro (~2.5× vs valores anteriores). */
+const MERCH_REPRICE: readonly { name: string; newCostCoins: number }[] = [
+  { name: 'Camiseta SocialPro', newCostCoins: 750 },
+  { name: 'Gorra SocialPro',    newCostCoins: 500 },
+];
+
+async function main() {
+  const confirm = process.env.CONFIRM_CLEANUP_LEGACY_SHOP;
+  if (confirm !== CONFIRM_TOKEN) {
+    console.error(
+      'Cleanup abortado. Requiere env var explícita:\n' +
+      `  CONFIRM_CLEANUP_LEGACY_SHOP=${CONFIRM_TOKEN} npx tsx scripts/cleanup-legacy-shop-items.ts\n\n` +
+      'Motivo: este script desactiva items en `shop_items` y actualiza\n' +
+      'precios. Requiere OK explícito antes de tocar la DB.',
+    );
+    process.exit(1);
+  }
+
+  console.log('Cleanup + repricing sobre shop_items...\n');
+
+  // 1) Soft-delete de las 3 skins legacy.
+  const deactivated = await db
+    .update(shopItems)
+    .set({ isActive: false, updatedAt: new Date() })
+    .where(inArray(shopItems.name, [...LEGACY_SKIN_NAMES]))
+    .returning({ id: shopItems.id, name: shopItems.name });
+
+  if (deactivated.length === 0) {
+    console.log('  · No se encontraron las 3 skins legacy — quizá ya fueron desactivadas.');
+  } else {
+    for (const row of deactivated) {
+      console.log(`  ~ isActive=false [id=${row.id}] ${row.name}`);
+    }
+  }
+
+  // 2) Repricing merch SocialPro.
+  let repriced = 0;
+  for (const { name, newCostCoins } of MERCH_REPRICE) {
+    const rows = await db
+      .update(shopItems)
+      .set({ costCoins: newCostCoins, updatedAt: new Date() })
+      .where(eq(shopItems.name, name))
+      .returning({ id: shopItems.id, name: shopItems.name, costCoins: shopItems.costCoins });
+    if (rows.length === 0) {
+      console.log(`  · Merch "${name}" no encontrado en DB — skip.`);
+    } else {
+      for (const row of rows) {
+        console.log(`  ~ costCoins=${row.costCoins} [id=${row.id}] ${row.name}`);
+        repriced++;
+      }
+    }
+  }
+
+  console.log(`\n✓ Cleanup completado. Desactivadas: ${deactivated.length}. Repriced: ${repriced}.`);
+}
+
+main()
+  .catch((err) => {
+    console.error('Cleanup fallido:', err);
+    process.exit(1);
+  })
+  .then(() => process.exit(0));

--- a/src/__tests__/server/cleanup-legacy-shop-items.test.ts
+++ b/src/__tests__/server/cleanup-legacy-shop-items.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Contratos del script de limpieza legacy + repricing merch SocialPro.
+ *
+ * Verifica:
+ *  - Requiere env var CONFIRM_CLEANUP_LEGACY_SHOP=I_ACCEPT_CLEANUP.
+ *  - Nombres exactos de las 3 skins legacy documentados.
+ *  - Nuevos precios de merch (Camiseta ≥ 2× de 300 = ≥ 600, Gorra ≥ 2× de 220 = ≥ 440).
+ *  - Usa soft-delete (`isActive: false`), NO `db.delete`.
+ *  - No toca otros items (no `db.update` sobre shop_items sin `where`).
+ *  - Doc no expone conversión € → puntos al usuario.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(__dirname, '..', '..', '..');
+const read = (rel: string) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');
+
+const SCRIPT_PATH = 'scripts/cleanup-legacy-shop-items.ts';
+
+/**
+ * Devuelve solo las líneas de código — filtra comentarios JSDoc y `//`.
+ * Los comentarios pueden mencionar identificadores como REAL_STEAM_REWARDS
+ * o `redemptions` como contexto sin que el script los toque.
+ */
+function readCodeOnly(rel: string): string {
+  return read(rel)
+    .split('\n')
+    .filter((l) => !/^\s*\*/.test(l) && !/^\s*\/\/\s/.test(l) && !/^\s*\/\*/.test(l))
+    .join('\n');
+}
+
+describe('[cleanup-legacy] script existe y requiere confirmación', () => {
+  const src = read(SCRIPT_PATH);
+
+  it('usa el token de confirmación exacto', () => {
+    expect(src).toMatch(/CONFIRM_CLEANUP_LEGACY_SHOP/);
+    expect(src).toMatch(/I_ACCEPT_CLEANUP/);
+  });
+
+  it('aborta con exit(1) si la env var no matchea', () => {
+    expect(src).toMatch(/if\s*\(confirm\s*!==\s*CONFIRM_TOKEN\)/);
+    expect(src).toMatch(/process\.exit\(1\)/);
+  });
+});
+
+describe('[cleanup-legacy] retira las 3 skins legacy vía soft-delete', () => {
+  const src = read(SCRIPT_PATH);
+
+  it('lista los 3 nombres exactos', () => {
+    expect(src).toContain('★ Glock-18 · Water Elemental');
+    expect(src).toContain('★ USP-S · Kill Confirmed');
+    expect(src).toContain('★ AK-47 · Redline');
+  });
+
+  it('usa `isActive: false` (soft-delete) — nunca `db.delete`', () => {
+    expect(src).toMatch(/isActive:\s*false/);
+    // `db.delete` sobre `shopItems` sería peligroso: `redemptions.shop_item_id`
+    // es ON DELETE RESTRICT, y hard-delete rompería canjes históricos.
+    expect(src).not.toMatch(/db\s*\.delete/);
+  });
+
+  it('el update está limitado a las 3 skins vía `inArray`', () => {
+    expect(src).toMatch(/inArray\(shopItems\.name/);
+  });
+});
+
+describe('[cleanup-legacy] repricing merch SocialPro ≥ 2× vs valores anteriores', () => {
+  const src = read(SCRIPT_PATH);
+
+  it('Camiseta SocialPro sube a ≥ 600 puntos (2× vs 300)', () => {
+    // Ajustamos a un valor ≥ 600.
+    const m = src.match(/name:\s*'Camiseta SocialPro',\s*newCostCoins:\s*(\d+)/);
+    expect(m).not.toBeNull();
+    if (m) expect(Number(m[1])).toBeGreaterThanOrEqual(600);
+  });
+
+  it('Gorra SocialPro sube a ≥ 440 puntos (2× vs 220)', () => {
+    const m = src.match(/name:\s*'Gorra SocialPro',\s*newCostCoins:\s*(\d+)/);
+    expect(m).not.toBeNull();
+    if (m) expect(Number(m[1])).toBeGreaterThanOrEqual(440);
+  });
+
+  it('el update aplica solo a los items nombrados (no bulk sin where)', () => {
+    // Cada update debe llevar un `.where(eq(shopItems.name, name))`.
+    expect(src).toMatch(/\.where\(eq\(shopItems\.name,\s*name\)\)/);
+    // Verifica que TODOS los `db.update(shopItems)` van seguidos de un
+    // `.where(` antes de `.returning(`.
+    const updates = src.match(/db\s*\.update\(shopItems\)[\s\S]*?\.returning/g) ?? [];
+    expect(updates.length).toBeGreaterThanOrEqual(2);
+    for (const u of updates) {
+      expect(u).toMatch(/\.where\(/);
+    }
+  });
+});
+
+describe('[cleanup-legacy] no toca otros items (código, comentarios excluidos)', () => {
+  const code = readCodeOnly(SCRIPT_PATH);
+
+  it('no importa ni referencia REAL_STEAM_REWARDS en código', () => {
+    expect(code).not.toMatch(/import\s*\{[^}]*REAL_STEAM_REWARDS/);
+    expect(code).not.toContain('AK-47 | Asiimov');
+    expect(code).not.toContain('AWP | Atheris');
+  });
+
+  it('no importa ni referencia PLANNED_TEAM_MERCH en código', () => {
+    expect(code).not.toMatch(/import\s*\{[^}]*PLANNED_TEAM_MERCH/);
+    expect(code).not.toContain('Camiseta Team Vitality');
+  });
+
+  it('no toca gift cards ni cosméticos en código', () => {
+    expect(code).not.toContain('Tarjeta Steam');
+    expect(code).not.toContain('Profile Card');
+    expect(code).not.toContain('Avatar Frame');
+  });
+});
+
+describe('[cleanup-legacy] idempotente y sin efectos colaterales', () => {
+  const code = readCodeOnly(SCRIPT_PATH);
+
+  it('NO importa schemas de redemptions ni coin_transactions ni player_profiles', () => {
+    expect(code).not.toMatch(/import\s*\{[^}]*redemptions/);
+    expect(code).not.toMatch(/import\s*\{[^}]*coinTransactions/);
+    expect(code).not.toMatch(/import\s*\{[^}]*playerProfiles/);
+  });
+
+  it('no llama db.insert ni db.delete sobre esos schemas', () => {
+    expect(code).not.toMatch(/db\s*\.(insert|delete)\(redemptions/);
+    expect(code).not.toMatch(/db\s*\.(insert|delete)\(coinTransactions/);
+    expect(code).not.toMatch(/db\s*\.(insert|delete)\(playerProfiles/);
+  });
+
+  it('el update de precios va con `updatedAt: new Date()`', () => {
+    expect(code).toMatch(/updatedAt:\s*new Date\(\)/);
+  });
+});


### PR DESCRIPTION
Retira las 3 skins antiguas de placeholder (Water Elemental, Kill Confirmed, Redline) y sube el precio en puntos del merch SocialPro al menos ×2 según pediste.

## Nuevo script — no se ejecuta automáticamente

\`scripts/cleanup-legacy-shop-items.ts\` — requiere env var explícita:

\`\`\`bash
CONFIRM_CLEANUP_LEGACY_SHOP=I_ACCEPT_CLEANUP \
  npx tsx scripts/cleanup-legacy-shop-items.ts
\`\`\`

## Qué hace

**1. Retira 3 skins legacy vía soft-delete (\`isActive: false\`):**
- ★ Glock-18 · Water Elemental
- ★ USP-S · Kill Confirmed
- ★ AK-47 · Redline

NO hard-delete porque \`redemptions.shopItemId\` es \`ON DELETE RESTRICT\` — si hubiera canjes históricos, se rompería. Con \`isActive: false\` no aparecen en \`getActiveShopItems\` → dejan de mostrarse en el grid, pero las filas se conservan.

**2. Sube el precio en puntos de merch SocialPro (~2.5×):**
| Item | Antes | Después |
| --- | --- | --- |
| Camiseta SocialPro | 300 | **750** |
| Gorra SocialPro | 220 | **500** |

Ambos ≥ 2× según pediste. Redondeados a valores limpios.

## Qué NO cambia

- No borra ni modifica gift cards, cosméticos, skins Steam nuevas (\`REAL_STEAM_REWARDS\`) ni team merch planned (\`PLANNED_TEAM_MERCH\`).
- No toca \`redemptions\`, \`coin_transactions\`, \`player_profiles\`.
- No modifica el schema.
- No hay migración.

## Idempotente

Correr el script N veces produce el mismo resultado — soft-delete es idempotente, y el update de precios sobreescribe con el mismo valor.

## Archivos tocados

- \`scripts/cleanup-legacy-shop-items.ts\` — nuevo.
- \`src/__tests__/server/cleanup-legacy-shop-items.test.ts\` — nuevo (14 asserts).

## Checks

- \`npx tsc --noEmit\` → 0 errores.
- \`npx jest\` → **153 suites / 2850 tests verdes** (+14).
- ESLint → 0 errores.

Preview: no hay cambios de UI ni de código de producción — el efecto solo se ve tras ejecutar el script contra la DB. Puedes ejecutarlo cuando quieras y contra la DB que quieras.

**No mergear sin OK visual.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)