### PR TITLE
feat(finanzas): PR 6A — Rentabilidad base (pactado vs real)

### DIFF
--- a/src/__tests__/server/finanzas-nav-and-routing.test.ts
+++ b/src/__tests__/server/finanzas-nav-and-routing.test.ts
@@ -70,9 +70,10 @@ describe('[finanzas-nav-and-routing] redirects legacy', () => {
 describe('[finanzas-nav-and-routing] páginas placeholder usan PlaceholderSection', () => {
   // PR 5 (2026-07-06): `nominas-creadores` ya no es placeholder — pasó
   // a implementación real. Ver `finanzas-nominas-creadores.test.ts`.
+  // PR 6A (2026-07-07): `rentabilidad` ya no es placeholder — pasó a
+  // implementación real. Ver `finanzas-rentabilidad.test.ts`.
   const PLACEHOLDER_ROUTES = [
     'caja',
-    'rentabilidad',
     'documentos',
     'informes',
     'configuracion',

--- a/src/__tests__/server/finanzas-rentabilidad.test.ts
+++ b/src/__tests__/server/finanzas-rentabilidad.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Tests de /admin/finanzas/rentabilidad (PR 6A).
+ *
+ * Cubre:
+ *   - La página exige facturacion:read.
+ *   - La query es read-only (solo select en el archivo).
+ *   - Cálculos: margen pactado, margen real, desviación.
+ *   - Estado visual: rentable / bajo / negativo / sin_datos / sin_ejecucion_suficiente.
+ *   - Regla anti-ruido: ingresos reales < 100 € → sin_ejecucion_suficiente.
+ *   - Bloque "Rentabilidad por servicio" aparece como aparcado, no inventa datos.
+ *   - Filtros query params tolerantes.
+ *   - No hay migraciones ni mutaciones nuevas.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  classifyEstado,
+  LOW_MARGIN_THRESHOLD,
+  MIN_INCOME_FOR_CLASSIFICATION,
+} from '@/lib/queries/financeDashboard/rentabilidad';
+
+const PROJECT_ROOT = path.resolve(__dirname, '..', '..', '..');
+const read = (rel: string) => fs.readFileSync(path.join(PROJECT_ROOT, rel), 'utf-8');
+
+// ── Estática: seguridad + read-only + no scope creep ───────────────────
+
+describe('Rentabilidad — página y query', () => {
+  const PAGE = 'src/app/admin/(dashboard)/finanzas/rentabilidad/page.tsx';
+  const QUERY = 'src/lib/queries/financeDashboard/rentabilidad.ts';
+
+  it('la página exige facturacion:read', () => {
+    const src = read(PAGE);
+    expect(src).toMatch(/requirePermission\(['"]facturacion['"],\s*['"]read['"]\)/);
+  });
+
+  it('la página ya NO importa PlaceholderSection', () => {
+    const src = read(PAGE);
+    expect(src).not.toMatch(/PlaceholderSection/);
+  });
+
+  it('la query es read-only (no ejecuta insert/update/delete)', () => {
+    const src = read(QUERY);
+    // Marker 'server-only' presente
+    expect(src).toMatch(/['"]server-only['"]/);
+    // Ninguna mutación Drizzle
+    expect(src).not.toMatch(/db\.insert\(/);
+    expect(src).not.toMatch(/db\.update\(/);
+    expect(src).not.toMatch(/db\.delete\(/);
+  });
+
+  it('no introduce Server Actions nuevas', () => {
+    const src = read(PAGE);
+    expect(src).not.toMatch(/['"]use server['"]/);
+  });
+
+  it('reutiliza el umbral LOW_MARGIN_THRESHOLD = 20 (Decisión 3)', () => {
+    expect(LOW_MARGIN_THRESHOLD).toBe(20);
+  });
+
+  it('define el mínimo anti-ruido en 100 € (Decisión regla PR 6A)', () => {
+    expect(MIN_INCOME_FOR_CLASSIFICATION).toBe(100);
+  });
+});
+
+// ── Estática: bloque servicios aparcado ────────────────────────────────
+
+describe('Rentabilidad — bloque "Servicios" aparcado (Decisión 2 = C)', () => {
+  const COMP = 'src/features/admin/finance-dashboard/components/rentabilidad/RentabilidadServicioAparcado.tsx';
+
+  it('el componente existe', () => {
+    expect(fs.existsSync(path.join(PROJECT_ROOT, COMP))).toBe(true);
+  });
+
+  it('renderiza el badge "Aparcado"', () => {
+    const src = read(COMP);
+    expect(src).toMatch(/Aparcado/);
+  });
+
+  it('menciona explícitamente la falta de clasificación estructurada', () => {
+    const src = read(COMP);
+    expect(src).toMatch(/clasificar campañas o\s*[\r\n]?\s*facturas por tipo de servicio de forma estructurada/);
+  });
+
+  it('NO usa category/concept/expense_subtype como proxy inventado', () => {
+    const src = read(COMP);
+    expect(src).not.toMatch(/expense_subtype|expenseSubtype/);
+    expect(src).not.toMatch(/invoices\.category/);
+    expect(src).not.toMatch(/invoices\.concept/);
+  });
+});
+
+// ── Funcional: classifyEstado — todos los casos del brief ──────────────
+
+describe('classifyEstado — estado visual según brief PR 6A', () => {
+  it('amountBrand=0 y sin ingresos reales → sin_datos', () => {
+    expect(classifyEstado({ amountBrand: 0, ingresosReales: 0, margenRealPct: null })).toBe('sin_datos');
+  });
+
+  it('ingresos reales < 100 → sin_ejecucion_suficiente (anti-ruido)', () => {
+    expect(classifyEstado({ amountBrand: 5000, ingresosReales: 50,  margenRealPct: 40 })).toBe('sin_ejecucion_suficiente');
+    expect(classifyEstado({ amountBrand: 5000, ingresosReales: 99,  margenRealPct: 20 })).toBe('sin_ejecucion_suficiente');
+    // borde: 100 → ya se clasifica normal
+    expect(classifyEstado({ amountBrand: 5000, ingresosReales: 100, margenRealPct: 40 })).toBe('rentable');
+  });
+
+  it('margenRealPct null aunque haya ingresos → sin_datos (edge)', () => {
+    expect(classifyEstado({ amountBrand: 5000, ingresosReales: 5000, margenRealPct: null })).toBe('sin_datos');
+  });
+
+  it('margenRealPct < 0 → negativo', () => {
+    expect(classifyEstado({ amountBrand: 5000, ingresosReales: 5000, margenRealPct: -12 })).toBe('negativo');
+    expect(classifyEstado({ amountBrand: 5000, ingresosReales: 5000, margenRealPct: -0.1 })).toBe('negativo');
+  });
+
+  it('margen 0 ≤ x < 20 → bajo', () => {
+    expect(classifyEstado({ amountBrand: 5000, ingresosReales: 5000, margenRealPct: 0 })).toBe('bajo');
+    expect(classifyEstado({ amountBrand: 5000, ingresosReales: 5000, margenRealPct: 15 })).toBe('bajo');
+    expect(classifyEstado({ amountBrand: 5000, ingresosReales: 5000, margenRealPct: 19.99 })).toBe('bajo');
+  });
+
+  it('margen >= 20 → rentable', () => {
+    expect(classifyEstado({ amountBrand: 5000, ingresosReales: 5000, margenRealPct: 20 })).toBe('rentable');
+    expect(classifyEstado({ amountBrand: 5000, ingresosReales: 5000, margenRealPct: 42 })).toBe('rentable');
+  });
+
+  it('amountBrand>0 y sin ingresos reales → cae a sin_ejecucion_suficiente', () => {
+    expect(classifyEstado({ amountBrand: 5000, ingresosReales: 0, margenRealPct: null })).toBe('sin_ejecucion_suficiente');
+  });
+});
+
+// ── Funcional: cálculo margen pactado / real / desviación ──────────────
+//
+// Estos tests inspeccionan el código para verificar las fórmulas del brief,
+// evitando arrancar la DB. La query mezcla SQL y agregación en memoria; las
+// fórmulas de margen en memoria son la parte crítica del cálculo.
+
+describe('Fórmulas de margen — brief PR 6A', () => {
+  const QUERY_SRC = read('src/lib/queries/financeDashboard/rentabilidad.ts');
+
+  it('margen pactado usa amountBrand - amountTalent', () => {
+    expect(QUERY_SRC).toMatch(/amountBrand\s*>\s*0\s*\?\s*round2\(amountBrand\s*-\s*amountTalent\)\s*:\s*null/);
+  });
+
+  it('margen pactado % divide entre amountBrand y multiplica por 100', () => {
+    expect(QUERY_SRC).toMatch(/\(\(amountBrand\s*-\s*amountTalent\)\s*\/\s*amountBrand\)\s*\*\s*100/);
+  });
+
+  it('margen real usa ingresosReales - costesReales, null si ingresos=0', () => {
+    expect(QUERY_SRC).toMatch(/agg\.ingresosReales\s*>\s*0\s*\?[\s\S]{0,200}round2\(agg\.ingresosReales\s*-\s*agg\.costesReales\)/);
+  });
+
+  it('desviación = margenReal% - margenPactado%, null si falta alguno', () => {
+    expect(QUERY_SRC).toMatch(/margenPactadoPct\s*!==\s*null\s*&&\s*margenRealPct\s*!==\s*null[\s\S]{0,150}margenRealPct\s*-\s*margenPactadoPct/);
+  });
+
+  it('agregación de ingresos reales EXCLUYE anulada y borrador', () => {
+    expect(QUERY_SRC).toMatch(/kind[^']*'income'[\s\S]{0,150}NOT IN\s*\(\s*'anulada'\s*,\s*'borrador'\s*\)/);
+  });
+
+  it('agregación de costes reales EXCLUYE anulada y borrador', () => {
+    expect(QUERY_SRC).toMatch(/kind[^']*'expense'[\s\S]{0,150}NOT IN\s*\(\s*'anulada'\s*,\s*'borrador'\s*\)/);
+  });
+
+  it('pagos a talentos se filtran por expense_subtype = pago_talento', () => {
+    expect(QUERY_SRC).toMatch(/expenseSubtype[^']*'pago_talento'/);
+  });
+
+  it('otros costes directos = coste_produccion + comision_plataforma + otros_campana', () => {
+    expect(QUERY_SRC).toMatch(/'coste_produccion'\s*,\s*'comision_plataforma'\s*,\s*'otros_campana'/);
+  });
+
+  it('excluye campañas canceladas', () => {
+    expect(QUERY_SRC).toMatch(/ne\(campaigns\.status,\s*['"]cancelada['"]\)/);
+  });
+});
+
+// ── Estática: filtros query params ─────────────────────────────────────
+
+describe('Filtros query params', () => {
+  const PAGE = 'src/app/admin/(dashboard)/finanzas/rentabilidad/page.tsx';
+  const src = read(PAGE);
+
+  it('acepta from/to como ISO date con validación', () => {
+    expect(src).toMatch(/ISO_DATE_RE/);
+    expect(src).toMatch(/safeIsoDate/);
+  });
+
+  it('acepta marca/talento como positive int', () => {
+    expect(src).toMatch(/safePosInt/);
+    expect(src).toMatch(/\{\s*brandId\s*\}/);
+    expect(src).toMatch(/\{\s*talentId\s*\}/);
+  });
+
+  it('acepta margen con enum validado y default "todos"', () => {
+    expect(src).toMatch(/safeMargenFilter/);
+    expect(src).toMatch(/MARGEN_VALID/);
+  });
+
+  it('rechaza estado de campaña no válido usando allowlist', () => {
+    expect(src).toMatch(/CAMPAIGN_STATUS_VALID/);
+  });
+});
+
+// ── Estática: no migraciones + no scope creep ──────────────────────────
+
+describe('PR 6A — sin scope creep', () => {
+  it('no toca src/db/schema/', () => {
+    // Nada de esta PR debería aparecer en schemas
+    const schemaFiles = ['campaigns.ts', 'invoices.ts'];
+    for (const f of schemaFiles) {
+      const src = read(`src/db/schema/${f}`);
+      // Si por accidente añadimos una columna nueva relacionada con rentabilidad, este test fallará
+      expect(src).not.toMatch(/rentabilidad|margen_real|profitability/i);
+    }
+  });
+
+  it('no crea migración nueva 011X', () => {
+    // Comprobamos que el último journal entry sigue siendo el conocido del PR anterior.
+    // Si en el futuro se hace una migración legítima, este test debe actualizarse.
+    const journal = read('drizzle/meta/_journal.json');
+    expect(journal).toMatch(/"tag":\s*"0109_billing_clients_pdf_language"/);
+    // No hay 0110 aún en PR 6A
+    expect(journal).not.toMatch(/"tag":\s*"0110_/);
+  });
+});

--- a/src/app/admin/(dashboard)/finanzas/FinanzasNav.tsx
+++ b/src/app/admin/(dashboard)/finanzas/FinanzasNav.tsx
@@ -49,7 +49,7 @@ const TABS: readonly Tab[] = [
     label: 'Nóminas y creadores',
     extraPaths: ['/admin/finanzas/nominas'],
   },
-  { href: '/admin/finanzas/rentabilidad', label: 'Rentabilidad', soon: true },
+  { href: '/admin/finanzas/rentabilidad', label: 'Rentabilidad' },
   { href: '/admin/finanzas/documentos', label: 'Documentos', soon: true },
   { href: '/admin/finanzas/informes', label: 'Informes', soon: true },
   {

--- a/src/app/admin/(dashboard)/finanzas/rentabilidad/page.tsx
+++ b/src/app/admin/(dashboard)/finanzas/rentabilidad/page.tsx
@@ -1,26 +1,112 @@
+import { asc } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import { crmBrands, talents } from '@/db/schema';
 import { requirePermission } from '@/lib/permissions';
-import { PlaceholderSection } from '@/features/admin/finance-dashboard/components/PlaceholderSection';
+import { getRentabilidadData, type RentabilidadFiltroMargen } from '@/lib/queries/financeDashboard/rentabilidad';
+
+import { RentabilidadFilters } from '@/features/admin/finance-dashboard/components/rentabilidad/RentabilidadFilters';
+import { RentabilidadKpisBlock } from '@/features/admin/finance-dashboard/components/rentabilidad/RentabilidadKpis';
+import { RentabilidadLecturaRapida } from '@/features/admin/finance-dashboard/components/rentabilidad/RentabilidadLecturaRapida';
+import { RentabilidadTabla } from '@/features/admin/finance-dashboard/components/rentabilidad/RentabilidadTabla';
+import { RentabilidadServicioAparcado } from '@/features/admin/finance-dashboard/components/rentabilidad/RentabilidadServicioAparcado';
+import { RentabilidadAccesosRapidos } from '@/features/admin/finance-dashboard/components/rentabilidad/RentabilidadAccesosRapidos';
 
 export const metadata = { title: 'Rentabilidad · Finanzas' };
 
-export default async function FinanzasRentabilidadPage(): Promise<React.ReactElement> {
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const MARGEN_VALID: readonly RentabilidadFiltroMargen[] = ['todos', 'rentable', 'bajo', 'negativo', 'sin_datos'];
+const CAMPAIGN_STATUS_VALID = new Set([
+  'propuesta', 'negociacion', 'aprobada', 'activa',
+  'completada', 'pendiente_pago', 'pagada',
+]);
+
+function todayInMadrid(): string {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Europe/Madrid',
+    year: 'numeric', month: '2-digit', day: '2-digit',
+  }).format(new Date());
+}
+
+function firstParam(v: string | string[] | undefined): string | undefined {
+  if (v === undefined) return undefined;
+  return Array.isArray(v) ? v[0] : v;
+}
+
+function safeIsoDate(v: string | undefined): string | undefined {
+  if (!v || !ISO_DATE_RE.test(v)) return undefined;
+  return v;
+}
+
+function safePosInt(v: string | undefined): number | undefined {
+  if (!v) return undefined;
+  const n = Number(v);
+  return Number.isInteger(n) && n > 0 ? n : undefined;
+}
+
+function safeMargenFilter(v: string | undefined): RentabilidadFiltroMargen {
+  if (!v) return 'todos';
+  return (MARGEN_VALID as readonly string[]).includes(v)
+    ? (v as RentabilidadFiltroMargen)
+    : 'todos';
+}
+
+type PageProps = {
+  readonly searchParams?: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export default async function FinanzasRentabilidadPage({ searchParams }: PageProps): Promise<React.ReactElement> {
   await requirePermission('facturacion', 'read');
+
+  const sp = (await searchParams) ?? {};
+  const from     = safeIsoDate(firstParam(sp.from));
+  const to       = safeIsoDate(firstParam(sp.to));
+  const brandId  = safePosInt(firstParam(sp.marca));
+  const talentId = safePosInt(firstParam(sp.talento));
+  const estadoRaw = firstParam(sp.estado);
+  const campaignStatus = estadoRaw && CAMPAIGN_STATUS_VALID.has(estadoRaw) ? estadoRaw : undefined;
+  const margenFilter = safeMargenFilter(firstParam(sp.margen));
+
+  const [data, brandsList, talentsList] = await Promise.all([
+    getRentabilidadData({
+      ...(from ? { from } : {}),
+      ...(to ? { to } : {}),
+      ...(brandId ? { brandId } : {}),
+      ...(talentId ? { talentId } : {}),
+      ...(campaignStatus ? { campaignStatus } : {}),
+      margenFilter,
+    }),
+    db.select({ id: crmBrands.id, name: crmBrands.name }).from(crmBrands).orderBy(asc(crmBrands.name)),
+    db.select({ id: talents.id, name: talents.name }).from(talents).orderBy(asc(talents.name)),
+  ]);
+
+  const today = todayInMadrid();
+  const defaults = { from: `${today.slice(0, 4)}-01-01`, to: today };
+
   return (
-    <PlaceholderSection
-      icon="📈"
-      title="Rentabilidad"
-      subtitle="Qué campañas, marcas, clientes y talentos dejan dinero."
-      bullets={[
-        'Rentabilidad por marca / cliente / campaña / talento / servicio.',
-        'Ingresos, costes directos, pagos a talentos, producción, gastos asociados, margen bruto, % margen.',
-        'Rankings de campañas más y menos rentables, concentración de ingresos.',
-        'Alertas: campaña con margen bajo, cliente concentra demasiado ingreso, talento con coste alto.',
-        'PR 2 muestra placeholder; el detalle vive en el histórico mensual mientras tanto.',
-      ]}
-      relatedLinks={[
-        { href: '/admin/finanzas/pl', label: 'Histórico mensual P&L' },
-        { href: '/admin/finanzas/mes', label: 'Control mensual' },
-      ]}
-    />
+    <div className="space-y-5 pt-2">
+      <header>
+        <h1 className="text-xl font-bold text-sp-admin-fg">Rentabilidad</h1>
+        <p className="text-sm text-sp-admin-muted">
+          Margen pactado vs margen real facturado por campaña. Read-only.
+        </p>
+      </header>
+
+      <RentabilidadFilters
+        defaults={defaults}
+        applied={data.period}
+        brands={brandsList}
+        talentos={talentsList}
+      />
+
+      <RentabilidadKpisBlock kpis={data.kpis} />
+
+      <RentabilidadLecturaRapida data={data} />
+
+      <RentabilidadTabla rows={data.filteredRows} totalRows={data.totalCount} />
+
+      <RentabilidadServicioAparcado />
+
+      <RentabilidadAccesosRapidos />
+    </div>
   );
 }

--- a/src/features/admin/finance-dashboard/components/rentabilidad/RentabilidadAccesosRapidos.tsx
+++ b/src/features/admin/finance-dashboard/components/rentabilidad/RentabilidadAccesosRapidos.tsx
@@ -1,0 +1,30 @@
+import Link from 'next/link';
+
+const LINKS = [
+  { href: '/admin/finanzas/ingresos',            label: 'Ver ingresos',            emoji: '💰' },
+  { href: '/admin/finanzas/gastos',              label: 'Ver gastos',              emoji: '🧾' },
+  { href: '/admin/finanzas/nominas-creadores',   label: 'Ver nóminas y creadores', emoji: '👥' },
+  { href: '/admin/finanzas/pl',                  label: 'Ver P&L',                 emoji: '📈' },
+] as const;
+
+export function RentabilidadAccesosRapidos(): React.ReactElement {
+  return (
+    <section aria-labelledby="rentabilidad-accesos-title" className="rounded-2xl border border-sp-border bg-sp-admin-card p-4">
+      <h2 id="rentabilidad-accesos-title" className="text-[11px] uppercase tracking-wider font-bold text-sp-admin-muted mb-3">
+        Accesos rápidos
+      </h2>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+        {LINKS.map((l) => (
+          <Link
+            key={l.href}
+            href={l.href}
+            className="flex items-center gap-2 px-3 py-2 rounded-lg border border-sp-border text-[12px] text-sp-admin-fg hover:border-sp-admin-accent/50 hover:bg-sp-admin-hover transition-colors"
+          >
+            <span aria-hidden>{l.emoji}</span>
+            <span>{l.label}</span>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/features/admin/finance-dashboard/components/rentabilidad/RentabilidadFilters.tsx
+++ b/src/features/admin/finance-dashboard/components/rentabilidad/RentabilidadFilters.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useTransition, type FormEvent } from 'react';
+
+type BrandOpt = { readonly id: number; readonly name: string };
+type TalentOpt = { readonly id: number; readonly name: string };
+
+type Props = {
+  readonly defaults: { readonly from: string; readonly to: string };
+  readonly applied:  { readonly from: string; readonly to: string };
+  readonly brands:   readonly BrandOpt[];
+  readonly talentos: readonly TalentOpt[];
+};
+
+const CAMPAIGN_STATUSES = [
+  { value: 'todos',           label: 'Todos' },
+  { value: 'propuesta',       label: 'Propuesta' },
+  { value: 'negociacion',     label: 'Negociación' },
+  { value: 'aprobada',        label: 'Aprobada' },
+  { value: 'activa',          label: 'Activa' },
+  { value: 'completada',      label: 'Completada' },
+  { value: 'pendiente_pago',  label: 'Pendiente pago' },
+  { value: 'pagada',          label: 'Pagada' },
+] as const;
+
+const MARGEN_CHIPS = [
+  { value: 'todos',      label: 'Todos' },
+  { value: 'rentable',   label: 'Rentables' },
+  { value: 'bajo',       label: 'Margen bajo' },
+  { value: 'negativo',   label: 'Negativos' },
+  { value: 'sin_datos',  label: 'Sin datos' },
+] as const;
+
+const INPUT =
+  'rounded-lg border border-sp-admin-border bg-sp-admin-bg px-2 py-1.5 text-[12px] text-sp-admin-fg outline-none focus:border-sp-admin-accent transition-colors';
+
+export function RentabilidadFilters({ defaults, applied, brands, talentos }: Props): React.ReactElement {
+  const router = useRouter();
+  const sp = useSearchParams();
+  const [isPending, startTransition] = useTransition();
+
+  const brandParam    = sp.get('marca') ?? '';
+  const talentoParam  = sp.get('talento') ?? '';
+  const estadoParam   = sp.get('estado') ?? 'todos';
+  const margenParam   = sp.get('margen') ?? 'todos';
+
+  function apply(next: URLSearchParams): void {
+    startTransition(() => router.push(`?${next.toString()}`));
+  }
+
+  function onSubmit(e: FormEvent<HTMLFormElement>): void {
+    e.preventDefault();
+    const fd = new FormData(e.currentTarget);
+    const next = new URLSearchParams();
+    const from = String(fd.get('from') ?? '').trim();
+    const to   = String(fd.get('to')   ?? '').trim();
+    const marca   = String(fd.get('marca')   ?? '').trim();
+    const talento = String(fd.get('talento') ?? '').trim();
+    const estado  = String(fd.get('estado')  ?? '').trim();
+    if (from && from !== defaults.from) next.set('from', from);
+    if (to   && to   !== defaults.to)   next.set('to', to);
+    if (marca)   next.set('marca', marca);
+    if (talento) next.set('talento', talento);
+    if (estado && estado !== 'todos') next.set('estado', estado);
+    if (margenParam !== 'todos') next.set('margen', margenParam);
+    apply(next);
+  }
+
+  function setChip(value: string): void {
+    const next = new URLSearchParams(sp.toString());
+    if (value === 'todos') next.delete('margen');
+    else next.set('margen', value);
+    apply(next);
+  }
+
+  return (
+    <div className="space-y-3">
+      <form onSubmit={onSubmit} className="rounded-xl border border-sp-border bg-sp-admin-card p-3 flex flex-wrap items-end gap-3">
+        <div>
+          <label className="block text-[10px] font-bold uppercase tracking-wider text-sp-admin-muted mb-1">Desde</label>
+          <input type="date" name="from" defaultValue={applied.from} className={INPUT} />
+        </div>
+        <div>
+          <label className="block text-[10px] font-bold uppercase tracking-wider text-sp-admin-muted mb-1">Hasta</label>
+          <input type="date" name="to" defaultValue={applied.to} className={INPUT} />
+        </div>
+        <div>
+          <label className="block text-[10px] font-bold uppercase tracking-wider text-sp-admin-muted mb-1">Marca</label>
+          <select name="marca" defaultValue={brandParam} className={INPUT}>
+            <option value="">Todas</option>
+            {brands.map((b) => <option key={b.id} value={String(b.id)}>{b.name}</option>)}
+          </select>
+        </div>
+        <div>
+          <label className="block text-[10px] font-bold uppercase tracking-wider text-sp-admin-muted mb-1">Talento</label>
+          <select name="talento" defaultValue={talentoParam} className={INPUT}>
+            <option value="">Todos</option>
+            {talentos.map((t) => <option key={t.id} value={String(t.id)}>{t.name}</option>)}
+          </select>
+        </div>
+        <div>
+          <label className="block text-[10px] font-bold uppercase tracking-wider text-sp-admin-muted mb-1">Estado campaña</label>
+          <select name="estado" defaultValue={estadoParam} className={INPUT}>
+            {CAMPAIGN_STATUSES.map((s) => <option key={s.value} value={s.value}>{s.label}</option>)}
+          </select>
+        </div>
+        <button
+          type="submit"
+          disabled={isPending}
+          className="h-8 px-4 rounded-lg bg-sp-admin-accent text-white text-[12px] font-semibold hover:bg-sp-admin-accent/90 disabled:opacity-50 transition-colors"
+        >
+          {isPending ? 'Aplicando…' : 'Aplicar'}
+        </button>
+      </form>
+      <div className="flex flex-wrap items-center gap-2 text-[11px]">
+        <span className="uppercase tracking-wider font-bold text-sp-admin-muted mr-1">Margen:</span>
+        {MARGEN_CHIPS.map((c) => (
+          <button
+            key={c.value}
+            type="button"
+            onClick={() => setChip(c.value)}
+            aria-pressed={margenParam === c.value}
+            className={`px-2.5 py-1 rounded-full border transition-colors ${
+              margenParam === c.value
+                ? 'border-sp-admin-accent bg-sp-admin-accent/15 text-sp-admin-accent font-semibold'
+                : 'border-sp-border text-sp-admin-muted hover:text-sp-admin-fg'
+            }`}
+          >
+            {c.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/features/admin/finance-dashboard/components/rentabilidad/RentabilidadKpis.tsx
+++ b/src/features/admin/finance-dashboard/components/rentabilidad/RentabilidadKpis.tsx
@@ -1,0 +1,56 @@
+import type { RentabilidadKpis } from '@/lib/queries/financeDashboard/rentabilidad';
+
+const EUR = new Intl.NumberFormat('es-ES', { style: 'currency', currency: 'EUR', maximumFractionDigits: 0 });
+function fmtMoney(n: number): string { return EUR.format(n); }
+function fmtPct(n: number | null): string { return n === null ? 'Sin datos' : `${n.toFixed(1)}%`; }
+
+type KpiCardProps = {
+  readonly label: string;
+  readonly value: string;
+  readonly accent: string;
+  readonly sub?: string;
+  readonly subAccent?: string;
+};
+
+function KpiCard({ label, value, accent, sub, subAccent }: KpiCardProps): React.ReactElement {
+  return (
+    <div className="rounded-xl bg-sp-admin-card border border-sp-border overflow-hidden">
+      <div className="h-[2px]" style={{ background: accent }} />
+      <div className="px-4 py-3">
+        <p className="text-[9px] font-black uppercase tracking-[0.18em] text-sp-admin-muted leading-none">{label}</p>
+        <p className="text-[17px] font-bold tabular-nums mt-1.5 leading-none" style={{ color: accent }}>{value}</p>
+        {sub && <p className="text-[9px] font-semibold mt-1 leading-none" style={{ color: subAccent ?? '#6b7280' }}>{sub}</p>}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Bloque de 8 KPIs de rentabilidad (PR 6A brief).
+ * Pactado vs Real + conteos por estado + mayor desviación negativa.
+ */
+export function RentabilidadKpisBlock({ kpis }: { readonly kpis: RentabilidadKpis }): React.ReactElement {
+  const worst = kpis.mayorDesviacionNegativa;
+  return (
+    <div className="space-y-2">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+        <KpiCard label="Ingresos pactados"        value={fmtMoney(kpis.ingresosPactados)}        accent="#5b9bd5" />
+        <KpiCard label="Margen pactado medio"     value={fmtPct(kpis.margenPactadoMedio)}        accent="#8b3aad" />
+        <KpiCard label="Ingresos reales asoc."    value={fmtMoney(kpis.ingresosRealesAsociados)} accent="#16a34a" />
+        <KpiCard label="Margen real medio"        value={fmtPct(kpis.margenRealMedio)}
+          accent={kpis.margenRealMedio !== null && kpis.margenRealMedio >= 20 ? '#16a34a' : '#f59e0b'} />
+      </div>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+        <KpiCard label="Campañas rentables"       value={String(kpis.campanasRentables)}         accent="#16a34a" />
+        <KpiCard label="Campañas margen bajo"     value={String(kpis.campanasMargenBajo)}        accent="#f59e0b" />
+        <KpiCard label="Campañas negativas"       value={String(kpis.campanasNegativas)}         accent="#ef4444" />
+        <KpiCard
+          label="Mayor desviación negativa"
+          value={worst ? `${worst.deviation.toFixed(1)}%` : 'Sin datos'}
+          accent="#ef4444"
+          {...(worst ? { sub: worst.name } : {})}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/features/admin/finance-dashboard/components/rentabilidad/RentabilidadLecturaRapida.tsx
+++ b/src/features/admin/finance-dashboard/components/rentabilidad/RentabilidadLecturaRapida.tsx
@@ -1,0 +1,66 @@
+import type { RentabilidadData } from '@/lib/queries/financeDashboard/rentabilidad';
+
+/**
+ * Bullets de lectura rápida — solo si los datos existen. No inventa nada.
+ */
+export function RentabilidadLecturaRapida({ data }: { readonly data: RentabilidadData }): React.ReactElement {
+  const { rows, kpis } = data;
+  const bullets: string[] = [];
+
+  if (rows.length === 0) {
+    bullets.push('Sin campañas en el período seleccionado.');
+  } else {
+    if (kpis.campanasMargenBajo + kpis.campanasNegativas > 0) {
+      const bajos = kpis.campanasMargenBajo;
+      const negs  = kpis.campanasNegativas;
+      const parts: string[] = [];
+      if (bajos > 0) parts.push(`${bajos} con margen bajo`);
+      if (negs  > 0) parts.push(`${negs} negativa${negs === 1 ? '' : 's'}`);
+      bullets.push(`Hay ${parts.join(' y ')} de ${rows.length} campañas.`);
+    }
+
+    if (kpis.mayorDesviacionNegativa) {
+      const w = kpis.mayorDesviacionNegativa;
+      bullets.push(`La mayor desviación negativa es "${w.name}" (${w.deviation.toFixed(1)}%).`);
+    }
+
+    // Campaña más rentable por margen real % (con ingresos > 0)
+    const bestReal = [...rows]
+      .filter((r) => r.margenRealPct !== null && r.estado === 'rentable')
+      .sort((a, b) => (b.margenRealPct ?? 0) - (a.margenRealPct ?? 0))[0];
+    if (bestReal && bestReal.margenRealPct !== null) {
+      bullets.push(`La campaña más rentable por margen real es "${bestReal.name}" (${bestReal.margenRealPct.toFixed(1)}%).`);
+    }
+
+    if (kpis.margenPactadoMedio !== null && kpis.margenRealMedio !== null) {
+      bullets.push(
+        `El margen pactado medio es ${kpis.margenPactadoMedio.toFixed(1)}%, frente a un margen real medio del ${kpis.margenRealMedio.toFixed(1)}%.`,
+      );
+    }
+  }
+
+  return (
+    <section aria-labelledby="lectura-rapida-title" className="rounded-2xl border border-sp-border bg-sp-admin-card p-4">
+      <div className="flex items-center gap-2 mb-2">
+        <span className="text-lg" aria-hidden>📊</span>
+        <h2 id="lectura-rapida-title" className="text-sm font-bold text-sp-admin-fg">
+          Lectura rápida de rentabilidad
+        </h2>
+      </div>
+      {bullets.length === 0 ? (
+        <p className="text-[12px] text-sp-admin-muted italic">
+          Aún no hay señales relevantes para este período.
+        </p>
+      ) : (
+        <ul className="space-y-1 text-[13px] text-sp-admin-fg">
+          {bullets.map((b, i) => (
+            <li key={i} className="flex items-start gap-2">
+              <span className="mt-1.5 w-1 h-1 rounded-full bg-sp-admin-muted shrink-0" aria-hidden />
+              <span>{b}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/features/admin/finance-dashboard/components/rentabilidad/RentabilidadServicioAparcado.tsx
+++ b/src/features/admin/finance-dashboard/components/rentabilidad/RentabilidadServicioAparcado.tsx
@@ -1,0 +1,31 @@
+/**
+ * Bloque INFORMATIVO — no funcional a propósito.
+ *
+ * En el brief de PR 6A el usuario aprobó (Decisión 2 = C) aparcar el ranking
+ * de rentabilidad por servicio: no existe un campo estructurado de servicio
+ * en el schema y usar `category` / `concept` libres como proxy sería engañoso.
+ */
+export function RentabilidadServicioAparcado(): React.ReactElement {
+  return (
+    <section
+      aria-labelledby="rentabilidad-servicio-title"
+      className="rounded-2xl border border-dashed border-sp-border bg-sp-admin-card/50 p-4"
+    >
+      <div className="flex items-center gap-2 mb-2">
+        <span className="text-lg" aria-hidden>🧩</span>
+        <h2 id="rentabilidad-servicio-title" className="text-sm font-bold text-sp-admin-fg">
+          Rentabilidad por servicio
+        </h2>
+        <span className="ml-auto text-[10px] font-bold uppercase tracking-wide px-2 py-0.5 rounded-full bg-slate-500/15 text-slate-400 border border-slate-500/30">
+          Aparcado
+        </span>
+      </div>
+      <p className="text-[12px] text-sp-admin-muted leading-relaxed">
+        Para calcular rentabilidad por servicio hace falta clasificar campañas o
+        facturas por tipo de servicio de forma estructurada. Ahora mismo no
+        existe un campo fiable, así que no se muestra para evitar datos
+        engañosos.
+      </p>
+    </section>
+  );
+}

--- a/src/features/admin/finance-dashboard/components/rentabilidad/RentabilidadTabla.tsx
+++ b/src/features/admin/finance-dashboard/components/rentabilidad/RentabilidadTabla.tsx
@@ -1,0 +1,143 @@
+import Link from 'next/link';
+import type { RentabilidadEstado, RentabilidadRow } from '@/lib/queries/financeDashboard/rentabilidad';
+
+const EUR = new Intl.NumberFormat('es-ES', { style: 'currency', currency: 'EUR', maximumFractionDigits: 0 });
+function fmtMoney(n: number): string { return EUR.format(n); }
+function fmtPct(n: number | null): string { return n === null ? '—' : `${n.toFixed(1)}%`; }
+
+const ESTADO_LABELS: Record<RentabilidadEstado, string> = {
+  rentable:                  'Rentable',
+  bajo:                      'Margen bajo',
+  negativo:                  'Negativa',
+  sin_datos:                 'Sin datos',
+  sin_ejecucion_suficiente:  'Sin ejecución suficiente',
+};
+
+const ESTADO_BADGE: Record<RentabilidadEstado, string> = {
+  rentable:                  'bg-emerald-500/15 text-emerald-500 border border-emerald-500/30',
+  bajo:                      'bg-amber-500/15  text-amber-500  border border-amber-500/30',
+  negativo:                  'bg-red-500/15    text-red-500    border border-red-500/30',
+  sin_datos:                 'bg-slate-500/15  text-slate-400  border border-slate-500/30',
+  sin_ejecucion_suficiente:  'bg-slate-500/15  text-slate-400  border border-slate-500/30',
+};
+
+const CAMPAIGN_STATUS_LABELS: Record<string, string> = {
+  propuesta:      'Propuesta',
+  negociacion:    'Negociación',
+  aprobada:       'Aprobada',
+  activa:         'Activa',
+  completada:     'Completada',
+  cancelada:      'Cancelada',
+  pendiente_pago: 'Pendiente pago',
+  pagada:         'Pagada',
+};
+
+function deviationClass(pct: number | null): string {
+  if (pct === null) return 'text-sp-admin-muted';
+  if (pct < -5)  return 'text-red-500 font-semibold';
+  if (pct < 0)   return 'text-amber-500';
+  return 'text-emerald-500';
+}
+
+type Props = {
+  readonly rows: readonly RentabilidadRow[];
+  readonly totalRows: number;
+};
+
+export function RentabilidadTabla({ rows, totalRows }: Props): React.ReactElement {
+  return (
+    <section aria-labelledby="rentabilidad-tabla-title" className="rounded-2xl border border-sp-border bg-sp-admin-card overflow-hidden">
+      <div className="px-4 py-3 border-b border-sp-border flex items-baseline justify-between gap-3">
+        <div>
+          <h2 id="rentabilidad-tabla-title" className="text-sm font-bold text-sp-admin-fg">Rentabilidad por campaña</h2>
+          <p className="text-[11px] text-sp-admin-muted mt-0.5">
+            Margen pactado vs margen real facturado · desviación en puntos porcentuales.
+          </p>
+        </div>
+        <p className="text-[11px] text-sp-admin-muted tabular-nums">
+          {rows.length}/{totalRows} campañas
+        </p>
+      </div>
+      {rows.length === 0 ? (
+        <div className="px-4 py-10 text-center">
+          <p className="text-sm text-sp-admin-muted italic">
+            {totalRows === 0
+              ? 'No hay campañas en el período seleccionado.'
+              : 'Ningún resultado con los filtros actuales.'}
+          </p>
+        </div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-sp-border bg-sp-admin-card/60">
+                {[
+                  'Campaña', 'Marca', 'Talento', 'Estado',
+                  'Ingr. pactados', 'Coste pactado', 'Margen pactado',
+                  'Ingr. reales', 'Costes reales', 'Margen real',
+                  'Desviación', 'Estado visual',
+                ].map((h) => (
+                  <th key={h} className="px-3 py-2 text-left text-[9px] font-bold uppercase tracking-wide text-sp-admin-muted whitespace-nowrap">
+                    {h}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <tr key={row.id} className="border-b border-sp-border/40 last:border-0 hover:bg-sp-admin-hover transition-colors">
+                  <td className="px-3 py-2 text-[12px] text-sp-admin-fg font-medium max-w-[180px] truncate">
+                    <Link href={`/admin/campanas/${row.id}`} className="hover:text-sp-admin-accent transition-colors">
+                      {row.name}
+                    </Link>
+                  </td>
+                  <td className="px-3 py-2 text-[11px] text-sp-admin-muted max-w-[120px] truncate">{row.brandName ?? '—'}</td>
+                  <td className="px-3 py-2 text-[11px] text-sp-admin-muted max-w-[120px] truncate">{row.talentName ?? '—'}</td>
+                  <td className="px-3 py-2 text-[10px] text-sp-admin-muted whitespace-nowrap">
+                    {CAMPAIGN_STATUS_LABELS[row.status] ?? row.status}
+                  </td>
+                  <td className="px-3 py-2 text-[12px] tabular-nums text-right text-sp-admin-fg whitespace-nowrap">
+                    {fmtMoney(row.amountBrand)}
+                  </td>
+                  <td className="px-3 py-2 text-[12px] tabular-nums text-right text-sp-admin-muted whitespace-nowrap">
+                    {fmtMoney(row.amountTalent)}
+                  </td>
+                  <td className="px-3 py-2 text-[12px] tabular-nums text-right whitespace-nowrap">
+                    <span className="text-sp-admin-fg">
+                      {row.margenPactado !== null ? fmtMoney(row.margenPactado) : '—'}
+                    </span>
+                    <span className="ml-1 text-[10px] text-sp-admin-muted">
+                      ({fmtPct(row.margenPactadoPct)})
+                    </span>
+                  </td>
+                  <td className="px-3 py-2 text-[12px] tabular-nums text-right text-emerald-500 whitespace-nowrap">
+                    {fmtMoney(row.ingresosReales)}
+                  </td>
+                  <td className="px-3 py-2 text-[12px] tabular-nums text-right text-amber-500 whitespace-nowrap">
+                    {fmtMoney(row.costesReales)}
+                  </td>
+                  <td className="px-3 py-2 text-[12px] tabular-nums text-right whitespace-nowrap">
+                    <span className="text-sp-admin-fg font-bold">
+                      {row.margenReal !== null ? fmtMoney(row.margenReal) : '—'}
+                    </span>
+                    <span className="ml-1 text-[10px] text-sp-admin-muted">
+                      ({fmtPct(row.margenRealPct)})
+                    </span>
+                  </td>
+                  <td className={`px-3 py-2 text-[12px] tabular-nums text-right whitespace-nowrap ${deviationClass(row.desviacionPct)}`}>
+                    {row.desviacionPct !== null ? `${row.desviacionPct > 0 ? '+' : ''}${row.desviacionPct.toFixed(1)} pp` : '—'}
+                  </td>
+                  <td className="px-3 py-2 whitespace-nowrap">
+                    <span className={`text-[10px] font-bold uppercase tracking-wide px-2 py-0.5 rounded-full inline-block ${ESTADO_BADGE[row.estado]}`}>
+                      {ESTADO_LABELS[row.estado]}
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/lib/queries/financeDashboard/rentabilidad.ts
+++ b/src/lib/queries/financeDashboard/rentabilidad.ts
@@ -1,0 +1,379 @@
+'server-only';
+
+/**
+ * Datos agregados para /admin/finanzas/rentabilidad (PR 6A).
+ *
+ * Compara margen PACTADO (campaigns.amountBrand - amountTalent) contra
+ * margen REAL FACTURADO (agregación de invoices reales por campaignId).
+ *
+ * Read-only. Cero mutaciones. Cero migraciones. Reutiliza tablas existentes:
+ *   - campaigns.amountBrand / amountTalent → margen pactado
+ *   - invoices con campaignId IS NOT NULL, status ∉ ('anulada','borrador') → real
+ *   - expenseSubtype 'pago_talento' → subtotal pagos talentos
+ *   - expenseSubtype IN ('coste_produccion','comision_plataforma','otros_campana') → otros costes
+ */
+
+import { and, asc, eq, isNotNull, ne, sql } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import { campaigns, crmBrands, invoices, talents } from '@/db/schema';
+
+/** Umbral heredado de campaignMargins.ts — mantener sincronizado. */
+export const LOW_MARGIN_THRESHOLD = 20;
+
+/** Ingreso real mínimo para considerar "ejecución suficiente" y clasificar rentabilidad. */
+export const MIN_INCOME_FOR_CLASSIFICATION = 100;
+
+// Los criterios de filtrado se aplican inline en el SQL agregado:
+//   - status NOT IN ('anulada', 'borrador') — excluye borrador y anulada
+//   - expense_subtype = 'pago_talento' — pagos a talentos
+//   - expense_subtype IN ('coste_produccion','comision_plataforma','otros_campana') — otros directos
+
+// ── Tipos ────────────────────────────────────────────────────────────────
+
+export type RentabilidadEstado =
+  | 'rentable'
+  | 'bajo'
+  | 'negativo'
+  | 'sin_datos'
+  | 'sin_ejecucion_suficiente';
+
+export type RentabilidadFiltroMargen =
+  | 'todos' | 'rentable' | 'bajo' | 'negativo' | 'sin_datos';
+
+export type RentabilidadFilters = {
+  readonly from?: string;
+  readonly to?: string;
+  readonly brandId?: number;
+  readonly talentId?: number;
+  readonly campaignStatus?: string;
+  readonly margenFilter?: RentabilidadFiltroMargen;
+};
+
+export type RentabilidadRow = {
+  readonly id: number;
+  readonly name: string;
+  readonly brandId: number | null;
+  readonly brandName: string | null;
+  readonly talentId: number | null;
+  readonly talentName: string | null;
+  readonly status: string;
+
+  // Pactado
+  readonly amountBrand: number;
+  readonly amountTalent: number;
+  readonly margenPactado: number | null;
+  readonly margenPactadoPct: number | null;
+
+  // Real (agregado desde invoices)
+  readonly ingresosReales: number;
+  readonly costesReales: number;
+  readonly pagosTalentosReales: number;
+  readonly otrosCostesDirectosReales: number;
+  readonly margenReal: number | null;
+  readonly margenRealPct: number | null;
+
+  // Desviación (real% - pactado%)
+  readonly desviacionPct: number | null;
+
+  // Estado visual
+  readonly estado: RentabilidadEstado;
+};
+
+export type RentabilidadKpis = {
+  readonly ingresosPactados: number;
+  readonly margenPactadoMedio: number | null;
+  readonly ingresosRealesAsociados: number;
+  readonly margenRealMedio: number | null;
+  readonly campanasRentables: number;
+  readonly campanasMargenBajo: number;
+  readonly campanasNegativas: number;
+  readonly mayorDesviacionNegativa: { readonly name: string; readonly deviation: number } | null;
+};
+
+export type RentabilidadPeriod = { readonly from: string; readonly to: string };
+
+export type RentabilidadData = {
+  readonly period: RentabilidadPeriod;
+  readonly rows: readonly RentabilidadRow[];
+  readonly filteredRows: readonly RentabilidadRow[];
+  readonly kpis: RentabilidadKpis;
+  readonly totalCount: number;
+  readonly filteredCount: number;
+};
+
+// ── Utilidades ─────────────────────────────────────────────────────────────
+
+function todayInMadridIso(): string {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Europe/Madrid',
+    year: 'numeric', month: '2-digit', day: '2-digit',
+  }).format(new Date());
+}
+
+function resolvePeriod(input: { readonly from?: string; readonly to?: string } = {}): RentabilidadPeriod {
+  const today = todayInMadridIso();
+  return {
+    from: input.from ?? `${today.slice(0, 4)}-01-01`,
+    to:   input.to   ?? today,
+  };
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+function round1(n: number): number {
+  return Math.round(n * 10) / 10;
+}
+
+/**
+ * Clasifica el estado visual de una campaña según su ejecución real.
+ *
+ * Reglas:
+ *   1. amountBrand=0 y sin ingresos reales → 'sin_datos'
+ *   2. ingresos reales < MIN_INCOME_FOR_CLASSIFICATION → 'sin_ejecucion_suficiente'
+ *      (evita ruido en campañas activas/aprobadas aún sin facturar)
+ *   3. margen real % < 0 → 'negativo'
+ *   4. margen real % >= 0 y < LOW_MARGIN_THRESHOLD → 'bajo'
+ *   5. margen real % >= LOW_MARGIN_THRESHOLD → 'rentable'
+ */
+export function classifyEstado(input: {
+  readonly amountBrand: number;
+  readonly ingresosReales: number;
+  readonly margenRealPct: number | null;
+}): RentabilidadEstado {
+  if (input.amountBrand === 0 && input.ingresosReales === 0) return 'sin_datos';
+  if (input.ingresosReales < MIN_INCOME_FOR_CLASSIFICATION) return 'sin_ejecucion_suficiente';
+  if (input.margenRealPct === null) return 'sin_datos';
+  if (input.margenRealPct < 0) return 'negativo';
+  if (input.margenRealPct < LOW_MARGIN_THRESHOLD) return 'bajo';
+  return 'rentable';
+}
+
+// ── Query principal ───────────────────────────────────────────────────────
+
+/**
+ * Devuelve el mapa de rentabilidad por campaña.
+ * Estrategia: 2 queries (campañas + invoices agregadas), join en memoria.
+ * Volumen esperado: 200-1000 campañas activas → aceptable sin materializar.
+ */
+export async function getRentabilidadData(input: RentabilidadFilters = {}): Promise<RentabilidadData> {
+  const period = resolvePeriod(input);
+
+  // ── 1) Campañas del período (por startDate, incluye null) ───────────
+  const campaignConds = [
+    ne(campaigns.status, 'cancelada'),
+  ];
+  if (input.brandId)  campaignConds.push(eq(campaigns.brandId, input.brandId));
+  if (input.talentId) campaignConds.push(eq(campaigns.talentId, input.talentId));
+  if (input.campaignStatus) campaignConds.push(eq(campaigns.status, input.campaignStatus as never));
+
+  // Filtro de período: si la campaña tiene startDate, exigimos que esté en rango.
+  // Si no tiene startDate (propuesta sin fechas), la incluimos igualmente para
+  // no ocultar campañas recién creadas.
+  const periodClause = sql`(${campaigns.startDate} IS NULL OR (${campaigns.startDate} >= ${period.from} AND ${campaigns.startDate} <= ${period.to}))`;
+  campaignConds.push(periodClause);
+
+  const campaignRows = await db
+    .select({
+      id:            campaigns.id,
+      name:          campaigns.name,
+      brandId:       campaigns.brandId,
+      talentId:      campaigns.talentId,
+      status:        campaigns.status,
+      amountBrand:   campaigns.amountBrand,
+      amountTalent:  campaigns.amountTalent,
+      brandName:     crmBrands.name,
+      talentName:    talents.name,
+    })
+    .from(campaigns)
+    .leftJoin(crmBrands, eq(crmBrands.id, campaigns.brandId))
+    .leftJoin(talents,   eq(talents.id,   campaigns.talentId))
+    .where(and(...campaignConds))
+    .orderBy(asc(campaigns.name));
+
+  if (campaignRows.length === 0) {
+    return {
+      period,
+      rows: [],
+      filteredRows: [],
+      kpis: emptyKpis(),
+      totalCount: 0,
+      filteredCount: 0,
+    };
+  }
+
+  const campaignIds = campaignRows.map((c) => c.id);
+
+  // ── 2) Agregado de invoices reales por campaignId ────────────────────
+  const invoiceAggRows = await db
+    .select({
+      campaignId:                 invoices.campaignId,
+      ingresosReales:             sql<string>`COALESCE(SUM(CASE WHEN ${invoices.kind} = 'income'  AND ${invoices.status} NOT IN ('anulada','borrador') THEN ${invoices.totalAmount} ELSE 0 END), 0)::text`,
+      costesReales:               sql<string>`COALESCE(SUM(CASE WHEN ${invoices.kind} = 'expense' AND ${invoices.status} NOT IN ('anulada','borrador') THEN ${invoices.totalAmount} ELSE 0 END), 0)::text`,
+      pagosTalentosReales:        sql<string>`COALESCE(SUM(CASE WHEN ${invoices.kind} = 'expense' AND ${invoices.status} NOT IN ('anulada','borrador') AND ${invoices.expenseSubtype} = 'pago_talento' THEN ${invoices.totalAmount} ELSE 0 END), 0)::text`,
+      otrosCostesDirectosReales:  sql<string>`COALESCE(SUM(CASE WHEN ${invoices.kind} = 'expense' AND ${invoices.status} NOT IN ('anulada','borrador') AND ${invoices.expenseSubtype} IN ('coste_produccion','comision_plataforma','otros_campana') THEN ${invoices.totalAmount} ELSE 0 END), 0)::text`,
+    })
+    .from(invoices)
+    .where(and(
+      isNotNull(invoices.campaignId),
+      sql`${invoices.campaignId} IN (${sql.join(campaignIds.map((id) => sql`${id}`), sql`, `)})`,
+    ))
+    .groupBy(invoices.campaignId);
+
+  const aggByCampaign = new Map<number, {
+    ingresosReales: number;
+    costesReales: number;
+    pagosTalentosReales: number;
+    otrosCostesDirectosReales: number;
+  }>();
+  for (const r of invoiceAggRows) {
+    if (r.campaignId === null) continue;
+    aggByCampaign.set(r.campaignId, {
+      ingresosReales:            Number(r.ingresosReales),
+      costesReales:              Number(r.costesReales),
+      pagosTalentosReales:       Number(r.pagosTalentosReales),
+      otrosCostesDirectosReales: Number(r.otrosCostesDirectosReales),
+    });
+  }
+
+  // ── 3) Compone RentabilidadRow por campaña ──────────────────────────
+  const rows: RentabilidadRow[] = campaignRows.map((c) => {
+    const amountBrand  = Number(c.amountBrand ?? 0);
+    const amountTalent = Number(c.amountTalent ?? 0);
+    const agg = aggByCampaign.get(c.id) ?? {
+      ingresosReales: 0,
+      costesReales: 0,
+      pagosTalentosReales: 0,
+      otrosCostesDirectosReales: 0,
+    };
+
+    // Pactado
+    const margenPactado    = amountBrand > 0 ? round2(amountBrand - amountTalent) : null;
+    const margenPactadoPct = amountBrand > 0
+      ? round1(((amountBrand - amountTalent) / amountBrand) * 100)
+      : null;
+
+    // Real
+    const margenReal     = agg.ingresosReales > 0
+      ? round2(agg.ingresosReales - agg.costesReales)
+      : null;
+    const margenRealPct  = agg.ingresosReales > 0
+      ? round1(((agg.ingresosReales - agg.costesReales) / agg.ingresosReales) * 100)
+      : null;
+
+    // Desviación
+    const desviacionPct = (margenPactadoPct !== null && margenRealPct !== null)
+      ? round1(margenRealPct - margenPactadoPct)
+      : null;
+
+    const estado = classifyEstado({
+      amountBrand,
+      ingresosReales: agg.ingresosReales,
+      margenRealPct,
+    });
+
+    return {
+      id:                         c.id,
+      name:                       c.name,
+      brandId:                    c.brandId,
+      brandName:                  c.brandName ?? null,
+      talentId:                   c.talentId,
+      talentName:                 c.talentName ?? null,
+      status:                     c.status,
+      amountBrand:                round2(amountBrand),
+      amountTalent:               round2(amountTalent),
+      margenPactado,
+      margenPactadoPct,
+      ingresosReales:             round2(agg.ingresosReales),
+      costesReales:               round2(agg.costesReales),
+      pagosTalentosReales:        round2(agg.pagosTalentosReales),
+      otrosCostesDirectosReales:  round2(agg.otrosCostesDirectosReales),
+      margenReal,
+      margenRealPct,
+      desviacionPct,
+      estado,
+    };
+  });
+
+  const filteredRows = applyMargenFilter(rows, input.margenFilter ?? 'todos');
+  const kpis = computeKpis(rows);
+
+  return {
+    period,
+    rows,
+    filteredRows,
+    kpis,
+    totalCount: rows.length,
+    filteredCount: filteredRows.length,
+  };
+}
+
+// ── KPIs agregados ─────────────────────────────────────────────────────────
+
+function computeKpis(rows: readonly RentabilidadRow[]): RentabilidadKpis {
+  if (rows.length === 0) return emptyKpis();
+
+  const ingresosPactados = round2(rows.reduce((s, r) => s + r.amountBrand, 0));
+  const ingresosRealesAsociados = round2(rows.reduce((s, r) => s + r.ingresosReales, 0));
+
+  const withPactado = rows.filter((r) => r.margenPactadoPct !== null);
+  const margenPactadoMedio = withPactado.length > 0
+    ? round1(withPactado.reduce((s, r) => s + (r.margenPactadoPct ?? 0), 0) / withPactado.length)
+    : null;
+
+  const withReal = rows.filter((r) => r.margenRealPct !== null);
+  const margenRealMedio = withReal.length > 0
+    ? round1(withReal.reduce((s, r) => s + (r.margenRealPct ?? 0), 0) / withReal.length)
+    : null;
+
+  const campanasRentables = rows.filter((r) => r.estado === 'rentable').length;
+  const campanasMargenBajo = rows.filter((r) => r.estado === 'bajo').length;
+  const campanasNegativas = rows.filter((r) => r.estado === 'negativo').length;
+
+  const negativas = rows
+    .filter((r) => r.desviacionPct !== null && r.desviacionPct < 0)
+    .sort((a, b) => (a.desviacionPct ?? 0) - (b.desviacionPct ?? 0));
+  const worst = negativas[0];
+  const mayorDesviacionNegativa = worst
+    ? { name: worst.name, deviation: worst.desviacionPct ?? 0 }
+    : null;
+
+  return {
+    ingresosPactados,
+    margenPactadoMedio,
+    ingresosRealesAsociados,
+    margenRealMedio,
+    campanasRentables,
+    campanasMargenBajo,
+    campanasNegativas,
+    mayorDesviacionNegativa,
+  };
+}
+
+function emptyKpis(): RentabilidadKpis {
+  return {
+    ingresosPactados: 0,
+    margenPactadoMedio: null,
+    ingresosRealesAsociados: 0,
+    margenRealMedio: null,
+    campanasRentables: 0,
+    campanasMargenBajo: 0,
+    campanasNegativas: 0,
+    mayorDesviacionNegativa: null,
+  };
+}
+
+// ── Filtro por chip de margen ─────────────────────────────────────────────
+
+function applyMargenFilter(
+  rows: readonly RentabilidadRow[],
+  filter: RentabilidadFiltroMargen,
+): readonly RentabilidadRow[] {
+  if (filter === 'todos') return rows;
+  if (filter === 'rentable') return rows.filter((r) => r.estado === 'rentable');
+  if (filter === 'bajo')     return rows.filter((r) => r.estado === 'bajo');
+  if (filter === 'negativo') return rows.filter((r) => r.estado === 'negativo');
+  // 'sin_datos' abarca también 'sin_ejecucion_suficiente' desde la UI
+  return rows.filter((r) => r.estado === 'sin_datos' || r.estado === 'sin_ejecucion_suficiente');
+}


### PR DESCRIPTION
## Summary

Convierte `/admin/finanzas/rentabilidad` de placeholder a sección real que compara **margen pactado** (`campaigns.amountBrand - amountTalent`) contra **margen real facturado** (agregación de `invoices` por `campaignId`), mostrando la desviación en puntos porcentuales.

Objetivo del brief: poder leer directo "Campaña pactada con 40% de margen, pero margen real actual 12% por sobrecoste de producción".

## Auditoría aplicada

- ✅ Estado previo: placeholder de 27 líneas con `<PlaceholderSection>` y 2 links.
- ✅ Reutiliza `campaigns.amountBrand/amountTalent` (Decisión 1 pactado) y `invoices` agregadas por `campaignId` (Decisión 1 real).
- ✅ Reutiliza el umbral `LOW_MARGIN_THRESHOLD = 20` heredado de `campaignMargins.ts` (Decisión 3).
- ✅ Servicios aparcado con badge "Aparcado" (Decisión 2 = C).
- ✅ Regla anti-ruido: ingresos reales < 100 € → `sin_ejecucion_suficiente`.

## Rutas tocadas

| Ruta | Cambio |
|---|---|
| `/admin/finanzas/rentabilidad` | Placeholder → implementación real |
| Tab en `FinanzasNav` | Quita badge "Pronto" |

## Queries

**Nueva**: `src/lib/queries/financeDashboard/rentabilidad.ts`
- `getRentabilidadData(filters)` — 2 SELECTs + agregación en memoria (volumen 200-1000 campañas)
- Excluye `campaigns.status = 'cancelada'` y `invoices.status IN ('anulada','borrador')`
- Filtro de período por `campaigns.startDate` (incluye `NULL` para no ocultar propuestas)
- Exporta `classifyEstado()`, `LOW_MARGIN_THRESHOLD`, `MIN_INCOME_FOR_CLASSIFICATION` para tests

**Reutilizadas**: patrones y funciones de `financeDashboard/` (mismo estilo que `nominasCreadores.ts` e `ingresos.ts`).

## KPIs implementados (8)

1. Ingresos pactados (`SUM(amountBrand)`)
2. Margen pactado medio (%)
3. Ingresos reales asociados (`SUM(ingresosReales)`)
4. Margen real medio (%)
5. Campañas rentables (count)
6. Campañas margen bajo (count)
7. Campañas negativas (count)
8. Mayor desviación negativa (nombre + valor)

## Tabla implementada (12 columnas)

`Campaña · Marca · Talento · Estado · Ingr. pactados · Coste pactado · Margen pactado (€/%) · Ingr. reales · Costes reales · Margen real (€/%) · Desviación (pp) · Estado visual`

Badge de estado con 5 valores: **Rentable · Margen bajo · Negativa · Sin datos · Sin ejecución suficiente**.

## Lectura rápida

Genera bullets solo cuando hay datos, sin inventar:
- Campañas con margen bajo o negativo (conteo).
- Mayor desviación negativa (campaña + valor).
- Campaña más rentable por margen real %.
- Comparación margen pactado medio vs margen real medio.

## Bloque servicios aparcado

Badge visible "Aparcado" con copy exacto del brief. **No** usa `category`, `concept` ni `expense_subtype` como proxy. Test estático lo vigila:
```ts
expect(src).not.toMatch(/expense_subtype|expenseSubtype/);
expect(src).not.toMatch(/invoices\.category/);
expect(src).not.toMatch(/invoices\.concept/);
```

## Filtros implementados

Query params persistentes: `from`, `to`, `marca`, `talento`, `estado`, `margen`.
- `from`/`to`: ISO date con validación regex.
- `marca`/`talento`: positive int con `safePosInt`.
- `estado`: allowlist de 7 estados de campaign (excl. cancelada).
- `margen`: chips `todos | rentable | bajo | negativo | sin_datos`.

## Confirmación sin migración

✅ Cero cambios en `src/db/schema/`.
✅ Cero SQL nuevo. Test estático:
```ts
expect(journal).toMatch(/"tag":\s*"0109_billing_clients_pdf_language"/);
expect(journal).not.toMatch(/"tag":\s*"0110_/);
```
✅ `drizzle-kit check` sigue verde (no se ejecuta desde tests, pero no hay cambios en meta).

## Tests (32 casos nuevos)

`src/__tests__/server/finanzas-rentabilidad.test.ts`:

**Seguridad y read-only (6)**:
- Página exige `facturacion:read`
- Ya no importa `PlaceholderSection`
- Query marker `'server-only'` presente
- Ningún `db.insert/update/delete`
- No introduce `'use server'`
- Umbrales `LOW_MARGIN_THRESHOLD=20` y `MIN_INCOME_FOR_CLASSIFICATION=100` sincronizados

**Bloque servicios aparcado (4)**: componente existe, badge "Aparcado", copy con "clasificar de forma estructurada", no proxy con campos débiles.

**`classifyEstado` (7)**: casos límite del brief (100 €, 0%, 20%, negativos, edge cases).

**Fórmulas (7)**: margen pactado, margen real, desviación, exclusión anulada/borrador, pago_talento, otros directos, exclusión cancelada.

**Filtros (4)**: ISO date validation, positive int, enum margen con allowlist, allowlist estado.

**No scope creep (2)**: schema campaigns/invoices no mencionan "rentabilidad/margen_real/profitability", journal 0109 sigue siendo el último.

Además `finanzas-nav-and-routing.test.ts` actualizado: `rentabilidad` sale de `PLACEHOLDER_ROUTES`.

## Checks locales

- `npx tsc --noEmit` — sin errores en el proyecto
- `npx eslint` — verde en los 11 archivos tocados
- `npx jest` — **3733/3733 tests pasan** (32 nuevos + 3701 previos)

## Riesgos pendientes

- **PR 6B pendiente** (visual avanzada): gráficos, rankings por marca/cliente/talento, distribución de margen, scatter/heatmap, alertas complejas, configuración de umbral.
- **Campañas sin `startDate`**: se incluyen aunque no tengan fecha (propuestas). Documentado en la query.
- **Volumen**: agregación en memoria para 200-1000 campañas. Si en el futuro superamos ~5000 activas, valorar mover el agregado a SQL con CTE. No urgente.
- **Facturas de gasto sin `expense_subtype`**: quedan en `costesReales` pero NO en `pagosTalentosReales` ni `otrosCostesDirectosReales`. Es correcto — la tabla las muestra en la columna genérica.

## Test plan

- [ ] En preview, `/admin/finanzas/rentabilidad` renderiza los 4 bloques (KPIs, lectura rápida, tabla, servicios aparcado, accesos rápidos) sin errores.
- [ ] Tab "Rentabilidad" del `FinanzasNav` ya no muestra badge "Pronto".
- [ ] Filtrar por `?margen=bajo` reduce filas a las con estado "Margen bajo".
- [ ] Cambiar `?from=2026-01-01&to=2026-06-30` filtra por rango de startDate.
- [ ] Clicar en una fila del nombre lleva a `/admin/campanas/{id}`.
- [ ] Verificar visualmente: KPI "Mayor desviación negativa" muestra sub-etiqueta con el nombre de la campaña.

🤖 Generated with [Claude Code](https://claude.com/claude-code)