### PR TITLE
feat(finanzas): PR 6B — Rentabilidad rankings + gráficos Recharts

### DIFF
--- a/src/__tests__/server/finanzas-rentabilidad-6b.test.ts
+++ b/src/__tests__/server/finanzas-rentabilidad-6b.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Tests de PR 6B — Rentabilidad visual avanzada.
+ *
+ * Cubre:
+ *   - computeRankings: marca por margen / marca por facturación / talento por coste /
+ *     peores desviaciones. Clientes marcado como insuficiente (aparcado honesto).
+ *   - computeCharts: ingresos vs costes top 15, margen por marca top 10, talentos top 10,
+ *     distribución por bandas. Sin NaN. Empty states protegidos.
+ *   - Componentes: RentabilidadRankings + RentabilidadCharts existen y montan.
+ *   - Recharts se usa desde componente 'use client' (no rompe SSR).
+ *   - Sigue sin mutaciones, sin migraciones, sin Server Actions.
+ *   - Servicios sigue aparcado.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const PROJECT_ROOT = path.resolve(__dirname, '..', '..', '..');
+const read = (rel: string) => fs.readFileSync(path.join(PROJECT_ROOT, rel), 'utf-8');
+
+// ── Estática: no scope creep, sigue read-only ──────────────────────────
+
+describe('Rentabilidad 6B — invariantes de PR 6A preservadas', () => {
+  const QUERY = 'src/lib/queries/financeDashboard/rentabilidad.ts';
+
+  it('sigue siendo server-only', () => {
+    expect(read(QUERY)).toMatch(/['"]server-only['"]/);
+  });
+
+  it('no introduce mutaciones (insert/update/delete)', () => {
+    const src = read(QUERY);
+    expect(src).not.toMatch(/db\.insert\(/);
+    expect(src).not.toMatch(/db\.update\(/);
+    expect(src).not.toMatch(/db\.delete\(/);
+  });
+
+  it('no introduce Server Actions en la página', () => {
+    const src = read('src/app/admin/(dashboard)/finanzas/rentabilidad/page.tsx');
+    expect(src).not.toMatch(/['"]use server['"]/);
+  });
+
+  it('sigue exigiendo facturacion:read', () => {
+    const src = read('src/app/admin/(dashboard)/finanzas/rentabilidad/page.tsx');
+    expect(src).toMatch(/requirePermission\(['"]facturacion['"],\s*['"]read['"]\)/);
+  });
+
+  it('no crea migración nueva 011X', () => {
+    const journal = read('drizzle/meta/_journal.json');
+    expect(journal).toMatch(/"tag":\s*"0109_billing_clients_pdf_language"/);
+    expect(journal).not.toMatch(/"tag":\s*"0110_/);
+    expect(journal).not.toMatch(/"tag":\s*"0111_/);
+  });
+});
+
+// ── Query: nuevos exports rankings + charts ────────────────────────────
+
+describe('Rentabilidad 6B — query exporta rankings y charts', () => {
+  const QUERY_SRC = read('src/lib/queries/financeDashboard/rentabilidad.ts');
+
+  it('exporta tipos de rankings', () => {
+    expect(QUERY_SRC).toMatch(/export type RentabilidadRankings/);
+    expect(QUERY_SRC).toMatch(/export type RankingMarcaRow/);
+    expect(QUERY_SRC).toMatch(/export type RankingTalentoRow/);
+    expect(QUERY_SRC).toMatch(/export type RankingCampanaDesviacionRow/);
+  });
+
+  it('exporta tipos de charts', () => {
+    expect(QUERY_SRC).toMatch(/export type RentabilidadCharts/);
+    expect(QUERY_SRC).toMatch(/export type ChartIngresosVsCostesPoint/);
+    expect(QUERY_SRC).toMatch(/export type ChartMargenPorMarcaPoint/);
+    expect(QUERY_SRC).toMatch(/export type ChartTalentoCostePoint/);
+    expect(QUERY_SRC).toMatch(/export type ChartDistribucionMargen/);
+  });
+
+  it('RentabilidadData incluye rankings y charts', () => {
+    expect(QUERY_SRC).toMatch(/rankings:\s*RentabilidadRankings/);
+    expect(QUERY_SRC).toMatch(/charts:\s*RentabilidadCharts/);
+  });
+
+  it('computeRankings marca clientesInsuficientes = true (honesto, no inventa)', () => {
+    expect(QUERY_SRC).toMatch(/clientesInsuficientes:\s*true/);
+  });
+
+  it('rankings de marca solo se ordenan por margen si ingresosReales > 0', () => {
+    // Protección contra NaN por división cuando no hay ingresos reales
+    expect(QUERY_SRC).toMatch(/topMarcasPorMargen[\s\S]{0,200}filter\([\s\S]{0,80}ingresosReales\s*>\s*0/);
+  });
+
+  it('rankings de talento excluyen filas con costeReal = 0', () => {
+    expect(QUERY_SRC).toMatch(/topTalentosPorCoste[\s\S]{0,600}filter\(\(t\)\s*=>\s*t\.costeReal\s*>\s*0\)/);
+  });
+
+  it('peores desviaciones excluyen null y positivos', () => {
+    expect(QUERY_SRC).toMatch(/desviacionPct[\s\S]{0,120}!==\s*null[\s\S]{0,80}<\s*0/);
+  });
+
+  it('empty state: campaignRows.length === 0 devuelve rankings + charts vacíos', () => {
+    expect(QUERY_SRC).toMatch(/rankings:\s*emptyRankings\(\)/);
+    expect(QUERY_SRC).toMatch(/charts:\s*emptyCharts\(\)/);
+  });
+});
+
+// ── Componente rankings ────────────────────────────────────────────────
+
+describe('RentabilidadRankings — Bloque 1', () => {
+  const REL = 'src/features/admin/finance-dashboard/components/rentabilidad/RentabilidadRankings.tsx';
+
+  it('el componente existe', () => {
+    expect(fs.existsSync(path.join(PROJECT_ROOT, REL))).toBe(true);
+  });
+
+  it('renderiza los 4 rankings esperados', () => {
+    const src = read(REL);
+    expect(src).toMatch(/Top marcas por margen real/);
+    expect(src).toMatch(/Top marcas por facturación asociada/);
+    expect(src).toMatch(/Top talentos por coste real/);
+    expect(src).toMatch(/Peores desviaciones/);
+  });
+
+  it('muestra ranking de clientes como aparcado honesto', () => {
+    const src = read(REL);
+    expect(src).toMatch(/Ranking de clientes/);
+    expect(src).toMatch(/Datos insuficientes/);
+    expect(src).toMatch(/no tiene un FK fiable/);
+  });
+
+  it('los items del ranking incluyen barra de progreso visual', () => {
+    const src = read(REL);
+    expect(src).toMatch(/function ProgressBar/);
+  });
+
+  it('las peores desviaciones enlazan al detalle de campaña', () => {
+    const src = read(REL);
+    expect(src).toMatch(/\/admin\/campanas\/\$\{row\.id\}/);
+  });
+
+  it('protege contra división por cero al calcular pct de barras', () => {
+    const src = read(REL);
+    expect(src).toMatch(/maxValue\s*>\s*0\s*\?/);
+  });
+});
+
+// ── Componente charts ─────────────────────────────────────────────────
+
+describe('RentabilidadCharts — Bloque 2', () => {
+  const REL = 'src/features/admin/finance-dashboard/components/rentabilidad/RentabilidadCharts.tsx';
+
+  it('el componente existe', () => {
+    expect(fs.existsSync(path.join(PROJECT_ROOT, REL))).toBe(true);
+  });
+
+  it('está marcado como client component (Recharts requiere DOM)', () => {
+    const src = read(REL);
+    expect(src).toMatch(/^['"]use client['"];/);
+  });
+
+  it('renderiza los 4 gráficos del brief PR 6B', () => {
+    const src = read(REL);
+    expect(src).toMatch(/Ingresos vs costes por campaña/);
+    expect(src).toMatch(/Margen bruto por marca/);
+    expect(src).toMatch(/Top talentos por coste real/);
+    expect(src).toMatch(/Distribución de campañas por banda de margen/);
+  });
+
+  it('importa recharts (no otras libs de charting)', () => {
+    const src = read(REL);
+    expect(src).toMatch(/from\s+['"]recharts['"]/);
+    expect(src).not.toMatch(/from\s+['"]chart\.js['"]/);
+    expect(src).not.toMatch(/from\s+['"]d3['"]/);
+  });
+
+  it('usa ResponsiveContainer en todos los gráficos', () => {
+    const src = read(REL);
+    // 4 gráficos → al menos 4 ResponsiveContainer
+    const matches = src.match(/<ResponsiveContainer/g) ?? [];
+    expect(matches.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('protege contra NaN con safeNumber en tick formatters y tooltips', () => {
+    const src = read(REL);
+    expect(src).toMatch(/function safeNumber/);
+    expect(src).toMatch(/Number\.isFinite/);
+  });
+
+  it('cada card tiene empty state (isEmpty)', () => {
+    const src = read(REL);
+    // Al menos 4 usos del prop isEmpty
+    const matches = src.match(/isEmpty=\{/g) ?? [];
+    expect(matches.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('los labels largos se truncan (no rompen el layout)', () => {
+    const src = read(REL);
+    expect(src).toMatch(/function truncateLabel/);
+  });
+});
+
+// ── Servicios sigue aparcado ──────────────────────────────────────────
+
+describe('Servicios sigue aparcado en PR 6B', () => {
+  const REL = 'src/features/admin/finance-dashboard/components/rentabilidad/RentabilidadServicioAparcado.tsx';
+
+  it('el bloque sigue existiendo', () => {
+    expect(fs.existsSync(path.join(PROJECT_ROOT, REL))).toBe(true);
+  });
+
+  it('sigue siendo informativo, no funcional', () => {
+    const src = read(REL);
+    expect(src).toMatch(/Aparcado/);
+  });
+
+  it('la página SÍ importa el bloque aparcado', () => {
+    const src = read('src/app/admin/(dashboard)/finanzas/rentabilidad/page.tsx');
+    expect(src).toMatch(/RentabilidadServicioAparcado/);
+  });
+});
+
+// ── Página monta los nuevos bloques ───────────────────────────────────
+
+describe('Página /admin/finanzas/rentabilidad — nuevos bloques', () => {
+  const src = read('src/app/admin/(dashboard)/finanzas/rentabilidad/page.tsx');
+
+  it('importa RentabilidadRankingsBlock', () => {
+    expect(src).toMatch(/RentabilidadRankingsBlock/);
+  });
+
+  it('importa RentabilidadChartsBlock', () => {
+    expect(src).toMatch(/RentabilidadChartsBlock/);
+  });
+
+  it('los rankings van antes de la tabla', () => {
+    const idxRankings = src.indexOf('<RentabilidadRankingsBlock');
+    const idxTabla    = src.indexOf('<RentabilidadTabla');
+    expect(idxRankings).toBeGreaterThan(-1);
+    expect(idxTabla).toBeGreaterThan(-1);
+    expect(idxRankings).toBeLessThan(idxTabla);
+  });
+
+  it('los gráficos van entre rankings y tabla', () => {
+    const idxRankings = src.indexOf('<RentabilidadRankingsBlock');
+    const idxCharts   = src.indexOf('<RentabilidadChartsBlock');
+    const idxTabla    = src.indexOf('<RentabilidadTabla');
+    expect(idxCharts).toBeGreaterThan(idxRankings);
+    expect(idxCharts).toBeLessThan(idxTabla);
+  });
+});

--- a/src/app/admin/(dashboard)/finanzas/rentabilidad/page.tsx
+++ b/src/app/admin/(dashboard)/finanzas/rentabilidad/page.tsx
@@ -7,6 +7,8 @@ import { getRentabilidadData, type RentabilidadFiltroMargen } from '@/lib/querie
 import { RentabilidadFilters } from '@/features/admin/finance-dashboard/components/rentabilidad/RentabilidadFilters';
 import { RentabilidadKpisBlock } from '@/features/admin/finance-dashboard/components/rentabilidad/RentabilidadKpis';
 import { RentabilidadLecturaRapida } from '@/features/admin/finance-dashboard/components/rentabilidad/RentabilidadLecturaRapida';
+import { RentabilidadRankingsBlock } from '@/features/admin/finance-dashboard/components/rentabilidad/RentabilidadRankings';
+import { RentabilidadChartsBlock } from '@/features/admin/finance-dashboard/components/rentabilidad/RentabilidadCharts';
 import { RentabilidadTabla } from '@/features/admin/finance-dashboard/components/rentabilidad/RentabilidadTabla';
 import { RentabilidadServicioAparcado } from '@/features/admin/finance-dashboard/components/rentabilidad/RentabilidadServicioAparcado';
 import { RentabilidadAccesosRapidos } from '@/features/admin/finance-dashboard/components/rentabilidad/RentabilidadAccesosRapidos';
@@ -101,6 +103,10 @@ export default async function FinanzasRentabilidadPage({ searchParams }: PagePro
       <RentabilidadKpisBlock kpis={data.kpis} />
 
       <RentabilidadLecturaRapida data={data} />
+
+      <RentabilidadRankingsBlock rankings={data.rankings} />
+
+      <RentabilidadChartsBlock charts={data.charts} />
 
       <RentabilidadTabla rows={data.filteredRows} totalRows={data.totalCount} />
 

--- a/src/features/admin/finance-dashboard/components/rentabilidad/RentabilidadCharts.tsx
+++ b/src/features/admin/finance-dashboard/components/rentabilidad/RentabilidadCharts.tsx
@@ -1,0 +1,237 @@
+'use client';
+
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Legend,
+  PieChart,
+  Pie,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import type { RentabilidadCharts as RentabilidadChartsData } from '@/lib/queries/financeDashboard/rentabilidad';
+
+const EUR         = new Intl.NumberFormat('es-ES', { style: 'currency', currency: 'EUR', maximumFractionDigits: 0 });
+const EUR_COMPACT = new Intl.NumberFormat('es-ES', { style: 'currency', currency: 'EUR', maximumFractionDigits: 0, notation: 'compact' });
+
+function safeNumber(v: unknown): number {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function truncateLabel(s: string, max = 22): string {
+  if (s.length <= max) return s;
+  return `${s.slice(0, max - 1)}…`;
+}
+
+// ── Chart wrapper card ────────────────────────────────────────────────────
+
+function ChartCard({
+  title,
+  subtitle,
+  isEmpty,
+  emptyLabel,
+  children,
+}: {
+  readonly title: string;
+  readonly subtitle: string;
+  readonly isEmpty: boolean;
+  readonly emptyLabel: string;
+  readonly children: React.ReactNode;
+}): React.ReactElement {
+  return (
+    <div className="rounded-2xl border border-sp-border bg-sp-admin-card p-4">
+      <h3 className="text-sm font-bold text-sp-admin-fg">{title}</h3>
+      <p className="text-[11px] text-sp-admin-muted mt-0.5 mb-3">{subtitle}</p>
+      {isEmpty ? (
+        <div className="h-52 flex items-center justify-center text-[12px] text-sp-admin-muted italic">
+          {emptyLabel}
+        </div>
+      ) : (
+        children
+      )}
+    </div>
+  );
+}
+
+// ── Componente principal ─────────────────────────────────────────────────
+
+export function RentabilidadChartsBlock({ charts }: { readonly charts: RentabilidadChartsData }): React.ReactElement {
+  const ivc = charts.ingresosVsCostesTop15.map((r) => ({
+    name:     truncateLabel(r.name),
+    fullName: r.name,
+    Ingresos: safeNumber(r.ingresosReales),
+    Costes:   safeNumber(r.costesReales),
+  }));
+
+  const marca = charts.margenPorMarcaTop10.map((r) => ({
+    brandName:     truncateLabel(r.brandName, 26),
+    fullBrandName: r.brandName,
+    margenReal:    safeNumber(r.margenReal),
+  }));
+
+  const talentos = charts.talentosPorCosteTop10.map((r) => ({
+    talentName:     truncateLabel(r.talentName, 26),
+    fullTalentName: r.talentName,
+    costeReal:      safeNumber(r.costeReal),
+  }));
+
+  const dist = [
+    { name: 'Rentables',   value: charts.distribucionMargen.rentable,  fill: '#16a34a' },
+    { name: 'Margen bajo', value: charts.distribucionMargen.bajo,      fill: '#f59e0b' },
+    { name: 'Negativas',   value: charts.distribucionMargen.negativo,  fill: '#ef4444' },
+    { name: 'Sin datos',   value: charts.distribucionMargen.sinDatos,  fill: '#94a3b8' },
+  ].filter((d) => d.value > 0);
+
+  return (
+    <div className="grid gap-4 lg:grid-cols-2">
+      {/* ── Ingresos vs costes por campaña ─────────────────────────────── */}
+      <ChartCard
+        title="Ingresos vs costes por campaña"
+        subtitle="Top 15 por volumen económico total (ingresos + costes)."
+        isEmpty={ivc.length === 0}
+        emptyLabel="Sin campañas con actividad económica en el período."
+      >
+        <ResponsiveContainer width="100%" height={280}>
+          <BarChart data={ivc} margin={{ top: 8, right: 8, left: 0, bottom: 42 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="rgba(107,114,128,0.15)" />
+            <XAxis
+              dataKey="name"
+              tick={{ fontSize: 9, fill: '#a8a39d' }}
+              interval={0}
+              angle={-30}
+              textAnchor="end"
+              tickLine={false}
+              height={60}
+            />
+            <YAxis
+              tickFormatter={(v) => EUR_COMPACT.format(safeNumber(v))}
+              tick={{ fontSize: 10, fill: '#a8a39d' }}
+              tickLine={false}
+              width={60}
+            />
+            <Tooltip
+              formatter={(value, name) => [EUR.format(safeNumber(value)), String(name)]}
+              labelFormatter={(_, payload) => {
+                const item = payload?.[0]?.payload as { fullName?: string } | undefined;
+                return item?.fullName ?? '';
+              }}
+              contentStyle={{ borderRadius: 8, border: '1px solid #e2ddd8', fontSize: 12 }}
+            />
+            <Legend wrapperStyle={{ fontSize: 11 }} />
+            <Bar dataKey="Ingresos" fill="#16a34a" />
+            <Bar dataKey="Costes"   fill="#f59e0b" />
+          </BarChart>
+        </ResponsiveContainer>
+      </ChartCard>
+
+      {/* ── Margen bruto por marca ─────────────────────────────────────── */}
+      <ChartCard
+        title="Margen bruto por marca"
+        subtitle="Top 10 por margen real (ingresos − costes) agregado por marca."
+        isEmpty={marca.length === 0}
+        emptyLabel="Sin marcas con margen registrado en el período."
+      >
+        <ResponsiveContainer width="100%" height={280}>
+          <BarChart data={marca} layout="vertical" margin={{ top: 4, right: 12, left: 0, bottom: 4 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="rgba(107,114,128,0.15)" />
+            <XAxis
+              type="number"
+              tickFormatter={(v) => EUR_COMPACT.format(safeNumber(v))}
+              tick={{ fontSize: 10, fill: '#a8a39d' }}
+              tickLine={false}
+            />
+            <YAxis
+              dataKey="brandName"
+              type="category"
+              tick={{ fontSize: 10, fill: '#a8a39d' }}
+              tickLine={false}
+              width={110}
+            />
+            <Tooltip
+              formatter={(value) => EUR.format(safeNumber(value))}
+              labelFormatter={(_, payload) => {
+                const item = payload?.[0]?.payload as { fullBrandName?: string } | undefined;
+                return item?.fullBrandName ?? '';
+              }}
+              contentStyle={{ borderRadius: 8, border: '1px solid #e2ddd8', fontSize: 12 }}
+            />
+            <Bar dataKey="margenReal" name="Margen real">
+              {marca.map((m, i) => (
+                <Cell key={i} fill={m.margenReal >= 0 ? '#16a34a' : '#ef4444'} />
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </ChartCard>
+
+      {/* ── Top talentos por coste ────────────────────────────────────── */}
+      <ChartCard
+        title="Top talentos por coste real"
+        subtitle="Pagos a talento agregados por persona, top 10."
+        isEmpty={talentos.length === 0}
+        emptyLabel="Sin pagos a talentos registrados en el período."
+      >
+        <ResponsiveContainer width="100%" height={280}>
+          <BarChart data={talentos} layout="vertical" margin={{ top: 4, right: 12, left: 0, bottom: 4 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="rgba(107,114,128,0.15)" />
+            <XAxis
+              type="number"
+              tickFormatter={(v) => EUR_COMPACT.format(safeNumber(v))}
+              tick={{ fontSize: 10, fill: '#a8a39d' }}
+              tickLine={false}
+            />
+            <YAxis
+              dataKey="talentName"
+              type="category"
+              tick={{ fontSize: 10, fill: '#a8a39d' }}
+              tickLine={false}
+              width={110}
+            />
+            <Tooltip
+              formatter={(value) => EUR.format(safeNumber(value))}
+              labelFormatter={(_, payload) => {
+                const item = payload?.[0]?.payload as { fullTalentName?: string } | undefined;
+                return item?.fullTalentName ?? '';
+              }}
+              contentStyle={{ borderRadius: 8, border: '1px solid #e2ddd8', fontSize: 12 }}
+            />
+            <Bar dataKey="costeReal" name="Coste real" fill="#e03070" />
+          </BarChart>
+        </ResponsiveContainer>
+      </ChartCard>
+
+      {/* ── Distribución de margen % por bandas ────────────────────────── */}
+      <ChartCard
+        title="Distribución de campañas por banda de margen"
+        subtitle="Cuántas campañas caen en cada zona (rentable, bajo, negativo, sin datos)."
+        isEmpty={dist.length === 0}
+        emptyLabel="Sin datos suficientes para calcular la distribución."
+      >
+        <ResponsiveContainer width="100%" height={280}>
+          <PieChart>
+            <Pie
+              data={dist}
+              dataKey="value"
+              nameKey="name"
+              innerRadius={55}
+              outerRadius={95}
+              paddingAngle={2}
+            >
+              {dist.map((d, idx) => <Cell key={idx} fill={d.fill} />)}
+            </Pie>
+            <Tooltip
+              formatter={(value, name) => [`${safeNumber(value)} camp.`, String(name)]}
+              contentStyle={{ borderRadius: 8, border: '1px solid #e2ddd8', fontSize: 12 }}
+            />
+            <Legend wrapperStyle={{ fontSize: 11 }} />
+          </PieChart>
+        </ResponsiveContainer>
+      </ChartCard>
+    </div>
+  );
+}

--- a/src/features/admin/finance-dashboard/components/rentabilidad/RentabilidadRankings.tsx
+++ b/src/features/admin/finance-dashboard/components/rentabilidad/RentabilidadRankings.tsx
@@ -1,0 +1,251 @@
+import Link from 'next/link';
+import type {
+  RentabilidadRankings,
+  RankingMarcaRow,
+  RankingTalentoRow,
+  RankingCampanaDesviacionRow,
+} from '@/lib/queries/financeDashboard/rentabilidad';
+
+const EUR = new Intl.NumberFormat('es-ES', { style: 'currency', currency: 'EUR', maximumFractionDigits: 0 });
+function fmtMoney(n: number): string { return EUR.format(n); }
+function fmtPct(n: number | null): string { return n === null ? '—' : `${n.toFixed(1)}%`; }
+
+/**
+ * Bar horizontal simple sin librería — evita cargar Recharts en cards de ranking
+ * y da un feedback visual claro de "cuánto peso tiene cada fila sobre el max".
+ */
+function ProgressBar({ pct, colorClass }: { readonly pct: number; readonly colorClass: string }): React.ReactElement {
+  const clamped = Math.max(0, Math.min(100, pct));
+  return (
+    <div className="w-full h-1.5 rounded-full bg-sp-border/40 overflow-hidden">
+      <div
+        className={`h-full rounded-full ${colorClass}`}
+        style={{ width: `${clamped}%` }}
+        aria-hidden
+      />
+    </div>
+  );
+}
+
+function RankCard({
+  title,
+  subtitle,
+  children,
+  emptyLabel,
+  isEmpty,
+}: {
+  readonly title: string;
+  readonly subtitle: string;
+  readonly children: React.ReactNode;
+  readonly emptyLabel: string;
+  readonly isEmpty: boolean;
+}): React.ReactElement {
+  return (
+    <section className="rounded-2xl border border-sp-border bg-sp-admin-card overflow-hidden">
+      <div className="px-4 py-3 border-b border-sp-border">
+        <h3 className="text-sm font-bold text-sp-admin-fg">{title}</h3>
+        <p className="text-[11px] text-sp-admin-muted mt-0.5">{subtitle}</p>
+      </div>
+      {isEmpty ? (
+        <div className="px-4 py-8 text-center">
+          <p className="text-[12px] text-sp-admin-muted italic">{emptyLabel}</p>
+        </div>
+      ) : (
+        <ul className="divide-y divide-sp-border/40">{children}</ul>
+      )}
+    </section>
+  );
+}
+
+// ── Marcas por margen ────────────────────────────────────────────────────
+
+function MarcaMargenItem({
+  rank,
+  row,
+  maxValue,
+}: {
+  readonly rank: number;
+  readonly row: RankingMarcaRow;
+  readonly maxValue: number;
+}): React.ReactElement {
+  const pct = maxValue > 0 ? (row.margenReal / maxValue) * 100 : 0;
+  return (
+    <li className="px-4 py-2.5 hover:bg-sp-admin-hover transition-colors">
+      <div className="flex items-baseline gap-2 mb-1.5">
+        <span className="text-[10px] font-bold text-sp-admin-muted w-4 tabular-nums shrink-0">#{rank}</span>
+        <span className="text-[13px] font-semibold text-sp-admin-fg truncate flex-1">{row.brandName}</span>
+        <span className="text-[12px] font-bold text-emerald-500 tabular-nums whitespace-nowrap">
+          {fmtMoney(row.margenReal)}
+        </span>
+      </div>
+      <ProgressBar pct={pct} colorClass="bg-emerald-500/60" />
+      <div className="flex items-center justify-between mt-1 text-[10px] text-sp-admin-muted">
+        <span>{fmtPct(row.margenRealPct)} margen</span>
+        <span>{row.campanas} camp.</span>
+      </div>
+    </li>
+  );
+}
+
+// ── Marcas por facturación ──────────────────────────────────────────────
+
+function MarcaFacturacionItem({
+  rank,
+  row,
+  maxValue,
+}: {
+  readonly rank: number;
+  readonly row: RankingMarcaRow;
+  readonly maxValue: number;
+}): React.ReactElement {
+  const pct = maxValue > 0 ? (row.ingresosReales / maxValue) * 100 : 0;
+  return (
+    <li className="px-4 py-2.5 hover:bg-sp-admin-hover transition-colors">
+      <div className="flex items-baseline gap-2 mb-1.5">
+        <span className="text-[10px] font-bold text-sp-admin-muted w-4 tabular-nums shrink-0">#{rank}</span>
+        <span className="text-[13px] font-semibold text-sp-admin-fg truncate flex-1">{row.brandName}</span>
+        <span className="text-[12px] font-bold text-sp-admin-fg tabular-nums whitespace-nowrap">
+          {fmtMoney(row.ingresosReales)}
+        </span>
+      </div>
+      <ProgressBar pct={pct} colorClass="bg-sp-orange/70" />
+      <div className="flex items-center justify-between mt-1 text-[10px] text-sp-admin-muted">
+        <span>Margen: {fmtPct(row.margenRealPct)}</span>
+        <span>{row.campanas} camp.</span>
+      </div>
+    </li>
+  );
+}
+
+// ── Talentos por coste ──────────────────────────────────────────────────
+
+function TalentoCosteItem({
+  rank,
+  row,
+}: {
+  readonly rank: number;
+  readonly row: RankingTalentoRow;
+}): React.ReactElement {
+  return (
+    <li className="px-4 py-2.5 hover:bg-sp-admin-hover transition-colors">
+      <div className="flex items-baseline gap-2 mb-1.5">
+        <span className="text-[10px] font-bold text-sp-admin-muted w-4 tabular-nums shrink-0">#{rank}</span>
+        <span className="text-[13px] font-semibold text-sp-admin-fg truncate flex-1">{row.talentName}</span>
+        <span className="text-[12px] font-bold text-amber-500 tabular-nums whitespace-nowrap">
+          {fmtMoney(row.costeReal)}
+        </span>
+      </div>
+      <ProgressBar pct={row.concentracionPctSobreTotal} colorClass="bg-amber-500/70" />
+      <div className="flex items-center justify-between mt-1 text-[10px] text-sp-admin-muted">
+        <span>{row.concentracionPctSobreTotal.toFixed(1)}% del coste total de talentos</span>
+        <span>{row.campanas} camp.</span>
+      </div>
+    </li>
+  );
+}
+
+// ── Campañas peor desviación ────────────────────────────────────────────
+
+function DesviacionItem({
+  rank,
+  row,
+}: {
+  readonly rank: number;
+  readonly row: RankingCampanaDesviacionRow;
+}): React.ReactElement {
+  return (
+    <li className="px-4 py-2.5 hover:bg-sp-admin-hover transition-colors">
+      <div className="flex items-baseline gap-2 mb-1">
+        <span className="text-[10px] font-bold text-sp-admin-muted w-4 tabular-nums shrink-0">#{rank}</span>
+        <Link
+          href={`/admin/campanas/${row.id}`}
+          className="text-[13px] font-semibold text-sp-admin-fg hover:text-sp-admin-accent truncate flex-1"
+        >
+          {row.name}
+        </Link>
+        <span className="text-[12px] font-bold text-red-500 tabular-nums whitespace-nowrap">
+          {row.desviacionPct.toFixed(1)} pp
+        </span>
+      </div>
+      <div className="flex items-center gap-3 text-[10px] text-sp-admin-muted mt-1">
+        <span>Pactado {row.margenPactadoPct.toFixed(1)}% → Real {row.margenRealPct.toFixed(1)}%</span>
+        <span className="ml-auto">{row.brandName ?? '—'} · {row.talentName ?? '—'}</span>
+      </div>
+    </li>
+  );
+}
+
+// ── Componente principal ─────────────────────────────────────────────────
+
+export function RentabilidadRankingsBlock({ rankings }: { readonly rankings: RentabilidadRankings }): React.ReactElement {
+  const maxMargen = Math.max(0, ...rankings.topMarcasPorMargen.map((m) => m.margenReal));
+  const maxFacturacion = Math.max(0, ...rankings.topMarcasPorFacturacion.map((m) => m.ingresosReales));
+
+  return (
+    <div className="grid gap-4 lg:grid-cols-2">
+      <RankCard
+        title="Top marcas por margen real"
+        subtitle="Ingresos reales − costes reales, orden descendente."
+        isEmpty={rankings.topMarcasPorMargen.length === 0}
+        emptyLabel="Aún no hay marcas con margen real facturado en el período."
+      >
+        {rankings.topMarcasPorMargen.map((r, i) => (
+          <MarcaMargenItem key={r.brandId} rank={i + 1} row={r} maxValue={maxMargen} />
+        ))}
+      </RankCard>
+
+      <RankCard
+        title="Top marcas por facturación asociada"
+        subtitle="Ingresos reales agregados por marca."
+        isEmpty={rankings.topMarcasPorFacturacion.length === 0}
+        emptyLabel="Aún no hay facturación asociada a marcas en el período."
+      >
+        {rankings.topMarcasPorFacturacion.map((r, i) => (
+          <MarcaFacturacionItem key={r.brandId} rank={i + 1} row={r} maxValue={maxFacturacion} />
+        ))}
+      </RankCard>
+
+      <RankCard
+        title="Top talentos por coste real"
+        subtitle="Pagos a talento agregados por persona (concentración sobre el total)."
+        isEmpty={rankings.topTalentosPorCoste.length === 0}
+        emptyLabel="Aún no hay pagos a talentos registrados en el período."
+      >
+        {rankings.topTalentosPorCoste.map((r, i) => (
+          <TalentoCosteItem key={r.talentId} rank={i + 1} row={r} />
+        ))}
+      </RankCard>
+
+      <RankCard
+        title="Peores desviaciones pactado vs real"
+        subtitle="Campañas con margen real por debajo del pactado. Click para abrir."
+        isEmpty={rankings.peoresDesviaciones.length === 0}
+        emptyLabel="Ninguna campaña con desviación negativa registrada."
+      >
+        {rankings.peoresDesviaciones.map((r, i) => (
+          <DesviacionItem key={r.id} rank={i + 1} row={r} />
+        ))}
+      </RankCard>
+
+      {/* Aparcado honesto — no hay FK fiable de campaña → billing_client */}
+      {rankings.clientesInsuficientes && (
+        <section className="lg:col-span-2 rounded-2xl border border-dashed border-sp-border bg-sp-admin-card/50 p-4">
+          <div className="flex items-center gap-2">
+            <span className="text-lg" aria-hidden>👤</span>
+            <h3 className="text-sm font-bold text-sp-admin-fg">Ranking de clientes</h3>
+            <span className="ml-auto text-[10px] font-bold uppercase tracking-wide px-2 py-0.5 rounded-full bg-slate-500/15 text-slate-400 border border-slate-500/30">
+              Datos insuficientes
+            </span>
+          </div>
+          <p className="text-[12px] text-sp-admin-muted leading-relaxed mt-2">
+            En el modelo actual del CRM la unidad comercial vinculada a campañas es la marca
+            (<code className="text-sp-admin-fg">crm_brands</code>). El concepto de cliente de facturación
+            (<code className="text-sp-admin-fg">billing_clients</code>) se usa sólo en facturas emitidas SP → cliente,
+            y no tiene un FK fiable con campañas o gastos internos. No mostramos el ranking para
+            evitar datos engañosos.
+          </p>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/src/lib/queries/financeDashboard/rentabilidad.ts
+++ b/src/lib/queries/financeDashboard/rentabilidad.ts
@@ -92,11 +92,87 @@ export type RentabilidadKpis = {
 
 export type RentabilidadPeriod = { readonly from: string; readonly to: string };
 
+// ── Rankings (PR 6B) ───────────────────────────────────────────────────
+
+export type RankingMarcaRow = {
+  readonly brandId: number;
+  readonly brandName: string;
+  readonly ingresosReales: number;
+  readonly costesReales: number;
+  readonly margenReal: number;
+  readonly margenRealPct: number | null;
+  readonly ingresosPactados: number;
+  readonly campanas: number;
+};
+
+export type RankingTalentoRow = {
+  readonly talentId: number;
+  readonly talentName: string;
+  readonly costeReal: number;
+  readonly ingresosReales: number;
+  readonly campanas: number;
+  readonly concentracionPctSobreTotal: number; // 0-100
+};
+
+export type RankingCampanaDesviacionRow = {
+  readonly id: number;
+  readonly name: string;
+  readonly brandName: string | null;
+  readonly talentName: string | null;
+  readonly margenPactadoPct: number;
+  readonly margenRealPct: number;
+  readonly desviacionPct: number;
+  readonly ingresosReales: number;
+};
+
+export type RentabilidadRankings = {
+  readonly topMarcasPorMargen: readonly RankingMarcaRow[];
+  readonly topMarcasPorFacturacion: readonly RankingMarcaRow[];
+  readonly topTalentosPorCoste: readonly RankingTalentoRow[];
+  readonly peoresDesviaciones: readonly RankingCampanaDesviacionRow[];
+  readonly clientesInsuficientes: boolean; // siempre true en 6B — sin FK campaign→client fiable
+};
+
+// ── Datos para gráficos (PR 6B) ────────────────────────────────────────
+
+export type ChartIngresosVsCostesPoint = {
+  readonly id: number;
+  readonly name: string;
+  readonly ingresosReales: number;
+  readonly costesReales: number;
+};
+
+export type ChartMargenPorMarcaPoint = {
+  readonly brandName: string;
+  readonly margenReal: number;
+};
+
+export type ChartTalentoCostePoint = {
+  readonly talentName: string;
+  readonly costeReal: number;
+};
+
+export type ChartDistribucionMargen = {
+  readonly negativo: number;
+  readonly bajo: number;
+  readonly rentable: number;
+  readonly sinDatos: number;
+};
+
+export type RentabilidadCharts = {
+  readonly ingresosVsCostesTop15: readonly ChartIngresosVsCostesPoint[];
+  readonly margenPorMarcaTop10: readonly ChartMargenPorMarcaPoint[];
+  readonly talentosPorCosteTop10: readonly ChartTalentoCostePoint[];
+  readonly distribucionMargen: ChartDistribucionMargen;
+};
+
 export type RentabilidadData = {
   readonly period: RentabilidadPeriod;
   readonly rows: readonly RentabilidadRow[];
   readonly filteredRows: readonly RentabilidadRow[];
   readonly kpis: RentabilidadKpis;
+  readonly rankings: RentabilidadRankings;
+  readonly charts: RentabilidadCharts;
   readonly totalCount: number;
   readonly filteredCount: number;
 };
@@ -198,6 +274,8 @@ export async function getRentabilidadData(input: RentabilidadFilters = {}): Prom
       rows: [],
       filteredRows: [],
       kpis: emptyKpis(),
+      rankings: emptyRankings(),
+      charts: emptyCharts(),
       totalCount: 0,
       filteredCount: 0,
     };
@@ -298,12 +376,16 @@ export async function getRentabilidadData(input: RentabilidadFilters = {}): Prom
 
   const filteredRows = applyMargenFilter(rows, input.margenFilter ?? 'todos');
   const kpis = computeKpis(rows);
+  const rankings = computeRankings(rows);
+  const charts = computeCharts(rows);
 
   return {
     period,
     rows,
     filteredRows,
     kpis,
+    rankings,
+    charts,
     totalCount: rows.length,
     filteredCount: filteredRows.length,
   };
@@ -364,6 +446,25 @@ function emptyKpis(): RentabilidadKpis {
   };
 }
 
+function emptyRankings(): RentabilidadRankings {
+  return {
+    topMarcasPorMargen: [],
+    topMarcasPorFacturacion: [],
+    topTalentosPorCoste: [],
+    peoresDesviaciones: [],
+    clientesInsuficientes: true,
+  };
+}
+
+function emptyCharts(): RentabilidadCharts {
+  return {
+    ingresosVsCostesTop15: [],
+    margenPorMarcaTop10: [],
+    talentosPorCosteTop10: [],
+    distribucionMargen: { negativo: 0, bajo: 0, rentable: 0, sinDatos: 0 },
+  };
+}
+
 // ── Filtro por chip de margen ─────────────────────────────────────────────
 
 function applyMargenFilter(
@@ -376,4 +477,182 @@ function applyMargenFilter(
   if (filter === 'negativo') return rows.filter((r) => r.estado === 'negativo');
   // 'sin_datos' abarca también 'sin_ejecucion_suficiente' desde la UI
   return rows.filter((r) => r.estado === 'sin_datos' || r.estado === 'sin_ejecucion_suficiente');
+}
+
+// ── Rankings agregados (PR 6B) ────────────────────────────────────────────
+
+function computeRankings(rows: readonly RentabilidadRow[]): RentabilidadRankings {
+  // ── Por marca ────────────────────────────────────────────────────────
+  const marcaMap = new Map<number, {
+    brandName: string;
+    ingresosReales: number;
+    costesReales: number;
+    ingresosPactados: number;
+    campanas: number;
+  }>();
+  for (const r of rows) {
+    if (r.brandId === null || r.brandName === null) continue;
+    const entry = marcaMap.get(r.brandId) ?? {
+      brandName: r.brandName,
+      ingresosReales: 0,
+      costesReales: 0,
+      ingresosPactados: 0,
+      campanas: 0,
+    };
+    entry.ingresosReales   += r.ingresosReales;
+    entry.costesReales     += r.costesReales;
+    entry.ingresosPactados += r.amountBrand;
+    entry.campanas         += 1;
+    marcaMap.set(r.brandId, entry);
+  }
+
+  const marcasAll: RankingMarcaRow[] = [...marcaMap.entries()].map(([brandId, v]) => {
+    const margenReal = v.ingresosReales - v.costesReales;
+    const margenRealPct = v.ingresosReales > 0
+      ? round1((margenReal / v.ingresosReales) * 100)
+      : null;
+    return {
+      brandId,
+      brandName:        v.brandName,
+      ingresosReales:   round2(v.ingresosReales),
+      costesReales:     round2(v.costesReales),
+      margenReal:       round2(margenReal),
+      margenRealPct,
+      ingresosPactados: round2(v.ingresosPactados),
+      campanas:         v.campanas,
+    };
+  });
+
+  const topMarcasPorMargen = [...marcasAll]
+    .filter((m) => m.ingresosReales > 0) // sin ingresos reales no ordenamos por margen
+    .sort((a, b) => b.margenReal - a.margenReal)
+    .slice(0, 10);
+
+  const topMarcasPorFacturacion = [...marcasAll]
+    .sort((a, b) => b.ingresosReales - a.ingresosReales)
+    .slice(0, 10);
+
+  // ── Por talento (coste concentrado) ─────────────────────────────────
+  const talentoMap = new Map<number, {
+    talentName: string;
+    costeReal: number;
+    ingresosReales: number;
+    campanas: number;
+  }>();
+  let totalCostesTalentos = 0;
+  for (const r of rows) {
+    if (r.talentId === null || r.talentName === null) continue;
+    const entry = talentoMap.get(r.talentId) ?? {
+      talentName: r.talentName,
+      costeReal: 0,
+      ingresosReales: 0,
+      campanas: 0,
+    };
+    // "Coste real de talento" incluye pagos_talento + amountTalent pactado si no hay ingresos reales?
+    // Mantenemos honesto: usamos pagosTalentosReales — el coste real facturado a talento.
+    entry.costeReal      += r.pagosTalentosReales;
+    entry.ingresosReales += r.ingresosReales;
+    entry.campanas       += 1;
+    totalCostesTalentos  += r.pagosTalentosReales;
+    talentoMap.set(r.talentId, entry);
+  }
+
+  const topTalentosPorCoste: RankingTalentoRow[] = [...talentoMap.entries()]
+    .map(([talentId, v]) => {
+      const concentracion = totalCostesTalentos > 0
+        ? round1((v.costeReal / totalCostesTalentos) * 100)
+        : 0;
+      return {
+        talentId,
+        talentName:                 v.talentName,
+        costeReal:                  round2(v.costeReal),
+        ingresosReales:             round2(v.ingresosReales),
+        campanas:                   v.campanas,
+        concentracionPctSobreTotal: concentracion,
+      };
+    })
+    .filter((t) => t.costeReal > 0)
+    .sort((a, b) => b.costeReal - a.costeReal)
+    .slice(0, 10);
+
+  // ── Peores desviaciones (campañas concretas) ─────────────────────────
+  const peoresDesviaciones: RankingCampanaDesviacionRow[] = rows
+    .filter((r) =>
+      r.desviacionPct !== null && r.desviacionPct < 0 &&
+      r.margenPactadoPct !== null && r.margenRealPct !== null,
+    )
+    .sort((a, b) => (a.desviacionPct ?? 0) - (b.desviacionPct ?? 0))
+    .slice(0, 10)
+    .map((r) => ({
+      id:               r.id,
+      name:             r.name,
+      brandName:        r.brandName,
+      talentName:       r.talentName,
+      margenPactadoPct: r.margenPactadoPct ?? 0,
+      margenRealPct:    r.margenRealPct ?? 0,
+      desviacionPct:    r.desviacionPct ?? 0,
+      ingresosReales:   r.ingresosReales,
+    }));
+
+  return {
+    topMarcasPorMargen,
+    topMarcasPorFacturacion,
+    topTalentosPorCoste,
+    peoresDesviaciones,
+    // En el CRM actual no hay FK fiable de campaña/factura interna → billing_client.
+    // billing_clients se usa sólo para facturas EMITIDAS (issued_invoices).
+    // Se muestra como "aparcado honesto" en la UI.
+    clientesInsuficientes: true,
+  };
+}
+
+// ── Datos para gráficos (PR 6B) ───────────────────────────────────────────
+
+function computeCharts(rows: readonly RentabilidadRow[]): RentabilidadCharts {
+  const ingresosVsCostesTop15: ChartIngresosVsCostesPoint[] = [...rows]
+    .filter((r) => r.ingresosReales > 0 || r.costesReales > 0)
+    .sort((a, b) => (b.ingresosReales + b.costesReales) - (a.ingresosReales + a.costesReales))
+    .slice(0, 15)
+    .map((r) => ({
+      id:             r.id,
+      name:           r.name,
+      ingresosReales: r.ingresosReales,
+      costesReales:   r.costesReales,
+    }));
+
+  const marcaMap = new Map<string, number>();
+  for (const r of rows) {
+    if (r.brandName === null) continue;
+    const margenReal = r.ingresosReales - r.costesReales;
+    marcaMap.set(r.brandName, (marcaMap.get(r.brandName) ?? 0) + margenReal);
+  }
+  const margenPorMarcaTop10: ChartMargenPorMarcaPoint[] = [...marcaMap.entries()]
+    .filter(([, v]) => v !== 0)
+    .sort(([, a], [, b]) => b - a)
+    .slice(0, 10)
+    .map(([brandName, margenReal]) => ({ brandName, margenReal: round2(margenReal) }));
+
+  const talentoCosteMap = new Map<string, number>();
+  for (const r of rows) {
+    if (r.talentName === null || r.pagosTalentosReales <= 0) continue;
+    talentoCosteMap.set(r.talentName, (talentoCosteMap.get(r.talentName) ?? 0) + r.pagosTalentosReales);
+  }
+  const talentosPorCosteTop10: ChartTalentoCostePoint[] = [...talentoCosteMap.entries()]
+    .sort(([, a], [, b]) => b - a)
+    .slice(0, 10)
+    .map(([talentName, costeReal]) => ({ talentName, costeReal: round2(costeReal) }));
+
+  const distribucionMargen: ChartDistribucionMargen = {
+    negativo:  rows.filter((r) => r.estado === 'negativo').length,
+    bajo:      rows.filter((r) => r.estado === 'bajo').length,
+    rentable:  rows.filter((r) => r.estado === 'rentable').length,
+    sinDatos:  rows.filter((r) => r.estado === 'sin_datos' || r.estado === 'sin_ejecucion_suficiente').length,
+  };
+
+  return {
+    ingresosVsCostesTop15,
+    margenPorMarcaTop10,
+    talentosPorCosteTop10,
+    distribucionMargen,
+  };
 }


### PR DESCRIPTION
## Summary

Bloque 1 (rankings visuales) + Bloque 2 (gráficos Recharts) sobre la base ya en producción de PR 6A. Preserva todas las decisiones semánticas previas (pactado vs real, desviación pp, servicios aparcado, `LOW_MARGIN_THRESHOLD=20`, regla anti-ruido `ingresos<100€ → sin_ejecucion_suficiente`).

## Rankings implementados (Bloque 1)

`RentabilidadRankings.tsx` — server component con 4 cards + 1 aparcado honesto:

| Ranking | Fuente | Nota |
|---|---|---|
| Top marcas por margen real | Agregado por brandId, filtro `ingresosReales > 0` | Barra verde, muestra margen % |
| Top marcas por facturación asociada | Agregado por brandId, ordenado por ingresos | Barra naranja, muestra margen % + nº campañas |
| Top talentos por coste real | Agregado por talentId, filtro `costeReal > 0` | Barra ámbar + % de concentración sobre total |
| Peores desviaciones pactado → real | Filas ordenadas por `desviacionPct` ascendente | Link al detalle de campaña |
| **Clientes** | — | **Aparcado honesto**: no hay FK fiable de `campaigns → billing_clients` en el modelo actual. Copy explícito visible. |

## Gráficos implementados (Bloque 2)

`RentabilidadCharts.tsx` — `'use client'` con Recharts v3.8 ya integrado:

| Gráfico | Tipo | Empty state |
|---|---|---|
| Ingresos vs costes por campaña (top 15) | `BarChart` vertical, dos series | "Sin campañas con actividad económica" |
| Margen bruto por marca (top 10) | `BarChart` horizontal, `Cell` verde/rojo según signo | "Sin marcas con margen registrado" |
| Top talentos por coste real (top 10) | `BarChart` horizontal | "Sin pagos a talentos registrados" |
| Distribución por bandas | `PieChart` con 4 colores (rentable/bajo/negativo/sin datos) | "Sin datos suficientes" |

Protecciones:
- **`safeNumber()`** con `Number.isFinite` en todos los tick formatters y tooltips → no aparece `NaN`.
- **`truncateLabel()`** protege el layout de nombres largos (26 chars) y guarda el nombre completo para el tooltip.
- **`ResponsiveContainer`** en los 4 gráficos.
- **Empty state con `h-52`** en cada card.

## Confirmación de que servicios sigue aparcado

`RentabilidadServicioAparcado.tsx` sigue montado sin cambios. Test estático lo vigila: la página SÍ importa el bloque aparcado y sigue mostrando "Aparcado".

## Confirmación sin migración
✅ Cero cambios en `src/db/schema/`.
✅ Cero SQL nuevo. Test estático verifica que journal 0109 sigue siendo el último y no hay 0110/0111.

## Confirmación sin DB changes
✅ Nueva agregación en memoria a partir de los `RentabilidadRow[]` ya calculados por PR 6A.
✅ Cero `db.insert/update/delete`. Marker `'server-only'` sigue presente.

## Orden en la página (brief UX)

```
1. Header + filtros
2. KPIs
3. Lectura rápida
4. Rankings visuales   ← NUEVO PR 6B
5. Gráficos            ← NUEVO PR 6B
6. Tabla principal
7. Servicios aparcado
8. Accesos rápidos
```

Tests estáticos vigilan que los rankings van antes de la tabla y los gráficos entre rankings y tabla.

## Archivos tocados (5)

**Nuevos (3)**:
- `src/features/admin/finance-dashboard/components/rentabilidad/RentabilidadRankings.tsx`
- `src/features/admin/finance-dashboard/components/rentabilidad/RentabilidadCharts.tsx`
- `src/__tests__/server/finanzas-rentabilidad-6b.test.ts`

**Modificados (2)**:
- `src/lib/queries/financeDashboard/rentabilidad.ts` — añade tipos + `computeRankings` + `computeCharts` + shape actualizado de `RentabilidadData` + empty helpers
- `src/app/admin/(dashboard)/finanzas/rentabilidad/page.tsx` — importa y monta los 2 bloques nuevos entre lectura rápida y tabla

## Tests (34 nuevos, total 66 en rentabilidad)

`finanzas-rentabilidad-6b.test.ts`:

**Invariantes de 6A preservadas (5)**: server-only, sin mutaciones, sin Server Actions, `facturacion:read`, sin migración 0110.

**Query — nuevos exports (8)**: rankings types, charts types, `RentabilidadData` incluye ambos, `clientesInsuficientes = true`, filtros de protección, early return con empty helpers.

**RentabilidadRankings (6)**: existe, 4 rankings, clientes aparcado con copy explícito, progress bar, links al detalle, protección contra div/0.

**RentabilidadCharts (7)**: existe, `'use client'`, 4 gráficos, importa recharts (no d3/chart.js), `ResponsiveContainer ≥ 4`, `safeNumber`, empty states, `truncateLabel`.

**Servicios sigue aparcado (3)**: componente sigue, informativo, la página lo importa.

**Página monta los nuevos bloques (5)**: importa ambos, orden correcto (rankings < gráficos < tabla).

## Checks locales

- `npx tsc --noEmit` — sin errores en el proyecto
- `npx eslint` — verde en los 5 archivos tocados
- `npx jest` — **3767/3767 tests pasan** (34 nuevos + 3733 previos)

## Riesgos pendientes

- **PR 6C** queda pendiente para: alertas complejas, configuración de umbral por query param, export CSV. Sólo si aparece necesidad real.
- **Scatter/heatmap** descartados por poco valor con el volumen actual (200-1000 campañas).
- **Rentabilidad por servicio** sigue esperando clasificación estructurada en el catálogo (requiere migración cuando llegue).
- **Ranking de clientes** queda aparcado con copy honesto — requiere FK fiable de `campaigns → billing_clients` en el modelo del CRM.

## Test plan

- [ ] En preview, `/admin/finanzas/rentabilidad` muestra los 4 rankings y los 4 gráficos entre "Lectura rápida" y "Rentabilidad por campaña".
- [ ] Al filtrar por `?margen=bajo`, la tabla filtra pero KPIs, rankings y gráficos siguen mostrando el conjunto completo (no filtrado por chip).
- [ ] Un ranking sin datos muestra el copy de empty state, no una lista vacía o error.
- [ ] En el pie chart, si sólo hay una banda con valor > 0, se renderiza sin errores.
- [ ] Un talento con nombre muy largo se trunca en el gráfico horizontal pero el nombre completo aparece en el tooltip.
- [ ] El ranking "Clientes" muestra el aviso "Datos insuficientes" y el copy sobre el FK faltante.

🤖 Generated with [Claude Code](https://claude.com/claude-code)