### PR TITLE
fix(campanas): persistir flags cobroConfirmado y pagoTalentConfirmado

### DIFF
--- a/src/__tests__/server/campaign-actions.test.ts
+++ b/src/__tests__/server/campaign-actions.test.ts
@@ -216,6 +216,48 @@ describe('updateCampaignAction', () => {
       { userId: 'mgr-42', role: 'manager' },
     );
   });
+
+  // Regresión: los selects "Cobro marca" y "Pago talento" del drawer emiten
+  // "0"/"1" strings. Antes del fix, `z.coerce.boolean()` parseaba "0" como
+  // true (Boolean("0") === true) y además updateCampaign no mapeaba los
+  // campos, dejando 70 campañas con flags stuck en false. Ver docs de PR.
+  it('persiste cobroConfirmado=false cuando el select emite "0"', async () => {
+    mockRequireAnyRole.mockResolvedValue(makeSession('admin'));
+    mockAssertCanEditCampaign.mockResolvedValue(undefined);
+    mockUpdateCampaign.mockResolvedValue({ id: 1 });
+
+    const fd = makeFormData({
+      ...validCampaignFields,
+      id: '1',
+      cobroConfirmado: '0',
+      pagoTalentConfirmado: '0',
+    });
+    await updateCampaignAction(fd);
+
+    expect(mockUpdateCampaign).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ cobroConfirmado: false, pagoTalentConfirmado: false }),
+    );
+  });
+
+  it('persiste cobroConfirmado=true y pagoTalentConfirmado=true cuando el select emite "1"', async () => {
+    mockRequireAnyRole.mockResolvedValue(makeSession('admin'));
+    mockAssertCanEditCampaign.mockResolvedValue(undefined);
+    mockUpdateCampaign.mockResolvedValue({ id: 1 });
+
+    const fd = makeFormData({
+      ...validCampaignFields,
+      id: '1',
+      cobroConfirmado: '1',
+      pagoTalentConfirmado: '1',
+    });
+    await updateCampaignAction(fd);
+
+    expect(mockUpdateCampaign).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ cobroConfirmado: true, pagoTalentConfirmado: true }),
+    );
+  });
 });
 
 // ── archiveCampaignAction ─────────────────────────────────────────────────────

--- a/src/lib/queries/campaigns.ts
+++ b/src/lib/queries/campaigns.ts
@@ -92,6 +92,9 @@ export type CreateCampaignInput = {
   brandPaymentMethod?: CampaignPaymentMethod;
   talentPaymentMethod?: CampaignPaymentMethod;
   visibility?: 'team' | 'private';
+  cobroConfirmado?: boolean;
+  pagoTalentConfirmado?: boolean;
+  cnmcChecklistOk?: boolean;
 };
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -414,6 +417,9 @@ export async function createCampaign(input: CreateCampaignInput): Promise<Campai
       brandPaymentMethod: input.brandPaymentMethod ?? null,
       talentPaymentMethod: input.talentPaymentMethod ?? null,
       visibility: input.visibility ?? 'team',
+      cobroConfirmado: input.cobroConfirmado ?? false,
+      pagoTalentConfirmado: input.pagoTalentConfirmado ?? false,
+      cnmcChecklistOk: input.cnmcChecklistOk ?? false,
     })
     .returning();
 
@@ -460,6 +466,10 @@ export async function updateCampaign(
   if ('brandPaymentMethod' in patch) setValue['brandPaymentMethod'] = patch.brandPaymentMethod ?? null;
   if ('talentPaymentMethod' in patch) setValue['talentPaymentMethod'] = patch.talentPaymentMethod ?? null;
   if (patch.visibility !== undefined) setValue['visibility'] = patch.visibility;
+  // Flags de cobro/pago — se persisten con valor explícito (true o false).
+  if (patch.cobroConfirmado !== undefined) setValue['cobroConfirmado'] = patch.cobroConfirmado;
+  if (patch.pagoTalentConfirmado !== undefined) setValue['pagoTalentConfirmado'] = patch.pagoTalentConfirmado;
+  if (patch.cnmcChecklistOk !== undefined) setValue['cnmcChecklistOk'] = patch.cnmcChecklistOk;
 
   const [row] = await db
     .update(campaigns)

--- a/src/lib/schemas/campaign.ts
+++ b/src/lib/schemas/campaign.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { FormBooleanSchema } from './common';
 
 export const CAMPAIGN_STATUSES = ['propuesta','negociacion','aprobada','activa','completada','cancelada','pendiente_pago','pagada'] as const;
 export const CAMPAIGN_ACTION_TYPES = ['stream','preroll','video_youtube','short_reel_tiktok','tweet','story_instagram','pack_mensual','afiliacion','otro'] as const;
@@ -96,10 +97,10 @@ const baseCampaign = z.object({
   estimatedCostAgency: z.coerce.number().nonnegative().optional(),
   estimatedMarginPct: z.coerce.number().min(0).max(100).optional(),
   // CNMC compliance checklist
-  cnmcChecklistOk: z.coerce.boolean().optional().default(false),
-  // Estado de pagos (Opción B — flags directos en campaña)
-  cobroConfirmado: z.coerce.boolean().optional().default(false),
-  pagoTalentConfirmado: z.coerce.boolean().optional().default(false),
+  cnmcChecklistOk: FormBooleanSchema.optional().default(false),
+  // Estado de pagos (flags directos en campaña, editables desde el drawer).
+  cobroConfirmado: FormBooleanSchema.optional().default(false),
+  pagoTalentConfirmado: FormBooleanSchema.optional().default(false),
 });
 
 export const createCampaignSchema = baseCampaign

--- a/src/lib/schemas/common.ts
+++ b/src/lib/schemas/common.ts
@@ -8,3 +8,25 @@ export const StrictIdSchema = z.number().int().positive();
 
 /** Boolean estricto — para args bound de Server Actions. */
 export const StrictBooleanSchema = z.boolean();
+
+/**
+ * Boolean parseado desde FormData/URLSearchParams.
+ *
+ * `z.coerce.boolean()` NO sirve aquí — usa `Boolean(v)`, que trata cualquier
+ * string no vacío como `true` (incluido `"0"`, `"false"`). Este preprocesador
+ * mapea los valores canónicos que emiten los `<select>` y `<input type="checkbox">`
+ * del proyecto:
+ *
+ *   - true:  `true`, `"1"`, `"true"`, `"on"`
+ *   - false: `false`, `"0"`, `"false"`, `""`, ausencia (default en caller)
+ *
+ * Cualquier otro valor deja pasar al `z.boolean()` interno, que lanza error.
+ */
+export const FormBooleanSchema = z.preprocess((v) => {
+  if (typeof v === 'boolean') return v;
+  if (typeof v === 'string') {
+    if (v === '1' || v === 'true' || v === 'on') return true;
+    if (v === '0' || v === 'false' || v === '') return false;
+  }
+  return v;
+}, z.boolean());


### PR DESCRIPTION
## Summary

Los selects "Cobro marca" y "Pago talento" del drawer nunca guardaban su valor. **De 70 campañas activas, el 100% tenía ambos flags en \`false\`**, incluidas las 15 con estado "Pagada".

## Diagnóstico

**Bug 1 — la query descarta los campos.**
\`updateCampaign\` y \`createCampaign\` en \`queries/campaigns.ts\` mapean columna a columna, y \`cobroConfirmado\`/\`pagoTalentConfirmado\`/\`cnmcChecklistOk\` **no estaban en el mapping**. Silenciosamente descartados.

**Bug 2 — el schema Zod usa \`z.coerce.boolean()\`.**
Verificado empíricamente con Zod 4.3.6:

\`\`\`js
z.coerce.boolean().parse("0") // → true (Boolean("0") === true)
z.coerce.boolean().parse("1") // → true
\`\`\`

Aunque el bug 1 se hubiera arreglado, el 2 habría convertido el bug visible en corrupción de datos silenciosa (todo guardado como \`true\` incluso al elegir "Sin cobrar").

## Fix

- **Nuevo helper** \`FormBooleanSchema\` en \`lib/schemas/common.ts\` — preprocesado explícito para los strings canónicos del proyecto (\`"0"/"1"/"true"/"false"/"on"/""\`).
- **Reemplaza** los tres \`z.coerce.boolean()\` de \`campaign.ts\` por el helper.
- **Añade** \`cobroConfirmado\`, \`pagoTalentConfirmado\`, \`cnmcChecklistOk\` al tipo \`CreateCampaignInput\` + al INSERT y al UPDATE.
- **Tests de regresión** en \`campaign-actions.test.ts\` (\`"0" → false\`, \`"1" → true\`).

## Facturación — no afectada

El dashboard financiero (\`/admin/facturacion/dashboard\`) calcula ingresos y gastos desde \`invoices.status IN ('cobrada','pagada')\`, **no** desde estos flags. El P&L y los KPIs financieros están correctos.

## Test plan

- [x] \`npx tsc --noEmit\` limpio
- [x] \`npx eslint\` limpio
- [x] \`npx jest\` — 53 tests verdes (campaign-actions + finance-dashboard + campaign-kpis)
- [ ] QA manual: editar un trato en \`/admin/campanas\`, marcar "Cobrado ✓" y "Pagado ✓", guardar → verificar que la lista muestra ambos como cobrado/pagado
- [ ] QA manual: crear un trato nuevo con flags marcados → persisten

🤖 Generated with [Claude Code](https://claude.com/claude-code)