### PR TITLE
feat(sorteos): integrar sorteos KeyDrop de naow

### DIFF
--- a/docs/external-giveaways-provider-onboarding.md
+++ b/docs/external-giveaways-provider-onboarding.md
@@ -287,7 +287,7 @@ Al mergear, memoria (`~/.claude/.../memory/`) recibe una entry
 |---|---|---|---|
 | zacketizor | KeyDrop + CSGO-SKINS | ZACKCSGO | ✅ KeyDrop con API real; CSGO-SKINS como card promocional. |
 | imantado | KeyDrop | IMANTADO | ✅ KeyDrop con API real (alta 2026-07-06). |
-| naow | — | — | ⏸ Pendiente de deal + datos confirmados. |
+| naow | KeyDrop | NAOW | ✅ KeyDrop con API real (alta 2026-07-06). |
 | huasopeek | — | — | ⏸ Pendiente de deal + datos confirmados. |
 | todocs2 | — | — | ⏸ Pendiente de deal + datos confirmados. |
 | jolu | — | — | ⏸ Pendiente de deal + datos confirmados. |

--- a/src/__tests__/server/creator-deals-config.test.ts
+++ b/src/__tests__/server/creator-deals-config.test.ts
@@ -8,7 +8,8 @@
  * Estado real 2026-07-06:
  *   zacketizor → keydrop + csgoskins   ✅
  *   imantado   → keydrop                ✅
- *   huasopeek / naow / todocs2 / jolu → sin deals
+ *   naow       → keydrop                ✅
+ *   huasopeek / todocs2 / jolu → sin deals
  */
 
 import * as fs from 'fs';
@@ -38,9 +39,12 @@ describe('[creator-deals-config] roster y datos', () => {
     expect([...CREATOR_DEALS.imantado].sort()).toEqual(['keydrop']);
   });
 
-  it('huasopeek / naow / todocs2 / jolu → sin deals confirmados ([])', () => {
+  it('naow tiene exactamente keydrop (afiliado NAOW)', () => {
+    expect([...CREATOR_DEALS.naow].sort()).toEqual(['keydrop']);
+  });
+
+  it('huasopeek / todocs2 / jolu → sin deals confirmados ([])', () => {
     expect(CREATOR_DEALS.huasopeek).toEqual([]);
-    expect(CREATOR_DEALS.naow).toEqual([]);
     expect(CREATOR_DEALS.todocs2).toEqual([]);
     expect(CREATOR_DEALS.jolu).toEqual([]);
   });
@@ -55,6 +59,7 @@ describe('[creator-deals-config] helpers', () => {
   it('getCreatorDeals devuelve la lista o array vacío defensivo', () => {
     expect(getCreatorDeals('zacketizor').length).toBe(2);
     expect(getCreatorDeals('imantado').length).toBe(1);
+    expect(getCreatorDeals('naow').length).toBe(1);
     expect(getCreatorDeals('huasopeek')).toEqual([]);
     expect(getCreatorDeals('nonexistent-slug')).toEqual([]);
   });
@@ -62,7 +67,8 @@ describe('[creator-deals-config] helpers', () => {
   it('hasAnyDeal true solo para creadores con al menos un partner', () => {
     expect(hasAnyDeal('zacketizor')).toBe(true);
     expect(hasAnyDeal('imantado')).toBe(true);
-    for (const slug of ['huasopeek', 'naow', 'todocs2', 'jolu']) {
+    expect(hasAnyDeal('naow')).toBe(true);
+    for (const slug of ['huasopeek', 'todocs2', 'jolu']) {
       expect(hasAnyDeal(slug)).toBe(false);
     }
   });

--- a/src/__tests__/server/external-giveaways-common.test.ts
+++ b/src/__tests__/server/external-giveaways-common.test.ts
@@ -91,10 +91,17 @@ describe('[external-giveaways] CREATOR_PROVIDER_BINDINGS', () => {
     expect(binding?.envKey).toBe('KEYDROP_IMANTADO_API_KEY');
   });
 
+  it('incluye naow → keydrop', () => {
+    const binding = getCreatorBinding('naow');
+    expect(binding).not.toBeNull();
+    expect(binding?.provider).toBe('keydrop');
+    expect(binding?.envKey).toBe('KEYDROP_NAOW_API_KEY');
+  });
+
   it('isExternalCreator true para bound, false para no bound', () => {
     expect(isExternalCreator('zacketizor')).toBe(true);
     expect(isExternalCreator('imantado')).toBe(true);
-    expect(isExternalCreator('naow')).toBe(false);
+    expect(isExternalCreator('naow')).toBe(true);
     expect(isExternalCreator('huasopeek')).toBe(false);
     expect(isExternalCreator('todocs2')).toBe(false);
     expect(isExternalCreator('jolu')).toBe(false);

--- a/src/__tests__/server/external-providers-inventory.test.ts
+++ b/src/__tests__/server/external-providers-inventory.test.ts
@@ -9,6 +9,7 @@
  * Hoy (2026-07-06) los partnerships confirmados son
  *   zacketizor → KeyDrop → ZACKCSGO
  *   imantado   → KeyDrop → IMANTADO
+ *   naow       → KeyDrop → NAOW
  */
 
 import * as fs from 'fs';
@@ -39,28 +40,34 @@ describe('[external-providers-inventory] estado real 2026-07-06', () => {
     expect(registryBlock).not.toMatch(/\b(csgoroll|hellcase|datdrop|csgoempire|skinsmonkey|gamerpay)\s*:/);
   });
 
-  it('creator-bindings.ts mapea zacketizor + imantado a keydrop, nada más', () => {
+  it('creator-bindings.ts mapea zacketizor + imantado + naow a keydrop, nada más', () => {
     const src = read('src/lib/external-giveaways/creator-bindings.ts');
     expect(src).toMatch(/^\s*zacketizor\s*:/m);
     expect(src).toMatch(/^\s*imantado\s*:/m);
+    expect(src).toMatch(/^\s*naow\s*:/m);
     expect(src).toMatch(/provider:\s*'keydrop'/);
     // Ni bindings "de prueba" para otros creadores.
-    for (const slug of ['naow', 'huasopeek', 'todocs2', 'jolu']) {
+    for (const slug of ['huasopeek', 'todocs2', 'jolu']) {
       // Aparecer en un comentario o import está OK; aparecer como key de binding no.
       expect(src).not.toMatch(new RegExp(`^\\s*${slug}\\s*:`, 'm'));
     }
   });
 
-  it('env.ts declara KEYDROP_ZACKETIZOR + KEYDROP_IMANTADO (patrón <PROVIDER>_<CREATOR>_API_KEY)', () => {
+  it('env.ts declara KEYDROP_ZACKETIZOR + KEYDROP_IMANTADO + KEYDROP_NAOW (patrón <PROVIDER>_<CREATOR>_API_KEY)', () => {
     const src = read('src/lib/env.ts');
     expect(src).toMatch(/KEYDROP_ZACKETIZOR_API_KEY:\s*z\.string\(\)\.min\(1\)\.optional\(\)/);
     expect(src).toMatch(/KEYDROP_IMANTADO_API_KEY:\s*z\.string\(\)\.min\(1\)\.optional\(\)/);
+    expect(src).toMatch(/KEYDROP_NAOW_API_KEY:\s*z\.string\(\)\.min\(1\)\.optional\(\)/);
     // No debe haber otras claves siguiendo el patrón sin OK del owner.
     const keys = Array.from(src.matchAll(/^\s*([A-Z][A-Z0-9_]+_API_KEY)\s*:/gm)).map((m) => m[1]!);
     // dedupe — env.ts declara cada key dos veces: en `server:` y en `runtimeEnv:`.
     const unique = Array.from(new Set(keys));
     const external = unique.filter((k) => /^(KEYDROP|CSGOROLL|HELLCASE|DATDROP|CSGOEMPIRE|SKINSMONKEY|GAMERPAY)_/.test(k)).sort();
-    expect(external).toEqual(['KEYDROP_IMANTADO_API_KEY', 'KEYDROP_ZACKETIZOR_API_KEY']);
+    expect(external).toEqual([
+      'KEYDROP_IMANTADO_API_KEY',
+      'KEYDROP_NAOW_API_KEY',
+      'KEYDROP_ZACKETIZOR_API_KEY',
+    ]);
   });
 
   it('doc de onboarding existe y refleja el estado real', () => {
@@ -68,8 +75,9 @@ describe('[external-providers-inventory] estado real 2026-07-06', () => {
     // Tabla de estado con partnerships confirmados.
     expect(doc).toMatch(/zacketizor[\s\S]{0,140}KeyDrop[\s\S]{0,140}ZACKCSGO/);
     expect(doc).toMatch(/imantado[\s\S]{0,140}KeyDrop[\s\S]{0,140}IMANTADO/);
+    expect(doc).toMatch(/naow[\s\S]{0,140}KeyDrop[\s\S]{0,140}NAOW/);
     // Los creadores sin deal siguen explícitamente pendientes.
-    for (const slug of ['naow', 'huasopeek', 'todocs2', 'jolu']) {
+    for (const slug of ['huasopeek', 'todocs2', 'jolu']) {
       expect(doc).toMatch(new RegExp(`\\|\\s*${slug}\\s*\\|[^|]*\\|[^|]*\\|[^|]*Pendiente`, 'i'));
     }
     // Regla dura visible.

--- a/src/__tests__/server/keydrop-provider-security.test.ts
+++ b/src/__tests__/server/keydrop-provider-security.test.ts
@@ -7,8 +7,8 @@
  *   - client-factory respeta las reglas de seguridad universales.
  *   - fetch.ts de KeyDrop pasa apiKey solo por config, jamás en URL.
  *   - ningún archivo del provider loggea la key.
- *   - env.ts declara KEYDROP_ZACKETIZOR_API_KEY y KEYDROP_IMANTADO_API_KEY
- *     como server-only + optional.
+ *   - env.ts declara KEYDROP_ZACKETIZOR_API_KEY, KEYDROP_IMANTADO_API_KEY
+ *     y KEYDROP_NAOW_API_KEY como server-only + optional.
  */
 
 import * as fs from 'fs';
@@ -19,7 +19,11 @@ const read = (rel: string) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');
 
 describe('[keydrop-provider] env var declaración', () => {
   const src = read('src/lib/env.ts');
-  const KEYS = ['KEYDROP_ZACKETIZOR_API_KEY', 'KEYDROP_IMANTADO_API_KEY'] as const;
+  const KEYS = [
+    'KEYDROP_ZACKETIZOR_API_KEY',
+    'KEYDROP_IMANTADO_API_KEY',
+    'KEYDROP_NAOW_API_KEY',
+  ] as const;
 
   it.each(KEYS)('%s vive en el bloque server', (key) => {
     expect(src).toMatch(new RegExp(`server:\\s*\\{[\\s\\S]*${key}[\\s\\S]*\\},`));
@@ -131,6 +135,7 @@ describe('[keydrop-provider] no leak en UI/queries/mapper', () => {
       const src = read(rel);
       expect(src).not.toMatch(/KEYDROP_ZACKETIZOR_API_KEY/);
       expect(src).not.toMatch(/KEYDROP_IMANTADO_API_KEY/);
+      expect(src).not.toMatch(/KEYDROP_NAOW_API_KEY/);
       expect(src).not.toMatch(/env\.KEYDROP/);
       expect(src).not.toMatch(/apiKey:\s*string/);
     });

--- a/src/__tests__/server/legal-pages.test.ts
+++ b/src/__tests__/server/legal-pages.test.ts
@@ -236,6 +236,7 @@ describe('[legal] reglas del PR — sin cambios prohibidos', () => {
       expect(src).not.toMatch(/process\.env/);
       expect(src).not.toMatch(/KEYDROP_ZACKETIZOR_API_KEY/);
       expect(src).not.toMatch(/KEYDROP_IMANTADO_API_KEY/);
+      expect(src).not.toMatch(/KEYDROP_NAOW_API_KEY/);
       expect(src).not.toMatch(/api[_-]?key/i);
     }
   });

--- a/src/__tests__/server/sorteos-public-routes.test.ts
+++ b/src/__tests__/server/sorteos-public-routes.test.ts
@@ -152,13 +152,14 @@ describe('[sorteos-routes] navegación no usa URLs legacy', () => {
 });
 
 describe('[sorteos-routes] providers reales — no inventar bindings', () => {
-  it('creator-bindings.ts mapea zacketizor + imantado → keydrop', () => {
+  it('creator-bindings.ts mapea zacketizor + imantado + naow → keydrop', () => {
     const src = read('src/lib/external-giveaways/creator-bindings.ts');
     expect(src).toMatch(/^\s*zacketizor\s*:/m);
     expect(src).toMatch(/^\s*imantado\s*:/m);
+    expect(src).toMatch(/^\s*naow\s*:/m);
     expect(src).toMatch(/provider:\s*'keydrop'/);
     // Los otros creadores del roster NO deben tener binding.
-    for (const slug of ['naow', 'huasopeek', 'todocs2', 'jolu']) {
+    for (const slug of ['huasopeek', 'todocs2', 'jolu']) {
       expect(src).not.toMatch(new RegExp(`^\\s*${slug}\\s*:`, 'm'));
     }
   });

--- a/src/features/giveaway-platform/constants/creator-deals.ts
+++ b/src/features/giveaway-platform/constants/creator-deals.ts
@@ -20,7 +20,7 @@ export type PlatformCreatorSlug = (typeof PLATFORM_CREATOR_SLUGS)[number];
 export const CREATOR_DEALS: Record<PlatformCreatorSlug, readonly BrandKey[]> = {
   zacketizor: ['keydrop', 'csgoskins'],
   huasopeek:  [],
-  naow:       [],
+  naow:       ['keydrop'],
   todocs2:    [],
   imantado:   ['keydrop'],
   jolu:       [],

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -56,6 +56,9 @@ export const env = createEnv({
     // base y auth (x-api-key) que ZACKETIZOR. Un secreto por par
     // creador+provider (regla del onboarding doc §1).
     KEYDROP_IMANTADO_API_KEY: z.string().min(1).optional(),
+    // KeyDrop Giveaway API — clave del afiliado NAOW. Un secreto por par
+    // creador+provider.
+    KEYDROP_NAOW_API_KEY: z.string().min(1).optional(),
 
     // ============================================================
     // Discord Missions Fase A — OAuth de terceros para verificar
@@ -139,6 +142,7 @@ export const env = createEnv({
     STEAM_API_KEY: process.env.STEAM_API_KEY,
     KEYDROP_ZACKETIZOR_API_KEY: process.env.KEYDROP_ZACKETIZOR_API_KEY,
     KEYDROP_IMANTADO_API_KEY: process.env.KEYDROP_IMANTADO_API_KEY,
+    KEYDROP_NAOW_API_KEY: process.env.KEYDROP_NAOW_API_KEY,
 
     // Discord Missions Fase A
     DISCORD_CLIENT_ID: process.env.DISCORD_CLIENT_ID,

--- a/src/lib/external-giveaways/creator-bindings.ts
+++ b/src/lib/external-giveaways/creator-bindings.ts
@@ -42,8 +42,12 @@ const BINDINGS: Record<string, CreatorBinding> = {
     envKey: 'KEYDROP_IMANTADO_API_KEY',
     apiKey: () => env.KEYDROP_IMANTADO_API_KEY,
   },
+  naow: {
+    provider: 'keydrop',
+    envKey: 'KEYDROP_NAOW_API_KEY',
+    apiKey: () => env.KEYDROP_NAOW_API_KEY,
+  },
   // Futuros bindings (comentados hasta que lleguen las API keys):
-  //   naow:       { provider: '...',  envKey: '<PROVIDER>_NAOW_API_KEY',      apiKey: () => env.<PROVIDER>_NAOW_API_KEY },
   //   huasopeek:  { provider: '...',  envKey: '<PROVIDER>_HUASOPEEK_API_KEY', apiKey: () => env.<PROVIDER>_HUASOPEEK_API_KEY },
 };
 


### PR DESCRIPTION
## Summary

Tercer binding real de KeyDrop tras zacketizor + imantado. Mismo endpoint base + auth (\`x-api-key\`).

## 6 datos §0 confirmados

- Marca: KeyDrop · https://keydrop.com
- Creador: \`naow\`
- Código promocional real: \`NAOW\` (confirmado 2026-07-06)
- Endpoint base: \`https://ws-2071.socket-cs.com/v1/giveaway-user\`
- Auth: \`x-api-key\`

## Cambios

- \`env.ts\`: \`KEYDROP_NAOW_API_KEY\` en \`server:\`, opcional, \`.min(1)\`.
- \`creator-bindings.ts\`: entry \`naow → keydrop\` con \`apiKey\` lazy.
- \`creator-deals.ts\`: \`naow: ['keydrop']\` — activa \`BrandCardKeyDrop\` en \`/sorteos/naow\`.
- Tests estructurales (6 archivos): inventario ahora asertan zacketizor + imantado + naow.
- Doc de onboarding: fila NAOW movida a ✅ activa.

## Test plan

- [x] \`npx tsc --noEmit\` limpio
- [x] \`npx jest\` — 6 suites afectadas, 184 tests verdes
- [ ] Owner configura \`KEYDROP_NAOW_API_KEY\` en Vercel → Production (sensitive)
- [ ] QA en Production: \`/sorteos/naow\` muestra card KeyDrop + sorteos externos con código \`NAOW\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)