### PR TITLE
feat(marcas): portal proxy PDF facturas — auth boundary brand session

### DIFF
--- a/src/__tests__/server/marcas-portal-invoice-proxy.test.ts
+++ b/src/__tests__/server/marcas-portal-invoice-proxy.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Tests del proxy portal marca para PDFs de facturas.
+ * Ruta: /api/marcas/facturas/[id]/pdf
+ *
+ * Boundary auth DIFERENTE del admin:
+ *   - Usa `requireRole('brand', '/marcas/login')` (Better Auth, rol de portal).
+ *   - Verifica ownership por `crmBrands.portalUserId === session.user.id`.
+ *   - Cualquier mismatch de propietario → 404 fail-closed.
+ *
+ * Verifica:
+ *   - id inválido → 404 sin tocar DB.
+ *   - Sesión sin rol brand → propaga error del guard.
+ *   - Factura de otra marca (portalUserId distinto) → 404.
+ *   - Factura kind='expense' → 404 (no visible en portal).
+ *   - Factura anulada → 404.
+ *   - Sin fileUrl → 404.
+ *   - Sin BLOB_READ_WRITE_TOKEN → 503.
+ *   - Camino feliz → 200 con Content-Type, Content-Disposition, Cache-Control,
+ *     X-Content-Type-Options correctos.
+ *   - Bearer token nunca en headers de respuesta.
+ *   - URL privada del Blob nunca en body de error.
+ *   - Página del portal usa el proxy, no el fileUrl directo.
+ */
+
+// ── Mocks ──────────────────────────────────────────────────────────────
+
+jest.mock('@/lib/auth', () => ({ auth: {} }));
+
+const mockRequireRole = jest.fn();
+jest.mock('@/lib/auth-guard', () => ({
+  requireRole: (...args: unknown[]) => mockRequireRole(...args),
+}));
+
+// Mock cadena Drizzle: select().from().innerJoin().leftJoin().where().limit()
+let mockRow: Record<string, unknown> | null = null;
+const mockDb = {
+  select: jest.fn(() => ({
+    from: jest.fn(() => ({
+      innerJoin: jest.fn(() => ({
+        leftJoin: jest.fn(() => ({
+          where: jest.fn(() => ({
+            limit: jest.fn(() => (mockRow ? [mockRow] : [])),
+          })),
+        })),
+      })),
+    })),
+  })),
+};
+jest.mock('@/lib/db', () => ({ db: mockDb }));
+
+jest.mock('@/db/schema/invoices', () => ({
+  invoices: {
+    id: 'id', brandId: 'brandId', fileUrl: 'fileUrl',
+    invoiceFileId: 'invoiceFileId', number: 'number',
+    kind: 'kind', status: 'status',
+  },
+}));
+jest.mock('@/db/schema/crmBrands', () => ({
+  crmBrands: { id: 'id', portalUserId: 'portalUserId' },
+}));
+jest.mock('@/db/schema/files', () => ({
+  files: { id: 'id', url: 'url', name: 'name' },
+}));
+
+jest.mock('@/lib/env', () => ({
+  env: {
+    get BLOB_READ_WRITE_TOKEN() {
+      return process.env.BLOB_READ_WRITE_TOKEN ?? '';
+    },
+  },
+}));
+
+// ── Imports tras mocks ─────────────────────────────────────────────────
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { NextRequest } from 'next/server';
+import { GET as brandInvoiceGET } from '@/app/api/marcas/facturas/[id]/pdf/route';
+
+const PROJECT_ROOT = path.resolve(__dirname, '..', '..', '..');
+const read = (rel: string) => fs.readFileSync(path.join(PROJECT_ROOT, rel), 'utf-8');
+
+const BLOB_SECRET = 'test-blob-token-marca-xyz';
+const PRIVATE_BLOB_URL = 'https://private-store.vercel-storage.com/invoices/marca-secret.pdf';
+const BRAND_USER_ID = 'user-brand-1';
+const OTHER_USER_ID = 'user-brand-2';
+
+const makeReq = (id: string) =>
+  new NextRequest(`http://localhost:3000/api/marcas/facturas/${id}/pdf`);
+const makeParams = (id: string) => ({ params: Promise.resolve({ id }) });
+
+const validRow = {
+  invoiceFileUrl:  PRIVATE_BLOB_URL,
+  invoiceFileName: 'Factura F-2026-0012.pdf',
+  legacyFileUrl:   null,
+  invoiceNumber:   'F-2026-0012',
+  kind:            'income',
+  status:          'emitida',
+  portalUserId:    BRAND_USER_ID,
+};
+
+const mockBlobOk = () => {
+  (global.fetch as jest.Mock).mockResolvedValue({
+    ok: true,
+    status: 200,
+    headers: { get: (k: string) => (k === 'content-type' ? 'application/pdf' : null) },
+    arrayBuffer: () => Promise.resolve(new ArrayBuffer(16)),
+  });
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockRow = null;
+  global.fetch = jest.fn();
+  process.env.BLOB_READ_WRITE_TOKEN = BLOB_SECRET;
+  mockRequireRole.mockResolvedValue({
+    user: { id: BRAND_USER_ID, email: 'brand@example.com', name: 'Brand', role: 'brand' },
+  });
+});
+
+afterEach(() => {
+  delete process.env.BLOB_READ_WRITE_TOKEN;
+});
+
+// ═════════════════════════════════════════════════════════════════════
+
+describe('/api/marcas/facturas/[id]/pdf — boundary de sesión brand', () => {
+  it('llama a requireRole con el rol "brand" y ruta de login del portal', async () => {
+    mockRow = validRow;
+    mockBlobOk();
+    await brandInvoiceGET(makeReq('12'), makeParams('12'));
+    expect(mockRequireRole).toHaveBeenCalledWith('brand', '/marcas/login');
+  });
+
+  it('sesión no autorizada → propaga error del guard (no llega a DB)', async () => {
+    mockRequireRole.mockRejectedValue(new Error('NEXT_REDIRECT: /marcas/login'));
+    await expect(brandInvoiceGET(makeReq('12'), makeParams('12'))).rejects.toThrow(/NEXT_REDIRECT/);
+    expect(mockDb.select).not.toHaveBeenCalled();
+  });
+});
+
+describe('/api/marcas/facturas/[id]/pdf — validación y fail-closed', () => {
+  it('id no numérico → 404 sin tocar DB', async () => {
+    const res = await brandInvoiceGET(makeReq('abc'), makeParams('abc'));
+    expect(res.status).toBe(404);
+    expect(mockDb.select).not.toHaveBeenCalled();
+  });
+
+  it('id 0 o negativo → 404', async () => {
+    expect((await brandInvoiceGET(makeReq('0'),  makeParams('0'))).status).toBe(404);
+    expect((await brandInvoiceGET(makeReq('-5'), makeParams('-5'))).status).toBe(404);
+  });
+
+  it('factura inexistente → 404', async () => {
+    mockRow = null;
+    const res = await brandInvoiceGET(makeReq('99'), makeParams('99'));
+    expect(res.status).toBe(404);
+  });
+
+  it('factura de OTRA marca (portalUserId distinto) → 404 fail-closed', async () => {
+    mockRow = { ...validRow, portalUserId: OTHER_USER_ID };
+    const res = await brandInvoiceGET(makeReq('12'), makeParams('12'));
+    expect(res.status).toBe(404);
+    expect(global.fetch).not.toHaveBeenCalled();
+    // El body de error no debe filtrar la URL privada
+    const body = await res.text();
+    expect(body).not.toContain(PRIVATE_BLOB_URL);
+  });
+
+  it('factura kind="expense" (no visible en portal) → 404', async () => {
+    mockRow = { ...validRow, kind: 'expense' };
+    const res = await brandInvoiceGET(makeReq('12'), makeParams('12'));
+    expect(res.status).toBe(404);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('factura anulada → 404', async () => {
+    mockRow = { ...validRow, status: 'anulada' };
+    const res = await brandInvoiceGET(makeReq('12'), makeParams('12'));
+    expect(res.status).toBe(404);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('sin fileUrl ni legacy → 404 "PDF no disponible"', async () => {
+    mockRow = { ...validRow, invoiceFileUrl: null, legacyFileUrl: null };
+    const res = await brandInvoiceGET(makeReq('12'), makeParams('12'));
+    expect(res.status).toBe(404);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('sólo legacy fileUrl (invoiceFileId=null) → sirve el legacy', async () => {
+    mockRow = {
+      ...validRow,
+      invoiceFileUrl: null,
+      invoiceFileName: null,
+      legacyFileUrl:   PRIVATE_BLOB_URL,
+    };
+    mockBlobOk();
+    const res = await brandInvoiceGET(makeReq('12'), makeParams('12'));
+    expect(res.status).toBe(200);
+    expect((global.fetch as jest.Mock).mock.calls[0]?.[0]).toBe(PRIVATE_BLOB_URL);
+  });
+});
+
+describe('/api/marcas/facturas/[id]/pdf — headers de seguridad y camino feliz', () => {
+  it('sin BLOB_READ_WRITE_TOKEN → 503', async () => {
+    mockRow = validRow;
+    delete process.env.BLOB_READ_WRITE_TOKEN;
+    const res = await brandInvoiceGET(makeReq('12'), makeParams('12'));
+    expect(res.status).toBe(503);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('fetch al blob falla (401 upstream) → 404, sin filtrar URL privada', async () => {
+    mockRow = validRow;
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 401,
+      headers: { get: () => null },
+      arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+    });
+    const res = await brandInvoiceGET(makeReq('12'), makeParams('12'));
+    expect(res.status).toBe(404);
+    const body = await res.text();
+    expect(body).not.toContain(PRIVATE_BLOB_URL);
+  });
+
+  it('camino feliz → 200 con Content-Type, Content-Disposition, Cache-Control y X-Content-Type-Options', async () => {
+    mockRow = validRow;
+    mockBlobOk();
+    const res = await brandInvoiceGET(makeReq('12'), makeParams('12'));
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toBe('application/pdf');
+    expect(res.headers.get('cache-control')).toBe('private, no-store');
+    expect(res.headers.get('x-content-type-options')).toBe('nosniff');
+    expect(res.headers.get('content-disposition')).toMatch(/inline; filename="Factura_F-2026-0012\.pdf"/);
+  });
+
+  it('Bearer token nunca aparece en headers de respuesta', async () => {
+    mockRow = validRow;
+    mockBlobOk();
+    const res = await brandInvoiceGET(makeReq('12'), makeParams('12'));
+
+    for (const [name, value] of res.headers.entries()) {
+      expect(`${name}: ${value}`).not.toContain(BLOB_SECRET);
+    }
+  });
+
+  it('fetch al blob se hace con Bearer server-side', async () => {
+    mockRow = validRow;
+    mockBlobOk();
+    await brandInvoiceGET(makeReq('12'), makeParams('12'));
+    const [url, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(url).toBe(PRIVATE_BLOB_URL);
+    expect(init.headers.Authorization).toBe(`Bearer ${BLOB_SECRET}`);
+  });
+
+  it('sin invoiceFileName ni número → filename fallback "factura.pdf"', async () => {
+    mockRow = {
+      ...validRow,
+      invoiceFileName: null,
+      invoiceNumber:   null,
+    };
+    mockBlobOk();
+    const res = await brandInvoiceGET(makeReq('12'), makeParams('12'));
+    expect(res.headers.get('content-disposition')).toMatch(/factura\.pdf/);
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════
+//  Test estático — la página del portal usa el proxy
+// ═════════════════════════════════════════════════════════════════════
+
+describe('src/app/marcas/(portal)/facturas/page.tsx — usa el proxy', () => {
+  it('enlaza al proxy /api/marcas/facturas/[id]/pdf', () => {
+    const src = read('src/app/marcas/(portal)/facturas/page.tsx');
+    expect(src).toMatch(/\/api\/marcas\/facturas\/\$\{inv\.id\}\/pdf/);
+  });
+
+  it('NO renderiza `<a href={inv.fileUrl}>` directo al Blob privado', () => {
+    const src = read('src/app/marcas/(portal)/facturas/page.tsx');
+    expect(src).not.toMatch(/href=\{inv\.fileUrl\}/);
+  });
+});

--- a/src/app/api/marcas/facturas/[id]/pdf/route.ts
+++ b/src/app/api/marcas/facturas/[id]/pdf/route.ts
@@ -1,0 +1,93 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { eq } from 'drizzle-orm';
+
+import { requireRole } from '@/lib/auth-guard';
+import { db } from '@/lib/db';
+import { invoices } from '@/db/schema/invoices';
+import { crmBrands } from '@/db/schema/crmBrands';
+import { files } from '@/db/schema/files';
+import { streamPrivateBlob } from '@/lib/files/streamPrivateBlob';
+
+/**
+ * Proxy portal marca para PDFs de facturas.
+ *
+ * Auth boundary DIFERENTE del admin: usa `requireRole('brand')` (Better Auth,
+ * rol específico del portal de marca), no `requirePermission`.
+ *
+ * Ownership:
+ *   Sólo sirve una factura si `invoices.brandId → crmBrands.portalUserId`
+ *   coincide con `session.user.id`. Si no coincide → 404 fail-closed
+ *   (no revelar existencia de la factura).
+ *
+ * Visibilidad consistente con `getInvoicesForBrandUser`:
+ *   - kind = 'income'
+ *   - status != 'anulada'
+ *
+ * Resuelve el PDF en este orden (mismo patrón que /api/admin/facturacion/[id]/pdf):
+ *   1. `invoices.invoiceFileId` → `files.url` (canónico)
+ *   2. `invoices.fileUrl` (legacy)
+ *
+ * El token de Blob nunca se expone al cliente — se descarga server-side y se
+ * re-streamea con `Cache-Control: private, no-store` + `X-Content-Type-Options: nosniff`.
+ */
+export const dynamic = 'force-dynamic';
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const session = await requireRole('brand', '/marcas/login');
+
+  const { id: idStr } = await params;
+  const id = Number(idStr);
+  if (!Number.isInteger(id) || id <= 0) {
+    return new NextResponse('Not found', { status: 404 });
+  }
+
+  const rows = await db
+    .select({
+      invoiceFileUrl:  files.url,
+      invoiceFileName: files.name,
+      legacyFileUrl:   invoices.fileUrl,
+      invoiceNumber:   invoices.number,
+      kind:            invoices.kind,
+      status:          invoices.status,
+      portalUserId:    crmBrands.portalUserId,
+    })
+    .from(invoices)
+    .innerJoin(crmBrands, eq(crmBrands.id, invoices.brandId))
+    .leftJoin(files,      eq(files.id,     invoices.invoiceFileId))
+    .where(eq(invoices.id, id))
+    .limit(1);
+
+  const row = rows[0];
+  if (!row) {
+    return new NextResponse('Not found', { status: 404 });
+  }
+
+  // Ownership fail-closed. Cualquier mismatch → 404 sin revelar detalles.
+  if (row.portalUserId !== session.user.id) {
+    return new NextResponse('Not found', { status: 404 });
+  }
+
+  // Visibilidad coherente con el listado del portal.
+  if (row.kind !== 'income' || row.status === 'anulada') {
+    return new NextResponse('Not found', { status: 404 });
+  }
+
+  const fileUrl = row.invoiceFileUrl ?? row.legacyFileUrl;
+  if (!fileUrl) {
+    return new NextResponse('PDF no disponible', { status: 404 });
+  }
+
+  const rawName =
+    row.invoiceFileName ??
+    (row.invoiceNumber ? `${row.invoiceNumber}.pdf` : 'factura.pdf');
+
+  return streamPrivateBlob({
+    fileUrl,
+    filename: rawName,
+    fallbackContentType: 'application/pdf',
+  });
+}

--- a/src/app/marcas/(portal)/facturas/page.tsx
+++ b/src/app/marcas/(portal)/facturas/page.tsx
@@ -101,7 +101,7 @@ export default async function BrandInvoicesPage(): Promise<React.ReactElement> {
                   </td>
                   <td className="px-4 py-3">
                     {inv.fileUrl ? (
-                      <a href={inv.fileUrl} target="_blank" rel="noreferrer" className="text-sp-orange hover:underline text-xs font-semibold">
+                      <a href={`/api/marcas/facturas/${inv.id}/pdf`} target="_blank" rel="noreferrer" className="text-sp-orange hover:underline text-xs font-semibold">
                         Descargar
                       </a>
                     ) : (


### PR DESCRIPTION
## Summary

Cierra el último punto de la deuda `access: 'private'`. El portal marca en `/marcas/(portal)/facturas` seguía con `<a href={inv.fileUrl}>` directo al Blob privado — dejado explícitamente para PR-D porque el auth boundary es distinto del admin (rol `brand` de Better Auth, no permisos admin).

## Auditoría auth portal marca

- **Guard**: `requireRole('brand', '/marcas/login')` (Better Auth, `src/lib/auth-guard.ts:129`).
- **Sesión**: `session.user.id` — no hay `brandId` directo en la sesión.
- **Relación user → brand**: `crm_brands.portal_user_id` (FK a `user.id`).
- **Relación invoice → brand**: `invoices.brandId` → `crm_brands.id`.
- **Query del listado**: `getInvoicesForBrandUser(userId)` (`src/lib/queries/invoices.ts:449`) filtra por `crm_brands.portalUserId = userId AND kind='income' AND status != 'anulada'`. El proxy replica exactamente los mismos criterios.
- **Campo PDF**: `invoices.invoiceFileId` → `files.url` (canónico, post-refactor) con fallback a `invoices.fileUrl` (legacy). Mismo patrón que el proxy admin.
- **Helper reutilizado**: `streamPrivateBlob` + `sanitizeFilename` de `src/lib/files/streamPrivateBlob.ts`.

## Endpoint creado

`src/app/api/marcas/facturas/[id]/pdf/route.ts` — flujo:

```
1. requireRole('brand', '/marcas/login')       ← Better Auth boundary
2. Validar id numérico                          → 404 si inválido
3. Query invoice + INNER JOIN crm_brands        → 404 si no existe
4. Verificar portalUserId === session.user.id   → 404 fail-closed si mismatch
5. Verificar kind='income' AND status != 'anulada' → 404 si no
6. Resolver PDF: files.url (canónico) → invoices.fileUrl (legacy) → 404
7. streamPrivateBlob con Bearer server-side
```

Headers de salida:
```
Content-Type: <content-type del blob> | application/pdf
Content-Disposition: inline; filename="<saneado>"
Cache-Control: private, no-store
X-Content-Type-Options: nosniff
```

Bearer token nunca fluye al cliente. URL privada del blob nunca aparece en body de error.

## UI corregida

`src/app/marcas/(portal)/facturas/page.tsx:104`:
```diff
- <a href={inv.fileUrl} target="_blank" rel="noreferrer" ...>
+ <a href={`/api/marcas/facturas/${inv.id}/pdf`} target="_blank" rel="noreferrer" ...>
```

## Tests añadidos (18 casos)

`src/__tests__/server/marcas-portal-invoice-proxy.test.ts`:

- Boundary auth:
  - `requireRole` invocado con `('brand', '/marcas/login')`.
  - Sesión no autorizada → propaga error del guard sin tocar DB.

- Validación:
  - id no numérico / 0 / negativo → 404 sin tocar DB.
  - Factura inexistente → 404.
  - Factura de OTRA marca (`portalUserId` distinto) → **404 fail-closed**, sin fetch, sin filtrar URL privada.
  - `kind='expense'` → 404.
  - `status='anulada'` → 404.
  - Sin fileUrl ni legacy → 404 sin fetch.
  - Sólo legacy → sirve el legacy correctamente.

- Seguridad:
  - Sin `BLOB_READ_WRITE_TOKEN` → 503 sin fetch.
  - Fetch al blob falla → 404 sin filtrar URL privada.
  - Camino feliz → 200 con `Content-Type`, `Content-Disposition`, `Cache-Control: private, no-store`, `X-Content-Type-Options: nosniff`.
  - Bearer token **nunca** aparece en headers de respuesta.
  - Fetch al blob se hace con `Authorization: Bearer` server-side.
  - Filename fallback correcto cuando no hay nombre.

- Regresión UI:
  - Página portal enlaza al proxy.
  - Página portal NO renderiza `<a href={inv.fileUrl}>` directo.

## Confirmaciones

- ✅ **Sin migración** — cero cambios en `src/db/schema/`, cero SQL nuevo.
- ✅ **Sin DB changes** — el proxy sólo lee, no muta.
- ✅ **Sin dependencia nueva** — `package.json` intacto.
- ✅ **Sin env nueva** — reutiliza `BLOB_READ_WRITE_TOKEN` ya presente.
- ✅ **Sin tocar admin proxies** (`/api/admin/files/[id]`, `/api/admin/campanas/[id]/contract/pdf`, `/api/admin/facturacion/import/[id]/pdf` intactos).
- ✅ **Sin tocar Facturación admin** (páginas `/admin/facturacion/*` intactas).
- ✅ **Sin tocar PDF bilingüe** (generador jsPDF intacto).
- ✅ **Sin tocar `storage.ts`** ni el `access: 'private'`.
- ✅ **Sin tocar Finanzas** ni Sorteos.

## Checks locales

- `npx tsc --noEmit` — sin errores en el proyecto.
- `npx eslint` — verde en los 3 archivos tocados.
- `npx jest` — **3690/3690 tests pasan** (18 nuevos + 3672 previos).

## Riesgos pendientes

- **Facturas legacy sin `crm_brands.portalUserId` asignado**: si algún cliente de portal marca aún no está vinculado a una `crm_brand` en concreto, verá lista vacía y ninguna descarga. Es el mismo comportamiento previo — no cambia.
- **`crm_brands` con dos usuarios de portal apuntando a la misma brand**: no aplica hoy (es una relación 1:1 por `portalUserId`), pero si en el futuro se soporta N:N habría que actualizar la lógica.
- La deuda `access: 'private'` queda **cerrada**: 5 sitios auditados originalmente, todos con proxy y test estático de regresión.

## Test plan

- [ ] Login como usuario de portal marca en preview.
- [ ] Ir a `/marcas/facturas`, verificar listado.
- [ ] Click "Descargar" en una factura → debería servir el PDF (o mostrar 404 controlado si el blob está roto).
- [ ] Intentar acceso directo a `/api/marcas/facturas/<id de otra marca>/pdf` → 404 fail-closed.
- [ ] Verificar en DevTools que la respuesta tiene `Cache-Control: private, no-store` y `X-Content-Type-Options: nosniff`.
- [ ] Verificar que ningún header incluye el `BLOB_READ_WRITE_TOKEN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)