### PR TITLE
feat(sorteos): integrar sorteos KeyDrop de imantado

### DIFF
--- a/docs/external-giveaways-provider-onboarding.md
+++ b/docs/external-giveaways-provider-onboarding.md
@@ -281,15 +281,15 @@ Al mergear, memoria (`~/.claude/.../memory/`) recibe una entry
 
 ---
 
-## Estado de providers hoy (2026-07-03)
+## Estado de providers hoy (2026-07-06)
 
 | Creador (slug) | Provider | Código | Estado |
 |---|---|---|---|
 | zacketizor | KeyDrop + CSGO-SKINS | ZACKCSGO | ✅ KeyDrop con API real; CSGO-SKINS como card promocional. |
+| imantado | KeyDrop | IMANTADO | ✅ KeyDrop con API real (alta 2026-07-06). |
 | naow | — | — | ⏸ Pendiente de deal + datos confirmados. |
 | huasopeek | — | — | ⏸ Pendiente de deal + datos confirmados. |
 | todocs2 | — | — | ⏸ Pendiente de deal + datos confirmados. |
-| imantado | — | — | ⏸ Pendiente de deal + datos confirmados. |
 | jolu | — | — | ⏸ Pendiente de deal + datos confirmados. |
 
 *(martinez retirado del roster público 2026-07-03.)*

--- a/src/__tests__/server/creator-deals-config.test.ts
+++ b/src/__tests__/server/creator-deals-config.test.ts
@@ -5,9 +5,10 @@
  * puede mostrar cards de partners si tiene deal REAL confirmado en
  * `CREATOR_DEALS`. Los otros ven placeholder honesto.
  *
- * Estado real 2026-07-03:
- *   zacketizor → keydrop + csgoskins   ✅ único con deals confirmados
- *   huasopeek / naow / todocs2 / imantado / jolu → sin deals
+ * Estado real 2026-07-06:
+ *   zacketizor → keydrop + csgoskins   ✅
+ *   imantado   → keydrop                ✅
+ *   huasopeek / naow / todocs2 / jolu → sin deals
  */
 
 import * as fs from 'fs';
@@ -33,11 +34,14 @@ describe('[creator-deals-config] roster y datos', () => {
     expect([...CREATOR_DEALS.zacketizor].sort()).toEqual(['csgoskins', 'keydrop']);
   });
 
-  it('huasopeek / naow / todocs2 / imantado / jolu → sin deals confirmados ([])', () => {
+  it('imantado tiene exactamente keydrop (afiliado IMANTADO)', () => {
+    expect([...CREATOR_DEALS.imantado].sort()).toEqual(['keydrop']);
+  });
+
+  it('huasopeek / naow / todocs2 / jolu → sin deals confirmados ([])', () => {
     expect(CREATOR_DEALS.huasopeek).toEqual([]);
     expect(CREATOR_DEALS.naow).toEqual([]);
     expect(CREATOR_DEALS.todocs2).toEqual([]);
-    expect(CREATOR_DEALS.imantado).toEqual([]);
     expect(CREATOR_DEALS.jolu).toEqual([]);
   });
 
@@ -50,13 +54,15 @@ describe('[creator-deals-config] roster y datos', () => {
 describe('[creator-deals-config] helpers', () => {
   it('getCreatorDeals devuelve la lista o array vacío defensivo', () => {
     expect(getCreatorDeals('zacketizor').length).toBe(2);
+    expect(getCreatorDeals('imantado').length).toBe(1);
     expect(getCreatorDeals('huasopeek')).toEqual([]);
     expect(getCreatorDeals('nonexistent-slug')).toEqual([]);
   });
 
   it('hasAnyDeal true solo para creadores con al menos un partner', () => {
     expect(hasAnyDeal('zacketizor')).toBe(true);
-    for (const slug of ['huasopeek', 'naow', 'todocs2', 'imantado', 'jolu']) {
+    expect(hasAnyDeal('imantado')).toBe(true);
+    for (const slug of ['huasopeek', 'naow', 'todocs2', 'jolu']) {
       expect(hasAnyDeal(slug)).toBe(false);
     }
   });

--- a/src/__tests__/server/external-giveaways-common.test.ts
+++ b/src/__tests__/server/external-giveaways-common.test.ts
@@ -84,12 +84,19 @@ describe('[external-giveaways] CREATOR_PROVIDER_BINDINGS', () => {
     }
   });
 
+  it('incluye imantado → keydrop', () => {
+    const binding = getCreatorBinding('imantado');
+    expect(binding).not.toBeNull();
+    expect(binding?.provider).toBe('keydrop');
+    expect(binding?.envKey).toBe('KEYDROP_IMANTADO_API_KEY');
+  });
+
   it('isExternalCreator true para bound, false para no bound', () => {
     expect(isExternalCreator('zacketizor')).toBe(true);
+    expect(isExternalCreator('imantado')).toBe(true);
     expect(isExternalCreator('naow')).toBe(false);
     expect(isExternalCreator('huasopeek')).toBe(false);
     expect(isExternalCreator('todocs2')).toBe(false);
-    expect(isExternalCreator('imantado')).toBe(false);
     expect(isExternalCreator('jolu')).toBe(false);
     expect(isExternalCreator('unknown-slug')).toBe(false);
   });

--- a/src/__tests__/server/external-providers-inventory.test.ts
+++ b/src/__tests__/server/external-providers-inventory.test.ts
@@ -6,8 +6,9 @@
  * (docs/external-giveaways-provider-onboarding.md) y sin OK del owner,
  * este test lo detecta.
  *
- * Hoy (2026-07-03) el único partnership confirmado es
- *   zacketizor → KeyDrop → ZACKCSGO.
+ * Hoy (2026-07-06) los partnerships confirmados son
+ *   zacketizor → KeyDrop → ZACKCSGO
+ *   imantado   → KeyDrop → IMANTADO
  */
 
 import * as fs from 'fs';
@@ -16,7 +17,7 @@ import * as path from 'path';
 const ROOT = path.resolve(__dirname, '..', '..', '..');
 const read = (rel: string) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');
 
-describe('[external-providers-inventory] estado real 2026-07-03', () => {
+describe('[external-providers-inventory] estado real 2026-07-06', () => {
   it('ProviderKey enum en types.ts SOLO incluye providers en producción — csgoroll/hellcase siguen comentados', () => {
     const src = read('src/lib/external-giveaways/types.ts');
     // Enum activo: solo keydrop hoy.
@@ -38,34 +39,37 @@ describe('[external-providers-inventory] estado real 2026-07-03', () => {
     expect(registryBlock).not.toMatch(/\b(csgoroll|hellcase|datdrop|csgoempire|skinsmonkey|gamerpay)\s*:/);
   });
 
-  it('creator-bindings.ts solo mapea zacketizor a keydrop', () => {
+  it('creator-bindings.ts mapea zacketizor + imantado a keydrop, nada más', () => {
     const src = read('src/lib/external-giveaways/creator-bindings.ts');
-    expect(src).toMatch(/zacketizor/);
+    expect(src).toMatch(/^\s*zacketizor\s*:/m);
+    expect(src).toMatch(/^\s*imantado\s*:/m);
     expect(src).toMatch(/provider:\s*'keydrop'/);
     // Ni bindings "de prueba" para otros creadores.
-    for (const slug of ['naow', 'huasopeek', 'todocs2', 'imantado', 'jolu']) {
+    for (const slug of ['naow', 'huasopeek', 'todocs2', 'jolu']) {
       // Aparecer en un comentario o import está OK; aparecer como key de binding no.
       expect(src).not.toMatch(new RegExp(`^\\s*${slug}\\s*:`, 'm'));
     }
   });
 
-  it('env.ts solo declara KEYDROP_ZACKETIZOR_API_KEY (patrón <PROVIDER>_<CREATOR>_API_KEY)', () => {
+  it('env.ts declara KEYDROP_ZACKETIZOR + KEYDROP_IMANTADO (patrón <PROVIDER>_<CREATOR>_API_KEY)', () => {
     const src = read('src/lib/env.ts');
     expect(src).toMatch(/KEYDROP_ZACKETIZOR_API_KEY:\s*z\.string\(\)\.min\(1\)\.optional\(\)/);
+    expect(src).toMatch(/KEYDROP_IMANTADO_API_KEY:\s*z\.string\(\)\.min\(1\)\.optional\(\)/);
     // No debe haber otras claves siguiendo el patrón sin OK del owner.
     const keys = Array.from(src.matchAll(/^\s*([A-Z][A-Z0-9_]+_API_KEY)\s*:/gm)).map((m) => m[1]!);
-    // dedupe — env.ts declara la key dos veces: en `server:` y en `runtimeEnv:`.
+    // dedupe — env.ts declara cada key dos veces: en `server:` y en `runtimeEnv:`.
     const unique = Array.from(new Set(keys));
-    const external = unique.filter((k) => /^(KEYDROP|CSGOROLL|HELLCASE|DATDROP|CSGOEMPIRE|SKINSMONKEY|GAMERPAY)_/.test(k));
-    expect(external).toEqual(['KEYDROP_ZACKETIZOR_API_KEY']);
+    const external = unique.filter((k) => /^(KEYDROP|CSGOROLL|HELLCASE|DATDROP|CSGOEMPIRE|SKINSMONKEY|GAMERPAY)_/.test(k)).sort();
+    expect(external).toEqual(['KEYDROP_IMANTADO_API_KEY', 'KEYDROP_ZACKETIZOR_API_KEY']);
   });
 
   it('doc de onboarding existe y refleja el estado real', () => {
     const doc = read('docs/external-giveaways-provider-onboarding.md');
-    // Tabla de estado con zacketizor confirmado.
+    // Tabla de estado con partnerships confirmados.
     expect(doc).toMatch(/zacketizor[\s\S]{0,140}KeyDrop[\s\S]{0,140}ZACKCSGO/);
-    // Los otros 3 creadores están explícitamente pendientes.
-    for (const slug of ['naow', 'huasopeek', 'todocs2', 'imantado', 'jolu']) {
+    expect(doc).toMatch(/imantado[\s\S]{0,140}KeyDrop[\s\S]{0,140}IMANTADO/);
+    // Los creadores sin deal siguen explícitamente pendientes.
+    for (const slug of ['naow', 'huasopeek', 'todocs2', 'jolu']) {
       expect(doc).toMatch(new RegExp(`\\|\\s*${slug}\\s*\\|[^|]*\\|[^|]*\\|[^|]*Pendiente`, 'i'));
     }
     // Regla dura visible.

--- a/src/__tests__/server/keydrop-provider-security.test.ts
+++ b/src/__tests__/server/keydrop-provider-security.test.ts
@@ -7,7 +7,8 @@
  *   - client-factory respeta las reglas de seguridad universales.
  *   - fetch.ts de KeyDrop pasa apiKey solo por config, jamás en URL.
  *   - ningún archivo del provider loggea la key.
- *   - env.ts declara KEYDROP_ZACKETIZOR_API_KEY como server-only + optional.
+ *   - env.ts declara KEYDROP_ZACKETIZOR_API_KEY y KEYDROP_IMANTADO_API_KEY
+ *     como server-only + optional.
  */
 
 import * as fs from 'fs';
@@ -18,18 +19,20 @@ const read = (rel: string) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');
 
 describe('[keydrop-provider] env var declaración', () => {
   const src = read('src/lib/env.ts');
-  it('KEYDROP_ZACKETIZOR_API_KEY vive en el bloque server', () => {
-    expect(src).toMatch(/server:\s*\{[\s\S]*KEYDROP_ZACKETIZOR_API_KEY[\s\S]*\},/);
+  const KEYS = ['KEYDROP_ZACKETIZOR_API_KEY', 'KEYDROP_IMANTADO_API_KEY'] as const;
+
+  it.each(KEYS)('%s vive en el bloque server', (key) => {
+    expect(src).toMatch(new RegExp(`server:\\s*\\{[\\s\\S]*${key}[\\s\\S]*\\},`));
   });
-  it('KEYDROP_ZACKETIZOR_API_KEY es opcional', () => {
-    expect(src).toMatch(/KEYDROP_ZACKETIZOR_API_KEY:\s*z\.string\(\)\.min\(1\)\.optional\(\)/);
+  it.each(KEYS)('%s es opcional', (key) => {
+    expect(src).toMatch(new RegExp(`${key}:\\s*z\\.string\\(\\)\\.min\\(1\\)\\.optional\\(\\)`));
   });
-  it('NO aparece en el bloque client', () => {
+  it('NO aparece KEYDROP en el bloque client', () => {
     const clientBlock = /client:\s*\{[\s\S]*?\},/.exec(src)?.[0] ?? '';
     expect(clientBlock).not.toMatch(/KEYDROP/);
   });
-  it('runtimeEnv incluye la mapping', () => {
-    expect(src).toMatch(/KEYDROP_ZACKETIZOR_API_KEY:\s*process\.env\.KEYDROP_ZACKETIZOR_API_KEY/);
+  it.each(KEYS)('runtimeEnv incluye la mapping de %s', (key) => {
+    expect(src).toMatch(new RegExp(`${key}:\\s*process\\.env\\.${key}`));
   });
 });
 
@@ -124,9 +127,10 @@ describe('[keydrop-provider] no leak en UI/queries/mapper', () => {
     'src/lib/external-giveaways/providers/keydrop/zod-schemas.ts',
   ];
   for (const rel of files) {
-    it(`${rel} no referencia KEYDROP_ZACKETIZOR_API_KEY ni env.KEYDROP`, () => {
+    it(`${rel} no referencia envs KEYDROP_* ni env.KEYDROP`, () => {
       const src = read(rel);
       expect(src).not.toMatch(/KEYDROP_ZACKETIZOR_API_KEY/);
+      expect(src).not.toMatch(/KEYDROP_IMANTADO_API_KEY/);
       expect(src).not.toMatch(/env\.KEYDROP/);
       expect(src).not.toMatch(/apiKey:\s*string/);
     });

--- a/src/__tests__/server/legal-pages.test.ts
+++ b/src/__tests__/server/legal-pages.test.ts
@@ -235,6 +235,7 @@ describe('[legal] reglas del PR — sin cambios prohibidos', () => {
       const src = read(file);
       expect(src).not.toMatch(/process\.env/);
       expect(src).not.toMatch(/KEYDROP_ZACKETIZOR_API_KEY/);
+      expect(src).not.toMatch(/KEYDROP_IMANTADO_API_KEY/);
       expect(src).not.toMatch(/api[_-]?key/i);
     }
   });

--- a/src/__tests__/server/rewards-unified-canjeable.test.ts
+++ b/src/__tests__/server/rewards-unified-canjeable.test.ts
@@ -36,7 +36,9 @@ describe('[rewards-unified] un solo grid — sin bloque separado', () => {
     expect(src).toMatch(/function UpcomingCard/);
     // Las cards planned se pintan dentro del mismo `<div className="gp-shop-grid">`.
     // Verificamos que UpcomingCard se referencia dentro del mapper del grid.
-    expect(src).toMatch(/visibleUpcoming\.map\([\s\S]{0,120}<UpcomingCard/);
+    // Nota: `shownUpcoming` es la lista paginada de `visibleUpcoming` tras
+    // el corte de "Ver más" (INITIAL_VISIBLE = 8).
+    expect(src).toMatch(/shownUpcoming\.map\([\s\S]{0,120}<UpcomingCard/);
   });
 
   it('tabs incluyen nueva categoría "Merch equipos CS2" (team)', () => {

--- a/src/__tests__/server/sorteos-public-routes.test.ts
+++ b/src/__tests__/server/sorteos-public-routes.test.ts
@@ -152,12 +152,13 @@ describe('[sorteos-routes] navegación no usa URLs legacy', () => {
 });
 
 describe('[sorteos-routes] providers reales — no inventar bindings', () => {
-  it('creator-bindings.ts SIGUE con solo zacketizor → keydrop', () => {
+  it('creator-bindings.ts mapea zacketizor + imantado → keydrop', () => {
     const src = read('src/lib/external-giveaways/creator-bindings.ts');
-    expect(src).toMatch(/zacketizor/);
+    expect(src).toMatch(/^\s*zacketizor\s*:/m);
+    expect(src).toMatch(/^\s*imantado\s*:/m);
     expect(src).toMatch(/provider:\s*'keydrop'/);
     // Los otros creadores del roster NO deben tener binding.
-    for (const slug of ['naow', 'huasopeek', 'todocs2', 'imantado', 'jolu']) {
+    for (const slug of ['naow', 'huasopeek', 'todocs2', 'jolu']) {
       expect(src).not.toMatch(new RegExp(`^\\s*${slug}\\s*:`, 'm'));
     }
   });

--- a/src/features/giveaway-platform/constants/creator-deals.ts
+++ b/src/features/giveaway-platform/constants/creator-deals.ts
@@ -22,7 +22,7 @@ export const CREATOR_DEALS: Record<PlatformCreatorSlug, readonly BrandKey[]> = {
   huasopeek:  [],
   naow:       [],
   todocs2:    [],
-  imantado:   [],
+  imantado:   ['keydrop'],
   jolu:       [],
 };
 

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -52,6 +52,10 @@ export const env = createEnv({
     // Base URL: https://ws-2071.socket-cs.com/v1/giveaway-user
     // Endpoints usados: GET /api/list, GET /api/giveaway/:id
     KEYDROP_ZACKETIZOR_API_KEY: z.string().min(1).optional(),
+    // KeyDrop Giveaway API — clave del afiliado IMANTADO. Mismo endpoint
+    // base y auth (x-api-key) que ZACKETIZOR. Un secreto por par
+    // creador+provider (regla del onboarding doc §1).
+    KEYDROP_IMANTADO_API_KEY: z.string().min(1).optional(),
 
     // ============================================================
     // Discord Missions Fase A — OAuth de terceros para verificar
@@ -134,6 +138,7 @@ export const env = createEnv({
     SHEETS_SYNC_CONCURRENCY: process.env.SHEETS_SYNC_CONCURRENCY,
     STEAM_API_KEY: process.env.STEAM_API_KEY,
     KEYDROP_ZACKETIZOR_API_KEY: process.env.KEYDROP_ZACKETIZOR_API_KEY,
+    KEYDROP_IMANTADO_API_KEY: process.env.KEYDROP_IMANTADO_API_KEY,
 
     // Discord Missions Fase A
     DISCORD_CLIENT_ID: process.env.DISCORD_CLIENT_ID,

--- a/src/lib/external-giveaways/creator-bindings.ts
+++ b/src/lib/external-giveaways/creator-bindings.ts
@@ -37,10 +37,14 @@ const BINDINGS: Record<string, CreatorBinding> = {
     envKey: 'KEYDROP_ZACKETIZOR_API_KEY',
     apiKey: () => env.KEYDROP_ZACKETIZOR_API_KEY,
   },
+  imantado: {
+    provider: 'keydrop',
+    envKey: 'KEYDROP_IMANTADO_API_KEY',
+    apiKey: () => env.KEYDROP_IMANTADO_API_KEY,
+  },
   // Futuros bindings (comentados hasta que lleguen las API keys):
   //   naow:       { provider: '...',  envKey: '<PROVIDER>_NAOW_API_KEY',      apiKey: () => env.<PROVIDER>_NAOW_API_KEY },
   //   huasopeek:  { provider: '...',  envKey: '<PROVIDER>_HUASOPEEK_API_KEY', apiKey: () => env.<PROVIDER>_HUASOPEEK_API_KEY },
-  //   martinez:   { provider: '...',  envKey: '<PROVIDER>_MARTINEZ_API_KEY',  apiKey: () => env.<PROVIDER>_MARTINEZ_API_KEY },
 };
 
 /**


### PR DESCRIPTION
## Summary

Segundo binding real de KeyDrop tras zacketizor. Mismo endpoint base + auth (`x-api-key`), un secreto por par creador/provider (regla del [onboarding doc §1](../blob/master/docs/external-giveaways-provider-onboarding.md)).

## 6 datos §0 confirmados por owner

- Marca: KeyDrop · https://keydrop.com
- Creador: `imantado` (slug ya en roster)
- Código promocional real: `IMANTADO` (confirmado 2026-07-06)
- Docs API: mismas que zacketizor
- Endpoint base: `https://ws-2071.socket-cs.com/v1/giveaway-user`
- Auth: `x-api-key`

## Cambios

- `env.ts`: `KEYDROP_IMANTADO_API_KEY` en `server:` block, opcional, `.min(1)`.
- `creator-bindings.ts`: entry `imantado → keydrop` con `apiKey` lazy.
- `creator-deals.ts`: `imantado: ['keydrop']` — activa `BrandCardKeyDrop` en `/sorteos/imantado`.
- Tests estructurales (6 archivos): asertan inventario real (zacketizor + imantado), no "solo zacketizor".
- Doc de onboarding: fila IMANTADO movida de ⏸ Pendiente a ✅ activa.

## Test plan

- [x] `npx tsc --noEmit` limpio en archivos tocados
- [x] `npx eslint <files>` limpio
- [x] `npx jest` — 6 suites afectadas, 178 tests verdes
- [ ] Owner configura `KEYDROP_IMANTADO_API_KEY` en Vercel → Environment Variables → Production (sensitive)
- [ ] QA en Production: `/sorteos/imantado` muestra card KeyDrop + sorteos externos con código `IMANTADO`
- [ ] QA: sin la key, la sección KeyDrop degrada silenciosamente (no crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)