### PR TITLE
feat(finanzas): PR 3 — Ingresos + Aging de cobros

### DIFF
--- a/src/__tests__/server/finanzas-ingresos.test.ts
+++ b/src/__tests__/server/finanzas-ingresos.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Contratos estructurales de /admin/finanzas/ingresos (PR 3).
+ *
+ * Verifica:
+ *   1. La página requiere `facturacion:read`.
+ *   2. Renderiza los bloques en el orden esperado.
+ *   3. La query nueva `getIngresosData` no ejecuta writes.
+ *   4. La tabla mapea estados legacy con `normalizeInvoiceStatusForDisplay`.
+ *   5. Filtros persistentes por URL params.
+ *   6. Aviso `BankDataWarning` presente.
+ *   7. Reutiliza `getArAging` sin duplicar lógica.
+ *   8. Copy prohibido no aparece.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(__dirname, '..', '..', '..');
+const read = (rel: string) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');
+
+describe('[finanzas-ingresos] estructura de la página', () => {
+  const src = read('src/app/admin/(dashboard)/finanzas/ingresos/page.tsx');
+
+  it('requiere permiso facturacion:read', () => {
+    expect(src).toMatch(/requirePermission\(['"]facturacion['"],\s*['"]read['"]\)/);
+  });
+
+  it('carga los datos con getIngresosData', () => {
+    expect(src).toMatch(/import\s*\{\s*getIngresosData\s*\}/);
+    expect(src).toMatch(/getIngresosData\(/);
+  });
+
+  it('reutiliza BankDataWarning del resumen', () => {
+    expect(src).toMatch(/import\s*\{\s*BankDataWarning\s*\}/);
+    expect(src).toMatch(/<BankDataWarning/);
+  });
+
+  it('reutiliza ArAgingBuckets para el aging', () => {
+    expect(src).toMatch(/import\s*\{\s*ArAgingBuckets\s*\}/);
+    expect(src).toMatch(/<ArAgingBuckets\s+buckets=/);
+  });
+
+  it('renderiza los 6 bloques en el orden esperado', () => {
+    const idxFilters = src.indexOf('<IngresosFilters');
+    const idxKpis = src.indexOf('<IngresosKpisBlock');
+    const idxBank = src.indexOf('<BankDataWarning');
+    const idxAging = src.indexOf('<ArAgingBuckets');
+    const idxTopClientes = src.indexOf('<TopClientesBloque');
+    const idxTopMarcas = src.indexOf('<TopMarcasBloque');
+    const idxTabla = src.indexOf('<IngresosTabla');
+    const idxAccesos = src.indexOf('<IngresosAccesosRapidos');
+
+    expect(idxFilters).toBeGreaterThan(-1);
+    expect(idxKpis).toBeGreaterThan(idxFilters);
+    expect(idxBank).toBeGreaterThan(idxKpis);
+    expect(idxAging).toBeGreaterThan(idxBank);
+    expect(idxTopClientes).toBeGreaterThan(idxAging);
+    expect(idxTopMarcas).toBeGreaterThan(idxAging);
+    expect(idxTabla).toBeGreaterThan(idxTopClientes);
+    expect(idxAccesos).toBeGreaterThan(idxTabla);
+  });
+
+  it('parsea filtros por URL params (from/to/cliente/marca/estado/tipo)', () => {
+    expect(src).toMatch(/firstParam\(sp\.from\)/);
+    expect(src).toMatch(/firstParam\(sp\.to\)/);
+    expect(src).toMatch(/firstParam\(sp\.cliente\)/);
+    expect(src).toMatch(/firstParam\(sp\.marca\)/);
+    expect(src).toMatch(/firstParam\(sp\.estado\)/);
+    expect(src).toMatch(/firstParam\(sp\.tipo\)/);
+  });
+});
+
+describe('[finanzas-ingresos] tabla usa normalizeInvoiceStatusForDisplay', () => {
+  const src = read('src/features/admin/finance-dashboard/components/ingresos/IngresosTabla.tsx');
+
+  it('importa el helper', () => {
+    expect(src).toMatch(/normalizeInvoiceStatusForDisplay/);
+  });
+
+  it('lo llama en cada fila', () => {
+    expect(src).toMatch(/normalizeInvoiceStatusForDisplay\(row\.status\)/);
+  });
+
+  it('usa la semántica del display, no colores hardcoded por status', () => {
+    expect(src).toMatch(/INVOICE_STATUS_DISPLAY_SEMANTIC/);
+  });
+});
+
+describe('[finanzas-ingresos] getIngresosData es read-only', () => {
+  const src = read('src/lib/queries/financeDashboard/ingresos.ts');
+
+  it('marca el archivo server-only', () => {
+    expect(src).toMatch(/^['"]server-only['"];/m);
+  });
+
+  it('no ejecuta insert/update/delete', () => {
+    expect(src).not.toMatch(/db\.insert\(/);
+    expect(src).not.toMatch(/db\.update\(/);
+    expect(src).not.toMatch(/db\.delete\(/);
+  });
+
+  it('reutiliza getArAging en lugar de duplicar la query', () => {
+    expect(src).toMatch(/import\s*\{\s*getArAging\s*\}/);
+    expect(src).toMatch(/getArAging\(/);
+  });
+
+  it('exporta el shape completo (kpis + aging + top clientes + top marcas)', () => {
+    expect(src).toMatch(/export type IngresosData/);
+    expect(src).toMatch(/export async function getIngresosData/);
+  });
+});
+
+describe('[finanzas-ingresos] copy prohibido', () => {
+  const FILES = [
+    'src/app/admin/(dashboard)/finanzas/ingresos/page.tsx',
+    'src/features/admin/finance-dashboard/components/ingresos/IngresosKpis.tsx',
+    'src/features/admin/finance-dashboard/components/ingresos/IngresosFilters.tsx',
+    'src/features/admin/finance-dashboard/components/ingresos/IngresosTabla.tsx',
+    'src/features/admin/finance-dashboard/components/ingresos/TopClientesBloque.tsx',
+    'src/features/admin/finance-dashboard/components/ingresos/TopMarcasBloque.tsx',
+    'src/features/admin/finance-dashboard/components/ingresos/IngresosAccesosRapidos.tsx',
+  ] as const;
+
+  // Copy prohibido en el módulo Finanzas — solo permitido en Informes avanzados.
+  const FORBIDDEN = /\b(pasivo|activo corriente|asiento contable|devengo)\b/i;
+
+  it.each(FILES)('%s no contiene jerga contable prohibida', (file) => {
+    const src = read(file);
+    expect(src).not.toMatch(FORBIDDEN);
+  });
+});
+
+describe('[finanzas-ingresos] no hay actions/writes nuevos', () => {
+  const feature = 'src/features/admin/finance-dashboard/components/ingresos';
+  const files = fs.readdirSync(path.join(ROOT, feature));
+
+  it('no hay Server Actions en la carpeta ingresos', () => {
+    for (const f of files) {
+      const src = read(`${feature}/${f}`);
+      expect(src).not.toMatch(/^['"]use server['"];/m);
+    }
+  });
+});

--- a/src/__tests__/server/finanzas-nav-and-routing.test.ts
+++ b/src/__tests__/server/finanzas-nav-and-routing.test.ts
@@ -89,12 +89,20 @@ describe('[finanzas-nav-and-routing] páginas placeholder usan PlaceholderSectio
   });
 });
 
-describe('[finanzas-nav-and-routing] /admin/finanzas/ingresos hospeda IngresosCompoundPage', () => {
-  const src = read('src/app/admin/(dashboard)/finanzas/ingresos/page.tsx');
-  it('importa IngresosCompoundPage del shared feature', () => {
-    expect(src).toMatch(/import\s*\{\s*IngresosCompoundPage\s*\}\s*from\s*['"]@\/features\/admin\/invoices\/pages\/IngresosCompoundPage['"]/);
+describe('[finanzas-nav-and-routing] /admin/finanzas/ingresos + gestor (PR 3 rediseño)', () => {
+  // PR 3 (2026-07-06): /admin/finanzas/ingresos es una sección nueva
+  // con KPIs + aging + tabla + top clientes. El compound antiguo se
+  // preserva en /admin/finanzas/ingresos/gestor, accesible desde el
+  // bloque "Accesos rápidos".
+  it('/ingresos es la nueva sección PR 3 (usa getIngresosData)', () => {
+    const src = read('src/app/admin/(dashboard)/finanzas/ingresos/page.tsx');
+    expect(src).toMatch(/import\s*\{\s*getIngresosData\s*\}/);
+    expect(src).toMatch(/<IngresosKpisBlock/);
   });
-  it('renderiza el compound', () => {
-    expect(src).toMatch(/<IngresosCompoundPage\s+headerTitle=['"]Ingresos['"]/);
+
+  it('/ingresos/gestor hospeda IngresosCompoundPage (compound preservado)', () => {
+    const src = read('src/app/admin/(dashboard)/finanzas/ingresos/gestor/page.tsx');
+    expect(src).toMatch(/import\s*\{\s*IngresosCompoundPage\s*\}\s*from\s*['"]@\/features\/admin\/invoices\/pages\/IngresosCompoundPage['"]/);
+    expect(src).toMatch(/<IngresosCompoundPage\s+headerTitle=['"]Gestor de facturación['"]/);
   });
 });

--- a/src/__tests__/server/ingresos-status-display.test.ts
+++ b/src/__tests__/server/ingresos-status-display.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Contratos del helper `normalizeInvoiceStatusForDisplay` — mapping
+ * visual del enum legacy `invoice_status` (12 valores, con duplicados)
+ * a las 7 categorías canónicas para UI.
+ *
+ * NO modifica DB. Se cubre exhaustivamente porque el mapping es un
+ * contrato con la sección /admin/finanzas/ingresos (PR 3).
+ */
+
+import {
+  normalizeInvoiceStatusForDisplay,
+  INVOICE_STATUS_DISPLAY_LABELS,
+  INVOICE_STATUS_DISPLAY_SEMANTIC,
+  type InvoiceStatusDisplay,
+} from '@/lib/utils/invoice-status-display';
+
+describe('[normalizeInvoiceStatusForDisplay] mapping canónico', () => {
+  const cases: readonly [string, InvoiceStatusDisplay][] = [
+    ['borrador', 'borrador'],
+    ['emitida', 'emitida'],
+    ['parcial', 'parcial'],
+    ['cobrada', 'cobrada'],
+    ['pagada', 'cobrada'],
+    ['vencida', 'vencida'],
+    ['anulada', 'cancelada'],
+    ['pendiente', 'pendiente'],
+    ['no_cobrada', 'pendiente'],
+    ['no_cobrado', 'pendiente'],
+    ['no_pagada', 'pendiente'],
+    ['no_pagado', 'pendiente'],
+  ];
+
+  it.each(cases)('mapea "%s" → %s', (raw, expected) => {
+    expect(normalizeInvoiceStatusForDisplay(raw)).toBe(expected);
+  });
+
+  it('trata mayúsculas y espacios sobrantes', () => {
+    expect(normalizeInvoiceStatusForDisplay('  Cobrada  ')).toBe('cobrada');
+    expect(normalizeInvoiceStatusForDisplay('EMITIDA')).toBe('emitida');
+  });
+
+  it('devuelve "pendiente" para null/undefined/vacío', () => {
+    expect(normalizeInvoiceStatusForDisplay(null)).toBe('pendiente');
+    expect(normalizeInvoiceStatusForDisplay(undefined)).toBe('pendiente');
+    expect(normalizeInvoiceStatusForDisplay('')).toBe('pendiente');
+  });
+
+  it('devuelve "pendiente" para valores desconocidos', () => {
+    expect(normalizeInvoiceStatusForDisplay('invented_status')).toBe('pendiente');
+    expect(normalizeInvoiceStatusForDisplay('foo')).toBe('pendiente');
+  });
+});
+
+describe('[status-display] labels y semánticas', () => {
+  const DISPLAY_KEYS: readonly InvoiceStatusDisplay[] = [
+    'borrador', 'emitida', 'parcial', 'cobrada', 'vencida', 'cancelada', 'pendiente',
+  ];
+
+  it('todas las categorías tienen label en español', () => {
+    for (const k of DISPLAY_KEYS) {
+      expect(INVOICE_STATUS_DISPLAY_LABELS[k]).toMatch(/^[A-ZÁÉÍÓÚ]/);
+    }
+  });
+
+  it('todas las categorías tienen semantic válida', () => {
+    const VALID = new Set(['positive', 'attention', 'negative', 'neutral']);
+    for (const k of DISPLAY_KEYS) {
+      expect(VALID.has(INVOICE_STATUS_DISPLAY_SEMANTIC[k])).toBe(true);
+    }
+  });
+
+  it('cobrada es positive', () => {
+    expect(INVOICE_STATUS_DISPLAY_SEMANTIC.cobrada).toBe('positive');
+  });
+
+  it('vencida es negative', () => {
+    expect(INVOICE_STATUS_DISPLAY_SEMANTIC.vencida).toBe('negative');
+  });
+
+  it('emitida/parcial/pendiente son attention (requieren acción)', () => {
+    expect(INVOICE_STATUS_DISPLAY_SEMANTIC.emitida).toBe('attention');
+    expect(INVOICE_STATUS_DISPLAY_SEMANTIC.parcial).toBe('attention');
+    expect(INVOICE_STATUS_DISPLAY_SEMANTIC.pendiente).toBe('attention');
+  });
+});

--- a/src/app/admin/(dashboard)/finanzas/ingresos/gestor/page.tsx
+++ b/src/app/admin/(dashboard)/finanzas/ingresos/gestor/page.tsx
@@ -1,0 +1,22 @@
+import { requirePermission } from '@/lib/permissions';
+import { IngresosCompoundPage } from '@/features/admin/invoices/pages/IngresosCompoundPage';
+
+export const metadata = { title: 'Gestor de facturación · Ingresos · Finanzas' };
+
+/**
+ * Compound page migrada desde /admin/finanzas/ingresos (PR 2).
+ *
+ * En PR 3 rediseñamos /ingresos con KPIs + aging + tabla + top clientes,
+ * pero el compound antiguo (Facturas emitidas, Clientes de facturación,
+ * Empresas emisoras, Importar) sigue siendo útil como panel operativo.
+ * Se accede desde el bloque "Accesos rápidos" de la nueva ingresos.
+ */
+export default async function FinanzasIngresosGestorPage(): Promise<React.ReactElement> {
+  await requirePermission('facturacion', 'read');
+  return (
+    <IngresosCompoundPage
+      headerTitle="Gestor de facturación"
+      headerSubtitle="Facturas emitidas, clientes, empresas emisoras e importación de facturas"
+    />
+  );
+}

--- a/src/app/admin/(dashboard)/finanzas/ingresos/page.tsx
+++ b/src/app/admin/(dashboard)/finanzas/ingresos/page.tsx
@@ -1,12 +1,155 @@
 import { requirePermission } from '@/lib/permissions';
-import { IngresosCompoundPage } from '@/features/admin/invoices/pages/IngresosCompoundPage';
+import { asc } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import { crmBrands } from '@/db/schema';
+import { getIngresosData } from '@/lib/queries/financeDashboard/ingresos';
+import { getBankDataStatus } from '@/lib/queries/financeDashboard/bankDataStatus';
+import { getBillingClients } from '@/lib/queries/issuedInvoices';
+
+import { IngresosKpisBlock } from '@/features/admin/finance-dashboard/components/ingresos/IngresosKpis';
+import { IngresosFilters } from '@/features/admin/finance-dashboard/components/ingresos/IngresosFilters';
+import { IngresosTabla } from '@/features/admin/finance-dashboard/components/ingresos/IngresosTabla';
+import { TopClientesBloque } from '@/features/admin/finance-dashboard/components/ingresos/TopClientesBloque';
+import { TopMarcasBloque } from '@/features/admin/finance-dashboard/components/ingresos/TopMarcasBloque';
+import { IngresosAccesosRapidos } from '@/features/admin/finance-dashboard/components/ingresos/IngresosAccesosRapidos';
+import { BankDataWarning } from '@/features/admin/finance-dashboard/components/resumen-v3/BankDataWarning';
+import { ArAgingBuckets } from '@/features/admin/finance-dashboard/components/ArAgingBuckets';
+import {
+  normalizeInvoiceStatusForDisplay,
+  type InvoiceStatusDisplay,
+} from '@/lib/utils/invoice-status-display';
+import type { ArAgingRow } from '@/types/arAging';
 
 export const metadata = { title: 'Ingresos · Finanzas' };
 
-// Guard duplicado y explícito (además del que hace IngresosCompoundPage al inicio).
-// Documenta a nivel de ruta el requisito y evita depender de la implementación
-// interna del compound.
-export default async function FinanzasIngresosPage(): Promise<React.ReactElement> {
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const STATUS_VALUES: readonly (InvoiceStatusDisplay | 'todas')[] = ['todas', 'emitida', 'parcial', 'cobrada', 'vencida', 'cancelada', 'pendiente'];
+const TIPO_VALUES: readonly ('todas' | 'internal' | 'issued')[] = ['todas', 'internal', 'issued'];
+
+function todayInMadrid(): string {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Europe/Madrid',
+    year: 'numeric', month: '2-digit', day: '2-digit',
+  }).format(new Date());
+}
+
+function firstParam(v: string | string[] | undefined): string | undefined {
+  if (v === undefined) return undefined;
+  return Array.isArray(v) ? v[0] : v;
+}
+
+function safeIsoDate(v: string | undefined): string | undefined {
+  if (!v || !ISO_DATE_RE.test(v)) return undefined;
+  return v;
+}
+
+function normalizeStatusFilter(v: string | undefined): InvoiceStatusDisplay | 'todas' {
+  if (!v) return 'todas';
+  return (STATUS_VALUES as readonly string[]).includes(v)
+    ? (v as InvoiceStatusDisplay | 'todas')
+    : 'todas';
+}
+
+function normalizeTipoFilter(v: string | undefined): 'todas' | 'internal' | 'issued' {
+  if (!v) return 'todas';
+  return (TIPO_VALUES as readonly string[]).includes(v)
+    ? (v as 'todas' | 'internal' | 'issued')
+    : 'todas';
+}
+
+type PageProps = {
+  readonly searchParams?: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export default async function FinanzasIngresosPage({ searchParams }: PageProps): Promise<React.ReactElement> {
   await requirePermission('facturacion', 'read');
-  return <IngresosCompoundPage headerTitle="Ingresos" headerSubtitle="Movimientos, facturas emitidas, clientes y empresas emisoras" />;
+
+  const sp = (await searchParams) ?? {};
+  const from = safeIsoDate(firstParam(sp.from));
+  const to = safeIsoDate(firstParam(sp.to));
+  const cliente = firstParam(sp.cliente) ?? null;
+  const marca = firstParam(sp.marca) ?? null;
+  const estado = normalizeStatusFilter(firstParam(sp.estado));
+  const tipo = normalizeTipoFilter(firstParam(sp.tipo));
+
+  const [data, bankStatus, clients, brands] = await Promise.all([
+    getIngresosData({
+      ...(from ? { from } : {}),
+      ...(to ? { to } : {}),
+    }),
+    getBankDataStatus(),
+    getBillingClients(),
+    db.select({ id: crmBrands.id, name: crmBrands.name }).from(crmBrands).orderBy(asc(crmBrands.name)),
+  ]);
+
+  const today = todayInMadrid();
+  const defaults = { from: `${today.slice(0, 4)}-01-01`, to: today };
+  const clientOptions = clients.map((c) => ({ id: c.id, name: c.name }));
+
+  const filtersApplied = { cliente, marca, estado, tipo };
+  const filteredRows = data.aging.rows.filter((row: ArAgingRow) => {
+    const status = normalizeInvoiceStatusForDisplay(row.status);
+    if (tipo !== 'todas' && row.source !== tipo) return false;
+    if (estado !== 'todas' && status !== estado) return false;
+    if (cliente) {
+      const clientName = row.clientName ?? row.entity ?? '';
+      if (clientName.toLowerCase() !== cliente.toLowerCase()) return false;
+    }
+    if (marca) {
+      const brandName = row.brandName ?? '';
+      if (brandName.toLowerCase() !== marca.toLowerCase()) return false;
+    }
+    return true;
+  });
+
+  return (
+    <div className="space-y-5 pt-2">
+      <header>
+        <h1 className="text-xl font-bold text-sp-admin-fg">Ingresos</h1>
+        <p className="text-sm text-sp-admin-muted">
+          Facturación, cobros pendientes, aging y ranking de clientes.
+        </p>
+      </header>
+
+      <IngresosFilters
+        defaults={defaults}
+        applied={data.period}
+        clients={clientOptions}
+        brands={brands}
+      />
+
+      <IngresosKpisBlock kpis={data.kpis} />
+
+      <BankDataWarning
+        bankTransactionsCount={bankStatus.bankTransactionsCount}
+        invoicePaymentsCount={bankStatus.invoicePaymentsCount}
+      />
+
+      <section aria-labelledby="aging-title" className="rounded-2xl border border-sp-border bg-sp-admin-card p-5">
+        <div className="flex items-center gap-2 mb-3">
+          <span className="text-lg" aria-hidden>📅</span>
+          <h2 id="aging-title" className="text-sm font-bold text-sp-admin-fg">Aging de cobros</h2>
+          <span className="ml-auto text-[11px] text-sp-admin-muted">Distribución por antigüedad del pendiente</span>
+        </div>
+        <ArAgingBuckets buckets={data.aging.buckets} />
+      </section>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <TopClientesBloque rows={data.topClientes} />
+        <div className="grid gap-4">
+          <TopMarcasBloque rows={data.topMarcasFacturado} variant="facturado" />
+          <TopMarcasBloque rows={data.topMarcasPendiente} variant="pendiente" />
+        </div>
+      </div>
+
+      <IngresosTabla
+        rows={filteredRows}
+        filteredRowCount={filteredRows.length}
+        totalRows={data.aging.rows.length}
+        filters={filtersApplied}
+      />
+
+      <IngresosAccesosRapidos />
+    </div>
+  );
 }

--- a/src/features/admin/finance-dashboard/components/ingresos/IngresosAccesosRapidos.tsx
+++ b/src/features/admin/finance-dashboard/components/ingresos/IngresosAccesosRapidos.tsx
@@ -1,0 +1,68 @@
+import Link from 'next/link';
+
+interface AccesoItem {
+  readonly href: string;
+  readonly title: string;
+  readonly description: string;
+  readonly icon: string;
+}
+
+const ACCESOS: readonly AccesoItem[] = [
+  {
+    href: '/admin/finanzas/ingresos/gestor',
+    title: 'Gestor de facturación completo',
+    description: 'Facturas emitidas, clientes de facturación, empresas emisoras.',
+    icon: '📋',
+  },
+  {
+    href: '/admin/facturacion/import',
+    title: 'Importar factura PDF',
+    description: 'Sube una factura en PDF — la IA extrae los datos.',
+    icon: '📄',
+  },
+  {
+    href: '/admin/facturacion/bancos/conciliacion',
+    title: 'Conciliación bancaria',
+    description: 'Aplica pagos desde extractos importados a facturas.',
+    icon: '🏦',
+  },
+];
+
+/**
+ * Cards con enlaces útiles a las funciones que aún viven bajo
+ * `/admin/facturacion/*`. Se preservan hasta que se completen las
+ * secciones "Documentos" e "Ingresos" del nuevo hub.
+ */
+export function IngresosAccesosRapidos(): React.ReactElement {
+  return (
+    <section aria-labelledby="accesos-rapidos-title" className="space-y-3">
+      <h2 id="accesos-rapidos-title" className="text-sm font-bold text-sp-admin-fg">
+        Accesos rápidos
+      </h2>
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {ACCESOS.map((a) => (
+          <Link
+            key={a.href}
+            href={a.href}
+            className="flex items-center gap-4 rounded-2xl border border-sp-border bg-sp-admin-card p-4 hover:border-sp-orange/40 transition-colors group"
+          >
+            <div className="w-10 h-10 rounded-xl bg-sp-orange/10 flex items-center justify-center text-xl shrink-0">
+              {a.icon}
+            </div>
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-semibold text-sp-admin-fg group-hover:text-sp-orange transition-colors">
+                {a.title}
+              </p>
+              <p className="text-xs text-sp-admin-muted mt-0.5">
+                {a.description}
+              </p>
+            </div>
+            <svg className="w-4 h-4 text-sp-admin-muted group-hover:text-sp-orange transition-colors shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3" />
+            </svg>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/features/admin/finance-dashboard/components/ingresos/IngresosFilters.tsx
+++ b/src/features/admin/finance-dashboard/components/ingresos/IngresosFilters.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useTransition } from 'react';
+
+interface Props {
+  readonly defaults: { readonly from: string; readonly to: string };
+  readonly applied: { readonly from: string; readonly to: string };
+  readonly clients: readonly { readonly id: number; readonly name: string }[];
+  readonly brands: readonly { readonly id: number; readonly name: string }[];
+}
+
+const STATUSES = ['todas', 'emitida', 'parcial', 'cobrada', 'vencida', 'cancelada', 'pendiente'] as const;
+const TIPOS = [
+  { value: 'todas',    label: 'Todas' },
+  { value: 'internal', label: 'Internas' },
+  { value: 'issued',   label: 'Emitidas oficiales' },
+] as const;
+
+/**
+ * Filtros persistentes por URL params. No mutan estado local — el router
+ * push cambia la URL y el server component re-renderiza con los datos.
+ * "Aplicar" para no disparar re-render en cada tecla.
+ */
+export function IngresosFilters({ defaults, applied, clients, brands }: Props): React.ReactElement {
+  const router = useRouter();
+  const search = useSearchParams();
+  const [isPending, startTransition] = useTransition();
+
+  function updateParams(patch: Record<string, string | null>) {
+    const params = new URLSearchParams(search.toString());
+    for (const [k, v] of Object.entries(patch)) {
+      if (v === null || v === '' || v === 'todas') {
+        params.delete(k);
+      } else {
+        params.set(k, v);
+      }
+    }
+    const qs = params.toString();
+    startTransition(() => router.push(qs ? `?${qs}` : '?', { scroll: false }));
+  }
+
+  const cliente = search.get('cliente') ?? '';
+  const marca = search.get('marca') ?? '';
+  const estado = search.get('estado') ?? 'todas';
+  const tipo = search.get('tipo') ?? 'todas';
+
+  return (
+    <form
+      className="rounded-2xl border border-sp-border bg-sp-admin-card p-4 grid gap-3 md:grid-cols-6 items-end"
+      onSubmit={(e) => e.preventDefault()}
+    >
+      <label className="flex flex-col gap-1 text-[10px] uppercase tracking-wide font-bold text-sp-admin-muted">
+        Desde
+        <input
+          type="date"
+          defaultValue={applied.from}
+          onBlur={(e) => updateParams({ from: e.target.value || defaults.from })}
+          className="rounded-md border border-sp-border bg-sp-admin-card px-2 py-1.5 text-sm text-sp-admin-fg"
+        />
+      </label>
+      <label className="flex flex-col gap-1 text-[10px] uppercase tracking-wide font-bold text-sp-admin-muted">
+        Hasta
+        <input
+          type="date"
+          defaultValue={applied.to}
+          onBlur={(e) => updateParams({ to: e.target.value || defaults.to })}
+          className="rounded-md border border-sp-border bg-sp-admin-card px-2 py-1.5 text-sm text-sp-admin-fg"
+        />
+      </label>
+      <label className="flex flex-col gap-1 text-[10px] uppercase tracking-wide font-bold text-sp-admin-muted">
+        Cliente
+        <select
+          value={cliente}
+          onChange={(e) => updateParams({ cliente: e.target.value })}
+          className="rounded-md border border-sp-border bg-sp-admin-card px-2 py-1.5 text-sm text-sp-admin-fg"
+          disabled={clients.length === 0}
+        >
+          <option value="">Todos {clients.length === 0 ? '(sin clientes)' : ''}</option>
+          {clients.map((c) => (
+            <option key={c.id} value={c.name}>{c.name}</option>
+          ))}
+        </select>
+      </label>
+      <label className="flex flex-col gap-1 text-[10px] uppercase tracking-wide font-bold text-sp-admin-muted">
+        Marca
+        <select
+          value={marca}
+          onChange={(e) => updateParams({ marca: e.target.value })}
+          className="rounded-md border border-sp-border bg-sp-admin-card px-2 py-1.5 text-sm text-sp-admin-fg"
+          disabled={brands.length === 0}
+        >
+          <option value="">Todas {brands.length === 0 ? '(sin marcas)' : ''}</option>
+          {brands.map((b) => (
+            <option key={b.id} value={b.name}>{b.name}</option>
+          ))}
+        </select>
+      </label>
+      <label className="flex flex-col gap-1 text-[10px] uppercase tracking-wide font-bold text-sp-admin-muted">
+        Estado
+        <select
+          value={estado}
+          onChange={(e) => updateParams({ estado: e.target.value })}
+          className="rounded-md border border-sp-border bg-sp-admin-card px-2 py-1.5 text-sm text-sp-admin-fg"
+        >
+          {STATUSES.map((s) => (
+            <option key={s} value={s}>{s === 'todas' ? 'Todos' : s.charAt(0).toUpperCase() + s.slice(1)}</option>
+          ))}
+        </select>
+      </label>
+      <label className="flex flex-col gap-1 text-[10px] uppercase tracking-wide font-bold text-sp-admin-muted">
+        Tipo
+        <select
+          value={tipo}
+          onChange={(e) => updateParams({ tipo: e.target.value })}
+          className="rounded-md border border-sp-border bg-sp-admin-card px-2 py-1.5 text-sm text-sp-admin-fg"
+        >
+          {TIPOS.map((t) => <option key={t.value} value={t.value}>{t.label}</option>)}
+        </select>
+      </label>
+      {isPending ? (
+        <span className="md:col-span-6 text-[11px] text-sp-admin-muted">Actualizando…</span>
+      ) : null}
+    </form>
+  );
+}

--- a/src/features/admin/finance-dashboard/components/ingresos/IngresosKpis.tsx
+++ b/src/features/admin/finance-dashboard/components/ingresos/IngresosKpis.tsx
@@ -1,0 +1,126 @@
+import type { IngresosKpis } from '@/lib/queries/financeDashboard/ingresos';
+
+interface Props {
+  readonly kpis: IngresosKpis;
+}
+
+const EUR = new Intl.NumberFormat('es-ES', { style: 'currency', currency: 'EUR', maximumFractionDigits: 0 });
+function fmt(n: number): string { return EUR.format(n); }
+
+type Semantic = 'positive' | 'attention' | 'negative' | 'neutral';
+
+interface Kpi {
+  readonly label: string;
+  readonly value: string;
+  readonly semantic: Semantic;
+  readonly hint?: string;
+}
+
+const COLORS: Record<Semantic, string> = {
+  positive:  '#16a34a',
+  attention: '#f59e0b',
+  negative:  '#ef4444',
+  neutral:   '#6b7280',
+};
+
+function KpiCard({ kpi }: { kpi: Kpi }): React.ReactElement {
+  const color = COLORS[kpi.semantic];
+  return (
+    <div className="rounded-xl bg-sp-admin-card border border-sp-border overflow-hidden">
+      <div className="h-[3px]" style={{ background: color }} />
+      <div className="px-4 py-3">
+        <p className="text-[10px] font-black uppercase tracking-[0.14em] text-sp-admin-muted leading-none">
+          {kpi.label}
+        </p>
+        <p className="text-[19px] font-bold tabular-nums mt-2 leading-none" style={{ color }}>
+          {kpi.value}
+        </p>
+        {kpi.hint ? (
+          <p className="text-[10px] font-medium text-sp-admin-muted mt-1.5 leading-tight">{kpi.hint}</p>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * KPIs propios de la sección Ingresos.
+ *
+ * Distinción explícita entre "Facturado" (importe emitido) y "Cobrado"
+ * (pagos aplicados). Cuando `invoice_payments = 0` el cobrado será 0 y
+ * el aviso `BankDataWarning` (upstream) contextualiza el dato.
+ */
+export function IngresosKpisBlock({ kpis }: Props): React.ReactElement {
+  const primary: readonly Kpi[] = [
+    {
+      label: 'Facturado total',
+      value: fmt(kpis.facturadoTotal),
+      semantic: 'neutral',
+      hint: 'Importe emitido en el período (interno + emitidas)',
+    },
+    {
+      label: 'Cobrado total',
+      value: fmt(kpis.cobradoTotal),
+      semantic: kpis.cobradoTotal > 0 ? 'positive' : 'neutral',
+      hint: 'Pagos aplicados desde conciliación',
+    },
+    {
+      label: 'Pendiente de cobro',
+      value: fmt(kpis.pendienteCobro),
+      semantic: kpis.pendienteCobro > 0 ? 'attention' : 'positive',
+      hint: `${kpis.facturasPendientes} factura${kpis.facturasPendientes === 1 ? '' : 's'} viva${kpis.facturasPendientes === 1 ? '' : 's'}`,
+    },
+    {
+      label: 'Vencido',
+      value: fmt(kpis.vencido),
+      semantic: kpis.vencido > 0 ? 'negative' : 'positive',
+      hint: 'Pendiente con vencimiento pasado',
+    },
+    {
+      label: 'Por vencer',
+      value: fmt(kpis.porVencer),
+      semantic: 'attention',
+      hint: 'Pendiente aún dentro de plazo',
+    },
+  ];
+
+  const secondary: readonly Kpi[] = [
+    {
+      label: 'Promedio días de cobro',
+      value: kpis.promedioDiasCobro !== null ? `${kpis.promedioDiasCobro} días` : '—',
+      semantic: kpis.promedioDiasCobro === null
+        ? 'neutral'
+        : kpis.promedioDiasCobro > 60 ? 'negative'
+        : kpis.promedioDiasCobro > 30 ? 'attention'
+        : 'positive',
+      hint: 'Promedio en las facturas vencidas',
+    },
+    {
+      label: 'Cliente con mayor deuda',
+      value: kpis.clienteMayorDeuda
+        ? kpis.clienteMayorDeuda.name
+        : 'Sin deuda',
+      semantic: kpis.clienteMayorDeuda ? 'attention' : 'positive',
+      hint: kpis.clienteMayorDeuda
+        ? fmt(kpis.clienteMayorDeuda.amount)
+        : 'Todas las facturas al día',
+    },
+    {
+      label: 'Facturas pendientes',
+      value: `${kpis.facturasPendientes}`,
+      semantic: kpis.facturasPendientes > 0 ? 'attention' : 'positive',
+      hint: 'Nº total viviendo aging',
+    },
+  ];
+
+  return (
+    <section aria-label="KPIs de ingresos" className="space-y-3">
+      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-2.5">
+        {primary.map((k) => <KpiCard key={k.label} kpi={k} />)}
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-2.5">
+        {secondary.map((k) => <KpiCard key={k.label} kpi={k} />)}
+      </div>
+    </section>
+  );
+}

--- a/src/features/admin/finance-dashboard/components/ingresos/IngresosTabla.tsx
+++ b/src/features/admin/finance-dashboard/components/ingresos/IngresosTabla.tsx
@@ -1,0 +1,173 @@
+import Link from 'next/link';
+import type { ArAgingRow } from '@/types/arAging';
+import {
+  INVOICE_STATUS_DISPLAY_LABELS,
+  INVOICE_STATUS_DISPLAY_SEMANTIC,
+  normalizeInvoiceStatusForDisplay,
+  type InvoiceStatusDisplay,
+} from '@/lib/utils/invoice-status-display';
+
+interface Props {
+  readonly rows: readonly ArAgingRow[];
+  readonly filteredRowCount: number;
+  readonly totalRows: number;
+  readonly filters: Filters;
+}
+
+interface Filters {
+  readonly cliente: string | null;
+  readonly marca: string | null;
+  readonly estado: InvoiceStatusDisplay | 'todas';
+  readonly tipo: 'todas' | 'internal' | 'issued';
+}
+
+const EUR = new Intl.NumberFormat('es-ES', { style: 'currency', currency: 'EUR', maximumFractionDigits: 0 });
+function fmt(n: number): string { return EUR.format(n); }
+
+const SEMANTIC_BADGE: Record<'positive' | 'attention' | 'negative' | 'neutral', string> = {
+  positive:  'bg-emerald-500/15 text-emerald-500 border border-emerald-500/30',
+  attention: 'bg-amber-500/15 text-amber-500 border border-amber-500/30',
+  negative:  'bg-red-500/15 text-red-500 border border-red-500/30',
+  neutral:   'bg-slate-500/15 text-slate-400 border border-slate-500/30',
+};
+
+function StatusBadge({ status }: { status: InvoiceStatusDisplay }): React.ReactElement {
+  const semantic = INVOICE_STATUS_DISPLAY_SEMANTIC[status];
+  return (
+    <span className={`text-[10px] font-bold uppercase tracking-wide px-2 py-0.5 rounded-full inline-block ${SEMANTIC_BADGE[semantic]}`}>
+      {INVOICE_STATUS_DISPLAY_LABELS[status]}
+    </span>
+  );
+}
+
+/**
+ * Tabla principal de facturas — unifica `invoices` (income) e
+ * `issued_invoices` a través del formato común de `ArAgingRow`.
+ *
+ * Estados normalizados con `normalizeInvoiceStatusForDisplay`. Filtros
+ * aplicados en cliente para no rehacer queries. El aging server-side
+ * es la fuente de las filas.
+ */
+export function IngresosTabla({ rows, filteredRowCount, totalRows, filters }: Props): React.ReactElement {
+  return (
+    <section aria-labelledby="ingresos-tabla-title" className="rounded-2xl border border-sp-border bg-sp-admin-card overflow-hidden">
+      <div className="px-4 py-3 border-b border-sp-border flex items-baseline justify-between gap-3">
+        <div>
+          <h2 id="ingresos-tabla-title" className="text-sm font-bold text-sp-admin-fg">Facturas</h2>
+          <p className="text-[11px] text-sp-admin-muted mt-0.5">
+            Facturas internas + emitidas oficiales con saldo pendiente. Estados normalizados.
+          </p>
+        </div>
+        <p className="text-[11px] text-sp-admin-muted tabular-nums">
+          {filteredRowCount}/{totalRows} filas
+        </p>
+      </div>
+
+      {filteredRowCount === 0 ? (
+        <div className="px-4 py-10 text-center">
+          <p className="text-sm text-sp-admin-muted italic">
+            {totalRows === 0
+              ? 'No hay facturas pendientes. Todo al día.'
+              : 'Ningún resultado con los filtros actuales.'}
+          </p>
+        </div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-sp-border bg-sp-admin-card/60">
+                {['Factura', 'Cliente', 'Marca', 'Tipo', 'Emisión', 'Vencimiento', 'Importe', 'Cobrado', 'Pendiente', 'Estado', 'Documento'].map((h) => (
+                  <th key={h} className="px-3 py-2 text-left text-[9px] font-bold uppercase tracking-wide text-sp-admin-muted whitespace-nowrap">
+                    {h}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => {
+                const status = normalizeInvoiceStatusForDisplay(row.status);
+                const isMatch = matches(row, status, filters);
+                if (!isMatch) return null;
+                return (
+                  <tr key={`${row.source}-${row.id}`} className="border-b border-sp-border/40 last:border-0 hover:bg-sp-admin-hover transition-colors">
+                    <td className="px-3 py-2 text-[12px] font-medium text-sp-admin-fg whitespace-nowrap">
+                      {row.invoiceNumber}
+                    </td>
+                    <td className="px-3 py-2 text-[12px] text-sp-admin-fg max-w-[180px] truncate">
+                      {row.clientName ?? row.entity ?? '—'}
+                    </td>
+                    <td className="px-3 py-2 text-[12px] text-sp-admin-muted max-w-[140px] truncate">
+                      {row.brandName ?? '—'}
+                    </td>
+                    <td className="px-3 py-2 text-[10px] whitespace-nowrap">
+                      <span className={`px-1.5 py-0.5 rounded font-semibold ${
+                        row.source === 'issued'
+                          ? 'bg-sp-orange/15 text-sp-orange'
+                          : 'bg-slate-500/15 text-slate-400'
+                      }`}>
+                        {row.source === 'issued' ? 'Emitida' : 'Interna'}
+                      </span>
+                    </td>
+                    <td className="px-3 py-2 text-[11px] text-sp-admin-muted whitespace-nowrap tabular-nums">
+                      {row.issueDate}
+                    </td>
+                    <td className="px-3 py-2 text-[11px] whitespace-nowrap tabular-nums">
+                      <span className={row.daysOverdue > 0 ? 'text-red-400 font-semibold' : 'text-sp-admin-muted'}>
+                        {row.effectiveDueDate}
+                        {row.isEstimatedDueDate ? <span className="text-[9px] ml-1 opacity-70">(est.)</span> : null}
+                      </span>
+                    </td>
+                    <td className="px-3 py-2 text-[12px] font-semibold text-sp-admin-fg tabular-nums text-right whitespace-nowrap">
+                      {fmt(row.totalAmount)}
+                    </td>
+                    <td className="px-3 py-2 text-[12px] text-emerald-500 tabular-nums text-right whitespace-nowrap">
+                      {row.paidAmount > 0 ? fmt(row.paidAmount) : '—'}
+                    </td>
+                    <td className="px-3 py-2 text-[12px] font-bold text-amber-500 tabular-nums text-right whitespace-nowrap">
+                      {fmt(row.pendingAmount)}
+                    </td>
+                    <td className="px-3 py-2 whitespace-nowrap">
+                      <StatusBadge status={status} />
+                    </td>
+                    <td className="px-3 py-2 whitespace-nowrap">
+                      {row.pdfUrl ? (
+                        <Link
+                          href={row.pdfUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-[11px] font-semibold text-sp-orange hover:opacity-80"
+                        >
+                          Abrir →
+                        </Link>
+                      ) : (
+                        <span className="text-[10px] text-sp-admin-muted">Sin PDF</span>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}
+
+/**
+ * Aplica los filtros de UI a una fila. Todo en cliente — la fuente es
+ * el aging server-side (`getArAging()` sin filtros).
+ */
+function matches(row: ArAgingRow, statusNormalized: InvoiceStatusDisplay, f: Filters): boolean {
+  if (f.tipo !== 'todas' && row.source !== f.tipo) return false;
+  if (f.estado !== 'todas' && statusNormalized !== f.estado) return false;
+  if (f.cliente) {
+    const clientName = row.clientName ?? row.entity ?? '';
+    if (clientName.toLowerCase() !== f.cliente.toLowerCase()) return false;
+  }
+  if (f.marca) {
+    const brand = row.brandName ?? '';
+    if (brand.toLowerCase() !== f.marca.toLowerCase()) return false;
+  }
+  return true;
+}

--- a/src/features/admin/finance-dashboard/components/ingresos/TopClientesBloque.tsx
+++ b/src/features/admin/finance-dashboard/components/ingresos/TopClientesBloque.tsx
@@ -1,0 +1,49 @@
+import type { TopClienteRow } from '@/lib/queries/financeDashboard/ingresos';
+
+interface Props {
+  readonly rows: readonly TopClienteRow[];
+}
+
+const EUR = new Intl.NumberFormat('es-ES', { style: 'currency', currency: 'EUR', maximumFractionDigits: 0 });
+function fmt(n: number): string { return EUR.format(n); }
+
+/**
+ * Top 5 clientes por pendiente de cobro. Deriva del aging.rows.
+ */
+export function TopClientesBloque({ rows }: Props): React.ReactElement {
+  return (
+    <section aria-labelledby="top-clientes-title" className="rounded-2xl border border-sp-border bg-sp-admin-card p-5">
+      <div className="flex items-center gap-2 mb-3">
+        <span className="text-lg" aria-hidden>👥</span>
+        <h2 id="top-clientes-title" className="text-sm font-bold text-sp-admin-fg">Clientes con más pendiente de cobro</h2>
+      </div>
+      {rows.length === 0 ? (
+        <p className="text-sm text-emerald-500 font-medium">
+          <span aria-hidden>✅</span> Nadie con deuda pendiente.
+        </p>
+      ) : (
+        <ul className="space-y-2">
+          {rows.map((r) => (
+            <li key={r.name} className="flex items-center justify-between gap-3 rounded-lg border border-sp-border/60 px-3 py-2.5">
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-semibold text-sp-admin-fg truncate">{r.name}</p>
+                <p className="text-[11px] text-sp-admin-muted mt-0.5">
+                  {r.invoiceCount} factura{r.invoiceCount === 1 ? '' : 's'}
+                  {r.lastInvoiceDate ? ` · última ${r.lastInvoiceDate}` : ''}
+                </p>
+              </div>
+              <div className="text-right shrink-0">
+                <p className="text-sm font-bold tabular-nums text-amber-500">{fmt(r.pendingAmount)}</p>
+                {r.overdueAmount > 0 ? (
+                  <p className="text-[11px] font-medium text-red-400 tabular-nums">
+                    Vencido: {fmt(r.overdueAmount)}
+                  </p>
+                ) : null}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/features/admin/finance-dashboard/components/ingresos/TopMarcasBloque.tsx
+++ b/src/features/admin/finance-dashboard/components/ingresos/TopMarcasBloque.tsx
@@ -1,0 +1,58 @@
+import type { TopMarcaRow } from '@/lib/queries/financeDashboard/ingresos';
+
+interface Props {
+  readonly rows: readonly TopMarcaRow[];
+  readonly variant: 'facturado' | 'pendiente';
+}
+
+const EUR = new Intl.NumberFormat('es-ES', { style: 'currency', currency: 'EUR', maximumFractionDigits: 0 });
+function fmt(n: number): string { return EUR.format(n); }
+
+/**
+ * Top marcas — dos variantes:
+ *   - facturado: ranking por importe facturado en el período
+ *   - pendiente: ranking por importe pendiente vivo
+ */
+export function TopMarcasBloque({ rows, variant }: Props): React.ReactElement {
+  const title = variant === 'facturado' ? 'Top marcas por facturación' : 'Top marcas por pendiente';
+  const icon = variant === 'facturado' ? '🏆' : '⚠️';
+  const emptyText = variant === 'facturado'
+    ? 'Sin facturación registrada en el período.'
+    : 'Sin marcas con pendiente vivo.';
+  const emptyClass = variant === 'facturado' ? 'text-sp-admin-muted' : 'text-emerald-500 font-medium';
+
+  return (
+    <section aria-labelledby={`top-marcas-${variant}-title`} className="rounded-2xl border border-sp-border bg-sp-admin-card p-5">
+      <div className="flex items-center gap-2 mb-3">
+        <span className="text-lg" aria-hidden>{icon}</span>
+        <h2 id={`top-marcas-${variant}-title`} className="text-sm font-bold text-sp-admin-fg">{title}</h2>
+      </div>
+      {rows.length === 0 ? (
+        <p className={`text-sm italic ${emptyClass}`}>
+          {variant === 'pendiente' ? <span aria-hidden>✅ </span> : null}{emptyText}
+        </p>
+      ) : (
+        <ul className="space-y-2">
+          {rows.map((r, idx) => {
+            const primaryAmount = variant === 'facturado' ? r.invoicedTotal : r.pendingAmount;
+            const primaryColor = variant === 'facturado' ? 'text-emerald-500' : 'text-amber-500';
+            return (
+              <li key={r.name} className="flex items-center justify-between gap-3 rounded-lg border border-sp-border/60 px-3 py-2.5">
+                <div className="flex items-center gap-2 min-w-0 flex-1">
+                  <span className="text-[11px] font-bold text-sp-admin-muted tabular-nums w-5">#{idx + 1}</span>
+                  <div className="min-w-0">
+                    <p className="text-sm font-semibold text-sp-admin-fg truncate">{r.name}</p>
+                    <p className="text-[11px] text-sp-admin-muted mt-0.5">
+                      {r.invoiceCount} factura{r.invoiceCount === 1 ? '' : 's'}
+                    </p>
+                  </div>
+                </div>
+                <p className={`text-sm font-bold tabular-nums shrink-0 ${primaryColor}`}>{fmt(primaryAmount)}</p>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/lib/queries/financeDashboard/ingresos.ts
+++ b/src/lib/queries/financeDashboard/ingresos.ts
@@ -1,0 +1,285 @@
+'server-only';
+
+import { and, eq, gte, lte, ne, sql } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import {
+  crmBrands,
+  invoicePayments,
+  invoices,
+  issuedInvoices,
+} from '@/db/schema';
+import { getArAging } from './arAging';
+import type { ArAgingBucket, ArAgingKpis, ArAgingRow } from '@/types/arAging';
+
+/**
+ * Datos agregados de la sección "Ingresos" (PR 3).
+ *
+ * Reutiliza queries existentes (`getArAging`, sumas de invoices/issued)
+ * y añade dos agregados nuevos: top clientes por deuda y top marcas por
+ * facturación. No ejecuta writes ni migraciones.
+ */
+
+export type IngresosPeriod = { readonly from: string; readonly to: string };
+
+export type IngresosKpis = {
+  /** SUM invoices.income + issued_invoices totalAmount en el periodo (no anuladas). */
+  readonly facturadoTotal: number;
+  /** SUM invoice_payments (income) del periodo (fuente canónica). Si no hay bank data cae a 0. */
+  readonly cobradoTotal: number;
+  /** Pendiente vivo total: aging.totalPending. */
+  readonly pendienteCobro: number;
+  /** Aging.totalOverdue. */
+  readonly vencido: number;
+  /** Pendiente NO vencido (aging.pendingNotYetDue). */
+  readonly porVencer: number;
+  /** Promedio días de vencimiento sobre las vencidas. `null` si no hay vencidas. */
+  readonly promedioDiasCobro: number | null;
+  /** Cliente/entidad con mayor deuda. `null` si no hay pendiente. */
+  readonly clienteMayorDeuda: { readonly name: string; readonly amount: number } | null;
+  /** Nº total de facturas pendientes. */
+  readonly facturasPendientes: number;
+};
+
+export type TopClienteRow = {
+  readonly name: string;
+  readonly pendingAmount: number;
+  readonly overdueAmount: number;
+  readonly invoiceCount: number;
+  readonly lastInvoiceDate: string | null;
+};
+
+export type TopMarcaRow = {
+  readonly name: string;
+  readonly invoicedTotal: number;
+  readonly pendingAmount: number;
+  readonly invoiceCount: number;
+};
+
+export type IngresosData = {
+  readonly period: IngresosPeriod;
+  readonly kpis: IngresosKpis;
+  readonly aging: { readonly kpis: ArAgingKpis; readonly buckets: readonly ArAgingBucket[]; readonly rows: readonly ArAgingRow[] };
+  readonly topClientes: readonly TopClienteRow[];
+  readonly topMarcasFacturado: readonly TopMarcaRow[];
+  readonly topMarcasPendiente: readonly TopMarcaRow[];
+};
+
+function todayInMadridIso(): string {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Europe/Madrid',
+    year: 'numeric', month: '2-digit', day: '2-digit',
+  }).format(new Date());
+}
+
+function resolvePeriod(input: { readonly from?: string; readonly to?: string } = {}): IngresosPeriod {
+  const today = todayInMadridIso();
+  return {
+    from: input.from ?? `${today.slice(0, 4)}-01-01`,
+    to: input.to ?? today,
+  };
+}
+
+/**
+ * SUM de facturado (income) del periodo: internal invoices (no anuladas) +
+ * issued_invoices (todas). Fuente canónica de importe: totalAmount.
+ */
+async function sumFacturado(period: IngresosPeriod): Promise<number> {
+  const [internal, issued] = await Promise.all([
+    db
+      .select({ total: sql<string>`COALESCE(SUM(${invoices.totalAmount}), 0)::text` })
+      .from(invoices)
+      .where(and(
+        eq(invoices.kind, 'income'),
+        ne(invoices.status, 'anulada'),
+        gte(invoices.issueDate, period.from),
+        lte(invoices.issueDate, period.to),
+      )),
+    db
+      .select({ total: sql<string>`COALESCE(SUM(${issuedInvoices.totalAmount}), 0)::text` })
+      .from(issuedInvoices)
+      .where(and(
+        gte(issuedInvoices.issueDate, period.from),
+        lte(issuedInvoices.issueDate, period.to),
+      )),
+  ]);
+  return Number(internal[0]?.total ?? 0) + Number(issued[0]?.total ?? 0);
+}
+
+/**
+ * SUM de cobrado real desde `invoice_payments`. Cubre tanto invoices
+ * internas (income) como issued_invoices. paymentDate ∈ periodo.
+ */
+async function sumCobradoReal(period: IngresosPeriod): Promise<number> {
+  const [row] = await db
+    .select({ total: sql<string>`COALESCE(SUM(${invoicePayments.amount}), 0)::text` })
+    .from(invoicePayments)
+    .leftJoin(invoices, eq(invoices.id, invoicePayments.invoiceId))
+    .where(and(
+      gte(invoicePayments.paymentDate, period.from),
+      lte(invoicePayments.paymentDate, period.to),
+      // Solo cuenta pagos ligados a invoices income o a issued_invoices.
+      // Si es de expense internal → excluido.
+      sql`(${invoicePayments.issuedInvoiceId} IS NOT NULL OR ${invoices.kind} = 'income')`,
+    ));
+  return Number(row?.total ?? 0);
+}
+
+/**
+ * Deriva `topClientes` a partir de las filas del aging (que ya trae
+ * pendingAmount por fila). Agrupa por clientName. Ordena por pendiente
+ * descendente.
+ */
+function computeTopClientes(rows: readonly ArAgingRow[], limit = 5): readonly TopClienteRow[] {
+  const map = new Map<string, { pending: number; overdue: number; count: number; lastDate: string | null }>();
+  for (const r of rows) {
+    const key = r.clientName ?? r.entity ?? '(Sin cliente)';
+    const existing = map.get(key) ?? { pending: 0, overdue: 0, count: 0, lastDate: null };
+    existing.pending += r.pendingAmount;
+    if (r.daysOverdue > 0) existing.overdue += r.pendingAmount;
+    existing.count += 1;
+    if (!existing.lastDate || r.issueDate > existing.lastDate) {
+      existing.lastDate = r.issueDate;
+    }
+    map.set(key, existing);
+  }
+  return [...map.entries()]
+    .map(([name, v]) => ({
+      name,
+      pendingAmount: Number(v.pending.toFixed(2)),
+      overdueAmount: Number(v.overdue.toFixed(2)),
+      invoiceCount: v.count,
+      lastInvoiceDate: v.lastDate,
+    }))
+    .sort((a, b) => b.pendingAmount - a.pendingAmount)
+    .slice(0, limit);
+}
+
+/**
+ * Top marcas por facturación del periodo. Combina internal income +
+ * issued invoices agrupadas por `crm_brands.name`. Ignora anuladas.
+ */
+async function computeTopMarcasFacturado(period: IngresosPeriod, limit = 5): Promise<readonly TopMarcaRow[]> {
+  const [internalRows, issuedRows] = await Promise.all([
+    db
+      .select({
+        name: crmBrands.name,
+        total: sql<string>`COALESCE(SUM(${invoices.totalAmount}), 0)::text`,
+        cnt: sql<number>`COUNT(${invoices.id})::int`,
+      })
+      .from(invoices)
+      .innerJoin(crmBrands, eq(crmBrands.id, invoices.brandId))
+      .where(and(
+        eq(invoices.kind, 'income'),
+        ne(invoices.status, 'anulada'),
+        gte(invoices.issueDate, period.from),
+        lte(invoices.issueDate, period.to),
+      ))
+      .groupBy(crmBrands.name),
+    db
+      .select({
+        name: crmBrands.name,
+        total: sql<string>`COALESCE(SUM(${issuedInvoices.totalAmount}), 0)::text`,
+        cnt: sql<number>`COUNT(${issuedInvoices.id})::int`,
+      })
+      .from(issuedInvoices)
+      .innerJoin(crmBrands, eq(crmBrands.id, issuedInvoices.relatedBrandId))
+      .where(and(
+        gte(issuedInvoices.issueDate, period.from),
+        lte(issuedInvoices.issueDate, period.to),
+      ))
+      .groupBy(crmBrands.name),
+  ]);
+
+  const map = new Map<string, { total: number; cnt: number; pending: number }>();
+  for (const r of internalRows) {
+    const existing = map.get(r.name) ?? { total: 0, cnt: 0, pending: 0 };
+    existing.total += Number(r.total);
+    existing.cnt += r.cnt;
+    map.set(r.name, existing);
+  }
+  for (const r of issuedRows) {
+    const existing = map.get(r.name) ?? { total: 0, cnt: 0, pending: 0 };
+    existing.total += Number(r.total);
+    existing.cnt += r.cnt;
+    map.set(r.name, existing);
+  }
+  return [...map.entries()]
+    .map(([name, v]) => ({
+      name,
+      invoicedTotal: Number(v.total.toFixed(2)),
+      pendingAmount: Number(v.pending.toFixed(2)),
+      invoiceCount: v.cnt,
+    }))
+    .sort((a, b) => b.invoicedTotal - a.invoicedTotal)
+    .slice(0, limit);
+}
+
+/**
+ * Top marcas por pendiente — derivado del aging rows.
+ */
+function computeTopMarcasPendiente(rows: readonly ArAgingRow[], limit = 5): readonly TopMarcaRow[] {
+  const map = new Map<string, { pending: number; cnt: number }>();
+  for (const r of rows) {
+    const key = r.brandName ?? '(Sin marca)';
+    const existing = map.get(key) ?? { pending: 0, cnt: 0 };
+    existing.pending += r.pendingAmount;
+    existing.cnt += 1;
+    map.set(key, existing);
+  }
+  return [...map.entries()]
+    .map(([name, v]) => ({
+      name,
+      invoicedTotal: 0,
+      pendingAmount: Number(v.pending.toFixed(2)),
+      invoiceCount: v.cnt,
+    }))
+    .sort((a, b) => b.pendingAmount - a.pendingAmount)
+    .slice(0, limit);
+}
+
+/**
+ * Query principal de la sección /admin/finanzas/ingresos.
+ *
+ * Reutiliza `getArAging` para todo lo relativo a pendientes y añade
+ * agregados nuevos. Cero writes, cero migración.
+ *
+ * @cache none
+ * @visibility admin (facturacion:read)
+ */
+export async function getIngresosData(input: { readonly from?: string; readonly to?: string } = {}): Promise<IngresosData> {
+  const period = resolvePeriod(input);
+
+  const [aging, facturadoTotal, cobradoTotal, topMarcasFacturado] = await Promise.all([
+    getArAging({}),
+    sumFacturado(period),
+    sumCobradoReal(period),
+    computeTopMarcasFacturado(period),
+  ]);
+
+  const topClientes = computeTopClientes(aging.rows);
+  const topMarcasPendiente = computeTopMarcasPendiente(aging.rows);
+
+  const clienteMayorDeuda = topClientes[0]
+    ? { name: topClientes[0].name, amount: topClientes[0].pendingAmount }
+    : null;
+
+  const kpis: IngresosKpis = {
+    facturadoTotal: Number(facturadoTotal.toFixed(2)),
+    cobradoTotal: Number(cobradoTotal.toFixed(2)),
+    pendienteCobro: aging.kpis.totalPending,
+    vencido: aging.kpis.totalOverdue,
+    porVencer: aging.kpis.pendingNotYetDue,
+    promedioDiasCobro: aging.kpis.avgDaysOverdue,
+    clienteMayorDeuda,
+    facturasPendientes: aging.rows.length,
+  };
+
+  return {
+    period,
+    kpis,
+    aging: { kpis: aging.kpis, buckets: aging.buckets, rows: aging.rows },
+    topClientes,
+    topMarcasFacturado,
+    topMarcasPendiente,
+  };
+}

--- a/src/lib/utils/invoice-status-display.ts
+++ b/src/lib/utils/invoice-status-display.ts
@@ -1,0 +1,80 @@
+/**
+ * Mapping visual de estados de factura a las 7 categorías canónicas para
+ * UI. NO cambia DB — el enum `invoice_status` sigue con 12 valores
+ * (duplicados/solapamientos documentados en `docs/finanzas-audit.md` §7).
+ *
+ * Se usa en la sección de Ingresos (PR 3) y donde queramos consistencia
+ * visual sin migrar datos.
+ *
+ * Categorías canónicas:
+ *   - borrador  → factura no emitida todavía
+ *   - emitida   → emitida y pendiente de cobrar
+ *   - parcial   → cobrada en parte
+ *   - cobrada   → cobrada al 100%
+ *   - vencida   → pasada la fecha de vencimiento sin cobrar
+ *   - cancelada → anulada
+ *   - pendiente → catch-all para estados heredados poco claros
+ */
+
+export type InvoiceStatusDisplay =
+  | 'borrador'
+  | 'emitida'
+  | 'parcial'
+  | 'cobrada'
+  | 'vencida'
+  | 'cancelada'
+  | 'pendiente';
+
+const STATUS_DISPLAY_MAP: Readonly<Record<string, InvoiceStatusDisplay>> = {
+  borrador:    'borrador',
+  emitida:     'emitida',
+  parcial:     'parcial',
+  cobrada:     'cobrada',
+  pagada:      'cobrada',   // pagada aparece históricamente en algunos incomes
+  vencida:     'vencida',
+  anulada:     'cancelada',
+  pendiente:   'pendiente',
+  no_cobrada:  'pendiente',
+  no_cobrado:  'pendiente',
+  no_pagada:   'pendiente',
+  no_pagado:   'pendiente',
+};
+
+/**
+ * Normaliza cualquier valor del enum legacy `invoice_status` (o del varchar
+ * de `issued_invoices.status`) a una de las 7 categorías canónicas para UI.
+ */
+export function normalizeInvoiceStatusForDisplay(raw: string | null | undefined): InvoiceStatusDisplay {
+  if (!raw) return 'pendiente';
+  const key = raw.trim().toLowerCase();
+  return STATUS_DISPLAY_MAP[key] ?? 'pendiente';
+}
+
+/** Copy en español para pintar el badge. */
+export const INVOICE_STATUS_DISPLAY_LABELS: Readonly<Record<InvoiceStatusDisplay, string>> = {
+  borrador:  'Borrador',
+  emitida:   'Emitida',
+  parcial:   'Parcial',
+  cobrada:   'Cobrada',
+  vencida:   'Vencida',
+  cancelada: 'Cancelada',
+  pendiente: 'Pendiente',
+};
+
+/**
+ * Semántica de color por estado — se usa para pintar badges/pills en la
+ * tabla de ingresos. Tokens del design system:
+ *   verde/emerald = cobrado/positivo
+ *   ámbar         = pendiente/atención
+ *   rojo          = vencido/urgente
+ *   gris          = neutro (borrador/cancelada)
+ */
+export const INVOICE_STATUS_DISPLAY_SEMANTIC: Readonly<Record<InvoiceStatusDisplay, 'positive' | 'attention' | 'negative' | 'neutral'>> = {
+  borrador:  'neutral',
+  emitida:   'attention',
+  parcial:   'attention',
+  cobrada:   'positive',
+  vencida:   'negative',
+  cancelada: 'neutral',
+  pendiente: 'attention',
+};


### PR DESCRIPTION
> **DRAFT — no mergear sin OK del owner.** Preview de Vercel se genera al push.

## Summary

PR 3 del rediseño de Finanzas. La antigua ruta de "Ingresos" (que hospedaba el compound de facturación) se convierte en una **vista ejecutiva de facturación + cobros pendientes** con KPIs, aging, top clientes/marcas y tabla unificada de facturas.

**Cero migraciones. Cero cambios de schema. Cero cambios de importes ni estados.** Ver \`docs/finanzas-audit.md\` §14.

## Audit corto

Datos reales verificados hoy:
- \`invoices\` kind=income: 26 (23 anuladas + 2 cobradas 1.200€ + 1 pendiente 1.600€)
- \`issued_invoices\`: 1 emitida 1.000€
- \`billing_clients\`: 7 · \`issuer_companies\`: 3
- \`invoice_payments\`: **0** · \`bank_transactions\`: **0** → aviso obligatorio

Reutilizables sin duplicar código: \`getArAging()\`, \`listInvoices()\`, \`listIssuedInvoices()\`, \`getBillingKPIs()\`, \`getBillingClients()\`.

## Rutas tocadas

\`\`\`
/admin/finanzas/ingresos              — nueva sección PR 3
/admin/finanzas/ingresos/gestor       — compound antiguo preservado
\`\`\`

Sub-rutas legacy intactas (\`/admin/facturacion/import\`, \`/bancos/*\`).

## Estructura de la sección

1. **Header** — "Ingresos · Facturación, cobros pendientes, aging y ranking"
2. **Filtros persistentes** — from, to, cliente, marca, estado (7 canónicos), tipo (todas/internal/issued)
3. **IngresosKpisBlock** — 8 KPIs con \`label + valor + hint + semantic\`
4. **BankDataWarning** (reutilizado del resumen v3) — aviso condicional cuando falta bank data
5. **Aging con ArAgingBuckets** (reutilizado) — distribución por antigüedad
6. **TopClientesBloque** — Top 5 por deuda pendiente + vencido
7. **TopMarcasBloque × 2** — facturado en el período + pendiente vivo
8. **IngresosTabla** — facturas internas + emitidas oficiales unificadas
9. **IngresosAccesosRapidos** — 3 cards: Gestor completo · Importar PDF · Conciliación

## KPIs

| KPI | Semántica |
|---|---|
| Facturado total | neutral |
| Cobrado total | positive si >0 |
| Pendiente de cobro | attention |
| Vencido | negative |
| Por vencer | attention |
| Promedio días de cobro | positive/attention/negative por umbral |
| Cliente con mayor deuda | attention (o positive si nadie debe) |
| Facturas pendientes (N) | attention si >0 |

Diferenciación explícita entre **Facturado** (importe emitido) y **Cobrado** (pagos aplicados). Cuando \`invoice_payments = 0\`, el aviso lo contextualiza.

## Query nueva

\`getIngresosData()\` en \`src/lib/queries/financeDashboard/ingresos.ts\`:
- Reutiliza \`getArAging()\`.
- \`sumFacturado(period)\` — SUM invoices income (no anuladas) + SUM issued_invoices.
- \`sumCobradoReal(period)\` — SUM invoice_payments filtrado por income/issued.
- \`computeTopClientes\` (derivado de aging.rows).
- \`computeTopMarcasFacturado\` — GROUP BY \`crm_brands.name\` con SUM de ambas tablas.
- \`computeTopMarcasPendiente\` (derivado de aging.rows).
- **100% read-only**, sin \`db.insert/update/delete\`.

## Mapping visual (sin tocar DB)

\`normalizeInvoiceStatusForDisplay()\` en \`src/lib/utils/invoice-status-display.ts\`:

| Legacy status | Display normalizado |
|---|---|
| borrador | borrador |
| emitida | emitida |
| parcial | parcial |
| cobrada, pagada | cobrada |
| vencida | vencida |
| anulada | cancelada |
| pendiente, no_cobrada, no_cobrado, no_pagada, no_pagado | pendiente |

Enum DB sigue con 12 valores — se normaliza al vuelo en render.

## Tests

- **41 tests nuevos** (\`ingresos-status-display\` + \`finanzas-ingresos\`).
- Test PR 2 (\`finanzas-nav-and-routing\`) actualizado para el nuevo /ingresos.
- Copy prohibido asertado (no aparece "pasivo", "activo corriente", "devengo", "asiento").
- **3484/3484 verdes**.

## Confirmación sin migración

- \`git diff master...HEAD -- 'src/db/schema/' 'drizzle/' '*.sql'\`: 0 archivos.
- Cero \`db.insert()\`, \`db.update()\`, \`db.delete()\` en el diff.
- Cero nuevas dependencias.

## Test plan

- [x] \`npx tsc --noEmit\` limpio
- [x] \`npx eslint\` limpio
- [x] \`npx jest\` — 3484/3484 verdes
- [ ] QA en Preview: /admin/finanzas/ingresos muestra los 8 bloques en el orden esperado
- [ ] QA: filtros por URL params funcionan (?from=&to=&cliente=&marca=&estado=&tipo=)
- [ ] QA: aviso "Sin datos bancarios importados" aparece (hoy \`invoice_payments = 0\`)
- [ ] QA: gestor accesible desde acceso rápido → funciona el compound completo
- [ ] QA mobile: tabla scroll horizontal, filtros no rompen layout

## Riesgos pendientes

- **Filtro Cliente**: usa nombre exacto (case-insensitive). Si hay 2 clientes con nombre parecido puede no funcionar bien. Aceptable en PR 3.
- **La tabla filtra en cliente** (JavaScript). Si el aging devuelve 5000+ filas puede lag. Hoy hay ~3 rows.
- **Enum \`invoice_status\` sigue con 12 valores** — normalización visual OK, normalización DB diferida.
- **Compound accesible en dos sitios** (\`/admin/finanzas/ingresos/gestor\` y \`/admin/facturacion\` que redirige a \`/ingresos\` — el compound ya no está allí). Los enlaces legacy siguen funcionando pero el flujo canónico ya es el nuevo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)