### PR TITLE
feat(sorteos): Twitch Fase B — misión verificable "Sigue en Twitch"

### DIFF
--- a/docs/twitch-mission-fase-b.md
+++ b/docs/twitch-mission-fase-b.md
@@ -1,0 +1,172 @@
+# Twitch Misiones · Fase B · Setup y Runbook
+
+Fase B añade la segunda misión social **verificable** de SocialPro Giveaways: **"Sigue a ZACKETIZOR en Twitch"** → +100 puntos. Sigue exactamente el patrón de Discord Fase A: OAuth de usuario, verificación real vía Helix, sin scraping y sin endpoints no oficiales.
+
+> **Alcance Fase B:** solo Twitch, solo `follow` (nunca subs de pago), solo un creador (`zacketizor`). Kick sigue aparcado (no expone endpoint público para verificar follow).
+
+## 1. Configuración en Twitch Developer Console
+
+Owner: Zack / SocialPro. Se hace una vez.
+
+1. Entra en https://dev.twitch.tv/console/apps.
+2. **Register Your Application**:
+   - Name: `SocialPro Giveaways`.
+   - **OAuth Redirect URLs** (una por entorno):
+     - Producción: `https://socialpro.es/api/auth/social/twitch/callback`
+     - Preview: `https://<preview-slug>.vercel.app/api/auth/social/twitch/callback`
+     - Local: `http://localhost:3000/api/auth/social/twitch/callback`
+   - Category: `Application Integration` (o la que más se aproxime).
+   - Client Type: **Confidential** (importante — necesitamos `client_secret`).
+3. Copia el **Client ID** que aparece tras crearla → variable `TWITCH_CLIENT_ID`.
+4. **New Secret** → genera el **Client Secret** → variable `TWITCH_CLIENT_SECRET`. Sólo se muestra una vez.
+
+> Si ya existe una app Twitch en tu cuenta para el servicio server-to-server (`sync-metrics`, `poll-live-status`), puedes **reutilizar el mismo Client ID/Secret** aquí; solo necesitas asegurarte de que la OAuth Redirect URL de user OAuth también está declarada.
+
+## 2. Broadcaster ID e URL del canal
+
+El `broadcaster_id` es el user ID Helix (numérico) del canal objetivo. Se obtiene una sola vez:
+
+```bash
+# 1) Consigue un app access token
+curl -X POST 'https://id.twitch.tv/oauth2/token' \
+  -d "client_id=$TWITCH_CLIENT_ID" \
+  -d "client_secret=$TWITCH_CLIENT_SECRET" \
+  -d "grant_type=client_credentials"
+# → { "access_token": "abcd...", ... }
+
+# 2) Resuelve el login "zacketizor" a su user ID
+curl 'https://api.twitch.tv/helix/users?login=zacketizor' \
+  -H "Authorization: Bearer <access_token>" \
+  -H "Client-Id: $TWITCH_CLIENT_ID"
+# → { "data": [{ "id": "1234567890", "login": "zacketizor", ... }] }
+```
+
+- Guarda el `id` en env: `TWITCH_ZACKETIZOR_BROADCASTER_ID=1234567890`.
+- La URL del canal es simplemente `https://www.twitch.tv/zacketizor` → env `TWITCH_ZACKETIZOR_CHANNEL_URL`.
+
+## 3. Clave de cifrado de tokens (reutilizada)
+
+Fase B **reutiliza** la misma `TOKEN_ENCRYPTION_KEY` que Discord Fase A. No hace falta generar una nueva. Los tokens Twitch se cifran con la misma primitiva AES-256-GCM.
+
+## 4. Env vars completas
+
+3 nuevas de Twitch, más las 2 que ya existían para el servicio server-to-server.
+
+```env
+# OAuth Twitch (usuario) — mismos client_id/secret que el servicio de sync.
+TWITCH_CLIENT_ID=xxxxxxxxxxxxxxxxx
+TWITCH_CLIENT_SECRET=yyyyyyyyyyyyyyyy
+TWITCH_OAUTH_REDIRECT_URL=https://socialpro.es/api/auth/social/twitch/callback
+
+# Target ZACKETIZOR (broadcaster_id + URL canal).
+TWITCH_ZACKETIZOR_BROADCASTER_ID=1234567890
+TWITCH_ZACKETIZOR_CHANNEL_URL=https://www.twitch.tv/zacketizor
+```
+
+`TOKEN_ENCRYPTION_KEY` ya está poblada (Fase A).
+
+## 5. Migración
+
+**No hace falta migración nueva.** Fase B reutiliza:
+- `connected_social_accounts` (con `provider = 'twitch'`).
+- `platform_missions` con `provider`, `target_id`, `target_url`, `verification_mode` (columnas añadidas en `0104`).
+- `mission_verification_attempts` para rate limit + auditoría.
+- `mission_claims` con su UNIQUE `(mission_id, user_id)`.
+
+## 6. Seed idempotente
+
+```bash
+CONFIRM_SEED_TWITCH_MISSION=I_ACCEPT_TWITCH_MISSION \
+  npx tsx --env-file=.env.local scripts/seed-twitch-mission-zacketizor.ts
+```
+
+Inserta o actualiza la misión con `title = "Sigue a ZACKETIZOR en Twitch"`, `rewardCoins = 100`, `provider = 'twitch'`, `verification_mode = 'twitch_follow_channel'`.
+
+Sin ese guard exacto el script sale con `exit 1`.
+
+## 7. Flujo end-to-end (Player)
+
+1. Jugador entra en `/sorteos` con Steam.
+2. Ve la card Twitch de la misión: "Abrir Twitch" + "Conectar Twitch".
+3. Pulsa **Conectar Twitch** → `GET /api/auth/social/twitch/connect`:
+   - Genera `state` 32 bytes hex.
+   - Cookie `sp_twitch_oauth_state` httpOnly + sameSite=Lax + TTL 10 min.
+   - Redirige a `https://id.twitch.tv/oauth2/authorize?scope=user:read:follows&force_verify=true&...`.
+4. Twitch pide consentimiento y redirige a `/api/auth/social/twitch/callback?code=...&state=...`.
+5. El callback:
+   - Verifica `state` cookie (CSRF).
+   - Intercambia `code` → `access_token` (+ `refresh_token` que **descartamos**).
+   - Fetchea `GET /helix/users` (usuario del token) para conseguir `id`, `login`, `display_name`.
+   - **Cifra** el `access_token` con AES-256-GCM.
+   - `INSERT/UPDATE` en `connected_social_accounts` con `disconnected_at = NULL`, `expires_at = now + expires_in`.
+   - Redirige a `/sorteos/perfil?twitch_status=ok`.
+6. En la card Twitch de `/sorteos` aparece ahora **"Verificar misión"**.
+7. Pulsa **Verificar misión** → server action `verifyTwitchMission`:
+   - Sesión Better Auth.
+   - Bloquea si ya reclamó (`mission_claims`).
+   - Rate limit 30s entre intentos por (mission, user).
+   - Cuenta Twitch conectada + token no caducado.
+   - Descifra el token.
+   - `GET https://api.twitch.tv/helix/channels/followed?user_id=<connected_user_id>&broadcaster_id=<target>` con `Authorization: Bearer` y `Client-Id`.
+   - Si `data[]` contiene el `broadcaster_id` → el jugador sigue.
+   - **INSERT** en `mission_claims` (UNIQUE evita doble claim en race).
+   - **INSERT** en `coin_transactions` con `source='mision'` y `amount=100`.
+   - Registra `success` en `mission_verification_attempts`.
+   - `revalidatePath('/sorteos', 'layout')`.
+
+Outcomes registrados en `mission_verification_attempts`:
+
+| outcome | significado |
+|---|---|
+| `success` | seguía el canal y puntos concedidos |
+| `not_verified` | Helix confirma que NO sigue el broadcaster objetivo |
+| `not_connected` | jugador aún no ha hecho OAuth |
+| `token_expired` | token caducado (Twitch ~4h), pedir reconectar |
+| `rate_limited` | intento bloqueado por el cooldown 30s |
+| `api_error` | fallo temporal Helix (5xx/timeout/rate limit externa) |
+| `invalid` | estado inconsistente (misión sin provider, etc.) |
+
+## 8. Seguridad y privacidad
+
+- **Scope mínimo:** `user:read:follows`. NO pedimos `user:read:subscriptions`, ni `chat:*`, ni scopes de moderación.
+- **NO subs de pago.** La misión es follow → gratis para el jugador.
+- **Token cifrado en reposo:** AES-256-GCM (misma clave que Discord).
+- **Fase B NO guarda `refresh_token`.** El access token de Twitch dura ~4h. Cuando caduque, la UI muestra "Reconectar Twitch" y el jugador vuelve a autorizar con un clic. Trade-off aceptado — evita gestionar el ciclo de refresh (que introduce nueva superficie).
+- **NO se guarda la lista de canales seguidos.** El endpoint `GET /helix/channels/followed` se llama **con filtro por `broadcaster_id`**, así que Helix solo devuelve la fila relevante (si sigue) o vacío. Se procesa en memoria y se descarta.
+- **NO logueamos tokens ni ciphertext.** Los tests estructurales bloquean regresiones.
+- **CSRF:** state cookie httpOnly + sameSite=Lax + single-use.
+- **Rate limit:** 30s entre intentos por (mission, user), sobre TODOS los intentos.
+- **NO scraping.** Solo endpoints oficiales `id.twitch.tv/oauth2` y `api.twitch.tv/helix`.
+- **NO endpoints deprecated.** Twitch retiró `/helix/users/follows` en agosto 2023; usamos el sustituto oficial `/helix/channels/followed` con `user:read:follows`.
+
+## 9. Runbook operativo
+
+**Añadir un creador nuevo:**
+1. Sacar broadcaster_id con `curl /helix/users?login=<slug>` (paso 2 arriba).
+2. Añadir en Vercel + `.env.local`: `TWITCH_<CREATOR>_BROADCASTER_ID` y `TWITCH_<CREATOR>_CHANNEL_URL`.
+3. Registrar ambas en `src/lib/env.ts` como `z.string().optional()` con regex adecuada.
+4. Añadir `case '<creator-slug>':` en `getTwitchMissionTarget` (`twitch-missions.ts`).
+5. Crear seed análogo a `scripts/seed-twitch-mission-zacketizor.ts` para el título correcto.
+
+**Rotar client secret:**
+1. Twitch Developer Console → **New Secret** (invalida el actual).
+2. Actualizar `TWITCH_CLIENT_SECRET` en Vercel y `.env.local`.
+3. Los usuarios ya conectados siguen operando (Helix acepta el `access_token` emitido, no re-verifica el secret).
+
+**Debug de un usuario que no consigue verificar:**
+1. `SELECT outcome, attempted_at FROM mission_verification_attempts WHERE user_id = '<sub>' ORDER BY attempted_at DESC LIMIT 10;`.
+2. Si `token_expired` reiteradamente → pedir reconexión desde la UI ("Reconectar Twitch").
+3. Si `not_verified` reiteradamente → confirmar con `curl` desde tu propia cuenta:
+   ```bash
+   curl -H "Authorization: Bearer <token>" -H "Client-Id: $TWITCH_CLIENT_ID" \
+     "https://api.twitch.tv/helix/channels/followed?user_id=<user>&broadcaster_id=<target>"
+   ```
+
+## 10. Qué NO cubre Fase B
+
+- Kick (sigue aparcado; no expone endpoint público para verificar follow).
+- YouTube (pendiente de OAuth Google + YouTube Data API v3, no arrancado).
+- Subs de pago Twitch (fuera de scope legal/producto).
+- Auto-refresh del access token (política: reconexión manual).
+- Panel admin para métricas de verificación (usar SQL directo).
+- Multi-canal por creador (una misión, un broadcaster).

--- a/scripts/seed-twitch-mission-zacketizor.ts
+++ b/scripts/seed-twitch-mission-zacketizor.ts
@@ -1,0 +1,107 @@
+/**
+ * Seed misión Twitch "Sigue el canal de ZACKETIZOR en Twitch".
+ *
+ * ============================================================
+ * NUNCA se ejecuta automáticamente. Requiere env var explícita:
+ *   CONFIRM_SEED_TWITCH_MISSION=I_ACCEPT_TWITCH_MISSION
+ *
+ * Comando real:
+ *   CONFIRM_SEED_TWITCH_MISSION=I_ACCEPT_TWITCH_MISSION \
+ *     npx tsx --env-file=.env.local scripts/seed-twitch-mission-zacketizor.ts
+ * ============================================================
+ *
+ * Requisitos previos (env `.env.local`):
+ *   TWITCH_CLIENT_ID
+ *   TWITCH_CLIENT_SECRET
+ *   TWITCH_OAUTH_REDIRECT_URL
+ *   TOKEN_ENCRYPTION_KEY (compartido con Discord Fase A)
+ *   TWITCH_ZACKETIZOR_BROADCASTER_ID
+ *   TWITCH_ZACKETIZOR_CHANNEL_URL
+ *
+ * Idempotente:
+ *   - Si ya existe una misión con `title === TITLE` NO la duplica.
+ *   - Actualiza `rewardCoins`, `provider`, `targetId`, `targetUrl`,
+ *     `verificationMode`, `isActive`, `sortOrder` a valores canónicos.
+ */
+import { eq } from 'drizzle-orm';
+import { db } from '../src/lib/db';
+import { platformMissions } from '../src/db/schema';
+import { env } from '../src/lib/env';
+import { TWITCH_FOLLOW_CHANNEL_MODE } from '../src/features/giveaway-platform/constants/twitch-missions';
+
+const CONFIRM_TOKEN = 'I_ACCEPT_TWITCH_MISSION';
+const TITLE = 'Sigue a ZACKETIZOR en Twitch';
+const REWARD_COINS = 100;
+// Discord ZACKETIZOR va con sortOrder=0. Ponemos Twitch inmediatamente
+// después para que aparezca en el top junto a Discord.
+const SORT_ORDER = 0;
+
+async function main() {
+  if (process.env.CONFIRM_SEED_TWITCH_MISSION !== CONFIRM_TOKEN) {
+    console.error(
+      'Seed abortado. Requiere env var explícita:\n' +
+      `  CONFIRM_SEED_TWITCH_MISSION=${CONFIRM_TOKEN} npx tsx --env-file=.env.local scripts/seed-twitch-mission-zacketizor.ts\n\n` +
+      'Motivo: este seed INSERTA/UPDATE una misión operativa que concede\n' +
+      'puntos reales tras verificación OAuth Twitch. Se ejecuta a mano.',
+    );
+    process.exit(1);
+  }
+
+  const broadcasterId = env.TWITCH_ZACKETIZOR_BROADCASTER_ID;
+  const channelUrl = env.TWITCH_ZACKETIZOR_CHANNEL_URL;
+  if (!broadcasterId || !channelUrl) {
+    console.error(
+      'Faltan env vars requeridas:\n' +
+      '  TWITCH_ZACKETIZOR_BROADCASTER_ID (numérico Helix user ID)\n' +
+      '  TWITCH_ZACKETIZOR_CHANNEL_URL (https://www.twitch.tv/<login>)',
+    );
+    process.exit(1);
+  }
+
+  const existing = await db.query.platformMissions.findFirst({
+    where: eq(platformMissions.title, TITLE),
+  });
+
+  const description = `Sigue el canal de ZACKETIZOR en Twitch y gana ${REWARD_COINS} puntos. Verificamos que le sigues en tiempo real vía OAuth Twitch.`;
+
+  if (existing) {
+    await db
+      .update(platformMissions)
+      .set({
+        description,
+        conditionType: 'external_verified',
+        goal: 1,
+        rewardCoins: REWARD_COINS,
+        isActive: true,
+        sortOrder: SORT_ORDER,
+        provider: 'twitch',
+        targetId: broadcasterId,
+        targetUrl: channelUrl,
+        verificationMode: TWITCH_FOLLOW_CHANNEL_MODE,
+      })
+      .where(eq(platformMissions.id, existing.id));
+    console.log(`Misión Twitch actualizada (id=${existing.id})`);
+    return;
+  }
+
+  const inserted = await db
+    .insert(platformMissions)
+    .values({
+      title: TITLE,
+      description,
+      conditionType: 'external_verified',
+      goal: 1,
+      rewardCoins: REWARD_COINS,
+      isActive: true,
+      sortOrder: SORT_ORDER,
+      provider: 'twitch',
+      targetId: broadcasterId,
+      targetUrl: channelUrl,
+      verificationMode: TWITCH_FOLLOW_CHANNEL_MODE,
+    })
+    .returning({ id: platformMissions.id });
+
+  console.log(`Misión Twitch creada (id=${inserted[0]?.id ?? 'unknown'})`);
+}
+
+main().then(() => process.exit(0)).catch((e) => { console.error(e); process.exit(1); });

--- a/src/__tests__/server/social-missions-audit-doc.test.ts
+++ b/src/__tests__/server/social-missions-audit-doc.test.ts
@@ -172,12 +172,13 @@ describe('[social-missions-audit] fuentes citadas', () => {
  *     integra vía rutas propias `/api/auth/social/discord/*`, no vía
  *     plugin de Better Auth).
  */
-describe('[social-missions-audit] Fase A Discord implementada, Twitch/Kick aún no', () => {
-  it('env.ts añade DISCORD_* y TOKEN_ENCRYPTION_KEY, no Kick', () => {
+describe('[social-missions-audit] Fase A Discord + Fase B Twitch implementadas, Kick aún no', () => {
+  it('env.ts añade DISCORD_* y TWITCH_* Fase B y TOKEN_ENCRYPTION_KEY, no Kick', () => {
     const envSrc = read('src/lib/env.ts');
     expect(envSrc).toContain('DISCORD_CLIENT_ID');
+    expect(envSrc).toContain('TWITCH_OAUTH_REDIRECT_URL');
     expect(envSrc).toContain('TOKEN_ENCRYPTION_KEY');
-    // Kick sigue fuera de scope en Fase A.
+    // Kick sigue fuera de scope.
     expect(envSrc).not.toContain('KICK_CLIENT_ID');
   });
 
@@ -197,20 +198,21 @@ describe('[social-missions-audit] Fase A Discord implementada, Twitch/Kick aún 
     expect(found).toBe(true);
   });
 
-  it('existen rutas /api/auth/social/discord/{connect,callback,disconnect}', () => {
+  it('existen rutas /api/auth/social/{discord,twitch}/{connect,callback,disconnect}', () => {
     for (const rel of [
       'src/app/api/auth/social/discord/connect/route.ts',
       'src/app/api/auth/social/discord/callback/route.ts',
       'src/app/api/auth/social/discord/disconnect/route.ts',
+      'src/app/api/auth/social/twitch/connect/route.ts',
+      'src/app/api/auth/social/twitch/callback/route.ts',
+      'src/app/api/auth/social/twitch/disconnect/route.ts',
     ]) {
       expect(fs.existsSync(path.join(ROOT, rel))).toBe(true);
     }
   });
 
-  it('NO existen rutas OAuth de usuario para Twitch ni Kick (siguen fuera de scope)', () => {
-    const twitchDir = path.join(ROOT, 'src/app/api/auth/social/twitch');
+  it('NO existen rutas OAuth de usuario para Kick (sigue aparcado — API no expone follow verificable)', () => {
     const kickDir = path.join(ROOT, 'src/app/api/auth/social/kick');
-    expect(fs.existsSync(twitchDir)).toBe(false);
     expect(fs.existsSync(kickDir)).toBe(false);
   });
 
@@ -223,13 +225,10 @@ describe('[social-missions-audit] Fase A Discord implementada, Twitch/Kick aún 
     expect(authSrc).not.toMatch(/twitch.*OAuth.*(user|player)/i);
   });
 
-  it('/sorteos/privacidad aún no menciona Discord (pendiente: actualizar copy antes del go-live real)', () => {
-    // El copy legal se actualiza como paso previo al primer usuario real
-    // conectando su Discord. Fase A puede vivir en preview/staging sin
-    // tocar la política visible; en prod habrá PR de copy dedicado.
-    const priv = read('src/app/sorteos/(legal)/privacidad/page.tsx');
-    expect(priv).not.toMatch(/\bTwitch\b/);
-  });
+  // Nota: la actualización del copy de /sorteos/privacidad (mencionar
+  // Discord y Twitch como providers de OAuth) queda como PR separado
+  // antes del go-live real. Fase A/B pueden vivir en preview/staging
+  // sin tocar el copy legal público.
 });
 
 describe('[social-missions-audit] no filtra secretos de ejemplo', () => {

--- a/src/__tests__/server/twitch-mission-fase-b.test.ts
+++ b/src/__tests__/server/twitch-mission-fase-b.test.ts
@@ -1,0 +1,354 @@
+/**
+ * Contratos estructurales de Twitch Misiones — Fase B.
+ *
+ * No arranca la app real. Verifica el shape del código, dependencias e
+ * invariantes de seguridad leyendo el source-tree. Complementa los tests
+ * de integración (que en Fase B no cubrimos porque requiere OAuth real).
+ *
+ * Reglas duras que estos tests fuerzan:
+ *   1) Solo pedimos scope mínimo: `user:read:follows`. Sin subscriptions.
+ *   2) El callback verifica el `state` cookie (protección CSRF).
+ *   3) El token siempre se guarda cifrado — nunca en claro.
+ *   4) NO se persiste `refresh_token` en Fase B (política acordada).
+ *   5) La server action de verificación:
+ *      - requiere sesión Better Auth,
+ *      - hace rate limit por (missionId, userId),
+ *      - registra intentos en `mission_verification_attempts`,
+ *      - inserta claim y coin_transactions solo si el usuario sigue el
+ *        broadcaster configurado,
+ *      - jamás loguea tokens ni ciphertext.
+ *   6) NO se persiste la lista de follows del usuario (privacy).
+ *   7) UI: TwitchMissionCard tiene los CTAs canónicos (Abrir Twitch,
+ *      Conectar / Reconectar Twitch, Verificar misión).
+ *   8) Card oculta si faltan env vars.
+ *   9) Seed y doc existen.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(__dirname, '..', '..', '..');
+const read = (rel: string) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');
+const exists = (rel: string) => fs.existsSync(path.join(ROOT, rel));
+
+const P = {
+  env: 'src/lib/env.ts',
+  constants: 'src/features/giveaway-platform/constants/twitch-missions.ts',
+  routeConnect: 'src/app/api/auth/social/twitch/connect/route.ts',
+  routeCallback: 'src/app/api/auth/social/twitch/callback/route.ts',
+  routeDisconnect: 'src/app/api/auth/social/twitch/disconnect/route.ts',
+  action: 'src/app/sorteos/plataforma/twitch-mission-action.ts',
+  ui: 'src/features/giveaway-platform/components/TwitchMissionCard.tsx',
+  grid: 'src/features/giveaway-platform/components/MissionsGrid.tsx',
+  landing: 'src/features/giveaway-platform/components/PlatformCreatorLanding.tsx',
+  css: 'src/app/sorteos/plataforma/platform-twitch-mission.css',
+  layout: 'src/app/sorteos/layout.tsx',
+  seed: 'scripts/seed-twitch-mission-zacketizor.ts',
+  doc: 'docs/twitch-mission-fase-b.md',
+};
+
+describe('[twitch-fase-b] estructura de ficheros', () => {
+  it.each(Object.entries(P))('existe %s', (_key, rel) => {
+    expect(exists(rel)).toBe(true);
+  });
+});
+
+describe('[twitch-fase-b] env vars registradas', () => {
+  const src = read(P.env);
+  it.each([
+    'TWITCH_CLIENT_ID',
+    'TWITCH_CLIENT_SECRET',
+    'TWITCH_OAUTH_REDIRECT_URL',
+    'TWITCH_ZACKETIZOR_BROADCASTER_ID',
+    'TWITCH_ZACKETIZOR_CHANNEL_URL',
+  ])('env declara %s', (name) => {
+    expect(src).toContain(name);
+  });
+
+  it('reutiliza TOKEN_ENCRYPTION_KEY (no crea uno específico de Twitch)', () => {
+    expect(src).toContain('TOKEN_ENCRYPTION_KEY');
+    expect(src).not.toContain('TWITCH_TOKEN_ENCRYPTION_KEY');
+  });
+});
+
+describe('[twitch-fase-b] constants', () => {
+  const src = read(P.constants);
+
+  it('scope mínimo user:read:follows — sin subscriptions', () => {
+    expect(src).toMatch(/TWITCH_OAUTH_SCOPES\s*=\s*['"]user:read:follows['"]/);
+    // NO pedir subscriptions ni chat/messages scopes.
+    expect(src).not.toMatch(/user:read:subscriptions/);
+    expect(src).not.toMatch(/channel:read:subscriptions/);
+    expect(src).not.toMatch(/chat:read/);
+    expect(src).not.toMatch(/chat:edit/);
+  });
+
+  it('verificationMode canónico', () => {
+    expect(src).toMatch(/TWITCH_FOLLOW_CHANNEL_MODE\s*=\s*['"]twitch_follow_channel['"]/);
+  });
+
+  it('helpers isTwitchOauthConfigured + getTwitchMissionTarget presentes', () => {
+    expect(src).toMatch(/export\s+function\s+isTwitchOauthConfigured/);
+    expect(src).toMatch(/export\s+function\s+getTwitchMissionTarget/);
+  });
+});
+
+describe('[twitch-fase-b] route /connect', () => {
+  const src = read(P.routeConnect);
+
+  it('exige sesión Better Auth (401 sin login)', () => {
+    expect(src).toMatch(/auth\.api\.getSession/);
+    expect(src).toMatch(/unauthenticated|401/);
+  });
+
+  it('genera state 32-byte hex y cookie httpOnly + sameSite=lax', () => {
+    expect(src).toMatch(/randomBytes\s*\(\s*32\s*\)/);
+    expect(src).toMatch(/httpOnly:\s*true/);
+    expect(src).toMatch(/sameSite:\s*['"]lax['"]/);
+  });
+
+  it('redirige a id.twitch.tv/oauth2/authorize con response_type=code y scope canónico', () => {
+    expect(src).toMatch(/id\.twitch\.tv\/oauth2\/authorize/);
+    expect(src).toMatch(/response_type/);
+    expect(src).toMatch(/TWITCH_OAUTH_SCOPES/);
+  });
+
+  it('fail-safe: 503 si Twitch OAuth no está configurado', () => {
+    expect(src).toMatch(/isTwitchOauthConfigured/);
+    expect(src).toMatch(/twitch_oauth_not_configured/);
+    expect(src).toMatch(/503/);
+  });
+});
+
+describe('[twitch-fase-b] route /callback', () => {
+  const src = read(P.routeCallback);
+
+  it('verifica state cookie contra querystring', () => {
+    expect(src).toMatch(/sp_twitch_oauth_state/);
+    expect(src).toMatch(/state_mismatch|savedState\s*!==\s*state/);
+  });
+
+  it('borra la state cookie tras usarla (single use)', () => {
+    expect(src).toMatch(/\.delete\(['"]sp_twitch_oauth_state['"]\)/);
+  });
+
+  it('intercambia code → token con grant_type=authorization_code', () => {
+    expect(src).toMatch(/grant_type/);
+    expect(src).toMatch(/authorization_code/);
+    expect(src).toMatch(/oauth2\/token/);
+  });
+
+  it('cifra el access_token antes de persistir', () => {
+    expect(src).toMatch(/encrypt\s*\(\s*tokenData\.access_token\s*\)/);
+    expect(src).toMatch(/upsertConnectedAccount/);
+  });
+
+  it('NO guarda refresh_token (Fase B — política acordada)', () => {
+    // Ninguna llamada a encrypt sobre refresh_token, ni asignación a
+    // refreshTokenEncrypted, ni referencia a la columna en el upsert.
+    expect(src).not.toMatch(/encrypt\s*\(\s*tokenData\.refresh_token/);
+    expect(src).not.toMatch(/refreshTokenEncrypted\s*:/);
+  });
+
+  it('NO persiste la lista de canales seguidos del usuario', () => {
+    // El callback no debe llamar a /helix/channels/followed — eso pasa
+    // en la server action, en cada verificación.
+    expect(src).not.toMatch(/channels\/followed/);
+  });
+
+  it('fetch usa Client-Id header como exige Helix', () => {
+    // GET /helix/users requiere Bearer + Client-Id.
+    expect(src).toMatch(/'Client-Id'\s*:\s*clientId/);
+  });
+});
+
+describe('[twitch-fase-b] route /disconnect', () => {
+  const src = read(P.routeDisconnect);
+
+  it('requiere sesión y llama markAccountDisconnected con provider="twitch"', () => {
+    expect(src).toMatch(/getSession/);
+    expect(src).toMatch(/markAccountDisconnected\(session\.user\.id,\s*['"]twitch['"]\)/);
+  });
+
+  it('es POST, no GET (evita CSRF trivial)', () => {
+    expect(src).toMatch(/export\s+async\s+function\s+POST/);
+    expect(src).not.toMatch(/export\s+async\s+function\s+GET/);
+  });
+});
+
+describe('[twitch-fase-b] server action verifyTwitchMission', () => {
+  const src = read(P.action);
+
+  it('marca "use server"', () => {
+    expect(src.trimStart()).toMatch(/^['"]use server['"]/);
+  });
+
+  it('exige sesión Better Auth', () => {
+    expect(src).toMatch(/getSession/);
+    expect(src).toMatch(/unauthenticated/);
+  });
+
+  it('bloquea si ya reclamó (mission_claims existente)', () => {
+    expect(src).toMatch(/already_claimed/);
+  });
+
+  it('rate limit por (missionId, userId) — cutoff 30s', () => {
+    expect(src).toMatch(/RATE_LIMIT_SECONDS\s*=\s*30/);
+    expect(src).toMatch(/missionVerificationAttempts/);
+  });
+
+  it('exige provider="twitch" y verificationMode="twitch_follow_channel"', () => {
+    expect(src).toMatch(/mission\.provider\s*!==\s*['"]twitch['"]/);
+    expect(src).toMatch(/TWITCH_FOLLOW_CHANNEL_MODE/);
+  });
+
+  it('descifra el token y llama al endpoint oficial Helix con Client-Id', () => {
+    expect(src).toMatch(/decrypt\s*\(\s*account\.accessTokenEncrypted\s*\)/);
+    expect(src).toMatch(/api\.twitch\.tv\/helix\/channels\/followed/);
+    expect(src).toMatch(/'Client-Id'\s*:\s*clientId/);
+    expect(src).toMatch(/cache:\s*['"]no-store['"]/);
+  });
+
+  it('NO usa endpoints deprecated ni no oficiales (ej. `/users/follows`)', () => {
+    // Old endpoint `/helix/users/follows` fue deprecado por Twitch (Aug 2023).
+    expect(src).not.toMatch(/\/helix\/users\/follows/);
+    // Ningún endpoint fuera de api.twitch.tv o id.twitch.tv.
+    expect(src).not.toMatch(/decapi\.me/);
+    expect(src).not.toMatch(/twitchtracker/);
+  });
+
+  it('registra intento en cada outcome canónico', () => {
+    expect(src).toMatch(/recordAttempt\s*\(/);
+    expect(src).toMatch(/['"]success['"]/);
+    expect(src).toMatch(/['"]not_verified['"]/);
+    expect(src).toMatch(/['"]api_error['"]/);
+    expect(src).toMatch(/['"]token_expired['"]/);
+    expect(src).toMatch(/['"]not_connected['"]/);
+  });
+
+  it('INSERT missionClaims usa onConflictDoNothing (anti race-condition)', () => {
+    expect(src).toMatch(/onConflictDoNothing/);
+  });
+
+  it('INSERT coinTransactions con source="mision" y refId=missionId', () => {
+    expect(src).toMatch(/coinTransactions/);
+    expect(src).toMatch(/source:\s*['"]mision['"]/);
+    expect(src).toMatch(/refId:\s*missionId/);
+  });
+
+  it('NO loguea tokens ni ciphertext', () => {
+    expect(src).not.toMatch(/console\.[a-z]+\s*\([^)]*accessToken/);
+    expect(src).not.toMatch(/console\.[a-z]+\s*\([^)]*access_token/);
+    expect(src).not.toMatch(/console\.[a-z]+\s*\([^)]*Encrypted/);
+    expect(src).not.toMatch(/console\.[a-z]+\s*\([^)]*client_secret/);
+  });
+});
+
+describe('[twitch-fase-b] UI — TwitchMissionCard', () => {
+  const src = read(P.ui);
+
+  it('marca "use client"', () => {
+    expect(src.trimStart()).toMatch(/^['"]use client['"]/);
+  });
+
+  it('CTA "Conectar Twitch" apunta a /api/auth/social/twitch/connect', () => {
+    expect(src).toMatch(/\/api\/auth\/social\/twitch\/connect/);
+    expect(src).toMatch(/Conectar Twitch/);
+  });
+
+  it('CTA "Reconectar Twitch" para estado token_expired', () => {
+    expect(src).toMatch(/Reconectar Twitch/);
+    expect(src).toMatch(/token_expired/);
+  });
+
+  it('CTA "Verificar misión" llama a verifyTwitchMission', () => {
+    expect(src).toMatch(/verifyTwitchMission/);
+    expect(src).toMatch(/Verificar misión/);
+  });
+
+  it('CTA "Abrir Twitch" solo si hay channelUrl', () => {
+    expect(src).toMatch(/channelUrl \?/);
+    expect(src).toMatch(/Abrir Twitch/);
+  });
+
+  it('nota de privacidad visible', () => {
+    expect(src).toMatch(/No publicaremos nada en tu nombre/);
+  });
+});
+
+describe('[twitch-fase-b] MissionsGrid wiring Twitch', () => {
+  const src = read(P.grid);
+
+  it('renderiza TwitchMissionCard cuando hay misión provider="twitch"', () => {
+    expect(src).toMatch(/TwitchMissionCard/);
+    expect(src).toMatch(/provider === ['"]twitch['"]/);
+  });
+
+  it('mantiene el bloque Discord', () => {
+    expect(src).toMatch(/DiscordMissionCard/);
+  });
+
+  it('el placeholder YouTube sigue rendered', () => {
+    expect(src).toMatch(/<YoutubeMissionsPlaceholder/);
+  });
+});
+
+describe('[twitch-fase-b] Landing pasa twitch prop con guard 3-piezas', () => {
+  const src = read(P.landing);
+
+  it('llama getConnectedAccount con provider "twitch"', () => {
+    expect(src).toMatch(/getConnectedAccount\(userId,\s*['"]twitch['"]\)/);
+  });
+  it('pasa twitch prop a <MissionsGrid />', () => {
+    expect(src).toMatch(/<MissionsGrid[\s\S]*twitch=\{/);
+  });
+  it('guard incluye target + OAuth + cifrado (fail-safe)', () => {
+    expect(src).toMatch(/getTwitchMissionTarget/);
+    expect(src).toMatch(/isTwitchOauthConfigured/);
+    expect(src).toMatch(/isTokenEncryptionConfigured/);
+  });
+});
+
+describe('[twitch-fase-b] CSS scoped bajo .giveaway-platform', () => {
+  const src = read(P.css);
+  const layout = read(P.layout);
+
+  it('todas las reglas scoped', () => {
+    const rules = src.match(/^\.\S+/gm) ?? [];
+    for (const rule of rules) {
+      expect(rule).toMatch(/^\.giveaway-platform/);
+    }
+  });
+
+  it('el layout importa el CSS Twitch', () => {
+    expect(layout).toMatch(/platform-twitch-mission\.css/);
+  });
+});
+
+describe('[twitch-fase-b] seed script con guard', () => {
+  const src = read(P.seed);
+  it('requiere CONFIRM_SEED_TWITCH_MISSION=I_ACCEPT_TWITCH_MISSION', () => {
+    expect(src).toMatch(/CONFIRM_SEED_TWITCH_MISSION/);
+    expect(src).toMatch(/I_ACCEPT_TWITCH_MISSION/);
+  });
+  it('provider="twitch", verificationMode=twitch_follow_channel', () => {
+    expect(src).toMatch(/provider:\s*['"]twitch['"]/);
+    expect(src).toMatch(/TWITCH_FOLLOW_CHANNEL_MODE/);
+  });
+  it('rewardCoins=100', () => {
+    expect(src).toMatch(/REWARD_COINS\s*=\s*100/);
+  });
+});
+
+describe('[twitch-fase-b] doc de setup existe y tiene secciones canónicas', () => {
+  const src = read(P.doc);
+  it.each([
+    'Twitch Developer Console',
+    'Redirect URL',
+    'broadcaster.{0,3}id',
+    'Fase B',
+    'refresh',
+  ])('menciona "%s"', (needle) => {
+    expect(src).toMatch(new RegExp(needle, 'i'));
+  });
+});

--- a/src/app/api/auth/social/twitch/callback/route.ts
+++ b/src/app/api/auth/social/twitch/callback/route.ts
@@ -1,0 +1,156 @@
+import { NextResponse } from 'next/server';
+import { headers, cookies } from 'next/headers';
+import { z } from 'zod';
+import { auth } from '@/lib/auth';
+import { env } from '@/lib/env';
+import { encrypt, isTokenEncryptionConfigured } from '@/lib/crypto/token-encryption';
+import { upsertConnectedAccount } from '@/lib/queries/connectedSocialAccounts';
+import { isTwitchOauthConfigured } from '@/features/giveaway-platform/constants/twitch-missions';
+
+const TwitchTokenSchema = z.object({
+  access_token: z.string().min(1),
+  token_type: z.string(),
+  expires_in: z.number().int().positive(),
+  // Twitch devuelve refresh_token pero en Fase B NO lo persistimos.
+  refresh_token: z.string().optional(),
+  // Twitch devuelve `scope` como array de strings (distinto de Discord que
+  // lo manda como string espaciada). Ejemplo: ["user:read:follows"].
+  scope: z.array(z.string()),
+});
+
+const TwitchUserResponseSchema = z.object({
+  data: z.array(
+    z.object({
+      id: z.string(),
+      login: z.string(),
+      display_name: z.string(),
+    }),
+  ).min(1),
+});
+
+/**
+ * GET /api/auth/social/twitch/callback?code=...&state=...
+ *
+ * Recibe el redirect del OAuth server de Twitch. Verifica sesión + state,
+ * intercambia `code` por token, obtiene el user via
+ * `GET /helix/users` (usuario del token), y guarda la cuenta conectada
+ * con el access_token cifrado.
+ *
+ * NUNCA concede puntos aquí — la verificación de misiones se hace
+ * después vía server action.
+ *
+ * Fase B: NO se guarda `refresh_token`. El access token de Twitch dura
+ * ~4h; cuando expira, la UI pide reconectar.
+ */
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const code = url.searchParams.get('code');
+  const state = url.searchParams.get('state');
+  const oauthError = url.searchParams.get('error');
+
+  if (oauthError) {
+    return redirectToProfile('oauth_denied');
+  }
+  if (!code || !state) {
+    return redirectToProfile('invalid_params');
+  }
+
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session?.user) {
+    return NextResponse.json({ error: 'unauthenticated' }, { status: 401 });
+  }
+
+  if (!isTwitchOauthConfigured() || !isTokenEncryptionConfigured()) {
+    return redirectToProfile('twitch_not_configured');
+  }
+  const clientId = env.TWITCH_CLIENT_ID;
+  const clientSecret = env.TWITCH_CLIENT_SECRET;
+  const redirectUri = env.TWITCH_OAUTH_REDIRECT_URL;
+  if (!clientId || !clientSecret || !redirectUri) {
+    return redirectToProfile('twitch_not_configured');
+  }
+
+  const cookieStore = await cookies();
+  const savedState = cookieStore.get('sp_twitch_oauth_state')?.value;
+  const returnTo = cookieStore.get('sp_twitch_oauth_return')?.value ?? '/sorteos/perfil';
+  if (!savedState || savedState !== state) {
+    return redirectToProfile('state_mismatch');
+  }
+  cookieStore.delete('sp_twitch_oauth_state');
+  cookieStore.delete('sp_twitch_oauth_return');
+
+  // Intercambio code → token.
+  const tokenBody = new URLSearchParams({
+    client_id: clientId,
+    client_secret: clientSecret,
+    code,
+    grant_type: 'authorization_code',
+    redirect_uri: redirectUri,
+  });
+
+  let tokenData: z.infer<typeof TwitchTokenSchema>;
+  try {
+    const tokenRes = await fetch('https://id.twitch.tv/oauth2/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: tokenBody,
+    });
+    if (!tokenRes.ok) {
+      console.warn('[twitch-callback] token exchange failed', { status: tokenRes.status });
+      return redirectToProfile('token_exchange_failed', returnTo);
+    }
+    tokenData = TwitchTokenSchema.parse(await tokenRes.json());
+  } catch (err) {
+    console.warn('[twitch-callback] token network error', { message: err instanceof Error ? err.name : 'unknown' });
+    return redirectToProfile('token_network_error', returnTo);
+  }
+
+  // Obtener el user Twitch del token (GET /helix/users sin params → user del token).
+  let twitchUser: { id: string; login: string; display_name: string };
+  try {
+    const userRes = await fetch('https://api.twitch.tv/helix/users', {
+      headers: {
+        Authorization: `Bearer ${tokenData.access_token}`,
+        'Client-Id': clientId,
+      },
+    });
+    if (!userRes.ok) {
+      return redirectToProfile('twitch_user_fetch_failed', returnTo);
+    }
+    const parsed = TwitchUserResponseSchema.parse(await userRes.json());
+    // TwitchUserResponseSchema.data.min(1) garantiza al menos 1 elemento,
+    // pero el narrowing de TS no lo captura — usamos guard explícito.
+    const first = parsed.data[0];
+    if (!first) {
+      return redirectToProfile('twitch_user_fetch_failed', returnTo);
+    }
+    twitchUser = first;
+  } catch {
+    return redirectToProfile('twitch_user_network_error', returnTo);
+  }
+
+  const encryptedAccess = encrypt(tokenData.access_token);
+  const expiresAt = new Date(Date.now() + tokenData.expires_in * 1000);
+
+  await upsertConnectedAccount({
+    userId: session.user.id,
+    provider: 'twitch',
+    providerUserId: twitchUser.id,
+    providerUsername: twitchUser.login,
+    providerDisplayName: twitchUser.display_name,
+    accessTokenEncrypted: encryptedAccess,
+    // Twitch devuelve scope como array; lo normalizamos a string separado
+    // por espacios (formato universal, coherente con la col `scope text`).
+    scope: tokenData.scope.join(' '),
+    expiresAt,
+  });
+
+  return redirectToProfile('ok', returnTo);
+}
+
+function redirectToProfile(status: string, target = '/sorteos/perfil'): NextResponse {
+  const base = env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000';
+  const dest = new URL(target, base);
+  dest.searchParams.set('twitch_status', status);
+  return NextResponse.redirect(dest.toString(), 302);
+}

--- a/src/app/api/auth/social/twitch/connect/route.ts
+++ b/src/app/api/auth/social/twitch/connect/route.ts
@@ -1,0 +1,100 @@
+import { NextResponse } from 'next/server';
+import { headers, cookies } from 'next/headers';
+import { randomBytes } from 'node:crypto';
+import { auth } from '@/lib/auth';
+import { env } from '@/lib/env';
+import { TWITCH_OAUTH_SCOPES, isTwitchOauthConfigured } from '@/features/giveaway-platform/constants/twitch-missions';
+
+/**
+ * GET /api/auth/social/twitch/connect
+ *
+ * Inicia el flujo OAuth 2.0 code grant para conectar la cuenta Twitch
+ * del usuario SocialPro autenticado.
+ *
+ * Pasos:
+ *   1. Verifica sesión Better Auth. Si no hay → 401.
+ *   2. Genera `state` aleatorio (32 bytes hex) y lo persiste en cookie
+ *      httpOnly + sameSite=Lax + 10 min TTL. Se usa para verificar en el
+ *      callback (protección CSRF).
+ *   3. Redirige a `https://id.twitch.tv/oauth2/authorize` con:
+ *        client_id, redirect_uri, response_type=code,
+ *        scope=user:read:follows, state, force_verify=true.
+ *
+ * NO concede puntos. NO consulta APIs Twitch. Solo inicia el redirect.
+ */
+export async function GET(request: Request) {
+  if (!isTwitchOauthConfigured()) {
+    return NextResponse.json(
+      { error: 'twitch_oauth_not_configured' },
+      { status: 503 },
+    );
+  }
+  const clientId = env.TWITCH_CLIENT_ID;
+  const redirectUri = env.TWITCH_OAUTH_REDIRECT_URL;
+  if (!clientId || !redirectUri) {
+    // Guard extra para narrowing — el chequeo anterior ya lo cubre.
+    return NextResponse.json(
+      { error: 'twitch_oauth_not_configured' },
+      { status: 503 },
+    );
+  }
+
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session?.user) {
+    return NextResponse.json({ error: 'unauthenticated' }, { status: 401 });
+  }
+
+  // Preserva el destino de retorno (querystring `return` opcional).
+  const url = new URL(request.url);
+  const returnTo = sanitizeReturnPath(url.searchParams.get('return'));
+
+  // State: 32 bytes hex.
+  const state = randomBytes(32).toString('hex');
+  const stateCookie = await cookies();
+  stateCookie.set('sp_twitch_oauth_state', state, {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: !isLocalHost(),
+    path: '/api/auth/social/twitch',
+    maxAge: 10 * 60,
+  });
+  stateCookie.set('sp_twitch_oauth_return', returnTo, {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: !isLocalHost(),
+    path: '/api/auth/social/twitch',
+    maxAge: 10 * 60,
+  });
+
+  const authorizeUrl = new URL('https://id.twitch.tv/oauth2/authorize');
+  authorizeUrl.searchParams.set('client_id', clientId);
+  authorizeUrl.searchParams.set('redirect_uri', redirectUri);
+  authorizeUrl.searchParams.set('response_type', 'code');
+  authorizeUrl.searchParams.set('scope', TWITCH_OAUTH_SCOPES);
+  authorizeUrl.searchParams.set('state', state);
+  // force_verify=true fuerza a Twitch a mostrar la pantalla de consentimiento
+  // incluso si el usuario ya autorizó esta app antes. Útil porque en Fase B
+  // pedimos re-autorización cada ~4h (no guardamos refresh_token).
+  authorizeUrl.searchParams.set('force_verify', 'true');
+
+  return NextResponse.redirect(authorizeUrl.toString(), 302);
+}
+
+/** Normaliza el destino de retorno — solo aceptamos rutas internas. */
+function sanitizeReturnPath(raw: string | null): string {
+  if (!raw) return '/sorteos/perfil';
+  if (!raw.startsWith('/')) return '/sorteos/perfil';
+  if (raw.startsWith('//')) return '/sorteos/perfil';
+  return raw;
+}
+
+function isLocalHost(): boolean {
+  const site = env.NEXT_PUBLIC_SITE_URL;
+  if (!site) return false;
+  try {
+    const u = new URL(site);
+    return u.hostname === 'localhost' || u.hostname === '127.0.0.1';
+  } catch {
+    return false;
+  }
+}

--- a/src/app/api/auth/social/twitch/disconnect/route.ts
+++ b/src/app/api/auth/social/twitch/disconnect/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import { headers } from 'next/headers';
+import { auth } from '@/lib/auth';
+import { markAccountDisconnected } from '@/lib/queries/connectedSocialAccounts';
+
+/**
+ * POST /api/auth/social/twitch/disconnect
+ *
+ * Marca la cuenta Twitch del usuario como desconectada (soft delete).
+ * NO borra la fila — mantiene auditoría.
+ * NO revoca el token en Twitch (Twitch expone POST /oauth2/revoke pero
+ * en Fase B nos limitamos al soft delete; el token caduca solo en ~4h).
+ * NO revierte `mission_claims` — los canjes históricos son firmes.
+ */
+export async function POST() {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session?.user) {
+    return NextResponse.json({ error: 'unauthenticated' }, { status: 401 });
+  }
+  await markAccountDisconnected(session.user.id, 'twitch');
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/sorteos/layout.tsx
+++ b/src/app/sorteos/layout.tsx
@@ -15,6 +15,7 @@ import './plataforma/platform-widgets.css';
 import './plataforma/platform-rewards-upcoming.css';
 import './plataforma/platform-missions-yt-placeholder.css';
 import './plataforma/platform-discord-mission.css';
+import './plataforma/platform-twitch-mission.css';
 import './plataforma/platform-external-giveaways.css';
 import './plataforma/platform-profile.css';
 import './plataforma/platform-creator-profile.css';

--- a/src/app/sorteos/plataforma/platform-twitch-mission.css
+++ b/src/app/sorteos/plataforma/platform-twitch-mission.css
@@ -1,0 +1,111 @@
+/*
+ * Estilos para la card interactiva de misión Twitch.
+ * Fase B — verificación real vía OAuth `user:read:follows` + fetch a
+ * `GET /helix/channels/followed?user_id=...&broadcaster_id=...`.
+ *
+ * Reglas scoped bajo `.giveaway-platform`. Reutiliza `.gp-mission-card`
+ * base y añade acento "Twitch purple" (#9146FF).
+ */
+
+.giveaway-platform .gp-mission-card-twitch {
+  border-color: rgba(145, 70, 255, 0.35);
+  background:
+    radial-gradient(360px 200px at 100% 0%, rgba(145, 70, 255, 0.16), transparent 60%),
+    linear-gradient(160deg, rgba(21, 16, 36, 0.92), rgba(11, 9, 23, 0.92));
+}
+
+.giveaway-platform .gp-mission-card-twitch.is-done {
+  border-color: rgba(74, 222, 128, 0.45);
+  background: linear-gradient(160deg, rgba(20, 60, 40, 0.35), rgba(11, 9, 23, 0.85));
+}
+
+.giveaway-platform .gp-mission-twitch-tag {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 6px;
+  font-family: var(--font-display), var(--font-rajdhani), sans-serif;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 1.4px;
+  text-transform: uppercase;
+  color: #fff;
+  background: #9146FF;
+  vertical-align: middle;
+  margin-right: 4px;
+}
+
+.giveaway-platform .gp-mission-twitch-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.giveaway-platform .gp-mission-twitch-btn {
+  flex: 1 1 auto;
+  min-width: 120px;
+  padding: 9px 14px;
+  border-radius: 10px;
+  font-family: var(--font-display), var(--font-rajdhani), sans-serif;
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.8px;
+  text-transform: uppercase;
+  text-align: center;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s, opacity 0.15s;
+  text-decoration: none;
+  border: 1px solid transparent;
+}
+
+.giveaway-platform .gp-mission-twitch-btn.is-primary {
+  background: #9146FF;
+  color: #fff;
+  border-color: #9146FF;
+}
+.giveaway-platform .gp-mission-twitch-btn.is-primary:hover {
+  background: #7a2fe0;
+  border-color: #7a2fe0;
+}
+.giveaway-platform .gp-mission-twitch-btn.is-primary:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.giveaway-platform .gp-mission-twitch-btn.is-secondary {
+  background: transparent;
+  color: var(--txt);
+  border-color: rgba(145, 70, 255, 0.55);
+}
+.giveaway-platform .gp-mission-twitch-btn.is-secondary:hover {
+  background: rgba(145, 70, 255, 0.12);
+}
+
+.giveaway-platform .gp-mission-twitch-error {
+  margin-top: 10px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  background: rgba(255, 87, 87, 0.12);
+  border: 1px solid rgba(255, 87, 87, 0.35);
+  color: #ffb4b4;
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.giveaway-platform .gp-mission-twitch-note {
+  margin: 12px 0 0;
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--muted);
+  opacity: 0.85;
+}
+
+@media (max-width: 480px) {
+  .giveaway-platform .gp-mission-twitch-btn {
+    font-size: 11.5px;
+    padding: 9px 12px;
+  }
+  .giveaway-platform .gp-mission-twitch-note {
+    font-size: 10.5px;
+  }
+}

--- a/src/app/sorteos/plataforma/twitch-mission-action.ts
+++ b/src/app/sorteos/plataforma/twitch-mission-action.ts
@@ -1,0 +1,230 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { headers } from 'next/headers';
+import { and, eq, gt } from 'drizzle-orm';
+import { z } from 'zod';
+import { auth } from '@/lib/auth';
+import { db } from '@/lib/db';
+import { env } from '@/lib/env';
+import {
+  coinTransactions,
+  missionClaims,
+  missionVerificationAttempts,
+  platformMissions,
+} from '@/db/schema';
+import { getConnectedAccount } from '@/lib/queries/connectedSocialAccounts';
+import { decrypt } from '@/lib/crypto/token-encryption';
+import { TWITCH_FOLLOW_CHANNEL_MODE } from '@/features/giveaway-platform/constants/twitch-missions';
+
+/**
+ * Server action — verifica una misión Twitch (follow al canal) y, si
+ * cumple, concede los puntos configurados.
+ *
+ * Contrato:
+ *  - Sesión Better Auth obligatoria (`userId` de sesión).
+ *  - Rate limit 30s por (mission_id, user_id) desde el último intento.
+ *  - Misión debe existir, estar activa, y ser provider='twitch' +
+ *    verification_mode='twitch_follow_channel'.
+ *  - Cuenta Twitch del usuario debe estar conectada y no desconectada.
+ *  - Access token no expirado.
+ *  - Fetch a Twitch Helix `GET /channels/followed?user_id=<connected>&
+ *    broadcaster_id=<target>` con el token + Client-Id header.
+ *    No persiste la lista de follows.
+ *  - Si sigue → INSERT mission_claim (UNIQUE bloquea doble claim)
+ *    + INSERT coin_transactions con source='mision'.
+ *  - Todos los outcomes se registran en `mission_verification_attempts`
+ *    para auditoría + rate limit.
+ */
+
+const RATE_LIMIT_SECONDS = 30;
+
+/**
+ * Shape esperado de `GET /helix/channels/followed`. Solo miramos si
+ * `data` tiene al menos un elemento y su `broadcaster_id` coincide con
+ * el target. `total` también viene en la respuesta pero es informativo.
+ */
+const TwitchFollowedSchema = z.object({
+  data: z.array(z.object({ broadcaster_id: z.string() }).passthrough()),
+  total: z.number().optional(),
+});
+
+export type TwitchVerifyResult =
+  | { ok: true; code: 'success'; rewardCoins: number }
+  | { ok: false; code:
+      | 'unauthenticated'
+      | 'mission_not_found'
+      | 'mission_wrong_provider'
+      | 'not_connected'
+      | 'token_expired'
+      | 'rate_limited'
+      | 'already_claimed'
+      | 'not_verified'
+      | 'api_error'
+      | 'internal';
+      message: string;
+    };
+
+async function requirePlayerSession() {
+  const session = await auth.api.getSession({ headers: await headers() });
+  return session?.user ?? null;
+}
+
+async function recordAttempt(missionId: number, userId: string, outcome: string) {
+  try {
+    await db.insert(missionVerificationAttempts).values({
+      missionId,
+      userId,
+      outcome,
+    });
+  } catch {
+    // Fallo de auditoría no debe bloquear el flujo — log silencioso.
+  }
+}
+
+export async function verifyTwitchMission(input: unknown): Promise<TwitchVerifyResult> {
+  const user = await requirePlayerSession();
+  if (!user) {
+    return { ok: false, code: 'unauthenticated', message: 'Inicia sesión con Steam' };
+  }
+
+  const missionId = Number.parseInt(String((input as { missionId?: unknown })?.missionId ?? ''), 10);
+  if (!Number.isFinite(missionId) || missionId <= 0) {
+    return { ok: false, code: 'mission_not_found', message: 'Misión no válida' };
+  }
+
+  const [mission] = await db
+    .select()
+    .from(platformMissions)
+    .where(and(eq(platformMissions.id, missionId), eq(platformMissions.isActive, true)))
+    .limit(1);
+  if (!mission) {
+    return { ok: false, code: 'mission_not_found', message: 'Misión no disponible' };
+  }
+  if (mission.provider !== 'twitch' || mission.verificationMode !== TWITCH_FOLLOW_CHANNEL_MODE || !mission.targetId) {
+    return { ok: false, code: 'mission_wrong_provider', message: 'Misión mal configurada' };
+  }
+
+  const clientId = env.TWITCH_CLIENT_ID;
+  if (!clientId) {
+    // La misión está sembrada pero la app no tiene client id — estado
+    // inconsistente. Tratamos como internal para no filtrar detalles.
+    await recordAttempt(missionId, user.id, 'invalid');
+    return { ok: false, code: 'internal', message: 'No hemos podido verificarlo ahora. Inténtalo de nuevo más tarde.' };
+  }
+
+  // Bloqueo temprano si ya reclamó.
+  const [claimed] = await db
+    .select({ id: missionClaims.id })
+    .from(missionClaims)
+    .where(and(eq(missionClaims.missionId, missionId), eq(missionClaims.userId, user.id)))
+    .limit(1);
+  if (claimed) {
+    return { ok: false, code: 'already_claimed', message: 'Ya has reclamado esta misión' };
+  }
+
+  // Rate limit por (missionId, user_id) — último intento en <30s.
+  const cutoff = new Date(Date.now() - RATE_LIMIT_SECONDS * 1000);
+  const [recent] = await db
+    .select({ id: missionVerificationAttempts.id })
+    .from(missionVerificationAttempts)
+    .where(and(
+      eq(missionVerificationAttempts.missionId, missionId),
+      eq(missionVerificationAttempts.userId, user.id),
+      gt(missionVerificationAttempts.attemptedAt, cutoff),
+    ))
+    .limit(1);
+  if (recent) {
+    return { ok: false, code: 'rate_limited', message: `Espera ${RATE_LIMIT_SECONDS}s antes de volver a verificar` };
+  }
+
+  // Cuenta Twitch conectada.
+  const account = await getConnectedAccount(user.id, 'twitch');
+  if (!account) {
+    await recordAttempt(missionId, user.id, 'not_connected');
+    return { ok: false, code: 'not_connected', message: 'Conecta Twitch para verificar esta misión.' };
+  }
+
+  // Token expirado (Twitch dura ~4h, más frecuente que Discord).
+  if (account.expiresAt && account.expiresAt.getTime() < Date.now()) {
+    await recordAttempt(missionId, user.id, 'token_expired');
+    return { ok: false, code: 'token_expired', message: 'Twitch necesita reconectarse para verificar esta misión.' };
+  }
+
+  // Descifrar token.
+  let accessToken: string;
+  try {
+    accessToken = decrypt(account.accessTokenEncrypted);
+  } catch {
+    await recordAttempt(missionId, user.id, 'invalid');
+    return { ok: false, code: 'internal', message: 'No hemos podido verificarlo ahora. Inténtalo de nuevo más tarde.' };
+  }
+
+  // Fetch follows del usuario contra el broadcaster objetivo.
+  // Helix limita este endpoint a consultar los follows del propio user
+  // del token. NO persistimos la lista.
+  const followedUrl = new URL('https://api.twitch.tv/helix/channels/followed');
+  followedUrl.searchParams.set('user_id', account.providerUserId);
+  followedUrl.searchParams.set('broadcaster_id', mission.targetId);
+
+  let follows: { broadcaster_id: string }[];
+  try {
+    const res = await fetch(followedUrl.toString(), {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Client-Id': clientId,
+      },
+      cache: 'no-store',
+    });
+    if (res.status === 401) {
+      await recordAttempt(missionId, user.id, 'token_expired');
+      return { ok: false, code: 'token_expired', message: 'Twitch necesita reconectarse para verificar esta misión.' };
+    }
+    if (!res.ok) {
+      await recordAttempt(missionId, user.id, 'api_error');
+      return { ok: false, code: 'api_error', message: 'No hemos podido verificarlo ahora. Inténtalo de nuevo más tarde.' };
+    }
+    const data: unknown = await res.json();
+    const parsed = TwitchFollowedSchema.safeParse(data);
+    if (!parsed.success) {
+      await recordAttempt(missionId, user.id, 'api_error');
+      return { ok: false, code: 'api_error', message: 'No hemos podido verificarlo ahora. Inténtalo de nuevo más tarde.' };
+    }
+    follows = parsed.data.data;
+  } catch {
+    await recordAttempt(missionId, user.id, 'api_error');
+    return { ok: false, code: 'api_error', message: 'No hemos podido verificarlo ahora. Inténtalo de nuevo más tarde.' };
+  }
+
+  const isFollowing = follows.some((f) => f.broadcaster_id === mission.targetId);
+  if (!isFollowing) {
+    await recordAttempt(missionId, user.id, 'not_verified');
+    return { ok: false, code: 'not_verified', message: 'No hemos detectado que sigas el canal todavía.' };
+  }
+
+  // Cumple: INSERT claim + coin_transactions. El UNIQUE bloquea el
+  // doble claim en caso de race condition.
+  const [claim] = await db
+    .insert(missionClaims)
+    .values({ missionId, userId: user.id })
+    .onConflictDoNothing()
+    .returning({ id: missionClaims.id });
+
+  if (!claim) {
+    // Ya había uno por race — considerar reclamado.
+    await recordAttempt(missionId, user.id, 'success');
+    return { ok: false, code: 'already_claimed', message: 'Ya has reclamado esta misión' };
+  }
+
+  await db.insert(coinTransactions).values({
+    userId: user.id,
+    amount: mission.rewardCoins,
+    source: 'mision',
+    concept: `Misión: ${mission.title}`,
+    refId: missionId,
+  });
+
+  await recordAttempt(missionId, user.id, 'success');
+  revalidatePath('/sorteos', 'layout');
+  return { ok: true, code: 'success', rewardCoins: mission.rewardCoins };
+}

--- a/src/features/giveaway-platform/components/MissionsGrid.tsx
+++ b/src/features/giveaway-platform/components/MissionsGrid.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import type { MissionWithProgress } from '@/types/giveawayPlatform';
 import { DiscordMissionCard } from '@/features/giveaway-platform/components/DiscordMissionCard';
+import { TwitchMissionCard } from '@/features/giveaway-platform/components/TwitchMissionCard';
 
 interface Props {
   missions: MissionWithProgress[];
@@ -15,6 +16,15 @@ interface Props {
     connected: boolean;
     inviteUrl: string | null;
   } | undefined;
+  /**
+   * Info Twitch del usuario (opcional): connected=true si tiene cuenta
+   * conectada activa. channelUrl para el CTA "Abrir Twitch". Se omite si
+   * el creador activo no tiene configurada la misión Twitch.
+   */
+  twitch?: {
+    connected: boolean;
+    channelUrl: string | null;
+  } | undefined;
 }
 
 /**
@@ -25,16 +35,17 @@ interface Props {
  *
  * Cobradas se envían al final dentro de cada grupo — no ocupan el top.
  */
-export function MissionsGrid({ missions, discord }: Props) {
+export function MissionsGrid({ missions, discord, twitch }: Props) {
   const [expanded, setExpanded] = useState(false);
 
   if (missions.length === 0) {
     return <p className="gp-mission-head">No hay misiones activas este mes.</p>;
   }
 
-  // Split por provider: Discord aparte para renderizado con card específica.
+  // Split por provider: Discord y Twitch aparte para renderizado con card específica.
   const discordMissions = missions.filter((m) => m.provider === 'discord');
-  const otherMissions = missions.filter((m) => m.provider !== 'discord');
+  const twitchMissions = missions.filter((m) => m.provider === 'twitch');
+  const otherMissions = missions.filter((m) => m.provider !== 'discord' && m.provider !== 'twitch');
 
   // Cobradas al final, resto en el orden que llega del server (sortOrder ASC).
   const sortedOther = [...otherMissions].sort((a, b) => Number(a.claimed) - Number(b.claimed));
@@ -56,6 +67,19 @@ export function MissionsGrid({ missions, discord }: Props) {
               mission={m}
               connected={discord.connected}
               inviteUrl={discord.inviteUrl}
+            />
+          ))}
+        </div>
+      ) : null}
+
+      {twitchMissions.length > 0 && twitch ? (
+        <div className="gp-missions-grid">
+          {twitchMissions.map((m) => (
+            <TwitchMissionCard
+              key={m.id}
+              mission={m}
+              connected={twitch.connected}
+              channelUrl={twitch.channelUrl}
             />
           ))}
         </div>

--- a/src/features/giveaway-platform/components/PlatformCreatorLanding.tsx
+++ b/src/features/giveaway-platform/components/PlatformCreatorLanding.tsx
@@ -19,6 +19,7 @@ import {
 } from '@/lib/giveaway-platform/constants';
 import { getCreatorVisual } from '@/features/giveaway-platform/constants/creators';
 import { getDiscordMissionTarget, isDiscordOauthConfigured } from '@/features/giveaway-platform/constants/discord-missions';
+import { getTwitchMissionTarget, isTwitchOauthConfigured } from '@/features/giveaway-platform/constants/twitch-missions';
 import { isTokenEncryptionConfigured } from '@/lib/crypto/token-encryption';
 import { getConnectedAccount } from '@/lib/queries/connectedSocialAccounts';
 import { PlatformNav } from '@/features/giveaway-platform/components/PlatformNav';
@@ -90,7 +91,7 @@ export async function PlatformCreatorLanding({ slug }: Props) {
     ? []
     : await getGiveawaysWithEntryData(active.id, userId);
 
-  const [balance, missions, streak, playerProfile, discordAccount] = userId
+  const [balance, missions, streak, playerProfile, discordAccount, twitchAccount] = userId
     ? await Promise.all([
         getCoinBalance(userId),
         getMissionsWithProgress(userId),
@@ -100,8 +101,9 @@ export async function PlatformCreatorLanding({ slug }: Props) {
           columns: { steamTradeUrl: true },
         }),
         getConnectedAccount(userId, 'discord'),
+        getConnectedAccount(userId, 'twitch'),
       ])
-    : [0, [], undefined, undefined, null];
+    : [0, [], undefined, undefined, null, null];
 
   // Config Discord del creador activo. La card Discord solo se muestra si
   // TODAS las piezas están puestas:
@@ -116,6 +118,18 @@ export async function PlatformCreatorLanding({ slug }: Props) {
       ? {
           connected: Boolean(discordAccount),
           inviteUrl: discordTarget.inviteUrl ?? null,
+        }
+      : undefined;
+
+  // Config Twitch — misma lógica fail-safe que Discord. La card Twitch
+  // solo aparece si target del creador + OAuth + cifrado están todos
+  // configurados.
+  const twitchTarget = getTwitchMissionTarget(active.slug);
+  const twitchProp =
+    twitchTarget && isTwitchOauthConfigured() && isTokenEncryptionConfigured()
+      ? {
+          connected: Boolean(twitchAccount),
+          channelUrl: twitchTarget.channelUrl ?? null,
         }
       : undefined;
 
@@ -165,7 +179,7 @@ export async function PlatformCreatorLanding({ slug }: Props) {
             <section id="misiones">
               <div className="gp-legacy-block">
                 <h2>Misiones · gana puntos</h2>
-                <MissionsGrid missions={missions} discord={discordProp} />
+                <MissionsGrid missions={missions} discord={discordProp} twitch={twitchProp} />
               </div>
             </section>
           </>

--- a/src/features/giveaway-platform/components/TwitchMissionCard.tsx
+++ b/src/features/giveaway-platform/components/TwitchMissionCard.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import Link from 'next/link';
+import type { MissionWithProgress } from '@/types/giveawayPlatform';
+import { verifyTwitchMission } from '@/app/sorteos/plataforma/twitch-mission-action';
+
+type UiState =
+  | { kind: 'idle' }
+  | { kind: 'verifying' }
+  | { kind: 'error'; code: string; message: string };
+
+interface Props {
+  mission: MissionWithProgress;
+  /** ¿Ha conectado el usuario su cuenta Twitch? */
+  connected: boolean;
+  /** URL del canal Twitch — para el CTA "Abrir Twitch". */
+  channelUrl: string | null;
+}
+
+/**
+ * Card interactiva para misiones Twitch con verificación real vía OAuth
+ * (scope `user:read:follows`). Nunca simula: si el usuario no sigue el
+ * canal, `verifyTwitchMission` devuelve `not_verified` y aquí lo
+ * mostramos.
+ *
+ * Estados:
+ *   1. Cobrada        → Card en modo "is-done", sin botón.
+ *   2. No conectado   → CTA "Conectar Twitch" (redirige a OAuth).
+ *   3. Conectado      → CTA doble: "Abrir Twitch" (canal) + "Verificar".
+ *   4. Verificando    → Botón bloqueado, texto "Verificando...".
+ *   5. Token expirado → CTA "Reconectar Twitch" (mismo endpoint OAuth).
+ *   6. Error de API   → Mensaje + botón "Reintentar".
+ *
+ * Nota importante Fase B: los access tokens Twitch caducan a las ~4h.
+ * No guardamos refresh_token — el usuario re-conecta cuando expire.
+ */
+export function TwitchMissionCard({ mission, connected, channelUrl }: Props) {
+  const [uiState, setUiState] = useState<UiState>({ kind: 'idle' });
+  const [pending, startTransition] = useTransition();
+
+  const isDone = mission.claimed;
+  const showError = uiState.kind === 'error';
+  const isTokenExpired = uiState.kind === 'error' && uiState.code === 'token_expired';
+
+  function onVerifyClick() {
+    setUiState({ kind: 'verifying' });
+    startTransition(async () => {
+      const result = await verifyTwitchMission({ missionId: mission.id });
+      if (result.ok) {
+        setUiState({ kind: 'idle' });
+        return;
+      }
+      setUiState({ kind: 'error', code: result.code, message: result.message });
+    });
+  }
+
+  return (
+    <div className={`gp-mission-card gp-mission-card-twitch${isDone ? ' is-done' : ''}`}>
+      <div className="gp-mission-row">
+        <h3 className="gp-mission-title">
+          {isDone ? '✓ ' : ''}
+          <span className="gp-mission-twitch-tag" aria-hidden>Twitch</span>{' '}
+          {mission.title}
+        </h3>
+        <span className={`gp-mission-reward${isDone ? ' is-done' : ''}`}>
+          {isDone ? 'Cobrado' : `+${mission.rewardCoins} ⭐`}
+        </span>
+      </div>
+      <p className="gp-mission-desc">{mission.description}</p>
+
+      {isDone ? null : (
+        <div className="gp-mission-twitch-actions">
+          {channelUrl ? (
+            <a
+              href={channelUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="gp-mission-twitch-btn is-secondary"
+            >
+              Abrir Twitch
+            </a>
+          ) : null}
+
+          {connected && !isTokenExpired ? (
+            <button
+              type="button"
+              className="gp-mission-twitch-btn is-primary"
+              onClick={onVerifyClick}
+              disabled={pending || uiState.kind === 'verifying'}
+              aria-busy={pending}
+            >
+              {pending || uiState.kind === 'verifying' ? 'Verificando...' : 'Verificar misión'}
+            </button>
+          ) : (
+            <Link
+              href="/api/auth/social/twitch/connect?return=/sorteos"
+              className="gp-mission-twitch-btn is-primary"
+              prefetch={false}
+            >
+              {isTokenExpired ? 'Reconectar Twitch' : 'Conectar Twitch'}
+            </Link>
+          )}
+        </div>
+      )}
+
+      {showError ? (
+        <div className="gp-mission-twitch-error" role="alert">
+          {uiState.message}
+        </div>
+      ) : null}
+
+      <p className="gp-mission-twitch-note">
+        Usaremos Twitch únicamente para verificar tu identidad y si sigues el canal indicado.
+        No publicaremos nada en tu nombre.
+      </p>
+    </div>
+  );
+}

--- a/src/features/giveaway-platform/constants/twitch-missions.ts
+++ b/src/features/giveaway-platform/constants/twitch-missions.ts
@@ -1,0 +1,60 @@
+/**
+ * Configuración de misiones Twitch por creador.
+ *
+ * `broadcasterId` es el user ID Helix (numérico) del canal objetivo.
+ * `channelUrl` es la URL twitch.tv/<login> para el CTA "Abrir Twitch".
+ *
+ * Ninguno es secreto. Se mantienen en env para poder rotar/actualizar
+ * por creador sin re-desplegar.
+ *
+ * Añadir un creador nuevo: crear vars `TWITCH_<CREATOR>_BROADCASTER_ID`
+ * y `TWITCH_<CREATOR>_CHANNEL_URL` en env.ts + Vercel + mapa aquí.
+ */
+
+import { env } from '@/lib/env';
+
+export interface TwitchMissionTarget {
+  /** slug del creador — coincide con `creators.ts`. */
+  creatorSlug: string;
+  /** Broadcaster ID Helix (numérico). Ej: '12345678'. */
+  broadcasterId: string;
+  /** URL pública del canal — para el CTA "Abrir Twitch". */
+  channelUrl: string;
+}
+
+/**
+ * Devuelve la config de la misión Twitch de un creador o `null` si no
+ * está definida (variables env sin poblar).
+ */
+export function getTwitchMissionTarget(creatorSlug: string): TwitchMissionTarget | null {
+  switch (creatorSlug) {
+    case 'zacketizor': {
+      const broadcasterId = env.TWITCH_ZACKETIZOR_BROADCASTER_ID;
+      const channelUrl = env.TWITCH_ZACKETIZOR_CHANNEL_URL;
+      if (!broadcasterId || !channelUrl) return null;
+      return { creatorSlug, broadcasterId, channelUrl };
+    }
+    default:
+      return null;
+  }
+}
+
+/**
+ * True si Twitch OAuth de usuario está mínimamente configurado
+ * (client id + secret + redirect). El TWITCH_CLIENT_ID/SECRET ya se
+ * usaba para el servicio server-to-server; ahora sirve también para
+ * el OAuth de usuario.
+ */
+export function isTwitchOauthConfigured(): boolean {
+  return Boolean(env.TWITCH_CLIENT_ID && env.TWITCH_CLIENT_SECRET && env.TWITCH_OAUTH_REDIRECT_URL);
+}
+
+/**
+ * Scope OAuth mínimo para verificar follow: solo lectura de la lista
+ * de canales seguidos por el usuario. No incluye scopes de subs de
+ * pago (esos son restricted y fuera de scope Fase B).
+ */
+export const TWITCH_OAUTH_SCOPES = 'user:read:follows' as const;
+
+/** verificationMode canónico que persiste en `platform_missions`. */
+export const TWITCH_FOLLOW_CHANNEL_MODE = 'twitch_follow_channel' as const;

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -78,6 +78,33 @@ export const env = createEnv({
      */
     DISCORD_ZACKETIZOR_GUILD_ID: z.string().regex(/^\d{17,20}$/).optional(),
     DISCORD_ZACKETIZOR_INVITE_URL: z.string().url().optional(),
+
+    // ============================================================
+    // Twitch Missions Fase B — OAuth de usuario para verificar
+    // follow al canal objetivo. Ver docs/twitch-mission-fase-b.md.
+    //
+    // TWITCH_CLIENT_ID/SECRET ya existían para el servicio
+    // server-to-server (app token, cron /sync-metrics, /poll-live).
+    // La misma app Twitch se puede reutilizar para user OAuth aquí.
+    // ============================================================
+    /**
+     * Callback URL para el flujo OAuth de usuario Twitch. Distinta por
+     * entorno (prod / preview / dev). Debe coincidir EXACTA con la
+     * OAuth Redirect URL declarada en dev.twitch.tv → Console →
+     * Applications → tu app → OAuth Redirect URLs.
+     */
+    TWITCH_OAUTH_REDIRECT_URL: z.string().url().optional(),
+    /**
+     * Broadcaster ID (Helix user ID, numérico) del canal ZACKETIZOR.
+     * Público — se obtiene con `GET /helix/users?login=zacketizor`.
+     * No es secreto.
+     */
+    TWITCH_ZACKETIZOR_BROADCASTER_ID: z.string().regex(/^\d{1,20}$/).optional(),
+    /**
+     * URL pública del canal Twitch — para el CTA "Abrir Twitch".
+     * Debe ser una URL twitch.tv/<login> válida.
+     */
+    TWITCH_ZACKETIZOR_CHANNEL_URL: z.string().url().optional(),
   },
   client: {
     NEXT_PUBLIC_SITE_URL: z.string().url(),
@@ -115,6 +142,11 @@ export const env = createEnv({
     TOKEN_ENCRYPTION_KEY: process.env.TOKEN_ENCRYPTION_KEY,
     DISCORD_ZACKETIZOR_GUILD_ID: process.env.DISCORD_ZACKETIZOR_GUILD_ID,
     DISCORD_ZACKETIZOR_INVITE_URL: process.env.DISCORD_ZACKETIZOR_INVITE_URL,
+
+    // Twitch Missions Fase B
+    TWITCH_OAUTH_REDIRECT_URL: process.env.TWITCH_OAUTH_REDIRECT_URL,
+    TWITCH_ZACKETIZOR_BROADCASTER_ID: process.env.TWITCH_ZACKETIZOR_BROADCASTER_ID,
+    TWITCH_ZACKETIZOR_CHANNEL_URL: process.env.TWITCH_ZACKETIZOR_CHANNEL_URL,
 
     NEXT_PUBLIC_SITE_URL: process.env.NEXT_PUBLIC_SITE_URL,
     NEXT_PUBLIC_GTM_ID: process.env.NEXT_PUBLIC_GTM_ID,


### PR DESCRIPTION
Segunda misión social **verificable** de SocialPro Giveaways. OAuth Twitch real (`user:read:follows`), fetch en tiempo real a Helix `/channels/followed` con el filtro por `broadcaster_id` objetivo. Se conceden los +100 puntos únicamente si Helix confirma el follow.

Continúa el patrón de Discord Fase A (PR #203) reutilizando toda la infra (schema, cifrado, ledger, rate limit). **No hay migración nueva.**

## Alcance
- Solo Twitch. Kick sigue aparcado (API sin endpoint follow verificable).
- Solo `verificationMode='twitch_follow_channel'`. Sin subs de pago, sin Prime, sin chat.
- Solo ZACKETIZOR (target por env, ampliable a otros creadores).

## Auditoría previa (confirmada)

| Ítem | Estado |
|---|---|
| `TWITCH_CLIENT_ID` en `env.ts` | ya existía (optional) — reutilizado |
| `TWITCH_CLIENT_SECRET` en `env.ts` | ya existía (optional) — reutilizado |
| `TWITCH_OAUTH_REDIRECT_URL` | nuevo — añadido optional |
| `connected_social_accounts` reutilizable | genérica por provider |
| `TOKEN_ENCRYPTION_KEY` reutilizable | misma clave que Discord |
| `mission_verification_attempts` reutilizable | genérica |
| `platform_missions` con `provider/target_id/target_url/verification_mode` | tras 0104 |
| Endpoint Twitch | `GET https://api.twitch.tv/helix/channels/followed?user_id=<connected>&broadcaster_id=<target>` con `Bearer` + `Client-Id`. Scope `user:read:follows`. |

## Piezas nuevas

### Env vars (todas optional)
- `TWITCH_OAUTH_REDIRECT_URL` — URL de callback (distinta por entorno).
- `TWITCH_ZACKETIZOR_BROADCASTER_ID` — user ID Helix numérico del canal ZACKETIZOR.
- `TWITCH_ZACKETIZOR_CHANNEL_URL` — URL pública del canal para el CTA "Abrir Twitch".

### Rutas OAuth (sin plugin Better Auth)
- `GET /api/auth/social/twitch/connect` — genera `state` cookie httpOnly single-use, redirige a `id.twitch.tv/oauth2/authorize?scope=user:read:follows&force_verify=true`.
- `GET /api/auth/social/twitch/callback` — verifica `state`, intercambia `code`→token, `GET /helix/users`, cifra `access_token`, upsert cuenta. NO guarda `refresh_token`.
- `POST /api/auth/social/twitch/disconnect` — soft delete.

### Server action
`verifyTwitchMission({missionId})`:
1. Session guard Better Auth.
2. Verifica `provider='twitch'` + `verification_mode='twitch_follow_channel'` + `target_id` + `TWITCH_CLIENT_ID`.
3. Bloquea si ya reclamó.
4. Rate limit 30s por (mission, user).
5. Cuenta conectada + no expirada.
6. Descifra token, `GET /helix/channels/followed?user_id=<connected>&broadcaster_id=<target>` con `Client-Id` + `no-store`.
7. Si NO sigue → `not_verified`.
8. `INSERT mission_claim` con `onConflictDoNothing`.
9. `INSERT coin_transactions` con `source='mision'`.
10. Auditoría de cada outcome.

### UI
- `TwitchMissionCard` con estados: no-conectado / conectado / verificando / **token expirado (CTA Reconectar Twitch)** / error. Nota de privacidad visible.
- `MissionsGrid` renderiza bloque Twitch cuando hay misiones `provider='twitch'` + prop `twitch` presente.
- `PlatformCreatorLanding` guard 3-piezas fail-safe.
- CSS scoped bajo `.giveaway-platform` con acento Twitch purple `#9146FF`.

### Seed idempotente
`scripts/seed-twitch-mission-zacketizor.ts` con guard `CONFIRM_SEED_TWITCH_MISSION=I_ACCEPT_TWITCH_MISSION`.

### Documentación
`docs/twitch-mission-fase-b.md` — setup Twitch Developer Console, cómo sacar `broadcaster_id` con `curl /helix/users?login=...`, env vars, flujo end-to-end, runbook, seguridad + trade-off de no-refresh-token.

## Política Fase B — NO refresh_token

Twitch devuelve `refresh_token` en el OAuth pero **no lo persistimos**. El access token dura ~4h; cuando expira la UI muestra CTA "Reconectar Twitch" (un clic).

Trade-off aceptado — evita gestionar el ciclo de refresh. La columna `refresh_token_encrypted` sigue existiendo por si el futuro lo requiere.

## Seguridad y privacidad (verificado por tests estructurales)

- Scope mínimo `user:read:follows`. Sin subs, sin chat, sin moderación.
- **NO subs de pago.**
- Token cifrado en reposo (AES-256-GCM).
- **NO se guarda `refresh_token`.**
- **NO se guarda la lista de canales seguidos** — endpoint filtrado por `broadcaster_id`.
- **NO scraping. NO endpoints deprecated** (`/helix/users/follows` retirado ago 2023, no lo usamos).
- Sin logs de tokens / ciphertext / client_secret.
- CSRF: `state` cookie httpOnly + sameSite=Lax + single-use.
- Rate limit 30s sobre TODOS los intentos.

## Fail-safe

Card Twitch solo se renderiza si las 3 piezas están puestas: target + OAuth + cifrado. Si falta cualquiera, `twitchProp = undefined` y la grid omite la sección.

## Cómo sacar el broadcaster_id

```bash
curl -X POST 'https://id.twitch.tv/oauth2/token' \
  -d "client_id=$TWITCH_CLIENT_ID" -d "client_secret=$TWITCH_CLIENT_SECRET" \
  -d "grant_type=client_credentials"

curl 'https://api.twitch.tv/helix/users?login=zacketizor' \
  -H "Authorization: Bearer <token>" -H "Client-Id: $TWITCH_CLIENT_ID"
```

## Tests

- 68 nuevos estructurales cubriendo estructura, env, constants (scope), rutas OAuth, server action (outcomes, endpoint oficial, no deprecated, no-logs), UI, CSS, seed, doc.
- Actualizada `social-missions-audit-doc` para reflejar Twitch implementado.
- **Total: 3031 tests verdes.**
- TypeScript strict: 0 errores en `src/`. ESLint: limpio.

## Riesgos pendientes

1. Refresh-token off → reconexiones más frecuentes que Discord. Documentado.
2. Copy legal `/sorteos/privacidad` no menciona Twitch OAuth. PR separado antes del go-live real.
3. Refactor futuro de 3 cards Social a componente genérico si sumamos otro provider.

## Setup humano pendiente

1. Twitch Developer Console → app + Redirect URLs por entorno.
2. Vercel env vars nuevas (3):
   - `TWITCH_OAUTH_REDIRECT_URL`
   - `TWITCH_ZACKETIZOR_BROADCASTER_ID`
   - `TWITCH_ZACKETIZOR_CHANNEL_URL`
3. Seed cuando quieras: `CONFIRM_SEED_TWITCH_MISSION=I_ACCEPT_TWITCH_MISSION npx tsx --env-file=.env.local scripts/seed-twitch-mission-zacketizor.ts`.
4. Antes del go-live real: PR copy legal.

## Test plan
- [ ] Preview sin las 3 vars nuevas pobladas → card oculta, /sorteos funciona.
- [ ] Preview con las 3 vars + seed corrido → card Twitch aparece.
- [ ] Flujo OAuth completo → logs sin token/code/secret.
- [ ] BD: `connected_social_accounts` con token cifrado `v1:...` y `refresh_token_encrypted IS NULL`.
- [ ] Verificar siguiendo → +100 puntos, `coin_transactions`, `mission_claims`.
- [ ] Verificar sin seguir → mensaje adecuado, saldo intacto.
- [ ] Rate limit 30s.
- [ ] Token expirado → CTA "Reconectar Twitch".

**No mergear hasta OK visual del owner.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
