### PR TITLE
feat(admin): restaurar /admin/facturacion como módulo operativo

### DIFF
--- a/src/__tests__/server/admin-facturacion-restore.test.ts
+++ b/src/__tests__/server/admin-facturacion-restore.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Regresión — separación Facturación (operativo) vs Finanzas → Ingresos (análisis).
+ *
+ * Contexto: PR #212 (2026-07-06) colapsó Facturación bajo Finanzas → Ingresos
+ * haciendo que `/admin/facturacion` redirigiera a `/admin/finanzas/ingresos`.
+ * Esto ocultó el flujo "crear factura" y mezcló módulos con propósitos distintos.
+ * Restaurado en 2026-07-07 como módulo operativo propio.
+ *
+ * Estos tests fallan si el redirect original vuelve a introducirse o si el
+ * gestor deja de estar accesible desde la URL canónica.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const PROJECT_ROOT = path.resolve(__dirname, '..', '..', '..');
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(PROJECT_ROOT, rel), 'utf-8');
+}
+
+describe('Facturación restaurada como módulo operativo propio', () => {
+  it('/admin/facturacion NO redirige a /admin/finanzas/*', () => {
+    const src = read('src/app/admin/(dashboard)/facturacion/page.tsx');
+    expect(src).not.toMatch(/permanentRedirect\s*\(\s*['"`]\/admin\/finanzas/);
+    expect(src).not.toMatch(/redirect\s*\(\s*['"`]\/admin\/finanzas/);
+  });
+
+  it('/admin/facturacion renderiza IngresosCompoundPage', () => {
+    const src = read('src/app/admin/(dashboard)/facturacion/page.tsx');
+    expect(src).toMatch(/IngresosCompoundPage/);
+  });
+
+  it('/admin/facturacion pasa headerTitle "Facturación" al compound page', () => {
+    const src = read('src/app/admin/(dashboard)/facturacion/page.tsx');
+    expect(src).toMatch(/headerTitle=["']Facturación["']/);
+  });
+});
+
+describe('/admin/finanzas/ingresos/gestor redirige a /admin/facturacion', () => {
+  it('sirve permanentRedirect hacia la URL canónica', () => {
+    const src = read('src/app/admin/(dashboard)/finanzas/ingresos/gestor/page.tsx');
+    expect(src).toMatch(/permanentRedirect\s*\(\s*['"`]\/admin\/facturacion['"`]\s*\)/);
+  });
+
+  it('no renderiza el compound page directamente (evita duplicación de URLs)', () => {
+    const src = read('src/app/admin/(dashboard)/finanzas/ingresos/gestor/page.tsx');
+    expect(src).not.toMatch(/IngresosCompoundPage/);
+  });
+});
+
+describe('FinanzasNav — Ingresos ya no reclama /admin/facturacion como propio', () => {
+  it('tab Ingresos no lista /admin/facturacion en extraPaths', () => {
+    const src = read('src/app/admin/(dashboard)/finanzas/FinanzasNav.tsx');
+    // Localiza el bloque del tab Ingresos y verifica que no cita facturacion como extraPath
+    const ingresosBlock = src.match(
+      /href:\s*['"]\/admin\/finanzas\/ingresos['"][\s\S]*?\},/,
+    )?.[0];
+    expect(ingresosBlock).toBeDefined();
+    expect(ingresosBlock).not.toMatch(/extraPaths[\s\S]*['"]\/admin\/facturacion['"]/);
+  });
+});

--- a/src/__tests__/server/finanzas-nav-and-routing.test.ts
+++ b/src/__tests__/server/finanzas-nav-and-routing.test.ts
@@ -52,10 +52,9 @@ describe('[finanzas-nav-and-routing] las 9 tabs canónicas', () => {
 });
 
 describe('[finanzas-nav-and-routing] redirects legacy', () => {
-  it('/admin/facturacion redirige a /admin/finanzas/ingresos', () => {
-    const src = read('src/app/admin/(dashboard)/facturacion/page.tsx');
-    expect(src).toMatch(/permanentRedirect\(['"]\/admin\/finanzas\/ingresos['"]\)/);
-  });
+  // 2026-07-07: /admin/facturacion se restauró como módulo operativo propio.
+  // El contrato del redirect anterior (PR #212) queda cubierto en
+  // `admin-facturacion-restore.test.ts`, que además vigila la regresión inversa.
 
   it('/admin/facturacion/dashboard redirige a /admin/finanzas/resumen', () => {
     const src = read('src/app/admin/(dashboard)/facturacion/dashboard/page.tsx');
@@ -90,20 +89,21 @@ describe('[finanzas-nav-and-routing] páginas placeholder usan PlaceholderSectio
   });
 });
 
-describe('[finanzas-nav-and-routing] /admin/finanzas/ingresos + gestor (PR 3 rediseño)', () => {
+describe('[finanzas-nav-and-routing] /admin/finanzas/ingresos + gestor', () => {
   // PR 3 (2026-07-06): /admin/finanzas/ingresos es una sección nueva
-  // con KPIs + aging + tabla + top clientes. El compound antiguo se
-  // preserva en /admin/finanzas/ingresos/gestor, accesible desde el
-  // bloque "Accesos rápidos".
+  // con KPIs + aging + tabla + top clientes.
+  //
+  // 2026-07-07: /ingresos/gestor pasó a redirect canónico hacia
+  // /admin/facturacion (módulo operativo restaurado). El compound
+  // IngresosCompoundPage lo hospeda ahora la ruta /admin/facturacion.
   it('/ingresos es la nueva sección PR 3 (usa getIngresosData)', () => {
     const src = read('src/app/admin/(dashboard)/finanzas/ingresos/page.tsx');
     expect(src).toMatch(/import\s*\{\s*getIngresosData\s*\}/);
     expect(src).toMatch(/<IngresosKpisBlock/);
   });
 
-  it('/ingresos/gestor hospeda IngresosCompoundPage (compound preservado)', () => {
+  it('/ingresos/gestor redirige a /admin/facturacion (URL canónica)', () => {
     const src = read('src/app/admin/(dashboard)/finanzas/ingresos/gestor/page.tsx');
-    expect(src).toMatch(/import\s*\{\s*IngresosCompoundPage\s*\}\s*from\s*['"]@\/features\/admin\/invoices\/pages\/IngresosCompoundPage['"]/);
-    expect(src).toMatch(/<IngresosCompoundPage\s+headerTitle=['"]Gestor de facturación['"]/);
+    expect(src).toMatch(/permanentRedirect\(['"]\/admin\/facturacion['"]\)/);
   });
 });

--- a/src/app/admin/(dashboard)/facturacion/page.tsx
+++ b/src/app/admin/(dashboard)/facturacion/page.tsx
@@ -1,8 +1,24 @@
-import { permanentRedirect } from 'next/navigation';
+import { IngresosCompoundPage } from '@/features/admin/invoices/pages/IngresosCompoundPage';
 
-// PR 2 finanzas rediseño (2026-07-06): la ruta canónica es
-// /admin/finanzas/ingresos. Este redirect preserva bookmarks del equipo.
-// El contenido vive en `@/features/admin/invoices/pages/IngresosCompoundPage`.
-export default function FacturacionLegacyPage(): never {
-  permanentRedirect('/admin/finanzas/ingresos');
+/**
+ * Facturación — módulo operativo (URL canónica).
+ *
+ * Restaurado en 2026-07-07 como módulo propio tras PR #212, que había reducido
+ * esta ruta a un redirect y ocultado el flujo de "crear factura". Separa
+ * operativo (aquí) de análisis (Finanzas → Ingresos en /admin/finanzas/ingresos).
+ *
+ * Los sub-paths ya vigentes (import, bancos, bancos/importar, bancos/conciliacion,
+ * exports) siguen funcionando sin cambios.
+ *
+ * El guard de permiso `facturacion:read` se aplica dentro de `IngresosCompoundPage`.
+ */
+export const metadata = { title: 'Facturación · SocialPro' };
+
+export default async function FacturacionPage(): Promise<React.ReactElement> {
+  return (
+    <IngresosCompoundPage
+      headerTitle="Facturación"
+      headerSubtitle="Facturas emitidas, clientes, empresas emisoras e importación"
+    />
+  );
 }

--- a/src/app/admin/(dashboard)/finanzas/FinanzasNav.tsx
+++ b/src/app/admin/(dashboard)/finanzas/FinanzasNav.tsx
@@ -34,11 +34,10 @@ const TABS: readonly Tab[] = [
   {
     href: '/admin/finanzas/ingresos',
     label: 'Ingresos',
-    // Los sub-paths legacy de facturación siguen bajo /admin/facturacion/*
-    // (import, exports, bancos, bancos/importar, bancos/conciliacion). Los
-    // agregamos aquí para que el tab quede activo cuando el usuario navegue
-    // por ellos.
-    extraPaths: ['/admin/facturacion'],
+    // Facturación se restauró como módulo operativo propio (2026-07-07): la
+    // URL canónica es /admin/facturacion y ya no forma parte del scope de
+    // Finanzas → Ingresos (análisis). El tab Ingresos NO se marca activo
+    // cuando el usuario está operando facturas.
   },
   {
     href: '/admin/finanzas/gastos',

--- a/src/app/admin/(dashboard)/finanzas/ingresos/gestor/page.tsx
+++ b/src/app/admin/(dashboard)/finanzas/ingresos/gestor/page.tsx
@@ -1,22 +1,12 @@
-import { requirePermission } from '@/lib/permissions';
-import { IngresosCompoundPage } from '@/features/admin/invoices/pages/IngresosCompoundPage';
-
-export const metadata = { title: 'Gestor de facturación · Ingresos · Finanzas' };
+import { permanentRedirect } from 'next/navigation';
 
 /**
- * Compound page migrada desde /admin/finanzas/ingresos (PR 2).
+ * `/admin/finanzas/ingresos/gestor` → `/admin/facturacion` (URL canónica).
  *
- * En PR 3 rediseñamos /ingresos con KPIs + aging + tabla + top clientes,
- * pero el compound antiguo (Facturas emitidas, Clientes de facturación,
- * Empresas emisoras, Importar) sigue siendo útil como panel operativo.
- * Se accede desde el bloque "Accesos rápidos" de la nueva ingresos.
+ * Tras restaurar Facturación como módulo operativo propio (2026-07-07), esta
+ * ruta se mantiene como alias con 308 permanente para preservar bookmarks del
+ * equipo y accesos rápidos internos que apuntaban aquí desde PR #212.
  */
-export default async function FinanzasIngresosGestorPage(): Promise<React.ReactElement> {
-  await requirePermission('facturacion', 'read');
-  return (
-    <IngresosCompoundPage
-      headerTitle="Gestor de facturación"
-      headerSubtitle="Facturas emitidas, clientes, empresas emisoras e importación de facturas"
-    />
-  );
+export default function FinanzasIngresosGestorAlias(): never {
+  permanentRedirect('/admin/facturacion');
 }


### PR DESCRIPTION
## Summary

PR #212 (2026-07-06) redujo `/admin/facturacion` a un `permanentRedirect` a `/admin/finanzas/ingresos`, colapsando Facturación bajo Finanzas → Ingresos y ocultando el flujo de "crear factura". Los dos entries del sidebar acababan en el mismo bloque.

Restaura la separación conceptual:
- **Facturación** = operar facturas (URL canónica `/admin/facturacion`)
- **Finanzas → Ingresos** = analizar ingresos, cobros y aging

Cero cambios de DB, schema, storage, numeración de facturas o queries. `allocateInvoiceNumber` sigue siendo la única fuente de numeración (por issuer, atómica, sin duplicados). Los contadores `next_invoice_number` de cada emisora quedan intactos y visibles tras el deploy en el tab **Empresas emisoras**.

## Archivos tocados (5)

| Archivo | Cambio |
|---|---|
| `src/app/admin/(dashboard)/facturacion/page.tsx` | `permanentRedirect` → renderiza `<IngresosCompoundPage headerTitle="Facturación" headerSubtitle="Facturas emitidas, clientes, empresas emisoras e importación" />` |
| `src/app/admin/(dashboard)/finanzas/ingresos/gestor/page.tsx` | Renderizado del compound → `permanentRedirect('/admin/facturacion')` (URL canónica única) |
| `src/app/admin/(dashboard)/finanzas/FinanzasNav.tsx` | Elimina `extraPaths: ['/admin/facturacion']` del tab Ingresos |
| `src/__tests__/server/admin-facturacion-restore.test.ts` | **Nuevo** — 6 assertions que fallan si vuelve a introducirse el redirect antiguo o si el gestor sale de `/admin/facturacion` |
| `src/__tests__/server/finanzas-nav-and-routing.test.ts` | Actualiza los 2 tests que reflejaban el contrato invertido de PR #212 (borra assert de `/admin/facturacion → /admin/finanzas/ingresos`; invierte el de `/gestor`) |

## Confirmaciones

### /admin/facturacion restaurado ✅
- Ya no redirige a `/admin/finanzas/*`. Test estático lo vigila.
- Renderiza `IngresosCompoundPage` con `headerTitle="Facturación"`.
- Los 5 tabs internos siguen intactos: Movimientos · Importar · Facturas emitidas · Clientes · Empresas emisoras.
- El flujo Facturas emitidas → **Nueva factura** vuelve a ser accesible.
- `requirePermission('facturacion', 'read')` aplicado dentro de `IngresosCompoundPage` (línea 54 de ese componente).

### /admin/finanzas/ingresos/gestor redirect ✅
- `permanentRedirect('/admin/facturacion')`. Test estático lo vigila.
- Ningún import de `IngresosCompoundPage` — evita duplicación de URLs.

### FinanzasNav limpio ✅
- Tab **Ingresos** ya no reclama `/admin/facturacion` como propio.
- Cuando el usuario está en `/admin/facturacion/*` (fuera del layout de Finanzas), ningún tab de Finanzas se marca activo — comportamiento correcto porque Facturación tiene otro layout.

### Sin migración
✅ Cero cambios en `src/db/schema/`, cero SQL nuevo.

### Sin DB changes
✅ `next_invoice_number` intacto en todas las emisoras. No se ejecutan queries de actualización. `allocateInvoiceNumber` sigue siendo la única función que muta la numeración.

## Checks locales

- `npx tsc --noEmit` — sin errores en el proyecto.
- `npx eslint` — verde en los 4 archivos tocados.
- `npx jest` — **3614/3614 tests pasan** (incluidos los 6 nuevos + los 40 actualizados de `finanzas-nav-and-routing`).

## Riesgos pendientes

- **`revalidatePath('/admin/facturacion')`** en 5+ actions (`create-invoice-from-deal.ts:120`, `deal-movimiento-action.ts:74`, `invoices-actions.ts:148/193`, `import-actions.ts:257`) siguen válidos — la ruta ahora renderiza el gestor real.
- **Bookmarks a `/admin/finanzas/ingresos`** (nueva página análisis) siguen funcionando sin cambios.
- **Bookmarks a `/admin/finanzas/ingresos/gestor`** ahora responden 308 → `/admin/facturacion`. Preservan el flujo.
- **Numeración**: tras el deploy, el usuario verifica en el tab **Empresas emisoras** el `next_invoice_number` actual de cada emisora — no se toca desde esta PR.

## Test plan

- [ ] Verificar en preview: sidebar `Facturación` lleva a `/admin/facturacion` con los 5 tabs visibles.
- [ ] Verificar en preview: sidebar `Finanzas` lleva a `/admin/finanzas/resumen`; tab Ingresos muestra KPIs + aging.
- [ ] Verificar en preview: `/admin/finanzas/ingresos/gestor` responde 308 → `/admin/facturacion`.
- [ ] Verificar en preview: en `/admin/facturacion` → tab **Facturas emitidas** → botón "Nueva factura" abre el formulario `IssuedInvoiceForm` en modo create.
- [ ] Verificar en preview: en `/admin/facturacion` → tab **Empresas emisoras** muestra `next_invoice_number` de cada emisora (confirmación visual de la numeración actual antes de emitir la próxima).

🤖 Generated with [Claude Code](https://claude.com/claude-code)