### PR TITLE
fix(sorteos): PR-B · hardening seguridad — seed guard + race JSDoc

### DIFF
--- a/scripts/seed-giveaway-platform.ts
+++ b/scripts/seed-giveaway-platform.ts
@@ -1,7 +1,22 @@
 /**
  * Seed de la plataforma de sorteos: misiones e items de tienda demo.
- * Uso: npx tsx scripts/seed-giveaway-platform.ts
+ *
+ * ============================================================
+ * NUNCA se ejecuta automáticamente. Requiere env var explícita:
+ *   CONFIRM_SEED_GIVEAWAY_PLATFORM=I_ACCEPT_SEED
+ *
+ * Comando real:
+ *   CONFIRM_SEED_GIVEAWAY_PLATFORM=I_ACCEPT_SEED \
+ *     npx tsx --env-file=.env.local scripts/seed-giveaway-platform.ts
+ * ============================================================
+ *
  * Idempotente: no duplica si ya existen filas con el mismo título/nombre.
+ * Sin borrar filas — soft-deactivate para respetar claims/redemptions
+ * históricas.
+ *
+ * Alineado con el patrón de guardas de:
+ *   · scripts/seed-socialpro-rewards-steam.ts    (CONFIRM_SEED_STEAM_REWARDS)
+ *   · scripts/cleanup-legacy-shop-items.ts       (CONFIRM_CLEANUP_LEGACY_SHOP)
  *
  * Cambio PR-1a:
  *   - "Coleccionista" (10 entries totales) → isActive=false (no borrar; puede
@@ -12,6 +27,8 @@
 import { eq } from 'drizzle-orm';
 import { db } from '../src/lib/db';
 import { platformMissions, shopItems } from '../src/db/schema';
+
+const CONFIRM_TOKEN = 'I_ACCEPT_SEED';
 
 const MISSIONS = [
   { title: 'Primera participación',        description: 'Únete a tu primer sorteo',                                           conditionType: 'entries_total',      goal: 1,   rewardCoins: 50,   sortOrder: 1 },
@@ -78,6 +95,17 @@ const SHOP_ITEMS = [
 ];
 
 async function main() {
+  const confirm = process.env.CONFIRM_SEED_GIVEAWAY_PLATFORM;
+  if (confirm !== CONFIRM_TOKEN) {
+    console.error(
+      'Seed abortado. Requiere env var explícita:\n' +
+      `  CONFIRM_SEED_GIVEAWAY_PLATFORM=${CONFIRM_TOKEN} npx tsx --env-file=.env.local scripts/seed-giveaway-platform.ts\n\n` +
+      'Motivo: este seed añade/actualiza misiones e items de tienda demo\n' +
+      'en la DB. Se ejecuta siempre a mano tras revisar la lista.',
+    );
+    process.exit(1);
+  }
+
   const existingMissions = await db.query.platformMissions.findMany();
   const missionTitles = new Set(existingMissions.map((m) => m.title));
 

--- a/src/__tests__/server/security-hardening-pr-b.test.ts
+++ b/src/__tests__/server/security-hardening-pr-b.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Contratos estructurales del hardening de seguridad (PR-B).
+ *
+ * Verifica:
+ *  - `scripts/seed-giveaway-platform.ts` YA requiere env var explícita
+ *    para ejecutarse — alineado con el resto de scripts destructivos/DB.
+ *  - `redeemShopItem` tiene documentado en JSDoc el modelo de concurrencia
+ *    y la race condition teórica residual.
+ *
+ * Sin cambios de lógica: es hardening puramente defensivo. No toca DB,
+ * balances, providers ni auth.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(__dirname, '..', '..', '..');
+const read = (rel: string) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');
+
+const SEED_PATH = 'scripts/seed-giveaway-platform.ts';
+const ACTIONS_PATH = 'src/app/sorteos/plataforma/actions.ts';
+
+describe('[hardening-pr-b] seed-giveaway-platform.ts requiere confirmación', () => {
+  const src = read(SEED_PATH);
+
+  it('define el token de confirmación exacto', () => {
+    expect(src).toMatch(/const\s+CONFIRM_TOKEN\s*=\s*'I_ACCEPT_SEED'/);
+  });
+
+  it('la env var canónica es CONFIRM_SEED_GIVEAWAY_PLATFORM', () => {
+    expect(src).toMatch(/process\.env\.CONFIRM_SEED_GIVEAWAY_PLATFORM/);
+  });
+
+  it('aborta con exit(1) si la env var no matchea', () => {
+    expect(src).toMatch(/if\s*\(confirm\s*!==\s*CONFIRM_TOKEN\)/);
+    expect(src).toMatch(/process\.exit\(1\)/);
+  });
+
+  it('muestra el comando exacto al usuario en el mensaje de error', () => {
+    expect(src).toMatch(/CONFIRM_SEED_GIVEAWAY_PLATFORM=\$\{CONFIRM_TOKEN\}/);
+  });
+
+  it('menciona el archivo .env.local en el comando (paridad con el resto de scripts)', () => {
+    expect(src).toMatch(/--env-file=\.env\.local/);
+  });
+
+  it('el guard corre ANTES del primer query a la DB', () => {
+    // El check debe estar en las primeras líneas de main() — antes de
+    // `db.query.platformMissions.findMany()`.
+    const mainBody = src.match(/async function main\(\)[\s\S]*?^}/m)?.[0] ?? '';
+    const confirmIdx = mainBody.indexOf('CONFIRM_TOKEN');
+    const firstDbCall = mainBody.indexOf('db.query');
+    expect(confirmIdx).toBeGreaterThanOrEqual(0);
+    expect(firstDbCall).toBeGreaterThan(confirmIdx);
+  });
+});
+
+describe('[hardening-pr-b] alineamiento con otros scripts destructivos', () => {
+  it('cita en el comentario los otros seeds/cleanup con guards análogos', () => {
+    const src = read(SEED_PATH);
+    expect(src).toContain('CONFIRM_SEED_STEAM_REWARDS');
+    expect(src).toContain('CONFIRM_CLEANUP_LEGACY_SHOP');
+  });
+
+  it('los 3 scripts protegidos usan el mismo patrón `CONFIRM_...=I_ACCEPT_...`', () => {
+    for (const rel of [
+      'scripts/seed-giveaway-platform.ts',
+      'scripts/seed-socialpro-rewards-steam.ts',
+      'scripts/cleanup-legacy-shop-items.ts',
+    ]) {
+      const src = read(rel);
+      expect(src).toMatch(/CONFIRM_[A-Z_]+/);
+      expect(src).toMatch(/I_ACCEPT_[A-Z_]+/);
+      expect(src).toMatch(/process\.exit\(1\)/);
+    }
+  });
+});
+
+describe('[hardening-pr-b] redeemShopItem documenta race condition teórica', () => {
+  const src = read(ACTIONS_PATH);
+
+  it('JSDoc menciona el modelo de concurrencia con neon-http', () => {
+    expect(src).toMatch(/neon-http/);
+    expect(src).toMatch(/no soporta transacciones multi-statement/);
+  });
+
+  it('JSDoc explica el UPDATE condicional de stock (gt(stock, 0)) como gate', () => {
+    expect(src).toMatch(/UPDATE condicional de stock/);
+    expect(src).toMatch(/gt\(stock,\s*0\)/);
+    expect(src).toMatch(/gate anti-oversell|Atómico a nivel SQL/);
+  });
+
+  it('JSDoc identifica el riesgo teórico residual (doble descuento)', () => {
+    expect(src).toMatch(/Riesgo teórico residual/);
+    // Menciona el escenario de dos canjes en paralelo con saldo justo.
+    expect(src).toMatch(/dos canjes en paralelo/);
+  });
+
+  it('JSDoc propone mitigación futura (fuera de scope de este PR)', () => {
+    // Documenta neon-serverless WebSocket o UPSERT atómico.
+    expect(src).toMatch(/neon-serverless|WebSocket|UPSERT/);
+    // Permitir cortes de línea entre "Fuera" y "de scope".
+    expect(src).toMatch(/Fuera[\s\S]{0,10}de scope/i);
+  });
+});
+
+describe('[hardening-pr-b] no cambia lógica del canje', () => {
+  const src = read(ACTIONS_PATH);
+
+  it('el pipeline sigue igual: balance check → profile check → stock update → tx → redemption', () => {
+    // Verificamos que las llamadas SQL clave siguen presentes en el orden.
+    expect(src).toMatch(/getCoinBalance\(sessionUser\.id\)/);
+    expect(src).toMatch(/db\.query\.playerProfiles\.findFirst/);
+    expect(src).toMatch(/db\s*\.update\(shopItems\)[\s\S]{0,400}gt\(shopItems\.stock,\s*0\)/);
+    expect(src).toMatch(/db\.insert\(coinTransactions\)/);
+    expect(src).toMatch(/db\s*\.insert\(redemptions\)/);
+  });
+
+  it('el gate skin/trade URL sigue devolviendo code=trade_url_required', () => {
+    expect(src).toMatch(/code:\s*'trade_url_required'/);
+  });
+
+  it('el email interno sigue siendo fire-and-forget para category=skin', () => {
+    expect(src).toMatch(/sendRewardRedemptionEmail/);
+    expect(src).toMatch(/if\s*\(item\.category === 'skin'\)\s*\{[\s\S]{0,1500}try\s*\{/);
+  });
+});

--- a/src/app/sorteos/plataforma/actions.ts
+++ b/src/app/sorteos/plataforma/actions.ts
@@ -167,7 +167,36 @@ export type RedeemResult =
   | { ok: true; data: { redemptionId: number; requiresManualReview: boolean } }
   | { ok: false; code: RedeemErrorCode; error: string };
 
-/** Canjea un item de tienda: valida saldo, decrementa stock condicionalmente y registra el canje. */
+/**
+ * Canjea un item de tienda: valida saldo, decrementa stock condicionalmente
+ * y registra el canje.
+ *
+ * ## Modelo de concurrencia y race condition teórica
+ *
+ * El driver `neon-http` no soporta transacciones multi-statement — cada
+ * `await db.xxx(...)` es una petición independiente. La secuencia es:
+ *
+ *   1. Lee saldo (`getCoinBalance`).
+ *   2. Lee perfil (Trade URL/dirección) si aplica.
+ *   3. **UPDATE condicional de stock** con `.where(and(eq(id), gt(stock, 0)))`.
+ *      → Atómico a nivel SQL: solo gana una petición cuando `stock === 1`.
+ *   4. INSERT en `coin_transactions` (negativo, descuenta puntos).
+ *   5. INSERT en `redemptions`.
+ *
+ * El paso 3 es el gate anti-oversell — dos peticiones simultáneas sobre
+ * el último item disponible no pueden ambas retornar filas. Con `stock: 1`
+ * (skins Steam) esto es suficiente en la práctica.
+ *
+ * **Riesgo teórico residual (bajo)**: entre pasos 1 y 4 no hay lock —
+ * si el usuario dispara dos canjes en paralelo con saldo justo, ambos
+ * pueden pasar el balance check y descontar dos veces. La UNIQUE de
+ * `redemptions` NO existe (múltiples canjes del mismo item por el mismo
+ * usuario son legítimos). Mitigable con transaccion pooled (neon-serverless
+ * WebSocket) o UPSERT atómico via `WITH ... UPDATE ... RETURNING`. Fuera
+ * de scope aquí.
+ *
+ * Ver `docs/sorteos-rewards-catalog.md` §canje si se decide hardening.
+ */
 export async function redeemShopItem(input: unknown): Promise<RedeemResult> {
   const sessionUser = await requirePlayerSession();
   if (!sessionUser) return { ok: false, code: 'unauthenticated', error: 'Inicia sesión con Steam' };


### PR DESCRIPTION
Segundo PR de la trilogía aprobada. **Hardening defensivo. Sin cambios de lógica, sin migración, sin ejecutar seeds ni tocar la DB.**

## Cambios

### 1. Env-var guard en \`seed-giveaway-platform.ts\`

Antes: script ejecutable directamente contra prod con \`.env.local\`. Riesgo bajo (INSERT/UPDATE no destructivo) pero fuera del patrón del resto de scripts.

Ahora: requiere confirmación explícita, alineado con \`seed-socialpro-rewards-steam.ts\` y \`cleanup-legacy-shop-items.ts\`:

\`\`\`bash
CONFIRM_SEED_GIVEAWAY_PLATFORM=I_ACCEPT_SEED \
  npx tsx --env-file=.env.local scripts/seed-giveaway-platform.ts
\`\`\`

Sin la env var → \`process.exit(1)\` con el comando exacto en el mensaje.

### 2. JSDoc de \`redeemShopItem\` documenta la race condition teórica

Añade comentario explicando:
- Cada \`await db.xxx(...)\` en \`neon-http\` es petición independiente (no transaction multi-statement).
- Secuencia: balance → profile → **UPDATE stock \`gt(stock, 0)\` atómico** → coin_transactions → redemptions.
- El UPDATE condicional es el gate anti-oversell — solo gana una petición cuando \`stock === 1\`.
- **Riesgo teórico residual (bajo)**: dos canjes en paralelo con saldo justo pueden pasar el balance check simultáneamente.
- Mitigación futura fuera de scope: \`neon-serverless\` WebSocket con transactions, o UPSERT atómico via CTE.

## No toca

- Lógica del canje (pipeline exacto se preserva).
- DB, balances, providers, auth.
- Ejecución de seeds.
- Pricing, catálogos, sorteos externos.
- Migraciones.

## Archivos tocados

- \`scripts/seed-giveaway-platform.ts\` — guard + JSDoc actualizado (alineamiento).
- \`src/app/sorteos/plataforma/actions.ts\` — JSDoc de \`redeemShopItem\`.
- \`src/__tests__/server/security-hardening-pr-b.test.ts\` — nuevo (15 asserts).

## Checks

- \`npx tsc --noEmit\` → 0 errores en \`src/\`.
- \`npx jest\` → **155 suites / 2888 tests verdes** (+15).
- ESLint → 0 errores.

Preview: no cambia UI. Vercel preview build pasa igual.

**No mergear sin OK.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)