### PR TITLE
feat(admin): private files sweep — 3 proxies + 4 UI fixes

### DIFF
--- a/src/__tests__/server/admin-private-files-proxies.test.ts
+++ b/src/__tests__/server/admin-private-files-proxies.test.ts
@@ -1,0 +1,368 @@
+/**
+ * Tests funcionales de los 3 proxies admin nuevos:
+ *   - /api/admin/files/[id]
+ *   - /api/admin/campanas/[id]/contract/pdf
+ *   - /api/admin/facturacion/import/[id]/pdf
+ *
+ * Verifica para cada uno:
+ *  - id inválido → 404 (sin tocar DB)
+ *  - fila inexistente / sin fileUrl → 404
+ *  - BLOB_READ_WRITE_TOKEN ausente → 503
+ *  - fetch al blob falla → 404
+ *  - camino feliz → 200 con Content-Type, Content-Disposition, Cache-Control y X-Content-Type-Options correctos
+ *  - Bearer token nunca se filtra en headers de respuesta
+ *  - URL del blob privado nunca aparece en body de error
+ *
+ * Para el proxy de /files/[id] verifica además el mapping relatedType → módulo:
+ *  - talent → talentos:read
+ *  - campaign → campanas:read
+ *  - brand → campanas:read
+ *  - invoice → facturacion:read
+ *  - followup → tareas:read
+ *  - task → tareas:read
+ *  - otro / desconocido → 404 fail-closed (sin llamar a requirePermission)
+ */
+
+// ── Mocks compartidos ─────────────────────────────────────────────────
+
+jest.mock('@/lib/auth', () => ({ auth: {} }));
+
+const mockRequirePermission = jest.fn();
+jest.mock('@/lib/permissions', () => ({
+  requirePermission: (...args: unknown[]) => mockRequirePermission(...args),
+  PERMISSIONS: {},
+}));
+
+// Mock cadena Drizzle sin importar tablas reales.
+let mockFilesRow: Record<string, unknown> | null = null;
+const mockDb = {
+  select: jest.fn(() => ({
+    from: jest.fn(() => ({
+      where: jest.fn(() => ({
+        limit: jest.fn(() => (mockFilesRow ? [mockFilesRow] : [])),
+      })),
+    })),
+  })),
+};
+jest.mock('@/lib/db', () => ({ db: mockDb }));
+
+jest.mock('@/db/schema/files', () => ({
+  files: {
+    id: 'id',
+    url: 'url',
+    name: 'name',
+    mime: 'mime',
+    relatedType: 'relatedType',
+  },
+}));
+
+const mockGetContractByCampaign = jest.fn();
+jest.mock('@/lib/queries/contracts', () => ({
+  getContractByCampaign: (...args: unknown[]) => mockGetContractByCampaign(...args),
+}));
+
+const mockGetImport = jest.fn();
+jest.mock('@/lib/queries/invoiceImports', () => ({
+  getImport: (...args: unknown[]) => mockGetImport(...args),
+}));
+
+jest.mock('@/lib/env', () => ({
+  env: {
+    get BLOB_READ_WRITE_TOKEN() {
+      return process.env.BLOB_READ_WRITE_TOKEN ?? '';
+    },
+  },
+}));
+
+import { NextRequest } from 'next/server';
+import { GET as filesGET } from '@/app/api/admin/files/[id]/route';
+import { GET as contractGET } from '@/app/api/admin/campanas/[id]/contract/pdf/route';
+import { GET as importGET } from '@/app/api/admin/facturacion/import/[id]/pdf/route';
+
+const BLOB_SECRET = 'test-blob-token-priv-xyz';
+const PRIVATE_BLOB_URL = 'https://private-store.vercel-storage.com/some/secret-path.pdf';
+
+const makeReq = (url: string) => new NextRequest(url);
+const makeParams = (id: string) => ({ params: Promise.resolve({ id }) });
+
+const mockBlobOk = (contentType = 'application/pdf') => {
+  (global.fetch as jest.Mock).mockResolvedValue({
+    ok: true,
+    status: 200,
+    headers: { get: (k: string) => (k === 'content-type' ? contentType : null) },
+    arrayBuffer: () => Promise.resolve(new ArrayBuffer(16)),
+  });
+};
+
+const mockBlobFail = () => {
+  (global.fetch as jest.Mock).mockResolvedValue({
+    ok: false,
+    status: 401,
+    headers: { get: () => null },
+    arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+  });
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockFilesRow = null;
+  global.fetch = jest.fn();
+  process.env.BLOB_READ_WRITE_TOKEN = BLOB_SECRET;
+  mockRequirePermission.mockResolvedValue({ user: { id: 'u1', role: 'admin' } });
+});
+
+afterEach(() => {
+  delete process.env.BLOB_READ_WRITE_TOKEN;
+});
+
+// ═════════════════════════════════════════════════════════════════════
+//  /api/admin/files/[id]
+// ═════════════════════════════════════════════════════════════════════
+
+describe('/api/admin/files/[id]', () => {
+  const call = (id = '1') =>
+    filesGET(makeReq(`http://localhost/api/admin/files/${id}`), makeParams(id));
+
+  it('id no numérico → 404 sin tocar DB ni permisos', async () => {
+    const res = await call('abc');
+    expect(res.status).toBe(404);
+    expect(mockDb.select).not.toHaveBeenCalled();
+    expect(mockRequirePermission).not.toHaveBeenCalled();
+  });
+
+  it('id 0 o negativo → 404', async () => {
+    expect((await call('0')).status).toBe(404);
+    expect((await call('-3')).status).toBe(404);
+  });
+
+  it('fila inexistente → 404 sin llamar a requirePermission', async () => {
+    mockFilesRow = null;
+    const res = await call('42');
+    expect(res.status).toBe(404);
+    expect(mockRequirePermission).not.toHaveBeenCalled();
+  });
+
+  it('relatedType desconocido → 404 fail-closed (no requirePermission)', async () => {
+    mockFilesRow = {
+      url: PRIVATE_BLOB_URL,
+      name: 'x.pdf',
+      mime: 'application/pdf',
+      relatedType: 'ufo',
+    };
+    const res = await call('7');
+    expect(res.status).toBe(404);
+    expect(mockRequirePermission).not.toHaveBeenCalled();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  describe('mapping relatedType → módulo', () => {
+    const CASES: Array<[string, string]> = [
+      ['talent',   'talentos'],
+      ['campaign', 'campanas'],
+      ['brand',    'campanas'],
+      ['invoice',  'facturacion'],
+      ['followup', 'tareas'],
+      ['task',     'tareas'],
+    ];
+
+    it.each(CASES)('relatedType=%s → requirePermission(%s, read)', async (relatedType, module) => {
+      mockFilesRow = {
+        url: PRIVATE_BLOB_URL,
+        name: 'doc.pdf',
+        mime: 'application/pdf',
+        relatedType,
+      };
+      mockBlobOk();
+      const res = await call('9');
+      expect(res.status).toBe(200);
+      expect(mockRequirePermission).toHaveBeenCalledWith(module, 'read');
+    });
+  });
+
+  it('permiso denegado → error propagado, no llega a fetch', async () => {
+    mockFilesRow = {
+      url: PRIVATE_BLOB_URL,
+      name: 'x.pdf',
+      mime: 'application/pdf',
+      relatedType: 'talent',
+    };
+    mockRequirePermission.mockRejectedValue(new Error('forbidden:talentos:read'));
+    await expect(call('1')).rejects.toThrow(/forbidden/);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('sin BLOB_READ_WRITE_TOKEN → 503', async () => {
+    mockFilesRow = { url: PRIVATE_BLOB_URL, name: 'x.pdf', mime: 'application/pdf', relatedType: 'talent' };
+    delete process.env.BLOB_READ_WRITE_TOKEN;
+    const res = await call('1');
+    expect(res.status).toBe(503);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('fetch al blob falla (401 upstream) → 404 hacia el cliente', async () => {
+    mockFilesRow = { url: PRIVATE_BLOB_URL, name: 'x.pdf', mime: 'application/pdf', relatedType: 'talent' };
+    mockBlobFail();
+    const res = await call('1');
+    expect(res.status).toBe(404);
+    // El body de error nunca contiene la URL privada del blob
+    const body = await res.text();
+    expect(body).not.toContain(PRIVATE_BLOB_URL);
+  });
+
+  it('camino feliz → 200 con headers de seguridad y Bearer no filtrado', async () => {
+    mockFilesRow = { url: PRIVATE_BLOB_URL, name: 'GEO-Stats octubre.pdf', mime: 'application/pdf', relatedType: 'talent' };
+    mockBlobOk();
+    const res = await call('1');
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toBe('application/pdf');
+    expect(res.headers.get('cache-control')).toBe('private, no-store');
+    expect(res.headers.get('x-content-type-options')).toBe('nosniff');
+    expect(res.headers.get('content-disposition')).toMatch(/inline; filename="GEO-Stats_octubre.pdf"/);
+
+    // Bearer nunca sale al cliente
+    for (const [name, value] of res.headers.entries()) {
+      expect(`${name}: ${value}`).not.toContain(BLOB_SECRET);
+    }
+
+    // fetch al blob se hace con Bearer server-side
+    const call0 = (global.fetch as jest.Mock).mock.calls[0];
+    expect(call0[0]).toBe(PRIVATE_BLOB_URL);
+    expect(call0[1].headers.Authorization).toBe(`Bearer ${BLOB_SECRET}`);
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════
+//  /api/admin/campanas/[id]/contract/pdf
+// ═════════════════════════════════════════════════════════════════════
+
+describe('/api/admin/campanas/[id]/contract/pdf', () => {
+  const call = (id = '10') =>
+    contractGET(makeReq(`http://localhost/api/admin/campanas/${id}/contract/pdf`), makeParams(id));
+
+  it('requiere campanas:read (permiso denegado → propaga error)', async () => {
+    mockRequirePermission.mockRejectedValue(new Error('forbidden:campanas:read'));
+    await expect(call('10')).rejects.toThrow(/forbidden:campanas/);
+    expect(mockGetContractByCampaign).not.toHaveBeenCalled();
+  });
+
+  it('id inválido → 404', async () => {
+    const res = await call('nope');
+    expect(res.status).toBe(404);
+    expect(mockGetContractByCampaign).not.toHaveBeenCalled();
+  });
+
+  it('sin contrato → 404', async () => {
+    mockGetContractByCampaign.mockResolvedValue(null);
+    const res = await call('10');
+    expect(res.status).toBe(404);
+  });
+
+  it('contrato sin fileUrl → 404', async () => {
+    mockGetContractByCampaign.mockResolvedValue({ id: 5, fileUrl: null, fileName: null });
+    const res = await call('10');
+    expect(res.status).toBe(404);
+  });
+
+  it('camino feliz → 200 con Content-Disposition y headers de seguridad', async () => {
+    mockGetContractByCampaign.mockResolvedValue({
+      id: 5,
+      fileUrl: PRIVATE_BLOB_URL,
+      fileName: 'Contrato Marca X.pdf',
+    });
+    mockBlobOk();
+
+    const res = await call('10');
+
+    expect(mockRequirePermission).toHaveBeenCalledWith('campanas', 'read');
+    expect(res.status).toBe(200);
+    expect(res.headers.get('cache-control')).toBe('private, no-store');
+    expect(res.headers.get('x-content-type-options')).toBe('nosniff');
+    expect(res.headers.get('content-disposition')).toMatch(/Contrato_Marca_X\.pdf/);
+    // Bearer no filtrado
+    for (const [name, value] of res.headers.entries()) {
+      expect(`${name}: ${value}`).not.toContain(BLOB_SECRET);
+    }
+  });
+
+  it('camino feliz sin fileName → usa "contrato.pdf" como fallback', async () => {
+    mockGetContractByCampaign.mockResolvedValue({
+      id: 5,
+      fileUrl: PRIVATE_BLOB_URL,
+      fileName: null,
+    });
+    mockBlobOk();
+
+    const res = await call('10');
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-disposition')).toMatch(/contrato\.pdf/);
+  });
+
+  it('sin BLOB_READ_WRITE_TOKEN → 503', async () => {
+    mockGetContractByCampaign.mockResolvedValue({ id: 5, fileUrl: PRIVATE_BLOB_URL, fileName: 'c.pdf' });
+    delete process.env.BLOB_READ_WRITE_TOKEN;
+    const res = await call('10');
+    expect(res.status).toBe(503);
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════
+//  /api/admin/facturacion/import/[id]/pdf
+// ═════════════════════════════════════════════════════════════════════
+
+describe('/api/admin/facturacion/import/[id]/pdf', () => {
+  const call = (id = '3') =>
+    importGET(makeReq(`http://localhost/api/admin/facturacion/import/${id}/pdf`), makeParams(id));
+
+  it('requiere facturacion:read (permiso denegado → propaga error)', async () => {
+    mockRequirePermission.mockRejectedValue(new Error('forbidden:facturacion:read'));
+    await expect(call('3')).rejects.toThrow(/forbidden:facturacion/);
+    expect(mockGetImport).not.toHaveBeenCalled();
+  });
+
+  it('id inválido → 404', async () => {
+    const res = await call('xyz');
+    expect(res.status).toBe(404);
+    expect(mockGetImport).not.toHaveBeenCalled();
+  });
+
+  it('import inexistente → 404', async () => {
+    mockGetImport.mockResolvedValue(null);
+    const res = await call('3');
+    expect(res.status).toBe(404);
+  });
+
+  it('import sin fileUrl → 404', async () => {
+    mockGetImport.mockResolvedValue({ id: 3, fileUrl: null, sourceFilename: 'factura.pdf' });
+    const res = await call('3');
+    expect(res.status).toBe(404);
+  });
+
+  it('camino feliz → 200 con headers y filename saneado', async () => {
+    mockGetImport.mockResolvedValue({
+      id: 3,
+      fileUrl: PRIVATE_BLOB_URL,
+      sourceFilename: 'Factura Enero 2026 (v2).pdf',
+    });
+    mockBlobOk();
+
+    const res = await call('3');
+    expect(mockRequirePermission).toHaveBeenCalledWith('facturacion', 'read');
+    expect(res.status).toBe(200);
+    expect(res.headers.get('cache-control')).toBe('private, no-store');
+    expect(res.headers.get('x-content-type-options')).toBe('nosniff');
+    // El (v2) contiene paréntesis → deben quedar saneados
+    expect(res.headers.get('content-disposition')).toMatch(/Factura_Enero_2026__v2_\.pdf/);
+    // Bearer no filtrado
+    for (const [name, value] of res.headers.entries()) {
+      expect(`${name}: ${value}`).not.toContain(BLOB_SECRET);
+    }
+  });
+
+  it('sin BLOB_READ_WRITE_TOKEN → 503', async () => {
+    mockGetImport.mockResolvedValue({ id: 3, fileUrl: PRIVATE_BLOB_URL, sourceFilename: 'x.pdf' });
+    delete process.env.BLOB_READ_WRITE_TOKEN;
+    const res = await call('3');
+    expect(res.status).toBe(503);
+  });
+});

--- a/src/__tests__/server/admin-private-files-ui-uses-proxy.test.ts
+++ b/src/__tests__/server/admin-private-files-ui-uses-proxy.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Tests estáticos: la UI admin ya no expone URLs directas de blob privado.
+ *
+ * Regresión que se está cerrando: PR #115 (2026-06-29) cambió `uploadFile()`
+ * a `access: 'private'`. Cualquier `<a href={file.url}>` / `<a href={contract.fileUrl}>` /
+ * `<a href={imp.fileUrl}>` posterior a esa fecha devuelve 401 al abrirse.
+ *
+ * Estos tests fallan si un futuro cambio vuelve a introducir un href al blob privado
+ * directo en cualquiera de los 4 archivos protegidos.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const PROJECT_ROOT = path.resolve(__dirname, '..', '..', '..');
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(PROJECT_ROOT, rel), 'utf-8');
+}
+
+describe('UI admin — archivos polimórficos usan /api/admin/files/[id]', () => {
+  const REL = 'src/features/admin/campaigns/components/CampaignFiles.parts.tsx';
+
+  it('CampaignFiles.parts.tsx enlaza al proxy /api/admin/files/[id]', () => {
+    const src = read(REL);
+    expect(src).toMatch(/\/api\/admin\/files\/\$\{file\.id\}/);
+  });
+
+  it('CampaignFiles.parts.tsx NO renderiza `<a href={file.url}>` directo', () => {
+    const src = read(REL);
+    expect(src).not.toMatch(/href=\{file\.url\}/);
+  });
+});
+
+describe('UI admin — FilesList usa /api/admin/files/[id]', () => {
+  const REL = 'src/features/admin/files/components/FilesList.tsx';
+
+  it('FilesList.tsx enlaza al proxy /api/admin/files/[id]', () => {
+    const src = read(REL);
+    expect(src).toMatch(/\/api\/admin\/files\/\$\{file\.id\}/);
+  });
+
+  it('FilesList.tsx NO renderiza `<a href={file.url}>` directo', () => {
+    const src = read(REL);
+    expect(src).not.toMatch(/href=\{file\.url\}/);
+  });
+});
+
+describe('UI admin — ContractTab usa /api/admin/campanas/[id]/contract/pdf', () => {
+  const REL = 'src/features/admin/_shared/components/campaigns/ContractTab.tsx';
+
+  it('ContractTab.tsx enlaza al proxy admin de contrato de campaña', () => {
+    const src = read(REL);
+    expect(src).toMatch(/\/api\/admin\/campanas\/\$\{campaignId\}\/contract\/pdf/);
+  });
+
+  it('ContractTab.tsx NO renderiza `<a href={contract.fileUrl}>` directo', () => {
+    const src = read(REL);
+    expect(src).not.toMatch(/href=\{contract\.fileUrl\}/);
+  });
+});
+
+describe('UI admin — ImportInbox usa /api/admin/facturacion/import/[id]/pdf', () => {
+  const REL = 'src/features/admin/invoices/components/ImportInbox.parts.tsx';
+
+  it('ImportInbox.parts.tsx enlaza al proxy admin de invoice_imports', () => {
+    const src = read(REL);
+    expect(src).toMatch(/\/api\/admin\/facturacion\/import\/\$\{imp\.id\}\/pdf/);
+  });
+
+  it('ImportInbox.parts.tsx NO renderiza `<a href={imp.fileUrl}>` directo', () => {
+    const src = read(REL);
+    expect(src).not.toMatch(/href=\{imp\.fileUrl\}/);
+  });
+});

--- a/src/app/api/admin/campanas/[id]/contract/pdf/route.ts
+++ b/src/app/api/admin/campanas/[id]/contract/pdf/route.ts
@@ -1,0 +1,40 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+import { requirePermission } from '@/lib/permissions';
+import { getContractByCampaign } from '@/lib/queries/contracts';
+import { streamPrivateBlob } from '@/lib/files/streamPrivateBlob';
+
+/**
+ * Proxy admin para PDFs de contratos manuales subidos por campaña (tabla `contracts`).
+ *
+ * NO confundir con `/api/admin/contratos/[id]/pdf`, que sirve contratos generados
+ * desde plantilla (tabla `generated_contracts`).
+ *
+ * Requiere `campanas:read`. El token de Blob jamás se expone al cliente.
+ */
+export const dynamic = 'force-dynamic';
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  await requirePermission('campanas', 'read');
+
+  const { id: idStr } = await params;
+  const campaignId = Number(idStr);
+  if (!Number.isInteger(campaignId) || campaignId <= 0) {
+    return new NextResponse('Not found', { status: 404 });
+  }
+
+  const contract = await getContractByCampaign(campaignId);
+  if (!contract || !contract.fileUrl) {
+    return new NextResponse('PDF no disponible', { status: 404 });
+  }
+
+  return streamPrivateBlob({
+    fileUrl: contract.fileUrl,
+    filename: contract.fileName ?? 'contrato.pdf',
+    fallbackContentType: 'application/pdf',
+  });
+}

--- a/src/app/api/admin/facturacion/import/[id]/pdf/route.ts
+++ b/src/app/api/admin/facturacion/import/[id]/pdf/route.ts
@@ -1,0 +1,37 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+import { requirePermission } from '@/lib/permissions';
+import { getImport } from '@/lib/queries/invoiceImports';
+import { streamPrivateBlob } from '@/lib/files/streamPrivateBlob';
+
+/**
+ * Proxy admin para PDFs del staging `invoice_imports`.
+ *
+ * Requiere `facturacion:read`. El token de Blob jamás se expone al cliente.
+ */
+export const dynamic = 'force-dynamic';
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  await requirePermission('facturacion', 'read');
+
+  const { id: idStr } = await params;
+  const id = Number(idStr);
+  if (!Number.isInteger(id) || id <= 0) {
+    return new NextResponse('Not found', { status: 404 });
+  }
+
+  const imp = await getImport(id);
+  if (!imp || !imp.fileUrl) {
+    return new NextResponse('PDF no disponible', { status: 404 });
+  }
+
+  return streamPrivateBlob({
+    fileUrl: imp.fileUrl,
+    filename: imp.sourceFilename,
+    fallbackContentType: 'application/pdf',
+  });
+}

--- a/src/app/api/admin/files/[id]/route.ts
+++ b/src/app/api/admin/files/[id]/route.ts
@@ -1,0 +1,75 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { eq } from 'drizzle-orm';
+
+import { requirePermission, type Module } from '@/lib/permissions';
+import { db } from '@/lib/db';
+import { files } from '@/db/schema/files';
+import { streamPrivateBlob } from '@/lib/files/streamPrivateBlob';
+
+/**
+ * Proxy admin para archivos polimórficos almacenados en Vercel Blob privado.
+ *
+ * Sirve la fila `files.id = :id` — el permiso requerido depende de `files.relatedType`:
+ *   talent    → talentos:read
+ *   campaign  → campanas:read
+ *   brand     → campanas:read  (brands se autoriza en el resto del código con `campanas`)
+ *   invoice   → facturacion:read
+ *   followup  → tareas:read
+ *   task      → tareas:read
+ *
+ * Cualquier valor no reconocido → 404 (fail-closed).
+ *
+ * El token de Blob nunca se expone al cliente — se usa server-side para descargar
+ * el archivo y se re-streamea con `Cache-Control: private, no-store` +
+ * `X-Content-Type-Options: nosniff`.
+ */
+export const dynamic = 'force-dynamic';
+
+const RELATED_TYPE_TO_MODULE: Record<string, Module> = {
+  talent: 'talentos',
+  campaign: 'campanas',
+  brand: 'campanas',
+  invoice: 'facturacion',
+  followup: 'tareas',
+  task: 'tareas',
+};
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id: idStr } = await params;
+  const id = Number(idStr);
+  if (!Number.isInteger(id) || id <= 0) {
+    return new NextResponse('Not found', { status: 404 });
+  }
+
+  const [row] = await db
+    .select({
+      url:         files.url,
+      name:        files.name,
+      mime:        files.mime,
+      relatedType: files.relatedType,
+    })
+    .from(files)
+    .where(eq(files.id, id))
+    .limit(1);
+
+  if (!row) {
+    return new NextResponse('Not found', { status: 404 });
+  }
+
+  const permissionModule = RELATED_TYPE_TO_MODULE[row.relatedType];
+  if (!permissionModule) {
+    return new NextResponse('Not found', { status: 404 });
+  }
+
+  await requirePermission(permissionModule, 'read');
+
+  return streamPrivateBlob({
+    fileUrl: row.url,
+    filename: row.name,
+    ...(row.mime ? { fallbackContentType: row.mime } : {}),
+  });
+}

--- a/src/features/admin/_shared/components/campaigns/ContractTab.tsx
+++ b/src/features/admin/_shared/components/campaigns/ContractTab.tsx
@@ -110,7 +110,7 @@ export function ContractTab({ campaignId, contract, templates, campaign, contrac
             </div>
             <div className="flex items-center gap-2">
               {contract.fileUrl && (
-                <a href={contract.fileUrl} target="_blank" rel="noreferrer" className={BG}>
+                <a href={`/api/admin/campanas/${campaignId}/contract/pdf`} target="_blank" rel="noreferrer" className={BG}>
                   Ver PDF →
                 </a>
               )}

--- a/src/features/admin/campaigns/components/CampaignFiles.parts.tsx
+++ b/src/features/admin/campaigns/components/CampaignFiles.parts.tsx
@@ -207,7 +207,7 @@ export function FileRow({ file, campaignId, canDelete }: FileRowProps): React.Re
       {/* Actions */}
       <div className="flex items-center gap-2 shrink-0">
         <a
-          href={file.url}
+          href={`/api/admin/files/${file.id}`}
           target="_blank"
           rel="noopener noreferrer"
           className="rounded-md border border-sp-admin-border px-2.5 py-1 text-xs text-sp-admin-muted hover:text-sp-admin-text transition-colors"

--- a/src/features/admin/files/components/FilesList.tsx
+++ b/src/features/admin/files/components/FilesList.tsx
@@ -72,7 +72,7 @@ export function FilesList({ files, talentId, isManager, deleteAction }: Props): 
           </div>
           <div className="flex items-center gap-2 shrink-0">
             <a
-              href={file.url}
+              href={`/api/admin/files/${file.id}`}
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg text-xs font-semibold border border-sp-admin-border text-sp-admin-text hover:bg-sp-admin-border/30 transition-colors"

--- a/src/features/admin/invoices/components/ImportInbox.parts.tsx
+++ b/src/features/admin/invoices/components/ImportInbox.parts.tsx
@@ -213,7 +213,7 @@ export function PendingRow({
           <div className="min-w-0">
             <p className="text-sm text-sp-admin-text truncate">
               {imp.fileUrl ? (
-                <a href={imp.fileUrl} target="_blank" rel="noreferrer" className="hover:underline">
+                <a href={`/api/admin/facturacion/import/${imp.id}/pdf`} target="_blank" rel="noreferrer" className="hover:underline">
                   {imp.sourceFilename}
                 </a>
               ) : (
@@ -281,7 +281,7 @@ export function PendingRow({
             {imp.sourceType === 'pdf-text' && imp.fileUrl && (
               <div className="px-5 pt-4 pb-0">
                 <a
-                  href={imp.fileUrl}
+                  href={`/api/admin/facturacion/import/${imp.id}/pdf`}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg border border-sp-admin-border text-[11px] font-semibold text-sp-admin-muted hover:text-sp-admin-accent hover:border-sp-admin-accent/50 transition-colors"

--- a/src/lib/files/streamPrivateBlob.ts
+++ b/src/lib/files/streamPrivateBlob.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from 'next/server';
+import { env } from '@/lib/env';
+
+/**
+ * Sanea un nombre de fichero para `Content-Disposition`:
+ * - Sustituye cualquier carácter que no sea `\w`, `.` o `-` por `_`.
+ * - Colapsa cualquier corrida de puntos a uno solo.
+ * - Trunca a 200 caracteres.
+ * Patrón alineado con los proxies existentes de contratos y facturación.
+ */
+export function sanitizeFilename(name: string): string {
+  return name
+    .replace(/[^\w.\-]/g, '_')
+    .replace(/\.+/g, '.')
+    .slice(0, 200);
+}
+
+/**
+ * Descarga un blob privado con Bearer server-side y lo re-streamea al cliente
+ * con cabeceras de seguridad (no cache, no sniff, inline).
+ *
+ * El token de Blob NUNCA se envía al cliente.
+ */
+export async function streamPrivateBlob(input: {
+  readonly fileUrl: string;
+  readonly filename: string;
+  readonly fallbackContentType?: string;
+}): Promise<NextResponse> {
+  const token = env.BLOB_READ_WRITE_TOKEN;
+  if (!token) {
+    return new NextResponse('Servicio no disponible', { status: 503 });
+  }
+
+  const blobRes = await fetch(input.fileUrl, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (!blobRes.ok) {
+    return new NextResponse('Archivo no disponible', { status: 404 });
+  }
+
+  const contentType =
+    blobRes.headers.get('content-type') ??
+    input.fallbackContentType ??
+    'application/octet-stream';
+  const buffer = await blobRes.arrayBuffer();
+  const safeName = sanitizeFilename(input.filename);
+
+  return new NextResponse(buffer, {
+    status: 200,
+    headers: {
+      'Content-Type': contentType,
+      'Content-Disposition': `inline; filename="${safeName}"`,
+      'Cache-Control': 'private, no-store',
+      'X-Content-Type-Options': 'nosniff',
+    },
+  });
+}


### PR DESCRIPTION
## Summary

Cierra la regresión de PR #115 (2026-06-29) por el cambio de `uploadFile()` a `access: 'private'`. Desde entonces, los `<a href={file.url}>` del admin devuelven 401 en cualquier archivo subido después.

Añade **3 proxies admin** con Bearer server-side + re-stream + headers de seguridad, corrige **4 UI** para enlazar a esos proxies, y añade **35 tests** (estáticos + funcionales) para prevenir regresión futura.

## Endpoints creados

| Ruta | Sirve | Permiso |
|---|---|---|
| `/api/admin/files/[id]` | tabla `files` polimórfica | switch por `relatedType`: talent→talentos, campaign/brand→campanas, invoice→facturacion, followup/task→tareas, desconocido→404 fail-closed |
| `/api/admin/campanas/[id]/contract/pdf` | tabla `contracts` (uploads manuales) | `campanas:read` |
| `/api/admin/facturacion/import/[id]/pdf` | tabla `invoice_imports` (staging) | `facturacion:read` |

Todos con `Cache-Control: private, no-store`, `X-Content-Type-Options: nosniff`, `Content-Disposition: inline` con filename saneado. Bearer token nunca fluye al cliente.

**No colisiona** con el existente `/api/admin/contratos/[id]/pdf` — ese sirve `generated_contracts` (plantillas), este sirve `contracts` (uploads manuales por campaña).

## UI corregida

| Archivo | Cambio |
|---|---|
| `src/features/admin/campaigns/components/CampaignFiles.parts.tsx` | `href={file.url}` → `/api/admin/files/${file.id}` |
| `src/features/admin/files/components/FilesList.tsx` | `href={file.url}` → `/api/admin/files/${file.id}` |
| `src/features/admin/_shared/components/campaigns/ContractTab.tsx` | `href={contract.fileUrl}` → `/api/admin/campanas/${campaignId}/contract/pdf` |
| `src/features/admin/invoices/components/ImportInbox.parts.tsx` (2 sitios) | `href={imp.fileUrl}` → `/api/admin/facturacion/import/${imp.id}/pdf` |

## Helper compartido

`src/lib/files/streamPrivateBlob.ts` encapsula el patrón Bearer+re-stream+`sanitizeFilename` para los 3 proxies nuevos. Los proxies existentes de `contratos` y `facturacion` no se refactorizan (fuera del alcance).

## Tests añadidos (35 casos)

- `admin-private-files-ui-uses-proxy.test.ts` — 8 assertions estáticas que fallan si vuelve a colarse un `href` al Blob privado en los 4 archivos.
- `admin-private-files-proxies.test.ts` — 27 casos funcionales:
  - id inválido → 404 sin tocar DB/permisos
  - permiso denegado → propaga error del guard
  - mapping completo `relatedType` → módulo (6 casos it.each)
  - `relatedType` desconocido → 404 fail-closed
  - sin `BLOB_READ_WRITE_TOKEN` → 503
  - fetch al blob falla → 404 sin filtrar URL privada en body
  - camino feliz devuelve `Content-Type`, `Content-Disposition`, `Cache-Control: private, no-store`, `X-Content-Type-Options: nosniff`
  - Bearer token nunca aparece en headers de respuesta
  - filename saneado correctamente (paréntesis, espacios, etc.)

## Checks locales

- `npx tsc --noEmit` — sin errores en el proyecto
- `npx eslint` — verde en los 10 archivos tocados
- `npx jest` — **3609/3609 tests pasan** (incluyendo los 35 nuevos)

## Confirmaciones

- ✅ Sin migración (`npx drizzle-kit check` no requerido — cero cambios de schema)
- ✅ Sin cambios de DB
- ✅ Sin cambios de `access` en storage
- ✅ Sin dependencia nueva
- ✅ Sin env nueva
- ✅ Todas las rutas están bajo `/api/admin` y requieren `requirePermission` antes de servir
- ✅ **Sin tocar `/marcas/(portal)/facturas/page.tsx`** — queda para PR-D
- ✅ Sin tocar Sorteos, compliance, misiones Discord/Twitch
- ✅ Sin tocar el proxy existente `/api/admin/contratos/[id]/pdf` (generated_contracts)

## Riesgos pendientes

- **Portal marca**: `<a href={inv.fileUrl}>` en `src/app/marcas/(portal)/facturas/page.tsx:104` sigue roto. Auth boundary distinto (brand session). Se aborda en **PR-D**.
- **Legacy pre-PR #115**: archivos subidos ANTES del 2026-06-29 tienen URL absoluta que aún funcionaba público. Tras este merge, seguirán funcionando porque el proxy usa el mismo Bearer y responde 200 igualmente. Ningún archivo antiguo se rompe.

## Test plan

- [ ] Verificar en preview: descargar un archivo de un talent GEO stats desde `/admin/talents/[id]`
- [ ] Verificar en preview: descargar un archivo de campaña desde `/admin/campanas/[id]` tab archivos
- [ ] Verificar en preview: abrir "Ver PDF" de un contrato manual desde `/admin/campanas/[id]` tab contrato
- [ ] Verificar en preview: abrir "Abrir PDF" desde bandeja de imports de facturación
- [ ] Confirmar en DevTools que los responses tienen `Cache-Control: private, no-store` y `X-Content-Type-Options: nosniff`

🤖 Generated with [Claude Code](https://claude.com/claude-code)