### PR TITLE
feat(sorteos): og:image + twitter card en /sorteos y /sorteos/[creatorSlug]

### DIFF
--- a/docs/estado-fase-estabilidad.md
+++ b/docs/estado-fase-estabilidad.md
@@ -9,7 +9,8 @@ Cerrado: 2026-05-08. Esta fase cubre quick wins, polish inicial y mobile UX bás
 ### OG / Social sharing
 - OG dinámica talentos: `/api/og-image/talent-img?slug=` con foto real, nodejs runtime
 - OG dinámica giveaways: `/api/og-image/giveaway?id=X` con título, valor, marca, creador
-- OG estática `/giveaways`: OpenGraph + Twitter card correctos
+- OG estática `/giveaways`: OpenGraph + Twitter card correctos (hoy es `/codigos` — redirect 301)
+- OG estática `/sorteos` y `/sorteos/[creatorSlug]`: OpenGraph + Twitter card con `/og-socialpro.png` (2026-07-07)
 - Metadata propia home: título, description, OG, Twitter, canonical
 - Schema JSON-LD sorteos: `Event.image` apunta a OG dinámica
 - Redirect 301 en ruta antigua `/api/og-image/talent/[slug]`

--- a/docs/roadmap-detailed.md
+++ b/docs/roadmap-detailed.md
@@ -2,6 +2,8 @@
 
 Generado 07-05-2026. Basado en análisis de código, conversaciones de sesión y análisis de deuda técnica.
 
+> **Nota 2026-07-07:** Los Quick Wins QW-1..QW-5 listados más abajo YA se cerraron el 2026-05-08 (fuente: `docs/estado-fase-estabilidad.md`). El único gap residual — OG explícita para `/sorteos` y `/sorteos/[creatorSlug]` — se cerró el 2026-07-07 en la PR de mini-QW. Consultar `docs/estado-fase-estabilidad.md` como fuente de verdad para el estado real de cada quick win.
+
 ---
 
 ## Estado actual — qué está hecho

--- a/src/app/sorteos/[creatorSlug]/page.tsx
+++ b/src/app/sorteos/[creatorSlug]/page.tsx
@@ -66,6 +66,21 @@ export async function generateMetadata({
       title: `Sorteos de ${name} · SocialPro Giveaways`,
       description: `Sorteos gratis con tus creadores favoritos de SocialPro. Participa con Steam, gana puntos y canjea recompensas.`,
       url: absoluteUrl(`/sorteos/${canonicalSlug}`),
+      siteName: 'SocialPro',
+      locale: 'es_ES',
+      type: 'website',
+      images: [{
+        url: absoluteUrl('/og-socialpro.png'),
+        width: 1200,
+        height: 630,
+        alt: 'SocialPro Giveaways',
+      }],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: `Sorteos de ${name} · SocialPro Giveaways`,
+      description: `Sorteos gratis con tus creadores favoritos de SocialPro. Participa con Steam, gana puntos y canjea recompensas.`,
+      images: [absoluteUrl('/og-socialpro.png')],
     },
   };
 }

--- a/src/app/sorteos/page.tsx
+++ b/src/app/sorteos/page.tsx
@@ -23,6 +23,22 @@ export const metadata: Metadata = {
     description:
       'Elige tu creador favorito, participa gratis, gana puntos y canjea recompensas. Login con Steam, sin depósitos, +18.',
     url: absoluteUrl('/sorteos'),
+    siteName: 'SocialPro',
+    locale: 'es_ES',
+    type: 'website',
+    images: [{
+      url: absoluteUrl('/og-socialpro.png'),
+      width: 1200,
+      height: 630,
+      alt: 'SocialPro Giveaways',
+    }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'SocialPro Giveaways · sorteos gratuitos de creadores',
+    description:
+      'Elige tu creador favorito, participa gratis, gana puntos y canjea recompensas. Login con Steam, sin depósitos, +18.',
+    images: [absoluteUrl('/og-socialpro.png')],
   },
 };
 


### PR DESCRIPTION
## Summary

- Añade `openGraph.images` + `twitter.card=summary_large_image` a `/sorteos/page.tsx` y `generateMetadata` de `/sorteos/[creatorSlug]/page.tsx`.
- Usa `/og-socialpro.png` (1200×630) como fallback estático.
- Documenta en `docs/estado-fase-estabilidad.md` y añade nota en `docs/roadmap-detailed.md` que QW-1..QW-5 ya se cerraron el 2026-05-08.

## Contexto

Auditoría del 2026-07-07 sobre el Bloque 1 (QW-1..QW-5). Confirmado que los cinco quick wins ya estaban cerrados desde el 2026-05-08. Único gap residual: falta `og:image` explícita en las rutas de sorteos, lo que hacía que las previews en Discord/WhatsApp usaran el fallback que herede el crawler.

## Archivos tocados

- `src/app/sorteos/page.tsx` — añade `openGraph.{siteName,locale,type,images}` + `twitter`.
- `src/app/sorteos/[creatorSlug]/page.tsx` — añade lo mismo dentro de `generateMetadata`.
- `docs/estado-fase-estabilidad.md` — línea de OG estática sorteos.
- `docs/roadmap-detailed.md` — nota de estado.

## Confirmaciones

- ✅ Sin cambios de `robots` — sigue `index: true` en ambas rutas.
- ✅ Sin retirar `LegalDraftBanner` de páginas legales (`(legal)/*`).
- ✅ Sin tocar compliance sorteos, misiones Discord/Twitch, Finanzas, LiveSection, redirects `/giveaways → /codigos`, `pdfAi`.
- ✅ Sin migración de DB.
- ✅ Sin dependencias nuevas.

## Checks

- `npx tsc --noEmit` — cero errores en el proyecto (los errores residuales son del directorio anidado `proyectozack/` untracked y de `.next/dev/types/` generado por Next, no relacionados con este cambio).
- `npx eslint` sobre los dos archivos tocados — verde.
- Diff: 4 archivos, +35 −1.

## Test plan

- [ ] Verificar preview OG de `/sorteos` con https://www.opengraph.xyz/ tras deploy
- [ ] Verificar preview OG de `/sorteos/zacketizor` tras deploy
- [ ] Confirmar que Twitter/X card aparece como `summary_large_image` con imagen 1200×630

🤖 Generated with [Claude Code](https://claude.com/claude-code)