### PR TITLE
feat(sorteos): script manual admin-grant-points (dev/staff only)

### DIFF
--- a/docs/admin-points-operations.md
+++ b/docs/admin-points-operations.md
@@ -1,0 +1,213 @@
+# Operaciones manuales sobre el ledger de puntos
+
+**Estado:** Herramienta interna dev/staff — 2026-07-04.
+**Ámbito:** `scripts/admin-grant-points.ts` y patrones relacionados.
+
+Este documento explica **cuándo y cómo** conceder puntos a un usuario concreto
+de SocialPro Giveaways de forma manual, y cómo hacer rollback si te equivocas.
+No es un panel administrativo público — es un script CLI que sólo se ejecuta
+desde una máquina de operador con `.env.local`.
+
+---
+
+## 1. Cuándo usar el script
+
+Casos aceptables:
+
+- **Prueba interna de canje**: darte a ti mismo los puntos justos para
+  validar el flujo Steam Trade URL → redemption pendiente → email interno
+  → decremento de stock (ver §5).
+- **Compensación de soporte**: usuario reportó bug legítimo que hizo que
+  perdiera puntos ganados. Documentar en el `reason` el ticket.
+- **Campaña especial**: sorteo one-shot fuera del sistema de misiones
+  (ej. Twitter/Discord). Documentar en el `reason` la campaña.
+- **Corrección post-incidente**: cuando un fallo de servicio afectó las
+  recompensas y hay que restablecer saldo.
+
+Casos **no** aceptables:
+
+- ❌ "Regalar" puntos a amigos sin justificación operativa.
+- ❌ "Corregir" el saldo de un canje que ya se completó — usar rollback
+  compensatorio (ver §Rollback) en su lugar, no borrar.
+- ❌ Grants recurrentes automatizados — cambia la lógica de misiones o
+  daily rewards en su lugar.
+
+---
+
+## 2. Cómo buscar el usuario
+
+La identificación es por Steam ID (recomendado) o por `user.id` (auth
+Better Auth interno).
+
+**Buscar Steam ID de un jugador (desde la propia web):**
+
+- Cada perfil `/sorteos/perfil` muestra el Steam ID pública. Pídele al
+  usuario que te lo pase (o localízalo desde el ranking mensual).
+- Formato Steam64: 17 dígitos empezando por `7656119...`.
+
+**Buscar user.id (Better Auth):**
+
+- Si necesitas hacer un grant y el usuario no tiene `player_profiles`
+  todavía (raro), puedes usar directamente `user.id`.
+- Consulta SQL de referencia:
+  ```sql
+  SELECT id, name, email FROM "user"
+   WHERE email ILIKE '%buscar%' OR name ILIKE '%buscar%';
+  ```
+
+---
+
+## 3. Cómo conceder puntos
+
+### Comando ejemplo (mío, Kevin — 1000 puntos para prueba Glock-18 Block-18)
+
+Reemplaza `76561198XXXXXXXXX` por tu Steam ID real:
+
+```bash
+CONFIRM_ADMIN_GRANT_POINTS=I_ACCEPT_GRANT_POINTS \
+  npx tsx --env-file=.env.local scripts/admin-grant-points.ts \
+  --steam-id 76561198XXXXXXXXX \
+  --amount 1000 \
+  --reason "Test canje Glock-18 Block-18 (800 pts) — 2026-07-04"
+```
+
+### Salida esperada
+
+```
+=== Grant de puntos manual ===
+  Usuario:    Kevin
+  Steam ID:   76561198XXXXXXXXX
+  User ID:    <uuid Better Auth>
+  Cantidad:   +1.000 pts
+  Reason:     Test canje Glock-18 Block-18 (800 pts) — 2026-07-04
+  Saldo ant.: 42 pts
+  Saldo post: 1.042 pts
+
+✓ Grant aplicado — tx#237 @ 2026-07-04T...Z
+  Saldo verificado post-INSERT: 1.042 pts
+```
+
+### Argumentos
+
+| Flag | Obligatorio | Descripción |
+|------|-------------|-------------|
+| `--steam-id <76561198…>` | ⚠️ Uno de los dos | Steam64 del jugador. Preferido. |
+| `--user-id <auth-uuid>` | ⚠️ Uno de los dos | ID interno Better Auth. Bypass Steam. |
+| `--amount <int>` | ✅ | Cantidad positiva 1..100.000. |
+| `--reason "<texto>"` | ✅ | Justificación (queda en el ledger). Max 200 chars. |
+
+### Guards
+
+- ❌ Bloqueado en CI, Vercel build, `NODE_ENV=production`, `GITHUB_ACTIONS`.
+- ❌ Sin `CONFIRM_ADMIN_GRANT_POINTS=I_ACCEPT_GRANT_POINTS` aborta con
+  `exit 1`.
+- ❌ `--amount <= 0` o `--amount > 100.000` → error.
+- ❌ `--reason` vacío o > 200 chars → error.
+- ❌ Pasar `--steam-id` y `--user-id` a la vez → error.
+
+---
+
+## 4. Prueba de canje end-to-end
+
+Flujo recomendado para la validación de Glock-18 Block-18 (800 pts):
+
+1. **Conceder 1.000 pts** con el comando de §3.
+2. **Verificar en `/sorteos/perfil`**: sección "🧾 Últimas transacciones"
+   muestra la línea `+1.000 · Admin · Test canje Glock-18 Block-18...`.
+3. **Comprobar que la Steam Trade URL está configurada** en el perfil
+   (input `Steam Trade URL` con el formato `https://steamcommunity.com/tradeoffer/new/?partner=…&token=…`).
+4. **Ir a `/sorteos/<creator>#recompensas`**, filtrar por tab
+   "🔫 Skins CS2", localizar **Glock-18 | Block-18** (800 pts). Debe
+   mostrarse como canjeable (botón "Canjear" activo).
+5. **Pulsar "Canjear"**. Debe aparecer el banner verde:
+   > *Solicitud recibida. Revisaremos el canje y enviaremos la recompensa
+   > manualmente por Steam Trade Offer.*
+6. **Verificar cambios en DB / UI**:
+   - `/sorteos/perfil` → "🎒 Inventario" muestra la nueva redemption con
+     estado "Pendiente".
+   - Card de Glock-18 Block-18 pasa a "Agotado" (stock 1 → 0).
+   - Historial de puntos añade `-800 · Tienda · Canje · Glock-18 | Block-18`.
+7. **Verificar email en `info@socialpro.es`**: asunto
+   `Nueva recompensa solicitada · Skin CS2 — Glock-18 | Block-18`.
+   Contenido con Redemption ID, Steam Trade URL, Steam ID, fecha.
+
+Si algún paso falla, **no** intentes canjear otra skin — reporta el fallo
+y depuramos primero.
+
+---
+
+## 5. Riesgos y prevenciones
+
+| Riesgo | Prevención |
+|--------|------------|
+| Concesión por typo (ej. 100.000 en lugar de 1.000) | `MAX_GRANT = 100_000` hard-cap por ejecución. Snapshot antes/después impreso siempre. |
+| Ejecutar el script en Vercel/CI por accidente | Guard `detectCiOrProd()` — abort con exit 1. |
+| Duplicar grants (correr dos veces por error) | Sin idempotencia — cada ejecución inserta una fila nueva. Verificar `Saldo post-INSERT` antes de reintentar. |
+| Grant a un Steam ID equivocado | Snapshot muestra `Usuario` (nombre) y `User ID` antes de la fila real. **Verifica antes** de confirmar cualquier acción downstream (canje real). |
+| Filtración del token de confirmación | `CONFIRM_ADMIN_GRANT_POINTS=I_ACCEPT_GRANT_POINTS` es un check de intención, no un secreto. La vulnerabilidad real es acceso al archivo `.env.local` (DB URL). Mantener `.env.local` fuera del repo. |
+| Modificar balances directos (bypass ledger) | El script **NUNCA** hace UPDATE a `shop_items`, `redemptions`, `player_profiles` ni al saldo del `user`. Ledger append-only por diseño. |
+| Rollback tardío | Ver §Rollback abajo. |
+
+---
+
+## 6. Rollback (compensación negativa)
+
+Si te equivocas al conceder puntos:
+
+- **NO** intentes borrar la fila insertada en `coin_transactions`. Rompe
+  auditoría. Además la FK `redemptions.shopItemId ON DELETE RESTRICT` y
+  patrones similares en el CRM asumen que el ledger es histórico.
+- El patrón correcto es **transacción negativa compensatoria** con
+  `concept` explícito:
+
+  ```sql
+  INSERT INTO coin_transactions (user_id, amount, source, concept, ref_id, created_at)
+  VALUES
+    ('<user-id>', -1000, 'admin', 'Reverso de tx#237 — typo en grant', NULL, NOW());
+  ```
+
+- El script actual **NO** permite `--amount` negativo por diseño — es un
+  guard extra contra typos. Si necesitas hacer un reverso:
+  1. Documenta el motivo en un ticket interno.
+  2. Ejecuta la SQL manualmente con `--env-file=.env.local`, verificando
+     el `user_id` con SELECT antes.
+  3. Verifica el saldo posterior con `getCoinBalance()` equivalente.
+
+Alternativa futura (**no implementada**): añadir bandera `--allow-negative`
+en el script con guard extra y sanity check en pantalla. Requeriría OK
+explícito y actualización de tests.
+
+---
+
+## 7. Auditoría — qué queda en la DB
+
+Cada grant deja una fila permanente en `coin_transactions`:
+
+| Campo | Valor |
+|-------|-------|
+| `id` | serial auto |
+| `user_id` | `target.userId` (resuelto desde `--steam-id` o `--user-id`) |
+| `amount` | positivo (1..100.000) |
+| `source` | `'admin'` (categoría del `CoinSource`, ya en tipos) |
+| `concept` | valor de `--reason` (max 200 chars) |
+| `ref_id` | `NULL` (no hay entidad origen — ni giveaway ni misión) |
+| `created_at` | `now()` con TZ |
+
+Para consultar grants históricos por reason:
+
+```sql
+SELECT id, user_id, amount, concept, created_at
+  FROM coin_transactions
+ WHERE source = 'admin'
+ ORDER BY created_at DESC
+ LIMIT 50;
+```
+
+---
+
+## 8. Historial
+
+- **2026-07-04** — Script inicial `admin-grant-points.ts` + doc. Nace por
+  necesidad de dotar de puntos a operador (Kevin) para prueba controlada
+  de canje Glock-18 Block-18 (800 pts). Alineado con el patrón de scripts
+  destructivos/DB existentes (`CONFIRM_...=I_ACCEPT_...`).

--- a/scripts/admin-grant-points.ts
+++ b/scripts/admin-grant-points.ts
@@ -1,0 +1,236 @@
+/**
+ * Herramienta interna manual — concesión de puntos SocialPro a un
+ * usuario concreto. Uso: pruebas de canje, compensaciones de soporte,
+ * campañas especiales manuales.
+ *
+ * ============================================================
+ * NUNCA se ejecuta automáticamente. Bloqueado en CI/producción y
+ * requiere env var explícita:
+ *
+ *   CONFIRM_ADMIN_GRANT_POINTS=I_ACCEPT_GRANT_POINTS \
+ *     npx tsx --env-file=.env.local scripts/admin-grant-points.ts \
+ *     --steam-id 76561198XXXXXXXXX \
+ *     --amount 1000 \
+ *     --reason "Test canje Glock-18 Block-18"
+ *
+ * Argumentos aceptados (exclusivos entre sí):
+ *   --steam-id <steam64>         Concede al usuario cuyo player_profiles.steam_id coincide.
+ *   --user-id  <auth-user-id>    Concede al usuario cuyo user.id coincide (bypass Steam).
+ *
+ * Obligatorios:
+ *   --amount   <int>             Cantidad positiva de puntos. Rango 1..MAX_GRANT.
+ *   --reason   <texto>           Justificación (concepto que queda en ledger).
+ * ============================================================
+ *
+ * Modelo:
+ *   - El saldo del usuario es SIEMPRE `SUM(coin_transactions.amount)`.
+ *   - Este script NUNCA actualiza un balance cacheado — inserta UNA fila
+ *     en `coin_transactions` con `amount > 0` y `source: 'admin'`.
+ *   - El `reason` se guarda como `concept` (max 200 chars por schema).
+ *   - No borra, no revierte, no toca redemptions ni shop_items.
+ *
+ * Rollback (compensación):
+ *   Si te equivocas, el patrón es una TRANSACCIÓN NEGATIVA compensatoria
+ *   con concept explícito ("Reverso de tx#N — motivo"). No hay flag de
+ *   "amount negativo" en este script — si necesitas rollback, edita el
+ *   script en una rama, cambia el guard MIN_AMOUNT y documenta el porqué.
+ *   Ver docs/admin-points-operations.md §Rollback.
+ */
+
+import { and, eq, sql } from 'drizzle-orm';
+import { db } from '../src/lib/db';
+import { coinTransactions, playerProfiles, user } from '../src/db/schema';
+
+const CONFIRM_TOKEN = 'I_ACCEPT_GRANT_POINTS';
+
+/** Cantidad máxima concedida por ejecución. Guard anti-typo. */
+const MAX_GRANT = 100_000;
+/** Cantidad mínima estricta. Este script NO permite valores negativos. */
+const MIN_AMOUNT = 1;
+/** Longitud máxima del concept (schema: varchar 200). */
+const REASON_MAX_LEN = 200;
+
+interface Args {
+  steamId?: string;
+  userId?: string;
+  amount: number;
+  reason: string;
+}
+
+function detectCiOrProd(): boolean {
+  return (
+    process.env.CI === 'true' ||
+    process.env.NODE_ENV === 'production' ||
+    process.env.VERCEL === '1' ||
+    Boolean(process.env.GITHUB_ACTIONS)
+  );
+}
+
+function parseArgs(argv: readonly string[]): Args | { error: string } {
+  const map = new Map<string, string>();
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (!arg?.startsWith('--')) continue;
+    const key = arg.slice(2);
+    const next = argv[i + 1];
+    if (!next || next.startsWith('--')) return { error: `Falta valor para --${key}` };
+    map.set(key, next);
+    i++;
+  }
+
+  const steamId = map.get('steam-id')?.trim();
+  const userId = map.get('user-id')?.trim();
+  const amountRaw = map.get('amount')?.trim();
+  const reason = map.get('reason')?.trim();
+
+  if (!steamId && !userId) {
+    return { error: 'Debes pasar --steam-id o --user-id' };
+  }
+  if (steamId && userId) {
+    return { error: 'Usa solo --steam-id o solo --user-id (no ambos)' };
+  }
+  if (!amountRaw) return { error: 'Falta --amount' };
+  if (!reason) return { error: 'Falta --reason' };
+
+  const amount = Number.parseInt(amountRaw, 10);
+  if (!Number.isFinite(amount) || `${amount}` !== amountRaw) {
+    return { error: `--amount debe ser un entero, recibido: "${amountRaw}"` };
+  }
+  if (amount < MIN_AMOUNT) {
+    return { error: `--amount debe ser >= ${MIN_AMOUNT} (recibido: ${amount})` };
+  }
+  if (amount > MAX_GRANT) {
+    return { error: `--amount excede el límite de ${MAX_GRANT} por ejecución (recibido: ${amount})` };
+  }
+  if (reason.length > REASON_MAX_LEN) {
+    return { error: `--reason no debe superar ${REASON_MAX_LEN} caracteres (recibido: ${reason.length})` };
+  }
+
+  const result: Args = { amount, reason };
+  if (steamId) result.steamId = steamId;
+  if (userId) result.userId = userId;
+  return result;
+}
+
+async function resolveTargetUser(args: Args): Promise<{ userId: string; steamId: string | null; name: string | null } | null> {
+  if (args.userId) {
+    const u = await db.query.user.findFirst({
+      where: eq(user.id, args.userId),
+      columns: { id: true, name: true },
+    });
+    if (!u) return null;
+    const p = await db.query.playerProfiles.findFirst({
+      where: eq(playerProfiles.userId, u.id),
+      columns: { steamId: true },
+    });
+    return { userId: u.id, name: u.name ?? null, steamId: p?.steamId ?? null };
+  }
+
+  // steamId
+  const p = await db.query.playerProfiles.findFirst({
+    where: eq(playerProfiles.steamId, args.steamId!),
+    columns: { userId: true, steamId: true },
+  });
+  if (!p) return null;
+  const u = await db.query.user.findFirst({
+    where: eq(user.id, p.userId),
+    columns: { id: true, name: true },
+  });
+  if (!u) return null;
+  return { userId: u.id, name: u.name ?? null, steamId: p.steamId };
+}
+
+async function getBalance(userId: string): Promise<number> {
+  const [row] = await db
+    .select({ balance: sql<number>`coalesce(sum(${coinTransactions.amount}), 0)::int` })
+    .from(coinTransactions)
+    .where(eq(coinTransactions.userId, userId));
+  return row?.balance ?? 0;
+}
+
+async function main() {
+  // 1) Guards de entorno.
+  if (detectCiOrProd()) {
+    console.error(
+      'Grant abortado: entorno CI o producción detectado.\n' +
+      'Este script es una herramienta local dev/staff — no se ejecuta en CI ni desde\n' +
+      'builds de producción. Correr solo desde una máquina de operador con .env.local.',
+    );
+    process.exit(1);
+  }
+
+  const confirm = process.env.CONFIRM_ADMIN_GRANT_POINTS;
+  if (confirm !== CONFIRM_TOKEN) {
+    console.error(
+      'Grant abortado. Requiere env var explícita:\n' +
+      `  CONFIRM_ADMIN_GRANT_POINTS=${CONFIRM_TOKEN} npx tsx --env-file=.env.local scripts/admin-grant-points.ts --steam-id <ID> --amount <N> --reason "<texto>"\n\n` +
+      'Motivo: modifica el ledger de puntos de un usuario en la DB. Requiere\n' +
+      'OK explícito antes de cada ejecución.',
+    );
+    process.exit(1);
+  }
+
+  // 2) Parseo y validación de args.
+  const parsed = parseArgs(process.argv.slice(2));
+  if ('error' in parsed) {
+    console.error(`Argumentos inválidos: ${parsed.error}\n`);
+    console.error('Uso:');
+    console.error('  --steam-id <76561198…>       (o --user-id <auth-user-id>)');
+    console.error(`  --amount   <entero 1..${MAX_GRANT}>`);
+    console.error(`  --reason   "<texto max ${REASON_MAX_LEN} chars>"`);
+    process.exit(1);
+  }
+  const args = parsed;
+
+  // 3) Resolver usuario destino.
+  const target = await resolveTargetUser(args);
+  if (!target) {
+    console.error(
+      'Usuario no encontrado.\n' +
+      (args.steamId ? `  --steam-id: ${args.steamId}\n` : '') +
+      (args.userId ? `  --user-id:  ${args.userId}\n` : ''),
+    );
+    process.exit(1);
+  }
+
+  // 4) Snapshot saldo antes.
+  const before = await getBalance(target.userId);
+
+  console.log('\n=== Grant de puntos manual ===');
+  console.log(`  Usuario:    ${target.name ?? '(sin nombre)'}`);
+  console.log(`  Steam ID:   ${target.steamId ?? '(sin player_profile)'}`);
+  console.log(`  User ID:    ${target.userId}`);
+  console.log(`  Cantidad:   +${args.amount.toLocaleString('es-ES')} pts`);
+  console.log(`  Reason:     ${args.reason}`);
+  console.log(`  Saldo ant.: ${before.toLocaleString('es-ES')} pts`);
+  console.log(`  Saldo post: ${(before + args.amount).toLocaleString('es-ES')} pts\n`);
+
+  // 5) Insertar UNA fila en el ledger. source='admin' — ya existe en el
+  //    tipo CoinSource y en la Column 'source' del schema.
+  const [tx] = await db
+    .insert(coinTransactions)
+    .values({
+      userId: target.userId,
+      amount: args.amount,
+      source: 'admin',
+      concept: args.reason,
+      // refId no aplica — no hay entidad origen (ni giveaway ni misión).
+    })
+    .returning({ id: coinTransactions.id, createdAt: coinTransactions.createdAt });
+
+  if (!tx) {
+    console.error('  ✗ INSERT devolvió 0 filas. Investigar antes de reintentar.');
+    process.exit(1);
+  }
+
+  const after = await getBalance(target.userId);
+  console.log(`✓ Grant aplicado — tx#${tx.id} @ ${tx.createdAt?.toISOString?.() ?? 'now'}`);
+  console.log(`  Saldo verificado post-INSERT: ${after.toLocaleString('es-ES')} pts`);
+}
+
+main()
+  .catch((err) => {
+    console.error('Grant fallido:', err);
+    process.exit(1);
+  })
+  .then(() => process.exit(0));

--- a/src/__tests__/server/admin-grant-points-script.test.ts
+++ b/src/__tests__/server/admin-grant-points-script.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Contratos del script manual de concesión de puntos.
+ *
+ * `scripts/admin-grant-points.ts` es una herramienta interna dev/staff:
+ *  - Requiere env var explícita de confirmación.
+ *  - Bloqueada en CI / producción.
+ *  - Argumentos obligatorios: (--steam-id | --user-id), --amount, --reason.
+ *  - Valida rangos (>= 1, <= 100_000).
+ *  - Inserta UNA fila en `coin_transactions` con source='admin'.
+ *  - NO toca redemptions, shop_items, player_profiles, ni actualiza
+ *    balances cacheados.
+ *
+ * Estos tests son estructurales (regex sobre el fuente). Ejecutar el
+ * script contra una DB real queda fuera de scope de la suite unitaria.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(__dirname, '..', '..', '..');
+const read = (rel: string) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');
+
+const SCRIPT = 'scripts/admin-grant-points.ts';
+
+describe('[admin-grant-points] archivo existe con estructura mínima', () => {
+  it('scripts/admin-grant-points.ts existe y no está vacío', () => {
+    const p = path.join(ROOT, SCRIPT);
+    expect(fs.existsSync(p)).toBe(true);
+    expect(fs.statSync(p).size).toBeGreaterThan(2000);
+  });
+
+  it('define main() async y process.exit(0) al terminar', () => {
+    const src = read(SCRIPT);
+    expect(src).toMatch(/async function main\(\)/);
+    expect(src).toMatch(/process\.exit\(0\)/);
+  });
+});
+
+describe('[admin-grant-points] guards de entorno', () => {
+  const src = read(SCRIPT);
+
+  it('detecta CI, VERCEL, GITHUB_ACTIONS y NODE_ENV=production', () => {
+    expect(src).toMatch(/CI[\s\S]{0,80}'true'/);
+    expect(src).toMatch(/VERCEL[\s\S]{0,80}'1'/);
+    expect(src).toMatch(/GITHUB_ACTIONS/);
+    expect(src).toMatch(/NODE_ENV[\s\S]{0,80}'production'/);
+  });
+
+  it('aborta con exit(1) si detecta CI/prod', () => {
+    expect(src).toMatch(/detectCiOrProd\(\)[\s\S]{0,300}process\.exit\(1\)/);
+  });
+});
+
+describe('[admin-grant-points] token de confirmación explícito', () => {
+  const src = read(SCRIPT);
+
+  it('define CONFIRM_TOKEN = "I_ACCEPT_GRANT_POINTS"', () => {
+    expect(src).toMatch(/const\s+CONFIRM_TOKEN\s*=\s*'I_ACCEPT_GRANT_POINTS'/);
+  });
+
+  it('la env var es CONFIRM_ADMIN_GRANT_POINTS', () => {
+    expect(src).toMatch(/process\.env\.CONFIRM_ADMIN_GRANT_POINTS/);
+  });
+
+  it('aborta con exit(1) si la env no matchea', () => {
+    expect(src).toMatch(/if\s*\(confirm\s*!==\s*CONFIRM_TOKEN\)[\s\S]{0,400}process\.exit\(1\)/);
+  });
+
+  it('muestra el comando exacto en el mensaje de error', () => {
+    expect(src).toMatch(/CONFIRM_ADMIN_GRANT_POINTS=\$\{CONFIRM_TOKEN\}/);
+    expect(src).toMatch(/--env-file=\.env\.local/);
+  });
+});
+
+describe('[admin-grant-points] parseo y validación de args', () => {
+  const src = read(SCRIPT);
+
+  it('acepta --steam-id y --user-id (mutuamente exclusivos)', () => {
+    expect(src).toMatch(/steamId\s*&&\s*userId/);
+    expect(src).toMatch(/Debes pasar --steam-id o --user-id/);
+  });
+
+  it('exige --amount y --reason', () => {
+    expect(src).toMatch(/Falta --amount/);
+    expect(src).toMatch(/Falta --reason/);
+  });
+
+  it('rechaza amount <= 0 (MIN_AMOUNT = 1)', () => {
+    expect(src).toMatch(/const\s+MIN_AMOUNT\s*=\s*1/);
+    expect(src).toMatch(/amount\s*<\s*MIN_AMOUNT/);
+  });
+
+  it('rechaza amount > MAX_GRANT (100_000)', () => {
+    expect(src).toMatch(/const\s+MAX_GRANT\s*=\s*100_?000/);
+    expect(src).toMatch(/amount\s*>\s*MAX_GRANT/);
+  });
+
+  it('reason limitado a 200 chars (schema varchar 200)', () => {
+    expect(src).toMatch(/const\s+REASON_MAX_LEN\s*=\s*200/);
+    expect(src).toMatch(/reason\.length\s*>\s*REASON_MAX_LEN/);
+  });
+
+  it('valida amount como entero (Number.parseInt + Number.isFinite)', () => {
+    expect(src).toMatch(/Number\.parseInt\(amountRaw,\s*10\)/);
+    expect(src).toMatch(/Number\.isFinite\(amount\)/);
+  });
+});
+
+describe('[admin-grant-points] inserta en el ledger, no toca balances directos', () => {
+  const src = read(SCRIPT);
+
+  it('inserta UNA fila en coin_transactions con source="admin"', () => {
+    expect(src).toMatch(
+      /db\s*\.insert\(coinTransactions\)[\s\S]{0,400}source:\s*'admin'/,
+    );
+  });
+
+  it('la fila insertada usa el reason como concept', () => {
+    expect(src).toMatch(/concept:\s*args\.reason/);
+  });
+
+  it('amount insertado es POSITIVO (args.amount, no negado)', () => {
+    expect(src).toMatch(/amount:\s*args\.amount(?![-\s]*[*-])/);
+  });
+
+  it('userId destino sale de la DB (no del cliente/args directamente)', () => {
+    // El args puede traer --user-id, pero el script SIEMPRE resuelve
+    // via `resolveTargetUser` que consulta `user` / `player_profiles`.
+    expect(src).toMatch(/resolveTargetUser/);
+    expect(src).toMatch(/target\.userId/);
+    expect(src).toMatch(/userId:\s*target\.userId/);
+  });
+
+  it('NO hace UPDATE sobre balances ni tablas de saldo cacheado', () => {
+    // El modelo es ledger append-only. No debe existir ninguna forma
+    // de UPDATE a shopItems/redemptions/playerProfiles/user desde aquí.
+    expect(src).not.toMatch(/db\s*\.update\(shopItems/);
+    expect(src).not.toMatch(/db\s*\.update\(redemptions/);
+    expect(src).not.toMatch(/db\s*\.update\(playerProfiles/);
+    expect(src).not.toMatch(/db\s*\.update\(user\b/);
+  });
+
+  it('NO borra filas de ninguna tabla', () => {
+    expect(src).not.toMatch(/db\s*\.delete/);
+  });
+});
+
+describe('[admin-grant-points] snapshot antes/después para auditoría', () => {
+  const src = read(SCRIPT);
+
+  it('calcula getBalance antes y después del INSERT', () => {
+    expect(src).toMatch(/getBalance/);
+    // Snapshot antes.
+    expect(src).toMatch(/const\s+before\s*=\s*await getBalance/);
+    // Verificación post.
+    expect(src).toMatch(/const\s+after\s*=\s*await getBalance/);
+  });
+
+  it('imprime resumen: usuario, steam id, user id, cantidad, reason, saldo ant/post', () => {
+    expect(src).toMatch(/Usuario:/);
+    expect(src).toMatch(/Steam ID:/);
+    expect(src).toMatch(/User ID:/);
+    expect(src).toMatch(/Cantidad:/);
+    expect(src).toMatch(/Reason:/);
+    expect(src).toMatch(/Saldo ant/);
+    expect(src).toMatch(/Saldo post/);
+  });
+});
+
+describe('[admin-grant-points] no contiene secrets hardcodeados', () => {
+  const src = read(SCRIPT);
+
+  it('no lleva claves ni cadenas Steam-token con "secret"/"key" literales', () => {
+    expect(src).not.toMatch(/DATABASE_URL\s*=\s*['"]/);
+    expect(src).not.toMatch(/RESEND_API_KEY\s*=\s*['"]/);
+    expect(src).not.toMatch(/STEAM_API_KEY\s*=\s*['"]/);
+    expect(src).not.toMatch(/BETTER_AUTH_SECRET\s*=\s*['"]/);
+  });
+
+  it('no imprime la env var de confirmación ni valores sensibles', () => {
+    // Debe usar `CONFIRM_TOKEN` como placeholder en el mensaje de error
+    // pero NUNCA loguear `process.env.DATABASE_URL` u otros secretos.
+    expect(src).not.toMatch(/console\.\w+\([^)]*process\.env\.(?!CONFIRM_ADMIN_GRANT_POINTS\b)/);
+  });
+});
+
+describe('[admin-grant-points] alineado con el patrón del resto de scripts', () => {
+  it('usa el mismo estilo CONFIRM_...=I_ACCEPT_... que los otros scripts destructivos/DB', () => {
+    const src = read(SCRIPT);
+    expect(src).toMatch(/CONFIRM_ADMIN_GRANT_POINTS/);
+    expect(src).toMatch(/I_ACCEPT_GRANT_POINTS/);
+  });
+
+  it('los 4 scripts protegidos siguen el mismo patrón', () => {
+    for (const rel of [
+      'scripts/seed-giveaway-platform.ts',
+      'scripts/seed-socialpro-rewards-steam.ts',
+      'scripts/cleanup-legacy-shop-items.ts',
+      'scripts/admin-grant-points.ts',
+    ]) {
+      const src = read(rel);
+      expect(src).toMatch(/CONFIRM_[A-Z_]+/);
+      expect(src).toMatch(/I_ACCEPT_[A-Z_]+/);
+      expect(src).toMatch(/process\.exit\(1\)/);
+    }
+  });
+});


### PR DESCRIPTION
Herramienta interna para conceder puntos SocialPro a un usuario concreto. **CLI dev/staff only. Sin UI pública, sin endpoints, sin migraciones.**

## Auditoría previa

- \`coin_transactions.source\` varchar(20) ya soporta \`'admin'\` (tipo \`CoinSource\` lo define). Sin migración.
- Balance = SUM(coin_transactions.amount) — ledger append-only. El script inserta UNA fila positiva, nunca actualiza balances cacheados.
- Identificación por Steam ID (recomendado) o \`user.id\` (auth Better Auth).
- Sin script previo similar — sigue el patrón de \`seed-*\`, \`cleanup-*\`.

## Comando exacto (dar 1000 puntos a un usuario)

\`\`\`bash
CONFIRM_ADMIN_GRANT_POINTS=I_ACCEPT_GRANT_POINTS \
  npx tsx --env-file=.env.local scripts/admin-grant-points.ts \
  --steam-id 76561198XXXXXXXXX \
  --amount 1000 \
  --reason "Test canje Glock-18 Block-18 (800 pts)"
\`\`\`

## Guards de seguridad

- ❌ Bloqueado en CI, Vercel build, \`NODE_ENV=production\`, \`GITHUB_ACTIONS\`.
- ❌ Sin \`CONFIRM_ADMIN_GRANT_POINTS=I_ACCEPT_GRANT_POINTS\` → \`exit 1\`.
- ❌ \`amount <= 0\` o \`amount > 100.000\` → error (hard-cap contra typos).
- ❌ \`reason\` vacío o > 200 chars → error.
- ❌ \`--steam-id\` y \`--user-id\` mutuamente exclusivos.
- ❌ Amount negativos NO permitidos — rollback vía SQL manual documentado.
- ✅ Resuelve usuario via DB, nunca confía en args crudos.
- ✅ Snapshot antes/después impreso siempre.
- ✅ Inserta UNA fila en \`coin_transactions\` con source='admin'.
- ✅ NUNCA UPDATE sobre \`shopItems\`/\`redemptions\`/\`playerProfiles\`/\`user\`.
- ✅ NUNCA \`db.delete\`.

## Documentación

\`docs/admin-points-operations.md\`:
- Cuándo usar / cuándo NO usar.
- Cómo buscar usuario.
- Comando ejemplo + salida esperada.
- Flujo completo de prueba de canje Glock-18 Block-18.
- Riesgos y prevenciones.
- **Rollback**: transacción negativa compensatoria via SQL manual (el script actual NO permite amount negativo por diseño; añadir bandera \`--allow-negative\` en el futuro requeriría OK explícito).
- Consulta SQL de auditoría.

## Archivos

- \`scripts/admin-grant-points.ts\` (nuevo).
- \`docs/admin-points-operations.md\` (nuevo).
- \`src/__tests__/server/admin-grant-points-script.test.ts\` (nuevo, 26 asserts).

## Qué NO cambia

Schema · migraciones · balances existentes · redemptions · shop_items · providers · auth · legales · UI pública. **No hay endpoint público.**

## Checks

- \`npx tsc --noEmit\` → 0 errores.
- \`npx jest\` → **158 suites / 2950 tests verdes** (+26).
- ESLint → 0 errores.

## Riesgos

- **Bajo**: script no llama Steam ni providers. Solo escribe una fila en el ledger. Guards múltiples contra typos/CI.
- **Filtración token confirmación**: no es un secreto (es check de intención). La vulnerabilidad real es acceso a \`.env.local\` (DATABASE_URL) — ya está en \`.gitignore\`.
- **Rollback tardío**: si te equivocas, patrón compensatorio SQL documentado.

## Ejecución

**No lo ejecuto sin tu OK explícito**. Cuando quieras, dime cuántos puntos quieres, tu Steam ID y el reason, y lo lanzo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)