### PR TITLE
feat(sorteos): integrar sorteos KeyDrop de todocs2

### DIFF
--- a/docs/external-giveaways-provider-onboarding.md
+++ b/docs/external-giveaways-provider-onboarding.md
@@ -288,8 +288,8 @@ Al mergear, memoria (`~/.claude/.../memory/`) recibe una entry
 | zacketizor | KeyDrop + CSGO-SKINS | ZACKCSGO | ✅ KeyDrop con API real; CSGO-SKINS como card promocional. |
 | imantado | KeyDrop | IMANTADO | ✅ KeyDrop con API real (alta 2026-07-06). |
 | naow | KeyDrop | NAOW | ✅ KeyDrop con API real (alta 2026-07-06). |
+| todocs2 | KeyDrop | TODOCS2 | ✅ KeyDrop con API real (alta 2026-07-06). |
 | huasopeek | — | — | ⏸ Pendiente de deal + datos confirmados. |
-| todocs2 | — | — | ⏸ Pendiente de deal + datos confirmados. |
 | jolu | — | — | ⏸ Pendiente de deal + datos confirmados. |
 
 *(martinez retirado del roster público 2026-07-03.)*

--- a/src/__tests__/server/creator-deals-config.test.ts
+++ b/src/__tests__/server/creator-deals-config.test.ts
@@ -9,7 +9,8 @@
  *   zacketizor → keydrop + csgoskins   ✅
  *   imantado   → keydrop                ✅
  *   naow       → keydrop                ✅
- *   huasopeek / todocs2 / jolu → sin deals
+ *   todocs2    → keydrop                ✅
+ *   huasopeek / jolu → sin deals
  */
 
 import * as fs from 'fs';
@@ -43,9 +44,12 @@ describe('[creator-deals-config] roster y datos', () => {
     expect([...CREATOR_DEALS.naow].sort()).toEqual(['keydrop']);
   });
 
-  it('huasopeek / todocs2 / jolu → sin deals confirmados ([])', () => {
+  it('todocs2 tiene exactamente keydrop (afiliado TODOCS2)', () => {
+    expect([...CREATOR_DEALS.todocs2].sort()).toEqual(['keydrop']);
+  });
+
+  it('huasopeek / jolu → sin deals confirmados ([])', () => {
     expect(CREATOR_DEALS.huasopeek).toEqual([]);
-    expect(CREATOR_DEALS.todocs2).toEqual([]);
     expect(CREATOR_DEALS.jolu).toEqual([]);
   });
 
@@ -60,6 +64,7 @@ describe('[creator-deals-config] helpers', () => {
     expect(getCreatorDeals('zacketizor').length).toBe(2);
     expect(getCreatorDeals('imantado').length).toBe(1);
     expect(getCreatorDeals('naow').length).toBe(1);
+    expect(getCreatorDeals('todocs2').length).toBe(1);
     expect(getCreatorDeals('huasopeek')).toEqual([]);
     expect(getCreatorDeals('nonexistent-slug')).toEqual([]);
   });
@@ -68,7 +73,8 @@ describe('[creator-deals-config] helpers', () => {
     expect(hasAnyDeal('zacketizor')).toBe(true);
     expect(hasAnyDeal('imantado')).toBe(true);
     expect(hasAnyDeal('naow')).toBe(true);
-    for (const slug of ['huasopeek', 'todocs2', 'jolu']) {
+    expect(hasAnyDeal('todocs2')).toBe(true);
+    for (const slug of ['huasopeek', 'jolu']) {
       expect(hasAnyDeal(slug)).toBe(false);
     }
   });

--- a/src/__tests__/server/external-giveaways-common.test.ts
+++ b/src/__tests__/server/external-giveaways-common.test.ts
@@ -98,12 +98,19 @@ describe('[external-giveaways] CREATOR_PROVIDER_BINDINGS', () => {
     expect(binding?.envKey).toBe('KEYDROP_NAOW_API_KEY');
   });
 
+  it('incluye todocs2 → keydrop', () => {
+    const binding = getCreatorBinding('todocs2');
+    expect(binding).not.toBeNull();
+    expect(binding?.provider).toBe('keydrop');
+    expect(binding?.envKey).toBe('KEYDROP_TODOCS2_API_KEY');
+  });
+
   it('isExternalCreator true para bound, false para no bound', () => {
     expect(isExternalCreator('zacketizor')).toBe(true);
     expect(isExternalCreator('imantado')).toBe(true);
     expect(isExternalCreator('naow')).toBe(true);
+    expect(isExternalCreator('todocs2')).toBe(true);
     expect(isExternalCreator('huasopeek')).toBe(false);
-    expect(isExternalCreator('todocs2')).toBe(false);
     expect(isExternalCreator('jolu')).toBe(false);
     expect(isExternalCreator('unknown-slug')).toBe(false);
   });

--- a/src/__tests__/server/external-providers-inventory.test.ts
+++ b/src/__tests__/server/external-providers-inventory.test.ts
@@ -10,6 +10,7 @@
  *   zacketizor → KeyDrop → ZACKCSGO
  *   imantado   → KeyDrop → IMANTADO
  *   naow       → KeyDrop → NAOW
+ *   todocs2    → KeyDrop → TODOCS2
  */
 
 import * as fs from 'fs';
@@ -40,24 +41,26 @@ describe('[external-providers-inventory] estado real 2026-07-06', () => {
     expect(registryBlock).not.toMatch(/\b(csgoroll|hellcase|datdrop|csgoempire|skinsmonkey|gamerpay)\s*:/);
   });
 
-  it('creator-bindings.ts mapea zacketizor + imantado + naow a keydrop, nada más', () => {
+  it('creator-bindings.ts mapea zacketizor + imantado + naow + todocs2 a keydrop, nada más', () => {
     const src = read('src/lib/external-giveaways/creator-bindings.ts');
     expect(src).toMatch(/^\s*zacketizor\s*:/m);
     expect(src).toMatch(/^\s*imantado\s*:/m);
     expect(src).toMatch(/^\s*naow\s*:/m);
+    expect(src).toMatch(/^\s*todocs2\s*:/m);
     expect(src).toMatch(/provider:\s*'keydrop'/);
     // Ni bindings "de prueba" para otros creadores.
-    for (const slug of ['huasopeek', 'todocs2', 'jolu']) {
+    for (const slug of ['huasopeek', 'jolu']) {
       // Aparecer en un comentario o import está OK; aparecer como key de binding no.
       expect(src).not.toMatch(new RegExp(`^\\s*${slug}\\s*:`, 'm'));
     }
   });
 
-  it('env.ts declara KEYDROP_ZACKETIZOR + KEYDROP_IMANTADO + KEYDROP_NAOW (patrón <PROVIDER>_<CREATOR>_API_KEY)', () => {
+  it('env.ts declara KEYDROP_ZACKETIZOR + IMANTADO + NAOW + TODOCS2 (patrón <PROVIDER>_<CREATOR>_API_KEY)', () => {
     const src = read('src/lib/env.ts');
     expect(src).toMatch(/KEYDROP_ZACKETIZOR_API_KEY:\s*z\.string\(\)\.min\(1\)\.optional\(\)/);
     expect(src).toMatch(/KEYDROP_IMANTADO_API_KEY:\s*z\.string\(\)\.min\(1\)\.optional\(\)/);
     expect(src).toMatch(/KEYDROP_NAOW_API_KEY:\s*z\.string\(\)\.min\(1\)\.optional\(\)/);
+    expect(src).toMatch(/KEYDROP_TODOCS2_API_KEY:\s*z\.string\(\)\.min\(1\)\.optional\(\)/);
     // No debe haber otras claves siguiendo el patrón sin OK del owner.
     const keys = Array.from(src.matchAll(/^\s*([A-Z][A-Z0-9_]+_API_KEY)\s*:/gm)).map((m) => m[1]!);
     // dedupe — env.ts declara cada key dos veces: en `server:` y en `runtimeEnv:`.
@@ -66,6 +69,7 @@ describe('[external-providers-inventory] estado real 2026-07-06', () => {
     expect(external).toEqual([
       'KEYDROP_IMANTADO_API_KEY',
       'KEYDROP_NAOW_API_KEY',
+      'KEYDROP_TODOCS2_API_KEY',
       'KEYDROP_ZACKETIZOR_API_KEY',
     ]);
   });
@@ -76,8 +80,9 @@ describe('[external-providers-inventory] estado real 2026-07-06', () => {
     expect(doc).toMatch(/zacketizor[\s\S]{0,140}KeyDrop[\s\S]{0,140}ZACKCSGO/);
     expect(doc).toMatch(/imantado[\s\S]{0,140}KeyDrop[\s\S]{0,140}IMANTADO/);
     expect(doc).toMatch(/naow[\s\S]{0,140}KeyDrop[\s\S]{0,140}NAOW/);
+    expect(doc).toMatch(/todocs2[\s\S]{0,140}KeyDrop[\s\S]{0,140}TODOCS2/);
     // Los creadores sin deal siguen explícitamente pendientes.
-    for (const slug of ['huasopeek', 'todocs2', 'jolu']) {
+    for (const slug of ['huasopeek', 'jolu']) {
       expect(doc).toMatch(new RegExp(`\\|\\s*${slug}\\s*\\|[^|]*\\|[^|]*\\|[^|]*Pendiente`, 'i'));
     }
     // Regla dura visible.

--- a/src/__tests__/server/keydrop-provider-security.test.ts
+++ b/src/__tests__/server/keydrop-provider-security.test.ts
@@ -7,8 +7,9 @@
  *   - client-factory respeta las reglas de seguridad universales.
  *   - fetch.ts de KeyDrop pasa apiKey solo por config, jamás en URL.
  *   - ningún archivo del provider loggea la key.
- *   - env.ts declara KEYDROP_ZACKETIZOR_API_KEY, KEYDROP_IMANTADO_API_KEY
- *     y KEYDROP_NAOW_API_KEY como server-only + optional.
+ *   - env.ts declara KEYDROP_ZACKETIZOR_API_KEY, KEYDROP_IMANTADO_API_KEY,
+ *     KEYDROP_NAOW_API_KEY y KEYDROP_TODOCS2_API_KEY como server-only +
+ *     optional.
  */
 
 import * as fs from 'fs';
@@ -23,6 +24,7 @@ describe('[keydrop-provider] env var declaración', () => {
     'KEYDROP_ZACKETIZOR_API_KEY',
     'KEYDROP_IMANTADO_API_KEY',
     'KEYDROP_NAOW_API_KEY',
+    'KEYDROP_TODOCS2_API_KEY',
   ] as const;
 
   it.each(KEYS)('%s vive en el bloque server', (key) => {
@@ -136,6 +138,7 @@ describe('[keydrop-provider] no leak en UI/queries/mapper', () => {
       expect(src).not.toMatch(/KEYDROP_ZACKETIZOR_API_KEY/);
       expect(src).not.toMatch(/KEYDROP_IMANTADO_API_KEY/);
       expect(src).not.toMatch(/KEYDROP_NAOW_API_KEY/);
+      expect(src).not.toMatch(/KEYDROP_TODOCS2_API_KEY/);
       expect(src).not.toMatch(/env\.KEYDROP/);
       expect(src).not.toMatch(/apiKey:\s*string/);
     });

--- a/src/__tests__/server/legal-pages.test.ts
+++ b/src/__tests__/server/legal-pages.test.ts
@@ -237,6 +237,7 @@ describe('[legal] reglas del PR — sin cambios prohibidos', () => {
       expect(src).not.toMatch(/KEYDROP_ZACKETIZOR_API_KEY/);
       expect(src).not.toMatch(/KEYDROP_IMANTADO_API_KEY/);
       expect(src).not.toMatch(/KEYDROP_NAOW_API_KEY/);
+      expect(src).not.toMatch(/KEYDROP_TODOCS2_API_KEY/);
       expect(src).not.toMatch(/api[_-]?key/i);
     }
   });

--- a/src/__tests__/server/sorteos-public-routes.test.ts
+++ b/src/__tests__/server/sorteos-public-routes.test.ts
@@ -152,14 +152,15 @@ describe('[sorteos-routes] navegación no usa URLs legacy', () => {
 });
 
 describe('[sorteos-routes] providers reales — no inventar bindings', () => {
-  it('creator-bindings.ts mapea zacketizor + imantado + naow → keydrop', () => {
+  it('creator-bindings.ts mapea zacketizor + imantado + naow + todocs2 → keydrop', () => {
     const src = read('src/lib/external-giveaways/creator-bindings.ts');
     expect(src).toMatch(/^\s*zacketizor\s*:/m);
     expect(src).toMatch(/^\s*imantado\s*:/m);
     expect(src).toMatch(/^\s*naow\s*:/m);
+    expect(src).toMatch(/^\s*todocs2\s*:/m);
     expect(src).toMatch(/provider:\s*'keydrop'/);
     // Los otros creadores del roster NO deben tener binding.
-    for (const slug of ['huasopeek', 'todocs2', 'jolu']) {
+    for (const slug of ['huasopeek', 'jolu']) {
       expect(src).not.toMatch(new RegExp(`^\\s*${slug}\\s*:`, 'm'));
     }
   });

--- a/src/features/giveaway-platform/constants/creator-deals.ts
+++ b/src/features/giveaway-platform/constants/creator-deals.ts
@@ -21,7 +21,7 @@ export const CREATOR_DEALS: Record<PlatformCreatorSlug, readonly BrandKey[]> = {
   zacketizor: ['keydrop', 'csgoskins'],
   huasopeek:  [],
   naow:       ['keydrop'],
-  todocs2:    [],
+  todocs2:    ['keydrop'],
   imantado:   ['keydrop'],
   jolu:       [],
 };

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -59,6 +59,9 @@ export const env = createEnv({
     // KeyDrop Giveaway API — clave del afiliado NAOW. Un secreto por par
     // creador+provider.
     KEYDROP_NAOW_API_KEY: z.string().min(1).optional(),
+    // KeyDrop Giveaway API — clave del afiliado TODOCS2. Un secreto por par
+    // creador+provider.
+    KEYDROP_TODOCS2_API_KEY: z.string().min(1).optional(),
 
     // ============================================================
     // Discord Missions Fase A — OAuth de terceros para verificar
@@ -143,6 +146,7 @@ export const env = createEnv({
     KEYDROP_ZACKETIZOR_API_KEY: process.env.KEYDROP_ZACKETIZOR_API_KEY,
     KEYDROP_IMANTADO_API_KEY: process.env.KEYDROP_IMANTADO_API_KEY,
     KEYDROP_NAOW_API_KEY: process.env.KEYDROP_NAOW_API_KEY,
+    KEYDROP_TODOCS2_API_KEY: process.env.KEYDROP_TODOCS2_API_KEY,
 
     // Discord Missions Fase A
     DISCORD_CLIENT_ID: process.env.DISCORD_CLIENT_ID,

--- a/src/lib/external-giveaways/creator-bindings.ts
+++ b/src/lib/external-giveaways/creator-bindings.ts
@@ -47,6 +47,11 @@ const BINDINGS: Record<string, CreatorBinding> = {
     envKey: 'KEYDROP_NAOW_API_KEY',
     apiKey: () => env.KEYDROP_NAOW_API_KEY,
   },
+  todocs2: {
+    provider: 'keydrop',
+    envKey: 'KEYDROP_TODOCS2_API_KEY',
+    apiKey: () => env.KEYDROP_TODOCS2_API_KEY,
+  },
   // Futuros bindings (comentados hasta que lleguen las API keys):
   //   huasopeek:  { provider: '...',  envKey: '<PROVIDER>_HUASOPEEK_API_KEY', apiKey: () => env.<PROVIDER>_HUASOPEEK_API_KEY },
 };


### PR DESCRIPTION
## Summary

Cuarto binding real de KeyDrop tras zacketizor + imantado + naow. Mismo endpoint base + auth (\`x-api-key\`).

## 6 datos §0 confirmados

- Marca: KeyDrop · https://keydrop.com
- Creador: \`todocs2\`
- Código promocional real: \`TODOCS2\` (mismo que el visual code en \`creators.ts\`, patrón imantado/naow)
- Endpoint base: \`https://ws-2071.socket-cs.com/v1/giveaway-user\`
- Auth: \`x-api-key\`

## Cambios

- \`env.ts\`: \`KEYDROP_TODOCS2_API_KEY\` en \`server:\`, opcional, \`.min(1)\`.
- \`creator-bindings.ts\`: entry \`todocs2 → keydrop\` con \`apiKey\` lazy.
- \`creator-deals.ts\`: \`todocs2: ['keydrop']\` — activa \`BrandCardKeyDrop\` en \`/sorteos/todocs2\`.
- Tests estructurales (6 archivos): asertan zacketizor + imantado + naow + todocs2.
- Doc de onboarding: fila TODOCS2 movida a ✅ activa.

## Test plan

- [x] \`npx tsc --noEmit\` limpio
- [x] \`npx jest\` — 6 suites afectadas, 190 tests verdes
- [ ] Owner configura \`KEYDROP_TODOCS2_API_KEY\` en Vercel → Production (sensitive)
- [ ] QA en Production: \`/sorteos/todocs2\` muestra card KeyDrop + sorteos externos con código \`TODOCS2\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)