### PR TITLE
feat(sorteos): placeholder 'Misiones YouTube · Próximamente'

### DIFF
--- a/src/__tests__/server/missions-youtube-placeholder.test.ts
+++ b/src/__tests__/server/missions-youtube-placeholder.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Contratos del placeholder "Misiones YouTube · Próximamente".
+ *
+ * Regla dura: es un componente meramente visual. NO tiene botón de
+ * reclamar, verificar ni conectar. NO ejecuta lógica ni fetch. NO
+ * concede puntos ni simula verificación.
+ *
+ * Cuando arranque la fase 2 (OAuth Google + YouTube Data API v3) se
+ * sustituye por la card real. Este placeholder existe solo para
+ * comunicar la ausencia intencional.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(__dirname, '..', '..', '..');
+const read = (rel: string) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');
+
+const COMPONENT = 'src/features/giveaway-platform/components/MissionsGrid.tsx';
+const CSS = 'src/app/sorteos/plataforma/platform-missions-yt-placeholder.css';
+const LAYOUT = 'src/app/sorteos/layout.tsx';
+
+describe('[missions-yt-placeholder] wiring básico', () => {
+  it('MissionsGrid.tsx renderiza <YoutubeMissionsPlaceholder />', () => {
+    const src = read(COMPONENT);
+    expect(src).toMatch(/function YoutubeMissionsPlaceholder/);
+    expect(src).toMatch(/<YoutubeMissionsPlaceholder\s*\/>/);
+  });
+
+  it('el placeholder se monta al final del <>...</>, después del botón "Ver más"', () => {
+    const src = read(COMPONENT);
+    const idxMore = src.indexOf('gp-missions-more');
+    const idxPlaceholder = src.indexOf('<YoutubeMissionsPlaceholder');
+    expect(idxMore).toBeGreaterThan(-1);
+    expect(idxPlaceholder).toBeGreaterThan(idxMore);
+  });
+
+  it('CSS existe y lo importa el layout raíz', () => {
+    expect(fs.existsSync(path.join(ROOT, CSS))).toBe(true);
+    const src = read(LAYOUT);
+    expect(src).toMatch(/import\s+['"]\.\/plataforma\/platform-missions-yt-placeholder\.css['"]/);
+  });
+});
+
+describe('[missions-yt-placeholder] copy visible correcto', () => {
+  const src = read(COMPONENT);
+
+  it('title contiene "Misiones YouTube" + "Próximamente"', () => {
+    expect(src).toMatch(/Misiones YouTube/);
+    expect(src).toMatch(/Próximamente/);
+  });
+
+  it('descripción explica que se conecta la cuenta y se ganan puntos verificando', () => {
+    expect(src).toMatch(/Conecta tu cuenta y completa acciones verificables/);
+    // Menciona los dos ejemplos que documentamos.
+    expect(src).toMatch(/suscribirte a un canal/);
+    expect(src).toMatch(/comentar en un vídeo/);
+  });
+
+  it('deja claro que la integración está en preparación', () => {
+    expect(src).toMatch(/verificación sea real y segura|preparando la integración/i);
+  });
+});
+
+describe('[missions-yt-placeholder] NO tiene botón de reclamar ni verificar', () => {
+  it('NO hay <button> dentro de YoutubeMissionsPlaceholder', () => {
+    const src = read(COMPONENT);
+    const fnBody = src.match(/function YoutubeMissionsPlaceholder[\s\S]*?^}$/m)?.[0] ?? '';
+    expect(fnBody.length).toBeGreaterThan(80);
+    expect(fnBody).not.toMatch(/<button[\s>]/);
+  });
+
+  it('NO hay <a href> (nada clickable dentro del componente)', () => {
+    const src = read(COMPONENT);
+    const fnBody = src.match(/function YoutubeMissionsPlaceholder[\s\S]*?^}$/m)?.[0] ?? '';
+    expect(fnBody).not.toMatch(/<a\s+href=/);
+    // Tampoco un onClick handler nativo.
+    expect(fnBody).not.toMatch(/onClick/);
+  });
+
+  it('el copy NO contiene labels de acción como "Conectar YouTube", "Verificar misión", "Reclamar"', () => {
+    const src = read(COMPONENT);
+    const fnBody = src.match(/function YoutubeMissionsPlaceholder[\s\S]*?^}$/m)?.[0] ?? '';
+    // Estos labels solo deben aparecer cuando exista la card real.
+    expect(fnBody).not.toMatch(/Conectar YouTube/);
+    expect(fnBody).not.toMatch(/Verificar misión/);
+    expect(fnBody).not.toMatch(/\bReclamar\b/);
+  });
+});
+
+describe('[missions-yt-placeholder] NO ejecuta lógica ni fetch', () => {
+  const src = read(COMPONENT);
+
+  it('el componente no hace fetch, no importa server actions ni next/router', () => {
+    const fnBody = src.match(/function YoutubeMissionsPlaceholder[\s\S]*?^}$/m)?.[0] ?? '';
+    expect(fnBody).not.toMatch(/fetch\s*\(/);
+    expect(fnBody).not.toMatch(/useTransition|useRouter/);
+    expect(fnBody).not.toMatch(/redeemShopItem|verifyYoutubeMission|claimDailyReward/);
+  });
+
+  it('el componente no usa useEffect / useState internos (es estático)', () => {
+    const fnBody = src.match(/function YoutubeMissionsPlaceholder[\s\S]*?^}$/m)?.[0] ?? '';
+    expect(fnBody).not.toMatch(/useState|useEffect|useMemo|useCallback/);
+  });
+});
+
+describe('[missions-yt-placeholder] NO simula verificación ni promete puntos concretos', () => {
+  const src = read(COMPONENT);
+  const fnBody = src.match(/function YoutubeMissionsPlaceholder[\s\S]*?^}$/m)?.[0] ?? '';
+
+  it('NO incluye número concreto de puntos en el copy del placeholder', () => {
+    // Un texto como "gana 100 puntos" sería confuso porque el sistema
+    // todavía no verifica ni concede nada. El copy habla en genérico.
+    expect(fnBody).not.toMatch(/\b\d+\s*puntos/);
+  });
+
+  it('NO usa palabras que sugieran acción "completed", "ganaste", "verificado"', () => {
+    expect(fnBody).not.toMatch(/completed|verificado|ganaste|has ganado/i);
+  });
+});
+
+describe('[missions-yt-placeholder] CSS scoped y sin efectos globales', () => {
+  const css = read(CSS);
+
+  it('todas las reglas están scoped bajo .giveaway-platform', () => {
+    // Capturamos el selector completo hasta el primer espacio o `{`.
+    const rules = css.match(/^\.\S+/gm) ?? [];
+    for (const rule of rules) {
+      expect(rule).toMatch(/^\.giveaway-platform/);
+    }
+  });
+
+  it('define título, icon, body y badge Próximamente', () => {
+    expect(css).toMatch(/\.gp-missions-yt-placeholder\s*\{/);
+    expect(css).toMatch(/\.gp-missions-yt-icon\s*\{/);
+    expect(css).toMatch(/\.gp-missions-yt-body\s*\{/);
+    expect(css).toMatch(/\.gp-missions-yt-soon\s*\{/);
+  });
+
+  it('incluye ajuste responsive en 480px', () => {
+    expect(css).toMatch(/@media\s*\(max-width:\s*480px\)/);
+  });
+
+  it('no filtra secretos ni URLs de OAuth Google (no aplica aún)', () => {
+    expect(css).not.toMatch(/GOOGLE_CLIENT_ID|GOCSPX-|accounts\.google\.com\/o\/oauth2/);
+  });
+});
+
+describe('[missions-yt-placeholder] no toca lógica ni schema de misiones', () => {
+  it('platform_missions schema no cambia', () => {
+    const schema = read('src/db/schema/platformMissions.ts');
+    // Se conservan los tipos base — no se meten aquí los youtube_* prematuros.
+    expect(schema).not.toMatch(/youtube_subscribe|youtube_comment/);
+  });
+
+  it('MissionConditionType type no ha añadido tipos youtube', () => {
+    const types = read('src/types/giveawayPlatform.ts');
+    expect(types).not.toMatch(/youtube_subscribe|youtube_comment/);
+  });
+
+  it('src/lib/env.ts no añade GOOGLE_CLIENT_ID/SECRET ni redirect', () => {
+    const env = read('src/lib/env.ts');
+    expect(env).not.toContain('GOOGLE_CLIENT_ID');
+    expect(env).not.toContain('GOOGLE_CLIENT_SECRET');
+    expect(env).not.toContain('GOOGLE_OAUTH_REDIRECT_URL');
+    expect(env).not.toContain('TOKEN_ENCRYPTION_KEY');
+  });
+});

--- a/src/app/sorteos/layout.tsx
+++ b/src/app/sorteos/layout.tsx
@@ -13,6 +13,7 @@ import './plataforma/platform-brand-leds.css';
 import './plataforma/platform-fx.css';
 import './plataforma/platform-widgets.css';
 import './plataforma/platform-rewards-upcoming.css';
+import './plataforma/platform-missions-yt-placeholder.css';
 import './plataforma/platform-external-giveaways.css';
 import './plataforma/platform-profile.css';
 import './plataforma/platform-creator-profile.css';

--- a/src/app/sorteos/plataforma/platform-missions-yt-placeholder.css
+++ b/src/app/sorteos/plataforma/platform-missions-yt-placeholder.css
@@ -1,0 +1,72 @@
+/*
+ * Placeholder informativo — misiones YouTube "Próximamente".
+ *
+ * Componente meramente visual sin lógica ni CTA. Se retira o se
+ * sustituye por la card real cuando arranque la fase 2 (OAuth Google
+ * + verificación via YouTube Data API v3). Ver
+ * `docs/youtube-missions-verification.md`.
+ *
+ * Scoped bajo `.giveaway-platform`. Cargado desde el layout raíz.
+ */
+
+.giveaway-platform .gp-missions-yt-placeholder {
+  margin-top: 20px;
+  padding: 18px 20px;
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  border-radius: 14px;
+  background:
+    radial-gradient(400px 220px at 100% 0%, rgba(255, 87, 87, 0.10), transparent 65%),
+    rgba(11, 8, 20, 0.55);
+  border: 1px dashed rgba(255, 87, 87, 0.35);
+}
+
+.giveaway-platform .gp-missions-yt-icon {
+  font-size: 26px;
+  line-height: 1;
+  flex-shrink: 0;
+  filter: drop-shadow(0 0 8px rgba(255, 87, 87, 0.35));
+}
+
+.giveaway-platform .gp-missions-yt-body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.giveaway-platform .gp-missions-yt-title {
+  font-family: var(--font-display), var(--font-rajdhani), sans-serif;
+  font-weight: 800;
+  font-size: 15px;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+  color: #fff;
+}
+
+.giveaway-platform .gp-missions-yt-soon {
+  color: #ff9a9a;
+  font-weight: 800;
+  letter-spacing: 1px;
+  margin-left: 4px;
+}
+
+.giveaway-platform .gp-missions-yt-desc {
+  margin: 0;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.55;
+  max-width: 720px;
+}
+
+/* Responsive — ajuste móvil sin sobrecargar el bloque genérico. */
+@media (max-width: 480px) {
+  .giveaway-platform .gp-missions-yt-placeholder {
+    padding: 14px 16px;
+    gap: 12px;
+  }
+  .giveaway-platform .gp-missions-yt-icon { font-size: 22px; }
+  .giveaway-platform .gp-missions-yt-title { font-size: 13.5px; }
+  .giveaway-platform .gp-missions-yt-desc { font-size: 12.5px; }
+}

--- a/src/features/giveaway-platform/components/MissionsGrid.tsx
+++ b/src/features/giveaway-platform/components/MissionsGrid.tsx
@@ -70,6 +70,40 @@ export function MissionsGrid({ missions }: Props) {
           {expanded ? 'Ver menos' : `Ver ${rest.length} misiones más`}
         </button>
       ) : null}
+      <YoutubeMissionsPlaceholder />
     </>
+  );
+}
+
+/**
+ * Placeholder informativo — misiones YouTube "Próximamente".
+ *
+ * NO tiene botón de reclamar, verificar ni conectar. NO concede puntos.
+ * NO simula verificación. Sólo comunica que la fase 2 (OAuth Google +
+ * verificación real vía YouTube Data API v3) está en preparación.
+ *
+ * Ver `docs/youtube-missions-verification.md` para el plan por fases.
+ */
+function YoutubeMissionsPlaceholder() {
+  return (
+    <div
+      className="gp-missions-yt-placeholder"
+      role="note"
+      aria-label="Misiones YouTube próximamente"
+    >
+      <div className="gp-missions-yt-icon" aria-hidden>
+        📺
+      </div>
+      <div className="gp-missions-yt-body">
+        <div className="gp-missions-yt-title">
+          Misiones YouTube <span className="gp-missions-yt-soon">· Próximamente</span>
+        </div>
+        <p className="gp-missions-yt-desc">
+          Conecta tu cuenta y completa acciones verificables (suscribirte a un canal,
+          comentar en un vídeo) para ganar puntos. Estamos preparando la integración
+          para que la verificación sea real y segura.
+        </p>
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
Añade bloque informativo al final de la sección Misiones. **UI-only.** Sin lógica, sin OAuth, sin verificación, sin conceder puntos. Sustituible cuando arranque la fase 2.

## Copy visible

Al final del grid de Misiones aparece:

> 📺 **Misiones YouTube · Próximamente**
>
> Conecta tu cuenta y completa acciones verificables (suscribirte a un canal, comentar en un vídeo) para ganar puntos. Estamos preparando la integración para que la verificación sea real y segura.

## Reglas duras

- ❌ No hay botón "Conectar YouTube", "Verificar misión", "Reclamar".
- ❌ No hay \`<a href>\` clickable.
- ❌ No hay \`onClick\`, \`useState\`, \`useEffect\`, \`fetch\`.
- ❌ No incluye número concreto de puntos (nada de "gana 100 puntos").
- ❌ No usa palabras que sugieran acción ("completed", "ganaste", "verificado").
- ❌ No importa server actions ni router.
- ❌ Icono neutro 📺 — sin logo oficial YouTube (evita issues de branding + scope sensible).

## Archivos tocados

- \`src/features/giveaway-platform/components/MissionsGrid.tsx\` — nuevo componente interno \`YoutubeMissionsPlaceholder\` al final del \`<>...</>\`.
- \`src/app/sorteos/plataforma/platform-missions-yt-placeholder.css\` (nuevo) — CSS scoped bajo \`.giveaway-platform\`, incluye responsive 480px.
- \`src/app/sorteos/layout.tsx\` — import del CSS nuevo.
- \`src/__tests__/server/missions-youtube-placeholder.test.ts\` (nuevo, 20 asserts).

## Qué NO cambia

- Schema \`platform_missions\` intacto.
- \`env.ts\` intacto (sin \`GOOGLE_CLIENT_ID\`, \`GOOGLE_CLIENT_SECRET\`, \`GOOGLE_OAUTH_REDIRECT_URL\`, \`TOKEN_ENCRYPTION_KEY\`).
- \`src/lib/auth.ts\` intacto (sin plugin Google).
- Rutas API intactas.
- Legales intactos.
- Tipo \`MissionConditionType\` intacto (sin youtube_subscribe/comment).

## Checks

- \`npx tsc --noEmit\` → 0 errores.
- \`npx jest\` → **160 suites / 3000 tests verdes** (+20).
- ESLint → 0 errores.

## Preview

Se despliega al abrir el PR. Verificar en:
- \`/sorteos/zacketizor#misiones\` — placeholder al final del grid.
- Comportamiento móvil (padding + tipografía reducidos en 480px).

**No mergear sin OK visual.**

Cuando arranque la fase 2 (OAuth Google + YouTube Data API v3, ver \`docs/youtube-missions-verification.md\`) este placeholder se sustituye por las cards reales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)