### PR TITLE
fix(finance-dashboard): cerrar fuga access:'private' — 4 sitios usan buildInvoicePdfUrl

### DIFF
--- a/src/__tests__/server/admin-private-files-ui-uses-proxy.test.ts
+++ b/src/__tests__/server/admin-private-files-ui-uses-proxy.test.ts
@@ -73,3 +73,53 @@ describe('UI admin — ImportInbox usa /api/admin/facturacion/import/[id]/pdf', 
     expect(src).not.toMatch(/href=\{imp\.fileUrl\}/);
   });
 });
+
+// ── Finance dashboard — fuga cerrada 2026-07-07 (PR-E) ────────────────
+//
+// Cuatro sitios se quedaron fuera del sweep de PR #217 porque grepaban por
+// `<a href={file.url}>` y estos usan `<Link href={pdfHref}>` construido con
+// un ternario inline. Además hardcodeaban una ruta INEXISTENTE `/api/admin/facturas/`
+// (typo — la ruta real es `/api/admin/facturacion/`). El fallback en null
+// caía a `row.fileUrl` directo al Blob privado.
+//
+// Estos tests fallan si vuelve a colarse el typo o el fallback al Blob.
+
+const FINANCE_DASHBOARD_FILES = [
+  'src/features/admin/finance-dashboard/components/nominas-creadores/NominasInternasTabla.tsx',
+  'src/features/admin/finance-dashboard/components/nominas-creadores/PagosTalentosTabla.tsx',
+  'src/features/admin/finance-dashboard/components/gastos/GastosTabla.tsx',
+  'src/lib/queries/financeDashboard/arAging.ts',
+] as const;
+
+describe('finance-dashboard — ninguno enlaza a la ruta inexistente /api/admin/facturas/', () => {
+  it.each(FINANCE_DASHBOARD_FILES)('%s no menciona /api/admin/facturas/', (rel) => {
+    const src = read(rel);
+    // Cualquier substring que arranque en `/api/admin/facturas/` es error de tipeo.
+    // El helper correcto emite `/api/admin/facturacion/${id}/pdf`.
+    expect(src).not.toMatch(/\/api\/admin\/facturas\//);
+  });
+});
+
+describe('finance-dashboard — usa buildInvoicePdfUrl (evita fallback a row.fileUrl privado)', () => {
+  it.each(FINANCE_DASHBOARD_FILES)('%s importa buildInvoicePdfUrl', (rel) => {
+    const src = read(rel);
+    expect(src).toMatch(/import\s*\{[^}]*buildInvoicePdfUrl[^}]*\}\s*from\s*['"][^'"]*expenseSubgroups['"]/);
+  });
+
+  it.each(FINANCE_DASHBOARD_FILES)('%s NO cae a row.fileUrl ni r.fileUrl como fallback', (rel) => {
+    const src = read(rel);
+    // El patrón peligroso: `(row.fileUrl ?? ...)` o `(r.fileUrl ?? ...)` dentro
+    // de la construcción del href/pdfUrl. Con el helper el fallback se decide
+    // dentro de buildInvoicePdfUrl y nunca retorna la URL del blob privado.
+    expect(src).not.toMatch(/\?\?\s*row\.fileUrl/);
+    expect(src).not.toMatch(/\?\?\s*r\.fileUrl/);
+  });
+});
+
+describe('finance-dashboard — el helper buildInvoicePdfUrl sigue apuntando al proxy correcto', () => {
+  it('expenseSubgroups.ts devuelve /api/admin/facturacion/${id}/pdf', () => {
+    const src = read('src/lib/queries/financeDashboard/expenseSubgroups.ts');
+    expect(src).toMatch(/`\/api\/admin\/facturacion\/\$\{input\.id\}\/pdf`/);
+    expect(src).not.toMatch(/\/api\/admin\/facturas\//);
+  });
+});

--- a/src/features/admin/finance-dashboard/components/gastos/GastosTabla.tsx
+++ b/src/features/admin/finance-dashboard/components/gastos/GastosTabla.tsx
@@ -5,6 +5,7 @@ import {
   EXPENSE_STATUS_DISPLAY_SEMANTIC,
   normalizeExpenseStatusForDisplay,
 } from '@/lib/utils/expense-status-display';
+import { buildInvoicePdfUrl } from '@/lib/queries/financeDashboard/expenseSubgroups';
 import type { InvoiceWithRelations } from '@/types/invoice';
 
 interface Props {
@@ -67,7 +68,11 @@ export function GastosTabla({ rows, totalRows }: Props): React.ReactElement {
                 const isUnclassified = !row.expenseGroup;
                 const groupLabel = row.expenseGroup ? EXPENSE_GROUP_LABELS[row.expenseGroup] : null;
                 const subtypeLabel = row.expenseSubtype ? EXPENSE_SUBTYPE_LABELS[row.expenseSubtype] : null;
-                const pdfHref = row.invoiceFileId ? `/api/admin/facturas/${row.id}/pdf` : (row.fileUrl ?? null);
+                const pdfHref = buildInvoicePdfUrl({
+                  id: row.id,
+                  invoiceFileId: row.invoiceFileId,
+                  fileUrl: row.fileUrl,
+                });
                 return (
                   <tr key={row.id} className="border-b border-sp-border/40 last:border-0 hover:bg-sp-admin-hover transition-colors">
                     <td className="px-3 py-2 text-[11px] text-sp-admin-muted whitespace-nowrap tabular-nums">{row.issueDate}</td>

--- a/src/features/admin/finance-dashboard/components/nominas-creadores/NominasInternasTabla.tsx
+++ b/src/features/admin/finance-dashboard/components/nominas-creadores/NominasInternasTabla.tsx
@@ -5,6 +5,7 @@ import {
   EXPENSE_STATUS_DISPLAY_SEMANTIC,
   normalizeExpenseStatusForDisplay,
 } from '@/lib/utils/expense-status-display';
+import { buildInvoicePdfUrl } from '@/lib/queries/financeDashboard/expenseSubgroups';
 import type { InvoiceWithRelations } from '@/types/invoice';
 
 interface Props {
@@ -65,7 +66,11 @@ export function NominasInternasTabla({ rows, totalRows }: Props): React.ReactEle
                 const semantic = EXPENSE_STATUS_DISPLAY_SEMANTIC[status];
                 const subtypeLabel = row.expenseSubtype ? EXPENSE_SUBTYPE_LABELS[row.expenseSubtype] : '—';
                 const periodo = row.issueDate.slice(0, 7); // YYYY-MM
-                const pdfHref = row.invoiceFileId ? `/api/admin/facturas/${row.id}/pdf` : (row.fileUrl ?? null);
+                const pdfHref = buildInvoicePdfUrl({
+                  id: row.id,
+                  invoiceFileId: row.invoiceFileId,
+                  fileUrl: row.fileUrl,
+                });
                 return (
                   <tr key={row.id} className="border-b border-sp-border/40 last:border-0 hover:bg-sp-admin-hover transition-colors">
                     <td className="px-3 py-2 text-[12px] text-sp-admin-fg font-medium max-w-[180px] truncate">

--- a/src/features/admin/finance-dashboard/components/nominas-creadores/PagosTalentosTabla.tsx
+++ b/src/features/admin/finance-dashboard/components/nominas-creadores/PagosTalentosTabla.tsx
@@ -4,6 +4,7 @@ import {
   EXPENSE_STATUS_DISPLAY_SEMANTIC,
   normalizeExpenseStatusForDisplay,
 } from '@/lib/utils/expense-status-display';
+import { buildInvoicePdfUrl } from '@/lib/queries/financeDashboard/expenseSubgroups';
 import type { InvoiceWithRelations } from '@/types/invoice';
 
 interface Props {
@@ -72,7 +73,11 @@ export function PagosTalentosTabla({ rows, totalRows }: Props): React.ReactEleme
               {rows.map((row) => {
                 const status = normalizeExpenseStatusForDisplay(row.status);
                 const semantic = EXPENSE_STATUS_DISPLAY_SEMANTIC[status];
-                const pdfHref = row.invoiceFileId ? `/api/admin/facturas/${row.id}/pdf` : (row.fileUrl ?? null);
+                const pdfHref = buildInvoicePdfUrl({
+                  id: row.id,
+                  invoiceFileId: row.invoiceFileId,
+                  fileUrl: row.fileUrl,
+                });
                 return (
                   <tr key={row.id} className="border-b border-sp-border/40 last:border-0 hover:bg-sp-admin-hover transition-colors">
                     <td className="px-3 py-2 text-[12px] text-sp-admin-fg font-medium max-w-[140px] truncate">

--- a/src/lib/queries/financeDashboard/arAging.ts
+++ b/src/lib/queries/financeDashboard/arAging.ts
@@ -25,6 +25,7 @@ import {
   summarizeBuckets,
   todayInMadrid,
 } from './arAging.shared';
+import { buildInvoicePdfUrl } from './expenseSubgroups';
 
 // Facturas emitidas: status es varchar libre pero convención observada.
 const ISSUED_PENDING_STATUSES = ['emitida', 'vencida', 'parcial'] as const;
@@ -154,7 +155,7 @@ export async function getArAging(
       status: r.status,
       issueDate: r.issueDate,
       dueDate: r.dueDate,
-      pdfUrl: r.invoiceFileId ? `/api/admin/facturas/${r.id}/pdf` : (r.fileUrl ?? null),
+      pdfUrl: buildInvoicePdfUrl({ id: r.id, invoiceFileId: r.invoiceFileId, fileUrl: r.fileUrl }),
       today,
     }))
     .filter((r) => r.pendingAmount > 0);


### PR DESCRIPTION
## Summary

**PR-E — extensión estricta de PR #217** (private files sweep). Cuatro sitios en `finance-dashboard` se quedaron fuera del sweep original porque el grep buscaba `<a href={file.url}>` y estos usan `<Link href={pdfHref}>` con un ternario inline.

Cada uno tenía **dos bugs superpuestos en la misma línea**:

1. **URL de proxy inexistente** — hardcode `/api/admin/facturas/${id}/pdf`. La ruta real montada bajo `/api/admin` es `/api/admin/facturacion/[id]/pdf`. Cualquier factura con `invoiceFileId` presente → **404** al pulsar "Doc" / "Abrir →".
2. **Fallback al Blob privado** — cuando `invoiceFileId` era null, caía a `row.fileUrl` que tras PR #115 (2026-06-29) apunta directamente al Blob privado → **401** al abrirse.

Ya existía el helper correcto `buildInvoicePdfUrl` en `src/lib/queries/financeDashboard/expenseSubgroups.ts:228` que devuelve la ruta correcta y retorna `null` cuando no hay fuente disponible **sin nunca exponer el fileUrl legacy al cliente**. Cuatro sitios lo esquivaron y hardcodearon el ternario con typo.

## Archivos tocados (5)

### Fix (4)

| Archivo | Línea | Cambio |
|---|---|---|
| `src/features/admin/finance-dashboard/components/nominas-creadores/NominasInternasTabla.tsx` | 68 | Ternario inline → `buildInvoicePdfUrl(...)` |
| `src/features/admin/finance-dashboard/components/nominas-creadores/PagosTalentosTabla.tsx` | 75 | Ternario inline → `buildInvoicePdfUrl(...)` |
| `src/features/admin/finance-dashboard/components/gastos/GastosTabla.tsx` | 70 | Ternario inline → `buildInvoicePdfUrl(...)` |
| `src/lib/queries/financeDashboard/arAging.ts` | 157 | Ternario inline → `buildInvoicePdfUrl(...)` |

### Tests (1)

`src/__tests__/server/admin-private-files-ui-uses-proxy.test.ts` — amplía el test estático existente con **13 casos nuevos** para prevenir regresión en los 4 sitios de finance-dashboard.

## Diff resumido

Patrón antes → después (idéntico en los 4 sitios):

```diff
- const pdfHref = row.invoiceFileId
-   ? `/api/admin/facturas/${row.id}/pdf`
-   : (row.fileUrl ?? null);
+ const pdfHref = buildInvoicePdfUrl({
+   id: row.id,
+   invoiceFileId: row.invoiceFileId,
+   fileUrl: row.fileUrl,
+ });
```

Y `+import { buildInvoicePdfUrl } from '@/lib/queries/financeDashboard/expenseSubgroups';` en cada uno.

Total: **+70 −4** líneas.

## Tests añadidos (13)

Extensión del test estático `admin-private-files-ui-uses-proxy.test.ts`:

- 4 casos: ninguno de los 4 sitios menciona `/api/admin/facturas/` (typo)
- 4 casos: cada uno importa `buildInvoicePdfUrl` del helper
- 4 casos: ninguno cae a `?? row.fileUrl` ni `?? r.fileUrl`
- 1 caso: el helper `buildInvoicePdfUrl` sigue emitiendo `/api/admin/facturacion/${id}/pdf`

**21/21 verdes en el archivo** (8 previos + 13 nuevos).

## Confirmaciones

### Ya no existe `/api/admin/facturas/` en `src/` ✅
```
$ grep -rn "/api/admin/facturas\b" src/
(sin matches)
```

### No queda fallback a `row.fileUrl` en esos 4 sitios ✅
Los tests estáticos lo vigilan explícitamente:
```ts
expect(src).not.toMatch(/\?\?\s*row\.fileUrl/);
expect(src).not.toMatch(/\?\?\s*r\.fileUrl/);
```

## Checks locales

- `npx tsc --noEmit` — sin errores en el proyecto
- `npx eslint` — verde en los 5 archivos tocados
- `npx jest` — **3703/3703 tests pasan** (13 nuevos + 3690 previos)

## Confirmación sin migración / sin DB

- ✅ Cero cambios en `src/db/schema/`, cero SQL nuevo, cero dependencia
- ✅ El proxy `/api/admin/facturacion/[id]/pdf` ya existía desde antes; sólo se corrigen los sitios que apuntaban mal a él
- ✅ Sin tocar `storage.ts`, permisos, portal marca, PDF bilingüe, Facturación, Nóminas (salvo las 4 líneas del link Doc)

## Riesgos pendientes

- **Cierre de la deuda `access:'private'` completo con esta PR**. Balance total: 5 sitios PR #217 + 4 sitios PR-E = 9 sitios auditados y protegidos por tests estáticos de regresión.
- Cualquier futuro componente que quiera enlazar a un PDF de factura debe pasar por `buildInvoicePdfUrl` — el test lo vigila cuando toque uno de los 4 archivos protegidos, pero un archivo NUEVO no está cubierto automáticamente. Deuda técnica menor: ampliar el test estático a "cualquier archivo en `finance-dashboard/` con `pdfHref =`". No incluido aquí por ser fuera de alcance.

## Test plan

- [ ] En preview: `/admin/finanzas/nominas-creadores` → tab "Nóminas internas" → cualquier fila con `invoiceFileId` → botón "Abrir →" abre el PDF correctamente.
- [ ] Tab "Pagos a talentos" → botón "Abrir →" idem.
- [ ] `/admin/finanzas/gastos` → columna Doc → click → PDF correcto.
- [ ] Verificar en DevTools: response del PDF tiene `Cache-Control: private, no-store` y `X-Content-Type-Options: nosniff` (el proxy admin ya los añade).
- [ ] Factura sin `invoiceFileId` ni `fileUrl` → columna Doc muestra "—" (sin link roto).

🤖 Generated with [Claude Code](https://claude.com/claude-code)