### PR TITLE
fix(sorteos): PR-C · Términos §6 refuerza 'revisión manual antes del envío'

### DIFF
--- a/src/__tests__/server/legal-terminos-6-manual-review.test.ts
+++ b/src/__tests__/server/legal-terminos-6-manual-review.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Refuerzo copy Términos §6 · Canjeo de recompensas (PR-C).
+ *
+ * La auditoría detectó que Términos §6 no mencionaba explícitamente la
+ * "revisión manual antes del envío" — sí estaba en FAQ y en el disclaimer
+ * de PlatformShop. Ahora también en Términos, con la fórmula pactada:
+ *
+ *   "Todos los canjes están sujetos a revisión manual por el equipo de
+ *    SocialPro antes del envío"
+ *
+ * Sin quitar el LegalDraftBanner, sin cambiar noindex, sin tocar
+ * jurisdicción (§11 sigue pendiente de gestoría).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(__dirname, '..', '..', '..');
+const read = (rel: string) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');
+
+const TERMINOS = 'src/app/sorteos/(legal)/terminos/page.tsx';
+
+describe('[legal-pr-c] Términos §6 menciona la revisión manual', () => {
+  const src = read(TERMINOS);
+
+  it('la sección 6 sigue titulada "Canjeo de recompensas"', () => {
+    expect(src).toMatch(/<h2>6\.\s*Canjeo de recompensas<\/h2>/);
+  });
+
+  it('incluye la frase canónica de revisión manual', () => {
+    expect(src).toMatch(
+      /Todos los canjes están sujetos a revisión manual por el equipo de SocialPro antes del envío/,
+    );
+  });
+
+  it('explica qué se revisa (identidad + stock + abuso)', () => {
+    expect(src).toMatch(/Comprobamos identidad,\s+disponibilidad real de stock y ausencia de indicios de uso/);
+    expect(src).toMatch(/abusivo o incumplimiento de estos términos/);
+  });
+
+  it('menciona que el plazo puede variar', () => {
+    // La frase se rompe entre "puede" y "variar" por wrap JSX.
+    expect(src).toMatch(/plazo de revisión y envío puede[\s\S]{0,20}variar/);
+  });
+
+  it('preserva el copy previo — no cancelable + derechos de consumidor', () => {
+    // No pisamos las cláusulas previas. Permitimos saltos de línea y
+    // etiquetas <b> entre partes por el formato JSX.
+    expect(src).toMatch(/no ser posible cancelarlo/);
+    expect(src).toMatch(/sin[\s\S]{0,20}perjuicio[\s\S]{0,120}derechos que correspondan al usuario/);
+    expect(src).toMatch(/normativa de consumidores/);
+  });
+});
+
+describe('[legal-pr-c] mantiene invariantes legales acordados', () => {
+  const src = read(TERMINOS);
+
+  it('LegalDraftBanner sigue montado (no quitarlo)', () => {
+    // El banner de borrador vive como componente compartido `<LegalDraftBanner />`
+    // en el layout legal, no en cada página. Aquí verificamos que el
+    // layout sigue importándolo.
+    const layoutSrc = read('src/app/sorteos/(legal)/layout.tsx');
+    expect(layoutSrc).toMatch(/LegalDraftBanner/);
+  });
+
+  it('robots noindex se mantiene', () => {
+    expect(src).toMatch(/robots:\s*\{\s*index:\s*false,\s*follow:\s*false\s*\}/);
+  });
+
+  it('§11 Ley y jurisdicción sigue marcada como pendiente (gestoría)', () => {
+    expect(src).toMatch(/11\.\s*Ley y jurisdicción/);
+    expect(src).toMatch(/Sección pendiente de definición por asesoría jurídica/);
+  });
+
+  it('§10 Limitación de responsabilidad sigue intacta (gestoría)', () => {
+    expect(src).toMatch(/10\.\s*Limitación de responsabilidad/);
+  });
+
+  it('no cambia el naming compliance (puntos, no monedas)', () => {
+    // Los 6 puntos base siguen presentes.
+    expect(src).toMatch(/no son dinero/i);
+    expect(src).toMatch(/no son criptomonedas/i);
+    expect(src).toMatch(/no tienen valor monetario/i);
+    expect(src).toMatch(/no son transferibles/i);
+    expect(src).toMatch(/no pueden canjearse por efectivo/i);
+    // Y no reintroducimos "monedas" como término público.
+    const bodyOnly = src.split(/^\s*\*/).join('').replace(/\/\/.*$/gm, '');
+    expect(bodyOnly).not.toMatch(/\bmonedas?\b/i);
+  });
+});
+
+describe('[legal-pr-c] alineamiento con FAQ y PlatformShop', () => {
+  it('el FAQ ya cita "revisión manual" (referencia consistente)', () => {
+    const faq = read('src/app/sorteos/(legal)/faq/page.tsx');
+    expect(faq).toMatch(/revisión manual|revisar|revisión/i);
+  });
+
+  it('PlatformShop muestra el mensaje de "revisaremos el canje"', () => {
+    const shop = read('src/features/giveaway-platform/components/PlatformShop.tsx');
+    expect(shop).toMatch(/Revisaremos el canje/);
+  });
+});

--- a/src/app/sorteos/(legal)/terminos/page.tsx
+++ b/src/app/sorteos/(legal)/terminos/page.tsx
@@ -91,11 +91,21 @@ export default function TerminosPage() {
         <p>
           El canjeo descuenta puntos del saldo y genera una solicitud de entrega. SocialPro
           coordinará contigo la entrega según el tipo de artículo (skin CS2 vía trade offer,
-          merchandising físico o tarjeta regalo digital). Una vez procesado o entregado un
-          canje puede no ser posible cancelarlo. Lo anterior se aplicará <b>sin perjuicio de
-          los derechos que correspondan al usuario</b> según la normativa de consumidores y
-          las excepciones aplicables, especialmente en productos digitales, códigos o
-          artículos ya entregados. La disponibilidad de cada artículo depende del stock.
+          merchandising físico o tarjeta regalo digital).
+        </p>
+        <p>
+          <b>Todos los canjes están sujetos a revisión manual por el equipo de SocialPro antes del envío.</b>
+          {' '}
+          Comprobamos identidad, disponibilidad real de stock y ausencia de indicios de uso
+          abusivo o incumplimiento de estos términos. El plazo de revisión y envío puede
+          variar según el tipo de artículo y la carga de trabajo del equipo.
+        </p>
+        <p>
+          Una vez procesado o entregado un canje puede no ser posible cancelarlo. Lo anterior
+          se aplicará <b>sin perjuicio de los derechos que correspondan al usuario</b> según
+          la normativa de consumidores y las excepciones aplicables, especialmente en
+          productos digitales, códigos o artículos ya entregados. La disponibilidad de cada
+          artículo depende del stock.
         </p>
       </section>
 


### PR DESCRIPTION
Tercer PR de la trilogía aprobada. **Solo copy legal. Sin migración, sin cambio de lógica.**

## Cambio

La auditoría detectó que Términos §6 no citaba explícitamente la revisión manual — sí estaba en FAQ y en el banner success de PlatformShop. Ahora también en Términos, con la fórmula acordada.

En \`src/app/sorteos/(legal)/terminos/page.tsx\` §6 se añade:

> **"Todos los canjes están sujetos a revisión manual por el equipo de SocialPro antes del envío"**

Con explicación de qué se revisa (identidad, disponibilidad real de stock, ausencia de indicios de uso abusivo) y aviso de que el plazo puede variar según el tipo de artículo.

Copy previo preservado — se re-estructura §6 en 3 párrafos para claridad, pero:
- Descuento de puntos + coordinación de entrega: intacto.
- No cancelable + derechos de consumidor + productos digitales: intacto.
- Naming compliance (los 6 puntos base): intacto.

## Alineamiento

Consistente con:
- **FAQ** §Puntos y recompensas: "coordina el envío... una vez procesado puede no ser posible cancelarlo, sin perjuicio de derechos..."
- **PlatformShop** success banner: "Solicitud recibida. Revisaremos el canje y enviaremos la recompensa manualmente por Steam Trade Offer."

## Lo que NO cambia (pactado)

- ✅ \`LegalDraftBanner\` sigue montado desde \`(legal)/layout.tsx\`.
- ✅ \`robots: { index: false, follow: false }\` en metadata.
- ✅ §10 Limitación de responsabilidad — intacto (pendiente de gestoría).
- ✅ §11 Ley y jurisdicción — sigue "pendiente de definición por asesoría jurídica".
- ✅ Los 6 puntos base de puntos-no-son-dinero conservados.

## Archivos tocados

- \`src/app/sorteos/(legal)/terminos/page.tsx\` — §6 re-estructurada + frase de revisión manual.
- \`src/__tests__/server/legal-terminos-6-manual-review.test.ts\` — nuevo (12 asserts).

## Checks

- \`npx tsc --noEmit\` → 0 errores.
- \`npx jest\` → **156 suites / 2900 tests verdes** (+12).
- ESLint → 0 errores.

## Preview

Se despliega al abrir el PR. Ruta: \`/sorteos/terminos\` (noindex se mantiene).

**No mergear sin OK.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)