### PR TITLE
feat(sorteos): Fase 1 PR2 — Audit UI admin + retención + blindaje portal marca

### DIFF
--- a/docs/legal/audit-retention.md
+++ b/docs/legal/audit-retention.md
@@ -1,0 +1,107 @@
+# Retención de `sp_audit_events`
+
+**Status**: política manual (sin cron). Última revisión: 2026-07-08.
+
+Fase 1 PR2 — se implementa la política de retención pero **sin cron automático**. La purga es un script manual con guard explícito, disponible en `scripts/purge-audit-events.ts`.
+
+## Qué son los eventos de auditoría
+
+`sp_audit_events` es el ledger append-only del módulo de Sorteos. Registra acciones sensibles que requieren forensics, antifraude o cumplimiento legal:
+
+- Consent: grant y revoke de consent con partners externos.
+- Participaciones en sorteos (pagados y gratuitos).
+- Elección de ganadores (acción admin).
+- Canjes en tienda.
+- Verificación y claim de misiones.
+- Reclamación de recompensa diaria (racha).
+
+Ver `AUDIT_ACTIONS` en `src/db/schema/giveawayAuditEvents.ts` para el set cerrado.
+
+## Qué datos contienen
+
+Por fila:
+
+| Columna | Contenido | PII directa |
+|---|---|---|
+| `userId` | id del usuario Better Auth (nullable) | Sí (indirecta — sujeta a acceso restringido) |
+| `action` | string del set cerrado | No |
+| `refType`, `refId` | referencia a entidad (giveaway, shop_item, mission…) | No |
+| `outcome` | success, blocked, error, rate_limited, already_done, unauthorized | No |
+| `ipHash` | SHA-256 sin salt global | Pseudonímica |
+| `userAgent` | primeros 500 chars del `user-agent` header | Pseudonímica |
+| `country` | ISO2 desde `x-vercel-ip-country` | Bajo |
+| `metadata` | jsonb — payload por-action | Depende — ver saneamiento |
+| `createdAt` | timestamp con TZ | No |
+
+## Qué NO contienen
+
+- **NO** contienen IP en claro. Solo el SHA-256 de la primera IP en `x-vercel-forwarded-for` / `x-forwarded-for`.
+- **NO** contienen email del usuario. Solo `userId` con FK a `user`.
+- **NO** contienen tokens OAuth, access tokens ni refresh tokens.
+- **NO** contienen contraseñas, secrets, ni credenciales de partners externos.
+- **NO** contienen dirección postal ni Steam trade URL (esos viven en `player_profiles`, con acceso restringido separado).
+
+La vista admin (`/admin/giveaways/auditoria`) aplica saneamiento adicional en render vía `src/lib/audit/redactMetadata.ts`:
+
+- Whitelist de claves de metadata visibles (giveawayId, coinsEarned, etc.). Todo lo demás se colapsa como "N ocultos".
+- Cualquier clave que matchee `email|token|secret|password|apiKey|authorization|cookie|jwt|refresh|access|steamId|tradeUrl|address|phone|nif|dni|iban|card|cvv` se sustituye por `[redacted]`.
+- `ipHash` truncado a 12 caracteres visibles.
+- `userAgent` truncado y resumido a ~60 caracteres.
+
+## Retención recomendada
+
+**Default: 730 días (~2 años)**.
+
+Fundamentos:
+- Cubre el marco típico de reclamos administrativos en España (procedimiento sancionador ordinario máximo 12 meses + margen).
+- Suficiente para tendencias antifraude interanuales.
+- Balance entre observabilidad y GDPR (art. 5.1.e, limitación del plazo de conservación).
+
+Ajustable por argumento CLI del script entre 30 y 3650 días.
+
+## Comando dry-run
+
+Dry-run es el modo por defecto. **No borra nada**. Muestra el conteo por `action` y el total que se borrarían.
+
+```bash
+DOTENV_CONFIG_PATH=.env.local npx tsx -r dotenv/config scripts/purge-audit-events.ts
+```
+
+Con retención personalizada:
+
+```bash
+DOTENV_CONFIG_PATH=.env.local npx tsx -r dotenv/config scripts/purge-audit-events.ts --older-than-days=365
+```
+
+## Comando real (con guard)
+
+El script solo borra si la variable de entorno `CONFIRM_PURGE_AUDIT_EVENTS` vale **exactamente** `I_ACCEPT_PURGE_AUDIT_EVENTS`.
+
+```bash
+DOTENV_CONFIG_PATH=.env.local \
+CONFIRM_PURGE_AUDIT_EVENTS=I_ACCEPT_PURGE_AUDIT_EVENTS \
+npx tsx -r dotenv/config scripts/purge-audit-events.ts --older-than-days=730
+```
+
+Cualquier otro valor (incluido `1`, `true`, `yes`) mantiene el modo dry-run. **Esto es intencional para evitar accidentes.**
+
+## Riesgos
+
+- **Irreversible**. La tabla no tiene versionado. Un borrado erróneo no se puede recuperar sin restore de backup Neon (ver política en `docs/tech-debt.md` § TD-15 sobre Preview aislado; el mismo backup automático de Neon aplica).
+- **Sin cron por diseño (por ahora)**. Un cron automático implica ejecutar borrado sin supervisión. En Fase 1 PR2 hemos decidido dejarlo manual para forzar decisión humana en cada ronda.
+- **Backups Neon**. Neon mantiene point-in-time recovery (PITR) por defecto en el plan actual del proyecto. Un borrado accidental puede restaurarse en la ventana de PITR.
+- **Cambios de retención rápidos** pueden borrar datos aún útiles. Cambiar `--older-than-days` de 730 a 90 vaciaría ~85% de la tabla. El dry-run **es la salvaguarda operativa** — hay que revisarlo antes.
+
+## Estado de automatización
+
+- **Hoy**: manual, ejecución mensual/trimestral por operaciones.
+- **Futuro**: se considerará añadir cron en `/api/cron/purge-audit-events` con la misma retención (730 días) y guard `CRON_SECRET`. Requiere PR separada + tests de idempotencia + señal explícita en `docs/tech-debt.md`.
+
+## Referencias
+
+- Schema: `src/db/schema/giveawayAuditEvents.ts`
+- Helper insert: `src/lib/audit/logGiveawayEvent.ts`
+- Saneamiento vista: `src/lib/audit/redactMetadata.ts`
+- UI admin: `src/app/admin/(dashboard)/giveaways/auditoria/`
+- Permiso: `sorteos:audit` en `src/lib/permissions.ts` (solo admin, admin_limited_tasks, manager)
+- Script: `scripts/purge-audit-events.ts`

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -150,6 +150,54 @@ Ninguno calcula "cobrado real" o "pendiente real" a partir de `.paidAmount`. Los
 
 ---
 
+## MEDIO — Infra / entornos
+
+### TD-15 · Preview Deployments sin DB ni Blob aislados
+**Contexto:** El guard `VERCEL_ENV === 'preview'` en `scripts/migrate.ts:31` evita que los Previews ejecuten migraciones contra producción (PR #108, 2026-06-26). Correcto pero insuficiente.
+
+**Problema:** No existe una entrada `DATABASE_URL` con target **Preview únicamente** en Vercel. Los Previews heredan la misma `DATABASE_URL` (y probablemente el mismo `BLOB_READ_WRITE_TOKEN`) de Production. Consecuencia: un upload o cualquier `INSERT/UPDATE/DELETE` desde un Preview Deployment escribe directamente en la base de datos y en el Vercel Blob de producción.
+
+**Impacto real detectado (2026-07-08):** Impide QA end-to-end del importador de nóminas ELEVATEX. Un PDF de prueba en Preview quedaría persistido en el Blob de producción para siempre. QA cerrada con Nivel 1 (tests) + Nivel 2 (audit read-only) porque Nivel 3 no es seguro sin este aislamiento.
+
+**Acción sugerida (Opción B histórica de `project_preview_db_state.md`):**
+1. Neon Console → crear branch de producción llamado `preview` (Copy-on-write, coste cero).
+2. Vercel Dashboard → Settings → Environment Variables → añadir `DATABASE_URL` con target Preview únicamente, apuntando a esa branch.
+3. Opcional pero recomendable: crear un segundo Vercel Blob store aislado y añadir `BLOB_READ_WRITE_TOKEN` con target Preview únicamente.
+4. Verificar en el siguiente Preview Deployment que `getRuntimeContext()` o similar reporta la DB aislada.
+
+**Confirmación de éxito:** un `console.log(process.env.DATABASE_URL?.slice(0, 40))` en un endpoint Preview debe devolver un endpoint Neon distinto al de producción.
+
+**Riesgo mientras no se haga:** ALTO en el sentido de "puede haber accidente si alguien confunde Preview con dev y prueba escrituras". Ningún accidente conocido a día de hoy. Guard del migrate ya cubre el peor caso (migraciones automáticas).
+
+**Esfuerzo:** 15-30 min de configuración, sin código.
+
+### TD-16 · `invoices.txId` sin UNIQUE index (dedup payroll solo en aplicación)
+**Archivo:** `src/db/schema/invoices.ts` — la column existe con index no-unique (`invoices_expense_subtype_idx` y otros), pero no hay `UNIQUE` sobre `txId`.
+
+**Problema:** El importador de nóminas deduplica antes del INSERT vía `getExistingPayrollTxIds()` (memoria de aplicación). Dos uploads concurrentes del mismo PDF podrían crear duplicados si la lectura del set y el INSERT no son atómicos. El scope real es reducido — el importador no es multi-usuario ni de alta concurrencia — pero el blindaje es una migración muy pequeña.
+
+**Verificación de estado (2026-07-08):** `scripts/audit-nominas.ts` bloque 7 confirmó cero duplicados en producción. No hay accidente conocido.
+
+**Acción sugerida:** Migration Drizzle añadiendo `uniqueIndex('invoices_tx_id_unique').on(t.txId)`. Debe filtrar solo filas con `txId IS NOT NULL` — muchas filas de cuota autónomo y recurring tienen txId con otro formato, y hay filas con txId=null (ids 81-86 de Pablo, ver audit). Considerar partial unique index para PostgreSQL:
+`CREATE UNIQUE INDEX invoices_tx_id_unique ON invoices (tx_id) WHERE tx_id IS NOT NULL;`
+
+**Riesgo:** BAJO hoy, MEDIO en cuanto haya más importaciones simultáneas.
+
+**Esfuerzo:** 30 min (migration + regenerar journal + test estático).
+
+### TD-17 · Carpeta `proyectozack/` duplicada dentro del repo
+**Archivo:** `proyectozack/` (raíz del repo, sin trackear en git — aparece como `??` en `git status`).
+
+**Problema:** Contiene copias de `src/__mocks__/lib/db.ts`, `src/__mocks__/lib/email.ts` y `scripts/migrate.ts`. Jest emite warnings `jest-haste-map: duplicate manual mock found` cada vez que corren los tests. No causa fallos (los mocks son idénticos), pero es ruido de infraestructura.
+
+**Acción sugerida:** Confirmar que no es material vivo (probablemente un artefacto de refactor o clone). Borrar la carpeta o añadirla al `.gitignore` explícito + `jest.config` `modulePathIgnorePatterns`.
+
+**Riesgo:** BAJO. Confirmar con el usuario antes de borrar.
+
+**Esfuerzo:** 5 min.
+
+---
+
 ## Rutas que necesitan clarificación de propósito
 
 | Ruta | Descripción | Estado |

--- a/scripts/purge-audit-events.ts
+++ b/scripts/purge-audit-events.ts
@@ -1,0 +1,129 @@
+/**
+ * Purga manual de eventos antiguos en `sp_audit_events`.
+ *
+ * Uso:
+ *
+ *   # Dry-run (default):
+ *   DOTENV_CONFIG_PATH=.env.local npx tsx -r dotenv/config scripts/purge-audit-events.ts
+ *   DOTENV_CONFIG_PATH=.env.local npx tsx -r dotenv/config scripts/purge-audit-events.ts --older-than-days=365
+ *
+ *   # Ejecución real (requiere guard explícito):
+ *   DOTENV_CONFIG_PATH=.env.local \
+ *   CONFIRM_PURGE_AUDIT_EVENTS=I_ACCEPT_PURGE_AUDIT_EVENTS \
+ *   npx tsx -r dotenv/config scripts/purge-audit-events.ts --older-than-days=730
+ *
+ * Reglas:
+ *   - Dry-run por defecto — nunca borra si no está el guard exacto.
+ *   - Guard: `CONFIRM_PURGE_AUDIT_EVENTS === 'I_ACCEPT_PURGE_AUDIT_EVENTS'`.
+ *   - Retención por defecto: 730 días (~2 años).
+ *   - Solo procesa filas con `created_at < NOW() - INTERVAL '<days> days'`.
+ *   - Salida agrupada por `action` + total. Sin datos sensibles.
+ *
+ * Ver `docs/legal/audit-retention.md` para política.
+ */
+
+import 'dotenv/config';
+import { drizzle } from 'drizzle-orm/neon-http';
+import { neon } from '@neondatabase/serverless';
+import { lt, sql } from 'drizzle-orm';
+import { giveawayAuditEvents } from '../src/db/schema/giveawayAuditEvents';
+
+export const PURGE_GUARD_ENV = 'CONFIRM_PURGE_AUDIT_EVENTS';
+export const PURGE_GUARD_VALUE = 'I_ACCEPT_PURGE_AUDIT_EVENTS';
+export const PURGE_DEFAULT_DAYS = 730;
+export const PURGE_MIN_DAYS = 30;
+export const PURGE_MAX_DAYS = 3650;
+
+interface Args {
+  readonly olderThanDays: number;
+}
+
+export function parseArgs(argv: readonly string[]): Args {
+  let olderThanDays = PURGE_DEFAULT_DAYS;
+  for (const arg of argv) {
+    if (arg.startsWith('--older-than-days=')) {
+      const raw = arg.slice('--older-than-days='.length);
+      const n = Number(raw);
+      if (!Number.isFinite(n) || n < PURGE_MIN_DAYS || n > PURGE_MAX_DAYS) {
+        throw new Error(
+          `--older-than-days debe estar entre ${PURGE_MIN_DAYS} y ${PURGE_MAX_DAYS} (recibido: "${raw}")`,
+        );
+      }
+      olderThanDays = Math.floor(n);
+    }
+  }
+  return { olderThanDays };
+}
+
+export function isPurgeConfirmed(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env[PURGE_GUARD_ENV] === PURGE_GUARD_VALUE;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const confirmed = isPurgeConfirmed();
+
+  const url = process.env.DATABASE_URL;
+  if (!url) {
+    console.error('Missing DATABASE_URL — abort.');
+    process.exit(1);
+  }
+  const client = neon(url);
+  const db = drizzle(client);
+
+  const cutoff = new Date(Date.now() - args.olderThanDays * 24 * 60 * 60 * 1000);
+  console.log(`── purge-audit-events ──────────────────────────────────`);
+  console.log(`Modo:        ${confirmed ? 'REAL (borrado)' : 'dry-run'}`);
+  console.log(`Retención:   ${args.olderThanDays} días`);
+  console.log(`Cutoff:      < ${cutoff.toISOString()}`);
+  console.log(`──────────────────────────────────────────────────────`);
+
+  const rowsByAction = await db
+    .select({
+      action: giveawayAuditEvents.action,
+      count: sql<number>`count(*)::int`,
+    })
+    .from(giveawayAuditEvents)
+    .where(lt(giveawayAuditEvents.createdAt, cutoff))
+    .groupBy(giveawayAuditEvents.action);
+
+  const total = rowsByAction.reduce((acc, r) => acc + Number(r.count), 0);
+
+  if (rowsByAction.length === 0 || total === 0) {
+    console.log('Sin eventos en el rango. Nada que hacer.');
+    return;
+  }
+
+  console.log('Conteo por acción:');
+  for (const r of rowsByAction) {
+    console.log(`  ${r.action.padEnd(28)} ${String(r.count).padStart(8)}`);
+  }
+  console.log(`  ${''.padEnd(28)} ${'─'.repeat(8)}`);
+  console.log(`  ${'TOTAL'.padEnd(28)} ${String(total).padStart(8)}`);
+
+  if (!confirmed) {
+    console.log('');
+    console.log(`⚠  DRY-RUN — no se ha borrado nada.`);
+    console.log(`   Para borrar realmente, exporta:`);
+    console.log(`   ${PURGE_GUARD_ENV}=${PURGE_GUARD_VALUE}`);
+    console.log(`   y vuelve a ejecutar el script con los MISMOS argumentos.`);
+    return;
+  }
+
+  console.log('');
+  console.log('Ejecutando DELETE …');
+  const deleted = await db.delete(giveawayAuditEvents).where(lt(giveawayAuditEvents.createdAt, cutoff));
+  const affected = typeof deleted === 'object' && deleted !== null && 'rowCount' in deleted
+    ? (deleted as { rowCount: number | null }).rowCount ?? total
+    : total;
+  console.log(`✓ Borrados ${affected} eventos.`);
+}
+
+if (require.main === module) {
+  main()
+    .catch((e: unknown) => {
+      console.error(e instanceof Error ? e.message : e);
+      process.exit(1);
+    })
+    .finally(() => process.exit(0));
+}

--- a/src/__tests__/server/assert-allowed-coin-source-hooks.test.ts
+++ b/src/__tests__/server/assert-allowed-coin-source-hooks.test.ts
@@ -20,16 +20,23 @@ const WRITER_FILES = [
 ] as const;
 
 describe('assertAllowedCoinSource — enganchado en escrituras a coinTransactions', () => {
-  it.each(WRITER_FILES)('%s importa assertAllowedCoinSource', (file) => {
+  it.each(WRITER_FILES)('%s importa assertAllowedCoinSource o su wrapper con audit', (file) => {
     const src = read(file);
-    expect(src).toMatch(/assertAllowedCoinSource/);
-    expect(src).toMatch(/from ['"]@\/lib\/rewards\/allowed-coin-sources['"]/);
+    // Fase 1 PR2 sustituyó el import directo por el wrapper `assertAllowedCoinSourceOrLog`
+    // que registra outcome='blocked' antes de propagar la excepción. El original o el
+    // wrapper cumplen el contrato — ambos aseguran el check antes del insert.
+    const importsOriginal = /from ['"]@\/lib\/rewards\/allowed-coin-sources['"]/.test(src);
+    const importsWrapper = /from ['"]@\/lib\/audit\/logBlockedCoinSource['"]/.test(src);
+    expect(importsOriginal || importsWrapper).toBe(true);
+    expect(src).toMatch(/assertAllowedCoinSource(OrLog)?\(/);
   });
 
   it.each(WRITER_FILES)('%s llama a assertAllowedCoinSource antes de db.insert(coinTransactions)', (file) => {
     const src = read(file);
-    // Cada `db.insert(coinTransactions)` debe estar precedido en las 3
-    // líneas anteriores por una llamada a `assertAllowedCoinSource(...)`.
+    // Cada `db.insert(coinTransactions)` debe estar precedido por una llamada a
+    // `assertAllowedCoinSource(...)` o `assertAllowedCoinSourceOrLog(...)`.
+    // Ampliamos la ventana a 8 líneas porque el wrapper puede tomar más líneas
+    // por llevar objeto de contexto (userId/action/refType/refId).
     const lines = src.split(/\r?\n/);
     const insertLines: number[] = [];
     for (let i = 0; i < lines.length; i += 1) {
@@ -37,8 +44,8 @@ describe('assertAllowedCoinSource — enganchado en escrituras a coinTransaction
     }
     expect(insertLines.length).toBeGreaterThan(0);
     for (const idx of insertLines) {
-      const window = lines.slice(Math.max(0, idx - 4), idx).join('\n');
-      expect(window).toMatch(/assertAllowedCoinSource\(/);
+      const window = lines.slice(Math.max(0, idx - 10), idx).join('\n');
+      expect(window).toMatch(/assertAllowedCoinSource(OrLog)?\(/);
     }
   });
 

--- a/src/__tests__/server/blocked-coin-source-audit.test.ts
+++ b/src/__tests__/server/blocked-coin-source-audit.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Sorteos Fase 1 PR2 — trazabilidad de intentos bloqueados por
+ * `assertAllowedCoinSource`.
+ *
+ * `assertAllowedCoinSourceOrLog(source, ctx)` reutiliza el action del set
+ * cerrado y añade outcome='blocked'. NO añade nueva action al schema.
+ * Sin migración.
+ */
+
+const mockLogGiveawayEvent = jest.fn();
+
+jest.mock('@/lib/audit/logGiveawayEvent', () => ({
+  logGiveawayEvent: (...args: unknown[]) => mockLogGiveawayEvent(...args),
+}));
+
+import { assertAllowedCoinSourceOrLog } from '@/lib/audit/logBlockedCoinSource';
+import { ForbiddenCoinSourceError } from '@/lib/rewards/allowed-coin-sources';
+
+beforeEach(() => {
+  mockLogGiveawayEvent.mockClear();
+});
+
+describe('assertAllowedCoinSourceOrLog', () => {
+  it('no lanza y NO loguea cuando source es allowed', async () => {
+    await expect(
+      assertAllowedCoinSourceOrLog('sorteo', {
+        userId: 'user-1',
+        action: 'giveaway_participate',
+      }),
+    ).resolves.toBeUndefined();
+    expect(mockLogGiveawayEvent).not.toHaveBeenCalled();
+  });
+
+  it('para cada source allowed (racha, mision, sorteo, tienda, admin) no loguea', async () => {
+    const sources = ['racha', 'mision', 'sorteo', 'tienda', 'admin'] as const;
+    for (const s of sources) {
+      await assertAllowedCoinSourceOrLog(s, { userId: null, action: 'shop_redeem' });
+    }
+    expect(mockLogGiveawayEvent).not.toHaveBeenCalled();
+  });
+
+  it('lanza ForbiddenCoinSourceError cuando source no está permitida', async () => {
+    await expect(
+      assertAllowedCoinSourceOrLog('apuesta', {
+        userId: 'user-1',
+        action: 'giveaway_participate',
+        refType: 'giveaway',
+        refId: 42,
+      }),
+    ).rejects.toBeInstanceOf(ForbiddenCoinSourceError);
+  });
+
+  it('loguea con outcome="blocked" al bloquear', async () => {
+    await expect(
+      assertAllowedCoinSourceOrLog('apuesta', {
+        userId: 'user-1',
+        action: 'giveaway_participate',
+        refType: 'giveaway',
+        refId: 42,
+      }),
+    ).rejects.toBeDefined();
+    expect(mockLogGiveawayEvent).toHaveBeenCalledTimes(1);
+    const call = mockLogGiveawayEvent.mock.calls[0]![0] as Record<string, unknown>;
+    expect(call.outcome).toBe('blocked');
+    expect(call.userId).toBe('user-1');
+    expect(call.action).toBe('giveaway_participate');
+    expect(call.refType).toBe('giveaway');
+    expect(call.refId).toBe(42);
+    const metadata = call.metadata as Record<string, unknown>;
+    expect(metadata.source).toBe('apuesta');
+    expect(metadata.reason).toBe('forbidden_coin_source');
+  });
+
+  it('reutiliza actions existentes (giveaway_participate, shop_redeem, streak_claim, mission_claim)', async () => {
+    const cases = [
+      { action: 'giveaway_participate' as const, source: 'jackpot' },
+      { action: 'shop_redeem' as const, source: 'wager' },
+      { action: 'streak_claim' as const, source: 'ruleta' },
+      { action: 'mission_claim' as const, source: 'case_battle' },
+    ];
+    for (const c of cases) {
+      mockLogGiveawayEvent.mockClear();
+      await expect(
+        assertAllowedCoinSourceOrLog(c.source, { userId: 'u', action: c.action }),
+      ).rejects.toBeDefined();
+      const call = mockLogGiveawayEvent.mock.calls[0]![0] as Record<string, unknown>;
+      expect(call.action).toBe(c.action);
+      expect(call.outcome).toBe('blocked');
+    }
+  });
+
+  it('no filtra source en la metadata (queremos ver la string que intentó pasar)', async () => {
+    await expect(
+      assertAllowedCoinSourceOrLog('partner_deposit', { userId: null, action: 'shop_redeem' }),
+    ).rejects.toBeDefined();
+    const call = mockLogGiveawayEvent.mock.calls[0]![0] as Record<string, unknown>;
+    const metadata = call.metadata as Record<string, unknown>;
+    expect(metadata.source).toBe('partner_deposit');
+  });
+});

--- a/src/__tests__/server/brand-portal-idor.test.ts
+++ b/src/__tests__/server/brand-portal-idor.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Sorteos Fase 1 PR2 — blindaje portal marca contra IDOR.
+ *
+ * Contrato: `getBrandCampaigns(brandUserId)` y `getBrandProposals(brandUserId)`
+ * DEBEN filtrar internamente por `brandUserId` recibido, sin confiar en
+ * ninguna capa superior. Un cambio futuro que elimine el where clause
+ * rompería estos tests.
+ *
+ * No hay migración ni cambio de código en estas queries — solo estos
+ * tests defensivos (no existían antes).
+ */
+
+// ── Mocks ────────────────────────────────────────────────────────────────
+
+interface Captured {
+  where?: unknown;
+  with?: unknown;
+  orderBy?: unknown;
+}
+
+let capturedCampaigns: Captured | null = null;
+let capturedProposals: Captured | null = null;
+
+const brandARows = [{ id: 1, brandUserId: 'brand-A', title: 'campaña A' }];
+const brandBRows = [{ id: 2, brandUserId: 'brand-B', title: 'campaña B' }];
+
+const proposalARows = [{ id: 10, brandUserId: 'brand-A', title: 'propuesta A' }];
+const proposalBRows = [{ id: 20, brandUserId: 'brand-B', title: 'propuesta B' }];
+
+jest.mock('@/lib/db', () => ({
+  db: {
+    query: {
+      brandCampaigns: {
+        findMany: jest.fn((opts: Captured) => {
+          capturedCampaigns = opts;
+          const w = opts.where as { column?: string; value?: unknown } | undefined;
+          if (w && w.column === 'brandUserId') {
+            return [...brandARows, ...brandBRows].filter((r) => r.brandUserId === w.value);
+          }
+          return [...brandARows, ...brandBRows];
+        }),
+      },
+      talentProposals: {
+        findMany: jest.fn((opts: Captured) => {
+          capturedProposals = opts;
+          const w = opts.where as { column?: string; value?: unknown } | undefined;
+          if (w && w.column === 'brandUserId') {
+            return [...proposalARows, ...proposalBRows].filter((r) => r.brandUserId === w.value);
+          }
+          return [...proposalARows, ...proposalBRows];
+        }),
+      },
+    },
+  },
+}));
+
+// Drizzle helpers: eq/and/desc devuelven objetos capturables por el mock.
+jest.mock('drizzle-orm', () => ({
+  eq: (col: unknown, value: unknown) => {
+    const colStr = typeof col === 'string' ? col : (col as { name?: string })?.name ?? 'unknown';
+    return { column: colStr, value };
+  },
+  and: (...args: unknown[]) => ({ and: args }),
+  desc: (col: unknown) => ({ desc: col }),
+  or: (...args: unknown[]) => ({ or: args }),
+}));
+
+jest.mock('@/db/schema', () => ({
+  brandCampaigns: { brandUserId: { name: 'brandUserId' }, createdAt: { name: 'createdAt' }, talentId: { name: 'talentId' } },
+  talentProposals: { brandUserId: { name: 'brandUserId' }, createdAt: { name: 'createdAt' } },
+}));
+
+// ── Imports tras mocks ───────────────────────────────────────────────────
+
+import { getBrandCampaigns, getBrandProposals } from '@/lib/queries/brands';
+
+beforeEach(() => {
+  capturedCampaigns = null;
+  capturedProposals = null;
+});
+
+describe('getBrandCampaigns — IDOR blindaje', () => {
+  it('marca A solo ve sus campañas, nunca las de marca B', async () => {
+    const result = await getBrandCampaigns('brand-A');
+    expect(result).toHaveLength(1);
+    expect(result[0]!.brandUserId).toBe('brand-A');
+    const bad = result.find((r) => r.brandUserId === 'brand-B');
+    expect(bad).toBeUndefined();
+  });
+
+  it('marca B solo ve sus campañas, nunca las de marca A', async () => {
+    const result = await getBrandCampaigns('brand-B');
+    expect(result).toHaveLength(1);
+    expect(result[0]!.brandUserId).toBe('brand-B');
+    const bad = result.find((r) => r.brandUserId === 'brand-A');
+    expect(bad).toBeUndefined();
+  });
+
+  it('la query pasa el where clause por brandUserId (contrato)', async () => {
+    await getBrandCampaigns('brand-A');
+    expect(capturedCampaigns).not.toBeNull();
+    const w = capturedCampaigns?.where as { column?: string; value?: unknown };
+    expect(w.column).toBe('brandUserId');
+    expect(w.value).toBe('brand-A');
+  });
+});
+
+describe('getBrandProposals — IDOR blindaje', () => {
+  it('marca A solo ve sus propuestas, nunca las de marca B', async () => {
+    const result = await getBrandProposals('brand-A');
+    expect(result).toHaveLength(1);
+    expect(result[0]!.brandUserId).toBe('brand-A');
+    const bad = result.find((r) => r.brandUserId === 'brand-B');
+    expect(bad).toBeUndefined();
+  });
+
+  it('marca B solo ve sus propuestas, nunca las de marca A', async () => {
+    const result = await getBrandProposals('brand-B');
+    expect(result).toHaveLength(1);
+    expect(result[0]!.brandUserId).toBe('brand-B');
+    const bad = result.find((r) => r.brandUserId === 'brand-A');
+    expect(bad).toBeUndefined();
+  });
+
+  it('la query pasa el where clause por brandUserId (contrato)', async () => {
+    await getBrandProposals('brand-A');
+    expect(capturedProposals).not.toBeNull();
+    const w = capturedProposals?.where as { column?: string; value?: unknown };
+    expect(w.column).toBe('brandUserId');
+    expect(w.value).toBe('brand-A');
+  });
+});
+
+describe('regresión — filtro brandUserId no debe eliminarse', () => {
+  it('el código fuente de brands.ts contiene el eq(...brandUserId, brandUserId)', () => {
+    // Test estático — bloquea regresión si alguien elimina el filtro.
+    const fs = jest.requireActual('fs') as typeof import('fs');
+    const path = jest.requireActual('path') as typeof import('path');
+    const source = fs.readFileSync(
+      path.join(process.cwd(), 'src/lib/queries/brands.ts'),
+      'utf8',
+    );
+    expect(source).toMatch(/eq\(brandCampaigns\.brandUserId,\s*brandUserId\)/);
+    expect(source).toMatch(/eq\(talentProposals\.brandUserId,\s*brandUserId\)/);
+  });
+});

--- a/src/__tests__/server/purge-audit-events-guard.test.ts
+++ b/src/__tests__/server/purge-audit-events-guard.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Sorteos Fase 1 PR2 — script purge-audit-events.
+ *
+ * Verifica el contrato del guard:
+ *   - Dry-run por defecto.
+ *   - Guard exacto: CONFIRM_PURGE_AUDIT_EVENTS=I_ACCEPT_PURGE_AUDIT_EVENTS.
+ *   - Retención por defecto: 730 días. Rango [30, 3650].
+ */
+
+import {
+  PURGE_GUARD_ENV,
+  PURGE_GUARD_VALUE,
+  PURGE_DEFAULT_DAYS,
+  PURGE_MIN_DAYS,
+  PURGE_MAX_DAYS,
+  parseArgs,
+  isPurgeConfirmed,
+} from '../../../scripts/purge-audit-events';
+
+// Cast local para el mock de env en tests — evitamos NodeJS.ProcessEnv rígido.
+const env = (obj: Record<string, string>): NodeJS.ProcessEnv => obj as NodeJS.ProcessEnv;
+
+describe('purge-audit-events — guard constants', () => {
+  it('PURGE_GUARD_ENV es CONFIRM_PURGE_AUDIT_EVENTS', () => {
+    expect(PURGE_GUARD_ENV).toBe('CONFIRM_PURGE_AUDIT_EVENTS');
+  });
+
+  it('PURGE_GUARD_VALUE es I_ACCEPT_PURGE_AUDIT_EVENTS (exacto)', () => {
+    expect(PURGE_GUARD_VALUE).toBe('I_ACCEPT_PURGE_AUDIT_EVENTS');
+  });
+
+  it('PURGE_DEFAULT_DAYS es 730 (~2 años)', () => {
+    expect(PURGE_DEFAULT_DAYS).toBe(730);
+  });
+
+  it('rango de días permitido: [30, 3650]', () => {
+    expect(PURGE_MIN_DAYS).toBe(30);
+    expect(PURGE_MAX_DAYS).toBe(3650);
+  });
+});
+
+describe('parseArgs — retención', () => {
+  it('sin argumentos → 730 días', () => {
+    expect(parseArgs([])).toEqual({ olderThanDays: 730 });
+  });
+
+  it('--older-than-days=365', () => {
+    expect(parseArgs(['--older-than-days=365'])).toEqual({ olderThanDays: 365 });
+  });
+
+  it('--older-than-days=30 (mínimo)', () => {
+    expect(parseArgs(['--older-than-days=30'])).toEqual({ olderThanDays: 30 });
+  });
+
+  it('--older-than-days=3650 (máximo)', () => {
+    expect(parseArgs(['--older-than-days=3650'])).toEqual({ olderThanDays: 3650 });
+  });
+
+  it('rechaza <30 días', () => {
+    expect(() => parseArgs(['--older-than-days=29'])).toThrow();
+    expect(() => parseArgs(['--older-than-days=0'])).toThrow();
+    expect(() => parseArgs(['--older-than-days=-100'])).toThrow();
+  });
+
+  it('rechaza >3650 días', () => {
+    expect(() => parseArgs(['--older-than-days=3651'])).toThrow();
+    expect(() => parseArgs(['--older-than-days=999999'])).toThrow();
+  });
+
+  it('rechaza valores no numéricos', () => {
+    expect(() => parseArgs(['--older-than-days=abc'])).toThrow();
+    expect(() => parseArgs(['--older-than-days='])).toThrow();
+  });
+
+  it('ignora argumentos desconocidos', () => {
+    expect(parseArgs(['--random-arg=1'])).toEqual({ olderThanDays: 730 });
+  });
+});
+
+describe('isPurgeConfirmed — guard estricto', () => {
+  it('sin variable → false', () => {
+    expect(isPurgeConfirmed(env({}))).toBe(false);
+  });
+
+  it('con valor exacto → true', () => {
+    expect(isPurgeConfirmed(env({ CONFIRM_PURGE_AUDIT_EVENTS: 'I_ACCEPT_PURGE_AUDIT_EVENTS' }))).toBe(true);
+  });
+
+  it('con "true" → false (intencional — bloquea accidentes)', () => {
+    expect(isPurgeConfirmed(env({ CONFIRM_PURGE_AUDIT_EVENTS: 'true' }))).toBe(false);
+  });
+
+  it('con "1" → false', () => {
+    expect(isPurgeConfirmed(env({ CONFIRM_PURGE_AUDIT_EVENTS: '1' }))).toBe(false);
+  });
+
+  it('con "yes" → false', () => {
+    expect(isPurgeConfirmed(env({ CONFIRM_PURGE_AUDIT_EVENTS: 'yes' }))).toBe(false);
+  });
+
+  it('con valor con espacios → false (no trim)', () => {
+    expect(isPurgeConfirmed(env({ CONFIRM_PURGE_AUDIT_EVENTS: ' I_ACCEPT_PURGE_AUDIT_EVENTS ' }))).toBe(false);
+  });
+
+  it('con valor case-different → false', () => {
+    expect(isPurgeConfirmed(env({ CONFIRM_PURGE_AUDIT_EVENTS: 'i_accept_purge_audit_events' }))).toBe(false);
+  });
+});

--- a/src/__tests__/server/raffle-winner-audit.test.ts
+++ b/src/__tests__/server/raffle-winner-audit.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Sorteos Fase 1 PR2 — pickRaffleWinnerAction emite audit
+ * `raffle_winner_picked`.
+ *
+ * Verificación estática del source: bloqueamos regresiones si alguien
+ * borra el `logGiveawayEvent(...raffle_winner_picked)`.
+ *
+ * Nota: no ejecutamos la Server Action end-to-end en unit test (requiere
+ * DB, sesión, revalidate). El test estático es suficiente para prevenir
+ * la regresión que motivó esta PR.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('pickRaffleWinnerAction — audit trace', () => {
+  const source = fs.readFileSync(
+    path.join(process.cwd(), 'src/app/admin/(dashboard)/giveaways/actions.ts'),
+    'utf8',
+  );
+
+  it('importa logGiveawayEvent', () => {
+    expect(source).toMatch(/from ['"]@\/lib\/audit\/logGiveawayEvent['"]/);
+  });
+
+  it('llama logGiveawayEvent con action="raffle_winner_picked"', () => {
+    expect(source).toMatch(/logGiveawayEvent\(\s*\{[\s\S]*?raffle_winner_picked/);
+  });
+
+  it('outcome="success" en el logueo', () => {
+    expect(source).toMatch(/raffle_winner_picked[\s\S]*?outcome:\s*['"]success['"]/);
+  });
+
+  it('captura adminUserId en metadata', () => {
+    expect(source).toMatch(/adminUserId/);
+  });
+
+  it('captura giveawayId, winnerCount, entriesCount en metadata', () => {
+    expect(source).toMatch(/giveawayId/);
+    expect(source).toMatch(/winnerCount/);
+    expect(source).toMatch(/entriesCount/);
+  });
+
+  it('el admin viene de requirePermission (no de fuente no verificada)', () => {
+    expect(source).toMatch(/const\s*\{\s*user:\s*adminUser\s*\}\s*=\s*await\s+requirePermission\(\s*['"]sorteos['"]\s*,\s*['"]write['"]\s*\)/);
+  });
+});

--- a/src/__tests__/server/sorteos-audit-permissions.test.ts
+++ b/src/__tests__/server/sorteos-audit-permissions.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Sorteos Fase 1 PR2 — permiso `sorteos:audit`.
+ *
+ * La vista `/admin/giveaways/auditoria` requiere `sorteos:audit`, distinto
+ * de `sorteos:read`. La razón: la vista puede contener metadata,
+ * userAgent, ipHash y trazas de otros usuarios. Solo roles con permiso
+ * explícito lo ven.
+ */
+
+// permissions.ts importa @/lib/auth-guard → @/lib/auth → better-auth (ESM),
+// que no carga bajo Jest. Mockeamos auth-guard antes del import de permissions.
+jest.mock('@/lib/auth-guard', () => ({
+  requireAnyRole: jest.fn(),
+}));
+jest.mock('@/lib/team-roles', () => ({
+  ASSIGNABLE_TEAM_ROLES: [],
+  isAssignableTeamUser: () => false,
+}));
+
+import { PERMISSIONS } from '@/lib/permissions';
+
+describe('PERMISSIONS.sorteos.audit', () => {
+  it('está definido en el mapa', () => {
+    const scope = PERMISSIONS.sorteos as { audit?: readonly string[] };
+    expect(scope.audit).toBeDefined();
+    expect(Array.isArray(scope.audit)).toBe(true);
+  });
+
+  it('incluye admin, admin_limited_tasks, manager', () => {
+    const audit = (PERMISSIONS.sorteos as { audit?: readonly string[] }).audit ?? [];
+    expect(audit).toEqual(expect.arrayContaining(['admin', 'admin_limited_tasks', 'manager']));
+  });
+
+  it('excluye staff y ops explícitamente', () => {
+    const audit = (PERMISSIONS.sorteos as { audit?: readonly string[] }).audit ?? [];
+    expect(audit).not.toContain('staff');
+    expect(audit).not.toContain('ops');
+  });
+
+  it('excluye roles brand/creator/editor/talent_manager/finance/analyst', () => {
+    const audit = (PERMISSIONS.sorteos as { audit?: readonly string[] }).audit ?? [];
+    for (const excluded of ['brand', 'creator', 'editor', 'talent_manager', 'finance', 'analyst']) {
+      expect(audit).not.toContain(excluded);
+    }
+  });
+
+  it('no expone strings sensibles como valor', () => {
+    const audit = (PERMISSIONS.sorteos as { audit?: readonly string[] }).audit ?? [];
+    for (const role of audit) {
+      expect(typeof role).toBe('string');
+      expect(role.length).toBeLessThan(50);
+    }
+  });
+
+  it('sorteos:read sigue permitiendo staff/ops (regresión)', () => {
+    const read = PERMISSIONS.sorteos.read ?? [];
+    expect(read).toContain('staff');
+    expect(read).toContain('ops');
+  });
+});

--- a/src/__tests__/server/sorteos-audit-redact-metadata.test.ts
+++ b/src/__tests__/server/sorteos-audit-redact-metadata.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Sorteos Fase 1 PR2 — saneamiento de metadata en vista admin.
+ *
+ * `redactAuditMetadata` es el gate PII/tokens del render. Solo claves
+ * whitelisted se muestran. Claves sensibles se redactan explícitamente.
+ * Strings largos se truncan. Claves ocultas se cuentan pero no se pintan.
+ */
+
+import { redactAuditMetadata, truncateIpHash, summarizeUserAgent } from '@/lib/audit/redactMetadata';
+
+describe('redactAuditMetadata', () => {
+  it('null/undefined → sin visible ni oculto', () => {
+    expect(redactAuditMetadata(null)).toEqual({ visible: {}, hiddenCount: 0 });
+    expect(redactAuditMetadata(undefined)).toEqual({ visible: {}, hiddenCount: 0 });
+  });
+
+  it('claves whitelisted se muestran', () => {
+    const input = { giveawayId: 42, coinsEarned: 20, category: 'skin' };
+    expect(redactAuditMetadata(input)).toEqual({
+      visible: { giveawayId: 42, coinsEarned: 20, category: 'skin' },
+      hiddenCount: 0,
+    });
+  });
+
+  it('claves no whitelisted se cuentan como ocultas', () => {
+    const input = { giveawayId: 1, foo: 'bar', baz: 42 };
+    const r = redactAuditMetadata(input);
+    expect(r.visible).toEqual({ giveawayId: 1 });
+    expect(r.hiddenCount).toBe(2);
+  });
+
+  it('claves sensibles (email/token/apiKey/etc) se redactan como "[redacted]"', () => {
+    const sensitiveInput = {
+      giveawayId: 1,
+      email: 'user@example.com',
+      accessToken: 'super-secret',
+      apiKey: 'ak-123',
+      steamId: '765611...',
+      steamTradeUrl: 'https://steamcommunity.com/tradeoffer/new/?partner=...',
+      phone: '+34600000000',
+      iban: 'ES12...',
+      password: '...',
+    };
+    const r = redactAuditMetadata(sensitiveInput);
+    expect(r.visible.giveawayId).toBe(1);
+    for (const key of ['email', 'accessToken', 'apiKey', 'steamId', 'steamTradeUrl', 'phone', 'iban', 'password']) {
+      expect(r.visible[key]).toBe('[redacted]');
+    }
+    expect(r.hiddenCount).toBe(0);
+  });
+
+  it('nunca expone valores concretos de email/token en visible', () => {
+    const r = redactAuditMetadata({ email: 'attacker@bad.tld', authorization: 'Bearer abc.def.ghi' });
+    for (const value of Object.values(r.visible)) {
+      expect(String(value)).not.toContain('attacker@bad.tld');
+      expect(String(value)).not.toContain('abc.def.ghi');
+    }
+  });
+
+  it('strings > 200 chars se truncan', () => {
+    const long = 'x'.repeat(500);
+    const r = redactAuditMetadata({ reason: long });
+    const value = r.visible.reason as string;
+    expect(value.length).toBeLessThanOrEqual(201);
+    expect(value.endsWith('…')).toBe(true);
+  });
+
+  it('arrays u otros primitivos van a { value: ... }', () => {
+    expect(redactAuditMetadata('foo')).toEqual({ visible: { value: 'foo' }, hiddenCount: 0 });
+    expect(redactAuditMetadata([1, 2, 3])).toEqual({ visible: { value: [1, 2, 3] }, hiddenCount: 0 });
+  });
+});
+
+describe('truncateIpHash', () => {
+  it('null/undefined → "—"', () => {
+    expect(truncateIpHash(null)).toBe('—');
+    expect(truncateIpHash(undefined)).toBe('—');
+  });
+
+  it('trunca a un máximo de 12 caracteres', () => {
+    const full = 'a'.repeat(64);
+    expect(truncateIpHash(full).length).toBe(12);
+  });
+
+  it('nunca devuelve el hash completo aunque venga limpio', () => {
+    const hash = '9baacc48c5ee80f4552ad722c16c20fea4e785ab6fa4dc25106e067507f489f1';
+    const truncated = truncateIpHash(hash);
+    expect(truncated).toBe(hash.slice(0, 12));
+    expect(truncated).not.toBe(hash);
+  });
+});
+
+describe('summarizeUserAgent', () => {
+  it('null/undefined → "—"', () => {
+    expect(summarizeUserAgent(null)).toBe('—');
+    expect(summarizeUserAgent(undefined)).toBe('—');
+  });
+
+  it('trunca strings largos con "…"', () => {
+    const huge = 'Mozilla/5.0 ' + 'x'.repeat(500);
+    const result = summarizeUserAgent(huge);
+    expect(result.length).toBeLessThanOrEqual(60);
+    expect(result.endsWith('…')).toBe(true);
+  });
+
+  it('extrae el primer segmento antes de "("', () => {
+    const ua = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+    const summary = summarizeUserAgent(ua);
+    expect(summary.startsWith('Mozilla/5.0')).toBe(true);
+    expect(summary.length).toBeLessThanOrEqual(60);
+  });
+});

--- a/src/__tests__/server/sorteos-auditoria-page-guard.test.ts
+++ b/src/__tests__/server/sorteos-auditoria-page-guard.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Sorteos Fase 1 PR2 — la ruta `/admin/giveaways/auditoria` DEBE requerir
+ * `sorteos:audit`. Nunca `sorteos:read` (permitiría staff/ops → fuga PII).
+ *
+ * Test estático source-scan: bloquea regresiones si alguien afloja el
+ * guard sin querer.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const PAGE_PATH = path.join(
+  process.cwd(),
+  'src/app/admin/(dashboard)/giveaways/auditoria/page.tsx',
+);
+
+describe('/admin/giveaways/auditoria — guard estático', () => {
+  const source = fs.readFileSync(PAGE_PATH, 'utf8');
+
+  it('existe el archivo de la página', () => {
+    expect(fs.existsSync(PAGE_PATH)).toBe(true);
+  });
+
+  it('llama requirePermission("sorteos", "audit")', () => {
+    expect(source).toMatch(/requirePermission\(\s*['"]sorteos['"]\s*,\s*['"]audit['"]/);
+  });
+
+  it('NO llama requirePermission("sorteos", "read") (evita permisos amplios)', () => {
+    expect(source).not.toMatch(/requirePermission\(\s*['"]sorteos['"]\s*,\s*['"]read['"]/);
+  });
+
+  it('la página consume la query saneada `listAuditEvents`', () => {
+    expect(source).toMatch(/listAuditEvents/);
+  });
+
+  it('la fila usa AuditoriaRow (que aplica redactAuditMetadata en render)', () => {
+    expect(source).toMatch(/AuditoriaRow/);
+  });
+
+  it('no expone ipHash completo en la vista (delega a AuditoriaRow → truncateIpHash)', () => {
+    const rowSource = fs.readFileSync(
+      path.join(process.cwd(), 'src/app/admin/(dashboard)/giveaways/auditoria/AuditoriaRow.tsx'),
+      'utf8',
+    );
+    expect(rowSource).toMatch(/truncateIpHash\(row\.ipHash\)/);
+    expect(rowSource).toMatch(/redactAuditMetadata\(row\.metadata\)/);
+    expect(rowSource).toMatch(/summarizeUserAgent\(row\.userAgent\)/);
+  });
+
+  it('la fila NO renderiza row.userAgent ni row.ipHash directamente sin helper', () => {
+    const rowSource = fs.readFileSync(
+      path.join(process.cwd(), 'src/app/admin/(dashboard)/giveaways/auditoria/AuditoriaRow.tsx'),
+      'utf8',
+    );
+    // Simple heurística — {row.ipHash} o {row.userAgent} sin envolver debería estar ausente.
+    expect(rowSource).not.toMatch(/\{row\.ipHash\}/);
+    expect(rowSource).not.toMatch(/\{row\.userAgent\}/);
+  });
+});

--- a/src/__tests__/server/sorteos-fase1-pr2-no-migration.test.ts
+++ b/src/__tests__/server/sorteos-fase1-pr2-no-migration.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Sorteos Fase 1 PR2 — verificación estática de "sin migración".
+ *
+ * La PR NO introduce migraciones nuevas. La última migration en el journal
+ * debe seguir siendo 0109. Si alguien añade una migration nueva, este
+ * test debe actualizarse Y el brief de la PR debe reflejarlo.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const DRIZZLE_DIR = path.join(process.cwd(), 'drizzle');
+
+describe('Fase 1 PR2 — sin migración nueva', () => {
+  it('la última migration en el journal es 0109_*', () => {
+    const files = fs.readdirSync(DRIZZLE_DIR).filter((f) => f.endsWith('.sql'));
+    const migrations = files
+      .filter((f) => /^\d{4}_/.test(f))
+      .sort();
+    const last = migrations[migrations.length - 1];
+    expect(last).toBeDefined();
+    expect(last!).toMatch(/^0109_/);
+  });
+
+  it('no existe migration 0110 ni 0111', () => {
+    const files = fs.readdirSync(DRIZZLE_DIR);
+    expect(files.find((f) => f.startsWith('0110_'))).toBeUndefined();
+    expect(files.find((f) => f.startsWith('0111_'))).toBeUndefined();
+  });
+
+  it('el journal de meta refleja 0109 como último', () => {
+    const journalPath = path.join(DRIZZLE_DIR, 'meta', '_journal.json');
+    const raw = fs.readFileSync(journalPath, 'utf8');
+    const parsed = JSON.parse(raw) as { entries?: Array<{ tag: string }> };
+    const entries = parsed.entries ?? [];
+    const last = entries[entries.length - 1];
+    expect(last).toBeDefined();
+    expect(last!.tag).toMatch(/^0109_/);
+  });
+});

--- a/src/app/admin/(dashboard)/giveaways/actions.ts
+++ b/src/app/admin/(dashboard)/giveaways/actions.ts
@@ -10,6 +10,7 @@ import { db } from '@/lib/db';
 import { parseFormData } from '@/lib/forms/parseFormData';
 import { firstError } from '@/lib/forms/firstError';
 import { logRedacted } from '@/lib/log';
+import { logGiveawayEvent } from '@/lib/audit/logGiveawayEvent';
 import { StrictIdSchema, StrictBooleanSchema } from '@/lib/schemas/common';
 import {
   BadgeSchema,
@@ -154,7 +155,7 @@ export async function pickRaffleWinnerAction(giveawayId: number): Promise<
   | { ok: true; winner: { userId: string; displayName: string } }
   | { ok: false; error: string }
 > {
-  await requirePermission('sorteos', 'write');
+  const { user: adminUser } = await requirePermission('sorteos', 'write');
   const parsed = StrictIdSchema.safeParse(giveawayId);
   if (!parsed.success) return { ok: false, error: 'ID inválido' };
 
@@ -164,6 +165,11 @@ export async function pickRaffleWinnerAction(giveawayId: number): Promise<
     .where(eq(giveaways.id, parsed.data))
     .limit(1);
   if (!giveaway) return { ok: false, error: 'Sorteo no encontrado' };
+
+  const entriesCountRow = await db.execute(sql`
+    SELECT count(*)::int AS c FROM giveaway_entries WHERE giveaway_id = ${parsed.data}
+  `);
+  const entriesCount = Number((entriesCountRow.rows[0] as { c: number } | undefined)?.c ?? 0);
 
   // Ganador random. Postgres `random()` es suficiente para promoción interna.
   // No es RNG certificado — para sorteos con impacto legal habría que
@@ -190,6 +196,20 @@ export async function pickRaffleWinnerAction(giveawayId: number): Promise<
   await db.update(giveaways)
     .set({ status: 'ended', updatedAt: new Date() })
     .where(eq(giveaways.id, parsed.data));
+
+  await logGiveawayEvent({
+    userId:  winner.user_id,
+    action:  'raffle_winner_picked',
+    outcome: 'success',
+    refType: 'giveaway',
+    refId:   parsed.data,
+    metadata: {
+      giveawayId:   parsed.data,
+      winnerCount:  1,
+      entriesCount,
+      adminUserId:  adminUser.id,
+    },
+  });
 
   revalidateGiveawayPaths();
   return { ok: true, winner: { userId: winner.user_id, displayName: winner.name } };

--- a/src/app/admin/(dashboard)/giveaways/auditoria/AuditoriaFilters.tsx
+++ b/src/app/admin/(dashboard)/giveaways/auditoria/AuditoriaFilters.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+
+interface Initial {
+  from?: string;
+  to?: string;
+  action?: string;
+  outcome?: string;
+  userId?: string;
+  refType?: string;
+  country?: string;
+}
+
+interface Props {
+  readonly initial: Initial;
+  readonly actionOptions: readonly string[];
+  readonly outcomeOptions: readonly string[];
+}
+
+// Excepción documentada a la Regla 14 (typescript.md): esto es un
+// filter form de solo lectura, no un data-entry form. Cada campo es
+// independiente (no hay validación cruzada) y el "submit" solo hace
+// una navegación con URL params. React Hook Form + Zod resolver
+// añadiría ~30 LOC sin beneficio real. La validación fuerte vive en
+// `parseAuditSearch` (server-side, Zod) — este cliente solo controla
+// UX del picker.
+
+export function AuditoriaFilters({ initial, actionOptions, outcomeOptions }: Props): React.ReactElement {
+  const router = useRouter();
+  const [from, setFrom] = useState(initial.from ?? '');
+  const [to, setTo] = useState(initial.to ?? '');
+  const [action, setAction] = useState(initial.action ?? '');
+  const [outcome, setOutcome] = useState(initial.outcome ?? '');
+  const [userId, setUserId] = useState(initial.userId ?? '');
+  const [refType, setRefType] = useState(initial.refType ?? '');
+  const [country, setCountry] = useState(initial.country ?? '');
+
+  function submit(e: React.FormEvent): void {
+    e.preventDefault();
+    const params = new URLSearchParams();
+    if (from) params.set('from', from);
+    if (to) params.set('to', to);
+    if (action) params.set('action', action);
+    if (outcome) params.set('outcome', outcome);
+    if (userId) params.set('userId', userId);
+    if (refType) params.set('refType', refType);
+    if (country) params.set('country', country);
+    const qs = params.toString();
+    router.push(qs ? `/admin/giveaways/auditoria?${qs}` : '/admin/giveaways/auditoria');
+  }
+
+  function clearAll(): void {
+    setFrom(''); setTo(''); setAction(''); setOutcome(''); setUserId(''); setRefType(''); setCountry('');
+    router.push('/admin/giveaways/auditoria');
+  }
+
+  return (
+    <form
+      onSubmit={submit}
+      className="rounded-lg border border-white/10 bg-white/5 p-4"
+    >
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+        <label className="block">
+          <span className="mb-1 block text-xs uppercase tracking-widest text-white/50">Desde</span>
+          <input
+            type="date"
+            value={from}
+            onChange={(e) => setFrom(e.target.value)}
+            className="w-full rounded-md border border-white/10 bg-black/40 px-2 py-1.5 text-sm text-white"
+          />
+        </label>
+        <label className="block">
+          <span className="mb-1 block text-xs uppercase tracking-widest text-white/50">Hasta</span>
+          <input
+            type="date"
+            value={to}
+            onChange={(e) => setTo(e.target.value)}
+            className="w-full rounded-md border border-white/10 bg-black/40 px-2 py-1.5 text-sm text-white"
+          />
+        </label>
+        <label className="block">
+          <span className="mb-1 block text-xs uppercase tracking-widest text-white/50">Acción</span>
+          <select
+            value={action}
+            onChange={(e) => setAction(e.target.value)}
+            className="w-full rounded-md border border-white/10 bg-black/40 px-2 py-1.5 text-sm text-white"
+          >
+            <option value="">— cualquiera —</option>
+            {actionOptions.map((a) => (
+              <option key={a} value={a}>{a}</option>
+            ))}
+          </select>
+        </label>
+        <label className="block">
+          <span className="mb-1 block text-xs uppercase tracking-widest text-white/50">Outcome</span>
+          <select
+            value={outcome}
+            onChange={(e) => setOutcome(e.target.value)}
+            className="w-full rounded-md border border-white/10 bg-black/40 px-2 py-1.5 text-sm text-white"
+          >
+            <option value="">— cualquiera —</option>
+            {outcomeOptions.map((o) => (
+              <option key={o} value={o}>{o}</option>
+            ))}
+          </select>
+        </label>
+        <label className="block">
+          <span className="mb-1 block text-xs uppercase tracking-widest text-white/50">User ID</span>
+          <input
+            type="text"
+            value={userId}
+            onChange={(e) => setUserId(e.target.value)}
+            className="w-full rounded-md border border-white/10 bg-black/40 px-2 py-1.5 text-sm text-white"
+            maxLength={200}
+          />
+        </label>
+        <label className="block">
+          <span className="mb-1 block text-xs uppercase tracking-widest text-white/50">Ref type</span>
+          <input
+            type="text"
+            value={refType}
+            onChange={(e) => setRefType(e.target.value)}
+            className="w-full rounded-md border border-white/10 bg-black/40 px-2 py-1.5 text-sm text-white"
+            maxLength={40}
+          />
+        </label>
+        <label className="block">
+          <span className="mb-1 block text-xs uppercase tracking-widest text-white/50">País (ISO2)</span>
+          <input
+            type="text"
+            value={country}
+            onChange={(e) => setCountry(e.target.value)}
+            className="w-full rounded-md border border-white/10 bg-black/40 px-2 py-1.5 text-sm uppercase text-white"
+            maxLength={2}
+          />
+        </label>
+        <div className="flex items-end gap-2">
+          <button
+            type="submit"
+            className="rounded-md bg-white/10 px-4 py-1.5 text-sm text-white hover:bg-white/20"
+          >
+            Aplicar
+          </button>
+          <button
+            type="button"
+            onClick={clearAll}
+            className="rounded-md border border-white/10 px-4 py-1.5 text-sm text-white/70 hover:bg-white/10"
+          >
+            Limpiar
+          </button>
+        </div>
+      </div>
+    </form>
+  );
+}

--- a/src/app/admin/(dashboard)/giveaways/auditoria/AuditoriaRow.tsx
+++ b/src/app/admin/(dashboard)/giveaways/auditoria/AuditoriaRow.tsx
@@ -1,0 +1,69 @@
+import { redactAuditMetadata, summarizeUserAgent, truncateIpHash } from '@/lib/audit/redactMetadata';
+import type { AuditEventRow } from '@/lib/queries/giveawayAudit';
+
+interface Props {
+  readonly row: AuditEventRow;
+}
+
+export function AuditoriaRow({ row }: Props): React.ReactElement {
+  const { visible, hiddenCount } = redactAuditMetadata(row.metadata);
+  const outcomeClass =
+    row.outcome === 'success' ? 'bg-emerald-500/15 text-emerald-300' :
+    row.outcome === 'blocked' ? 'bg-red-500/15 text-red-300' :
+    row.outcome === 'error' ? 'bg-orange-500/15 text-orange-300' :
+    row.outcome === 'rate_limited' ? 'bg-yellow-500/15 text-yellow-300' :
+    row.outcome === 'unauthorized' ? 'bg-purple-500/15 text-purple-300' :
+    'bg-white/10 text-white/60';
+
+  return (
+    <tr className="border-b border-white/5 align-top">
+      <td className="whitespace-nowrap px-3 py-2 text-xs text-white/70">
+        {row.createdAt.toISOString().replace('T', ' ').slice(0, 19)}
+      </td>
+      <td className="px-3 py-2 text-xs">
+        <code>{row.action}</code>
+      </td>
+      <td className="px-3 py-2 text-xs">
+        <span className={`inline-block rounded px-2 py-0.5 ${outcomeClass}`}>{row.outcome}</span>
+      </td>
+      <td className="px-3 py-2 text-xs">
+        {row.userId ? (
+          <div className="flex flex-col">
+            <span className="text-white">{row.userName ?? '(sin nombre)'}</span>
+            <code className="text-[10px] text-white/40">{row.userId.slice(0, 12)}</code>
+          </div>
+        ) : (
+          <span className="text-white/40">—</span>
+        )}
+      </td>
+      <td className="px-3 py-2 text-xs">
+        {row.refType || row.refId ? (
+          <code className="text-white/70">{row.refType ?? '?'}#{row.refId ?? '?'}</code>
+        ) : (
+          <span className="text-white/40">—</span>
+        )}
+      </td>
+      <td className="px-3 py-2 text-xs text-white/60">
+        {row.country ?? '—'}
+      </td>
+      <td className="px-3 py-2 text-xs" title="Solo primeros 12 caracteres del hash SHA-256">
+        <code className="text-white/50">{truncateIpHash(row.ipHash)}</code>
+      </td>
+      <td className="px-3 py-2 text-xs text-white/60" title={row.userAgent ?? ''}>
+        {summarizeUserAgent(row.userAgent)}
+      </td>
+      <td className="px-3 py-2 text-xs">
+        {Object.keys(visible).length === 0 && hiddenCount === 0 ? (
+          <span className="text-white/40">—</span>
+        ) : (
+          <details>
+            <summary className="cursor-pointer text-white/60 hover:text-white">
+              ver {Object.keys(visible).length} campo(s){hiddenCount > 0 ? ` +${hiddenCount} ocultos` : ''}
+            </summary>
+            <pre className="mt-2 max-w-md overflow-x-auto rounded bg-black/40 p-2 text-[11px] text-white/70">{JSON.stringify(visible, null, 2)}</pre>
+          </details>
+        )}
+      </td>
+    </tr>
+  );
+}

--- a/src/app/admin/(dashboard)/giveaways/auditoria/page.tsx
+++ b/src/app/admin/(dashboard)/giveaways/auditoria/page.tsx
@@ -1,0 +1,166 @@
+import Link from 'next/link';
+import { requirePermission } from '@/lib/permissions';
+import {
+  listAuditEvents,
+  countAuditEventsByAction,
+  AUDIT_DEFAULT_PAGE_SIZE,
+} from '@/lib/queries/giveawayAudit';
+import { AUDIT_ACTIONS, AUDIT_OUTCOMES } from '@/db/schema/giveawayAuditEvents';
+import { parseAuditSearch, decodeCursor } from '@/lib/schemas/giveawayAudit';
+import { AuditoriaFilters } from './AuditoriaFilters';
+import { AuditoriaRow } from './AuditoriaRow';
+
+export const dynamic = 'force-dynamic';
+
+interface Search {
+  from?: string;
+  to?: string;
+  action?: string;
+  outcome?: string;
+  userId?: string;
+  refType?: string;
+  country?: string;
+  cursor?: string;
+}
+
+export default async function AuditoriaPage({
+  searchParams,
+}: {
+  searchParams: Promise<Search>;
+}): Promise<React.ReactElement> {
+  await requirePermission('sorteos', 'audit');
+
+  const raw = await searchParams;
+  const filters = parseAuditSearch({ ...raw });
+  const cursor = decodeCursor(raw.cursor);
+
+  const [{ rows, nextCursor }, byAction] = await Promise.all([
+    listAuditEvents({
+      from: filters.from ?? null,
+      to: filters.to ?? null,
+      action: filters.action ?? null,
+      outcome: filters.outcome ?? null,
+      userId: filters.userId ?? null,
+      refType: filters.refType ?? null,
+      country: filters.country ?? null,
+      cursor,
+      pageSize: AUDIT_DEFAULT_PAGE_SIZE,
+    }),
+    countAuditEventsByAction({ from: filters.from ?? null, to: filters.to ?? null }),
+  ]);
+
+  const nextHref = buildNextHref(raw, nextCursor);
+
+  return (
+    <div className="mx-auto max-w-7xl px-4 py-8 text-white">
+      <header className="mb-6 flex items-baseline justify-between">
+        <div>
+          <h1 className="text-3xl font-display uppercase tracking-tight">Auditoría de Sorteos</h1>
+          <p className="mt-1 text-sm text-white/60">
+            Eventos registrados en <code>sp_audit_events</code>. Sin PII directa: IP hasheada, sin emails.
+          </p>
+        </div>
+        <Link
+          href="/admin/giveaways"
+          className="text-sm text-white/70 underline underline-offset-4 hover:text-white"
+        >
+          ← Volver a Sorteos
+        </Link>
+      </header>
+
+      <section className="mb-6 rounded-lg border border-white/10 bg-white/5 p-4">
+        <h2 className="mb-3 text-xs font-semibold uppercase tracking-widest text-white/60">
+          Conteo por acción {filters.from || filters.to ? '(rango filtrado)' : '(sin filtro de fecha)'}
+        </h2>
+        <div className="flex flex-wrap gap-2">
+          {AUDIT_ACTIONS.map((a) => (
+            <span key={a} className="inline-flex items-baseline gap-2 rounded-md bg-white/5 px-3 py-1.5 text-xs">
+              <span className="text-white/50">{a}</span>
+              <span className="font-mono text-white">{byAction[a] ?? 0}</span>
+            </span>
+          ))}
+        </div>
+      </section>
+
+      <AuditoriaFilters
+        initial={cleanInitial(raw)}
+        actionOptions={[...AUDIT_ACTIONS]}
+        outcomeOptions={[...AUDIT_OUTCOMES]}
+      />
+
+      <section className="mt-6 rounded-lg border border-white/10 bg-white/5 overflow-hidden">
+        {rows.length === 0 ? (
+          <div className="p-8 text-center text-sm text-white/50">
+            Sin eventos para los filtros seleccionados.
+          </div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-white/10 text-left text-xs uppercase tracking-widest text-white/50">
+                <th className="px-3 py-2">Fecha</th>
+                <th className="px-3 py-2">Acción</th>
+                <th className="px-3 py-2">Outcome</th>
+                <th className="px-3 py-2">Usuario</th>
+                <th className="px-3 py-2">Ref</th>
+                <th className="px-3 py-2">País</th>
+                <th className="px-3 py-2">IP hash</th>
+                <th className="px-3 py-2">User-Agent</th>
+                <th className="px-3 py-2">Metadata</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r) => (
+                <AuditoriaRow key={r.id} row={r} />
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+
+      {nextHref && (
+        <nav className="mt-4 flex justify-end">
+          <Link
+            href={nextHref}
+            className="rounded-md bg-white/10 px-4 py-2 text-sm text-white hover:bg-white/20"
+          >
+            Siguiente página →
+          </Link>
+        </nav>
+      )}
+
+      <p className="mt-8 text-xs text-white/40">
+        Retención: la política actual está en <code>docs/legal/audit-retention.md</code>. Los eventos no se borran automáticamente.
+      </p>
+    </div>
+  );
+}
+
+function cleanInitial(raw: Search): { from?: string; to?: string; action?: string; outcome?: string; userId?: string; refType?: string; country?: string } {
+  const out: { from?: string; to?: string; action?: string; outcome?: string; userId?: string; refType?: string; country?: string } = {};
+  if (raw.from) out.from = raw.from;
+  if (raw.to) out.to = raw.to;
+  if (raw.action) out.action = raw.action;
+  if (raw.outcome) out.outcome = raw.outcome;
+  if (raw.userId) out.userId = raw.userId;
+  if (raw.refType) out.refType = raw.refType;
+  if (raw.country) out.country = raw.country;
+  return out;
+}
+
+function encodeCursor(cursor: { createdAt: string; id: number }): string {
+  return Buffer.from(JSON.stringify(cursor), 'utf8').toString('base64url');
+}
+
+function buildNextHref(current: Search, next: { createdAt: string; id: number } | null): string | null {
+  if (!next) return null;
+  const params = new URLSearchParams();
+  if (current.from) params.set('from', current.from);
+  if (current.to) params.set('to', current.to);
+  if (current.action) params.set('action', current.action);
+  if (current.outcome) params.set('outcome', current.outcome);
+  if (current.userId) params.set('userId', current.userId);
+  if (current.refType) params.set('refType', current.refType);
+  if (current.country) params.set('country', current.country);
+  params.set('cursor', encodeCursor(next));
+  return `/admin/giveaways/auditoria?${params.toString()}`;
+}

--- a/src/app/sorteos/plataforma/actions.ts
+++ b/src/app/sorteos/plataforma/actions.ts
@@ -29,8 +29,8 @@ import {
 } from '@/lib/giveaway-platform/constants';
 import { evaluateAndClaimMissions } from '@/lib/giveaway-platform/missions';
 import { getCoinBalance } from '@/lib/queries/giveawayPlatform';
-import { assertAllowedCoinSource } from '@/lib/rewards/allowed-coin-sources';
 import { logGiveawayEvent } from '@/lib/audit/logGiveawayEvent';
+import { assertAllowedCoinSourceOrLog } from '@/lib/audit/logBlockedCoinSource';
 
 type ActionResult<T = undefined> =
   | { ok: true; data?: T }
@@ -99,7 +99,12 @@ export async function participateInGiveaway(input: unknown): Promise<ActionResul
   const awardCoins = giveaway.entryAwardCoins;
 
   if (awardCoins > 0) {
-    assertAllowedCoinSource('sorteo');
+    await assertAllowedCoinSourceOrLog('sorteo', {
+      userId: sessionUser.id,
+      action: 'giveaway_participate',
+      refType: 'giveaway',
+      refId: giveawayId,
+    });
     await db.insert(coinTransactions).values({
       userId: sessionUser.id,
       amount: awardCoins,
@@ -167,7 +172,12 @@ export async function claimDailyReward(): Promise<ActionResult<{ coinsEarned: nu
   }
 
   const coinsEarned = STREAK_REWARDS[day - 1] ?? STREAK_REWARDS[0];
-  assertAllowedCoinSource('racha');
+  await assertAllowedCoinSourceOrLog('racha', {
+    userId: sessionUser.id,
+    action: 'streak_claim',
+    refType: 'streak_day',
+    refId: day,
+  });
   await db.insert(coinTransactions).values({
     userId: sessionUser.id,
     amount: coinsEarned,
@@ -305,7 +315,12 @@ export async function redeemShopItem(input: unknown): Promise<RedeemResult> {
     .returning({ id: shopItems.id });
   if (stockUpdated.length === 0) return { ok: false, code: 'out_of_stock', error: 'Item agotado' };
 
-  assertAllowedCoinSource('tienda');
+  await assertAllowedCoinSourceOrLog('tienda', {
+    userId: sessionUser.id,
+    action: 'shop_redeem',
+    refType: 'shop_item',
+    refId: shopItemId,
+  });
   await db.insert(coinTransactions).values({
     userId: sessionUser.id,
     amount: -item.costCoins,

--- a/src/app/sorteos/plataforma/discord-mission-action.ts
+++ b/src/app/sorteos/plataforma/discord-mission-action.ts
@@ -15,8 +15,8 @@ import {
 import { getConnectedAccount } from '@/lib/queries/connectedSocialAccounts';
 import { decrypt } from '@/lib/crypto/token-encryption';
 import { DISCORD_GUILD_MEMBER_MODE } from '@/features/giveaway-platform/constants/discord-missions';
-import { assertAllowedCoinSource } from '@/lib/rewards/allowed-coin-sources';
 import { logGiveawayEvent } from '@/lib/audit/logGiveawayEvent';
+import { assertAllowedCoinSourceOrLog } from '@/lib/audit/logBlockedCoinSource';
 
 /** Shape mínimo del array que devuelve /users/@me/guilds — solo usamos `id`. */
 const DiscordGuildListSchema = z.array(z.object({ id: z.string() }).passthrough());
@@ -195,7 +195,12 @@ export async function verifyDiscordMission(input: unknown): Promise<DiscordVerif
     return { ok: false, code: 'already_claimed', message: 'Ya has reclamado esta misión' };
   }
 
-  assertAllowedCoinSource('mision');
+  await assertAllowedCoinSourceOrLog('mision', {
+    userId: user.id,
+    action: 'mission_claim',
+    refType: 'mission',
+    refId: missionId,
+  });
   await db.insert(coinTransactions).values({
     userId: user.id,
     amount: mission.rewardCoins,

--- a/src/app/sorteos/plataforma/twitch-mission-action.ts
+++ b/src/app/sorteos/plataforma/twitch-mission-action.ts
@@ -16,8 +16,8 @@ import {
 import { getConnectedAccount } from '@/lib/queries/connectedSocialAccounts';
 import { decrypt } from '@/lib/crypto/token-encryption';
 import { TWITCH_FOLLOW_CHANNEL_MODE } from '@/features/giveaway-platform/constants/twitch-missions';
-import { assertAllowedCoinSource } from '@/lib/rewards/allowed-coin-sources';
 import { logGiveawayEvent } from '@/lib/audit/logGiveawayEvent';
+import { assertAllowedCoinSourceOrLog } from '@/lib/audit/logBlockedCoinSource';
 
 /**
  * Server action — verifica una misión Twitch (follow al canal) y, si
@@ -218,7 +218,12 @@ export async function verifyTwitchMission(input: unknown): Promise<TwitchVerifyR
     return { ok: false, code: 'already_claimed', message: 'Ya has reclamado esta misión' };
   }
 
-  assertAllowedCoinSource('mision');
+  await assertAllowedCoinSourceOrLog('mision', {
+    userId: user.id,
+    action: 'mission_claim',
+    refType: 'mission',
+    refId: missionId,
+  });
   await db.insert(coinTransactions).values({
     userId: user.id,
     amount: mission.rewardCoins,

--- a/src/lib/audit/logBlockedCoinSource.ts
+++ b/src/lib/audit/logBlockedCoinSource.ts
@@ -1,0 +1,47 @@
+import { assertAllowedCoinSource, ForbiddenCoinSourceError } from '@/lib/rewards/allowed-coin-sources';
+import { logGiveawayEvent } from '@/lib/audit/logGiveawayEvent';
+import type { AuditAction } from '@/db/schema/giveawayAuditEvents';
+
+/**
+ * Ejecuta `assertAllowedCoinSource(source)` y, si lanza
+ * `ForbiddenCoinSourceError`, registra un evento de auditoría con
+ * `outcome: 'blocked'` antes de propagar la excepción.
+ *
+ * Reutiliza `action`s del set cerrado (`giveaway_participate`, `shop_redeem`,
+ * `streak_claim`, `mission_claim`) — no introduce una `action` nueva.
+ *
+ * Errores distintos de `ForbiddenCoinSourceError` se propagan sin logging
+ * (no son parte del contrato de fuentes prohibidas).
+ *
+ * Nota TS: `asserts source is AllowedCoinSource` NO se puede usar en
+ * funciones async (limitación del compilador). El caller pasa un string
+ * literal, no necesita narrowing.
+ */
+export async function assertAllowedCoinSourceOrLog(
+  source: string,
+  ctx: {
+    readonly userId: string | null;
+    readonly action: AuditAction;
+    readonly refType?: string | null;
+    readonly refId?: number | null;
+  },
+): Promise<void> {
+  try {
+    assertAllowedCoinSource(source);
+  } catch (err) {
+    if (err instanceof ForbiddenCoinSourceError) {
+      await logGiveawayEvent({
+        userId:  ctx.userId,
+        action:  ctx.action,
+        outcome: 'blocked',
+        refType: ctx.refType ?? null,
+        refId:   ctx.refId ?? null,
+        metadata: {
+          source,
+          reason: 'forbidden_coin_source',
+        },
+      });
+    }
+    throw err;
+  }
+}

--- a/src/lib/audit/redactMetadata.ts
+++ b/src/lib/audit/redactMetadata.ts
@@ -1,0 +1,97 @@
+/**
+ * Sanea metadata de `sp_audit_events` para la vista admin.
+ *
+ * La metadata jsonb puede contener campos operativos (giveawayId,
+ * coinsEarned, missionSlug, adminUserId, etc.) pero también podría
+ * incluir accidentalmente PII si un futuro callsite se despista.
+ *
+ * Reglas:
+ *   1. Solo se muestran keys en la whitelist explícita.
+ *   2. Cualquier key cuyo nombre coincida con `SENSITIVE_KEY_PATTERN`
+ *      se sustituye por `'[redacted]'`.
+ *   3. Strings largos (>200 chars) se truncan a 200 + '…'.
+ *   4. Todas las demás keys se agrupan en `_hidden_keys: N`.
+ *
+ * No confía en el remitente — se aplica al render, no al insert.
+ */
+
+const WHITELIST_METADATA_KEYS = new Set<string>([
+  'giveawayId',
+  'winnerCount',
+  'entriesCount',
+  'adminUserId',
+  'shopItemId',
+  'costCoins',
+  'category',
+  'coinsEarned',
+  'missionsCompleted',
+  'missionSlug',
+  'missionKey',
+  'isFree',
+  'consentVersion',
+  'partnerId',
+  'partnerKey',
+  'source',
+  'reason',
+  'streakDay',
+  'day',
+  'error',
+]);
+
+const SENSITIVE_KEY_PATTERN = /(email|token|secret|password|apiKey|api_key|authorization|cookie|jwt|refresh|access|steamId|tradeUrl|address|phone|nif|dni|iban|card|cvv)/i;
+
+const MAX_STRING_LENGTH = 200;
+const MAX_STRING_KEEP = 199;
+
+export interface RedactedMetadata {
+  readonly visible: Record<string, unknown>;
+  readonly hiddenCount: number;
+}
+
+export function redactAuditMetadata(input: unknown): RedactedMetadata {
+  if (input === null || input === undefined) {
+    return { visible: {}, hiddenCount: 0 };
+  }
+  if (typeof input !== 'object' || Array.isArray(input)) {
+    return { visible: { value: truncateValue(input) }, hiddenCount: 0 };
+  }
+
+  const visible: Record<string, unknown> = {};
+  let hiddenCount = 0;
+
+  for (const [key, value] of Object.entries(input as Record<string, unknown>)) {
+    if (SENSITIVE_KEY_PATTERN.test(key)) {
+      visible[key] = '[redacted]';
+      continue;
+    }
+    if (WHITELIST_METADATA_KEYS.has(key)) {
+      visible[key] = truncateValue(value);
+      continue;
+    }
+    hiddenCount += 1;
+  }
+
+  return { visible, hiddenCount };
+}
+
+function truncateValue(value: unknown): unknown {
+  if (typeof value === 'string' && value.length > MAX_STRING_LENGTH) {
+    return value.slice(0, MAX_STRING_KEEP) + '…';
+  }
+  return value;
+}
+
+const MAX_IP_HASH_VISIBLE = 12;
+const MAX_USER_AGENT_VISIBLE = 60;
+
+export function truncateIpHash(ipHash: string | null | undefined): string {
+  if (!ipHash) return '—';
+  return ipHash.slice(0, MAX_IP_HASH_VISIBLE);
+}
+
+export function summarizeUserAgent(userAgent: string | null | undefined): string {
+  if (!userAgent) return '—';
+  const first = userAgent.split(/[()]/)[0]?.trim() ?? userAgent;
+  if (first.length > MAX_USER_AGENT_VISIBLE) return first.slice(0, MAX_USER_AGENT_VISIBLE - 1) + '…';
+  return first;
+}

--- a/src/lib/giveaway-platform/missions.ts
+++ b/src/lib/giveaway-platform/missions.ts
@@ -10,8 +10,8 @@ import {
   redemptions,
 } from '@/db/schema';
 import { startOfCurrentMonthUtc, type MissionConditionType } from './constants';
-import { assertAllowedCoinSource } from '@/lib/rewards/allowed-coin-sources';
 import { logGiveawayEvent } from '@/lib/audit/logGiveawayEvent';
+import { assertAllowedCoinSourceOrLog } from '@/lib/audit/logBlockedCoinSource';
 
 /**
  * Estado agregado del progreso de un usuario contra todas las condition
@@ -121,7 +121,12 @@ export async function evaluateAndClaimMissions(
     if (inserted.length === 0) continue; // otra petición lo cobró antes
 
     // 2) Acreditar monedas (solo si el claim fue nuestro).
-    assertAllowedCoinSource('mision');
+    await assertAllowedCoinSourceOrLog('mision', {
+      userId,
+      action: 'mission_claim',
+      refType: 'mission',
+      refId: mission.id,
+    });
     await db.insert(coinTransactions).values({
       userId,
       amount: mission.rewardCoins,

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -53,7 +53,7 @@ export type Module =
   | 'bancos'
   | 'contratos';
 
-export type Action = 'read' | 'write' | 'publish' | 'delete' | 'manage_users';
+export type Action = 'read' | 'write' | 'publish' | 'delete' | 'manage_users' | 'audit';
 
 type PermissionsMap = Record<Module, Partial<Record<Action, readonly Role[]>>>;
 
@@ -69,6 +69,7 @@ export const PERMISSIONS = {
     write:   ['admin', 'admin_limited_tasks', 'manager', 'ops'],
     publish: ['admin', 'admin_limited_tasks', 'manager'],
     delete:  ['admin', 'admin_limited_tasks', 'manager'],
+    audit:   ['admin', 'admin_limited_tasks', 'manager'],
   },
   codigos: {
     read:    ['admin', 'admin_limited_tasks', 'manager', 'staff', 'ops'],

--- a/src/lib/queries/giveawayAudit.ts
+++ b/src/lib/queries/giveawayAudit.ts
@@ -1,0 +1,159 @@
+import 'server-only';
+import { and, desc, eq, gte, lte, lt, or, sql } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import { giveawayAuditEvents, AUDIT_ACTIONS, AUDIT_OUTCOMES, type AuditAction, type AuditOutcome } from '@/db/schema/giveawayAuditEvents';
+import { user } from '@/db/schema/auth';
+
+export const AUDIT_DEFAULT_PAGE_SIZE = 50;
+export const AUDIT_MAX_PAGE_SIZE = 200;
+
+export interface AuditEventRow {
+  readonly id: number;
+  readonly createdAt: Date;
+  readonly action: AuditAction;
+  readonly outcome: AuditOutcome;
+  readonly userId: string | null;
+  readonly userName: string | null;
+  readonly refType: string | null;
+  readonly refId: number | null;
+  readonly country: string | null;
+  readonly ipHash: string | null;
+  readonly userAgent: string | null;
+  readonly metadata: unknown;
+}
+
+export interface AuditFilters {
+  readonly from?: Date | null;
+  readonly to?: Date | null;
+  readonly action?: AuditAction | null;
+  readonly outcome?: AuditOutcome | null;
+  readonly userId?: string | null;
+  readonly refType?: string | null;
+  readonly country?: string | null;
+  readonly pageSize?: number;
+  readonly cursor?: { createdAt: string; id: number } | null;
+}
+
+export interface AuditListResult {
+  readonly rows: readonly AuditEventRow[];
+  readonly nextCursor: { createdAt: string; id: number } | null;
+}
+
+/**
+ * Lista `sp_audit_events` con filtros server-side. Nunca expone email del
+ * usuario asociado (solo `name`). El caller debe sanear metadata antes de
+ * pintar (ver `redactAuditMetadata`).
+ *
+ * Paginación estable con cursor `(createdAt DESC, id DESC)`.
+ */
+export async function listAuditEvents(filters: AuditFilters = {}): Promise<AuditListResult> {
+  const pageSize = clampPageSize(filters.pageSize);
+
+  const conditions = [] as ReturnType<typeof eq>[];
+  if (filters.from) conditions.push(gte(giveawayAuditEvents.createdAt, filters.from));
+  if (filters.to) conditions.push(lte(giveawayAuditEvents.createdAt, filters.to));
+  if (filters.action) conditions.push(eq(giveawayAuditEvents.action, filters.action));
+  if (filters.outcome) conditions.push(eq(giveawayAuditEvents.outcome, filters.outcome));
+  if (filters.userId) conditions.push(eq(giveawayAuditEvents.userId, filters.userId));
+  if (filters.refType) conditions.push(eq(giveawayAuditEvents.refType, filters.refType));
+  if (filters.country) conditions.push(eq(giveawayAuditEvents.country, filters.country));
+
+  if (filters.cursor) {
+    const c = filters.cursor;
+    const cursorDate = new Date(c.createdAt);
+    const equalDateAndOlderId = and(
+      eq(giveawayAuditEvents.createdAt, cursorDate),
+      lt(giveawayAuditEvents.id, c.id),
+    );
+    const olderDate = lt(giveawayAuditEvents.createdAt, cursorDate);
+    const cursorClause = equalDateAndOlderId ? or(olderDate, equalDateAndOlderId) : olderDate;
+    if (cursorClause) conditions.push(cursorClause);
+  }
+
+  const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+
+  const rows = await db
+    .select({
+      id: giveawayAuditEvents.id,
+      createdAt: giveawayAuditEvents.createdAt,
+      action: giveawayAuditEvents.action,
+      outcome: giveawayAuditEvents.outcome,
+      userId: giveawayAuditEvents.userId,
+      userName: user.name,
+      refType: giveawayAuditEvents.refType,
+      refId: giveawayAuditEvents.refId,
+      country: giveawayAuditEvents.country,
+      ipHash: giveawayAuditEvents.ipHash,
+      userAgent: giveawayAuditEvents.userAgent,
+      metadata: giveawayAuditEvents.metadata,
+    })
+    .from(giveawayAuditEvents)
+    .leftJoin(user, eq(giveawayAuditEvents.userId, user.id))
+    .where(whereClause)
+    .orderBy(desc(giveawayAuditEvents.createdAt), desc(giveawayAuditEvents.id))
+    .limit(pageSize + 1);
+
+  const hasMore = rows.length > pageSize;
+  const page = (hasMore ? rows.slice(0, pageSize) : rows).map((r) => ({
+    id: r.id,
+    createdAt: r.createdAt,
+    action: r.action as AuditAction,
+    outcome: r.outcome as AuditOutcome,
+    userId: r.userId,
+    userName: r.userName,
+    refType: r.refType,
+    refId: r.refId,
+    country: r.country,
+    ipHash: r.ipHash,
+    userAgent: r.userAgent,
+    metadata: r.metadata,
+  }));
+
+  const lastRow = page.length > 0 ? page[page.length - 1] : null;
+  const nextCursor = hasMore && lastRow
+    ? { createdAt: lastRow.createdAt.toISOString(), id: lastRow.id }
+    : null;
+
+  return { rows: page, nextCursor };
+}
+
+/**
+ * Devuelve counters por `action` para el rango de fechas dado. Útil para
+ * el sumario de la vista admin. No filtra por `action`/`outcome` para dar
+ * visión global.
+ */
+export async function countAuditEventsByAction(range: { from?: Date | null; to?: Date | null } = {}): Promise<Record<string, number>> {
+  const conditions = [] as ReturnType<typeof eq>[];
+  if (range.from) conditions.push(gte(giveawayAuditEvents.createdAt, range.from));
+  if (range.to) conditions.push(lte(giveawayAuditEvents.createdAt, range.to));
+  const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+
+  const rows = await db
+    .select({
+      action: giveawayAuditEvents.action,
+      count: sql<number>`count(*)::int`,
+    })
+    .from(giveawayAuditEvents)
+    .where(whereClause)
+    .groupBy(giveawayAuditEvents.action);
+
+  return Object.fromEntries(rows.map((r) => [r.action, r.count]));
+}
+
+function clampPageSize(input: number | undefined): number {
+  if (!input || !Number.isFinite(input)) return AUDIT_DEFAULT_PAGE_SIZE;
+  const n = Math.floor(input);
+  if (n < 1) return AUDIT_DEFAULT_PAGE_SIZE;
+  if (n > AUDIT_MAX_PAGE_SIZE) return AUDIT_MAX_PAGE_SIZE;
+  return n;
+}
+
+export function isValidAuditAction(value: string | null | undefined): value is AuditAction {
+  if (!value) return false;
+  return (AUDIT_ACTIONS as readonly string[]).includes(value);
+}
+
+export function isValidAuditOutcome(value: string | null | undefined): value is AuditOutcome {
+  if (!value) return false;
+  return (AUDIT_OUTCOMES as readonly string[]).includes(value);
+}

--- a/src/lib/schemas/giveawayAudit.ts
+++ b/src/lib/schemas/giveawayAudit.ts
@@ -1,0 +1,91 @@
+import { z } from 'zod';
+import { AUDIT_ACTIONS, AUDIT_OUTCOMES } from '@/db/schema/giveawayAuditEvents';
+
+/**
+ * Schema para los searchParams de `/admin/giveaways/auditoria`.
+ *
+ * Regla 4 (typescript.md): TODOS los inputs externos incluidos URL
+ * searchParams DEBEN pasar por Zod. Los helpers ad-hoc (parseDate, etc)
+ * se sustituyen por este schema.
+ *
+ * Todas las claves son opcionales — la vista tolera "sin filtros".
+ * `safeParse` devuelve valores normalizados; valores inválidos se
+ * omiten (no lanzan) para no bloquear la vista si un cursor viejo o un
+ * bookmark queda obsoleto.
+ */
+
+const AuditActionEnum = z.enum(AUDIT_ACTIONS);
+const AuditOutcomeEnum = z.enum(AUDIT_OUTCOMES);
+
+const DateStringToDate = z
+  .string()
+  .refine((v) => !Number.isNaN(new Date(v).getTime()), { message: 'invalid date' })
+  .transform((v) => new Date(v));
+
+const CountryIso2 = z
+  .string()
+  .transform((v) => v.trim().toUpperCase())
+  .pipe(z.string().regex(/^[A-Z]{2}$/));
+
+const BoundedString = (max: number) =>
+  z
+    .string()
+    .transform((v) => v.trim())
+    .pipe(z.string().min(1).max(max));
+
+export const AuditSearchParamsSchema = z.object({
+  from: DateStringToDate.optional(),
+  to: DateStringToDate.optional(),
+  action: AuditActionEnum.optional(),
+  outcome: AuditOutcomeEnum.optional(),
+  userId: BoundedString(200).optional(),
+  refType: BoundedString(40).optional(),
+  country: CountryIso2.optional(),
+  cursor: BoundedString(500).optional(),
+});
+
+export type AuditSearchParams = z.infer<typeof AuditSearchParamsSchema>;
+
+/**
+ * Parse cursor base64url → `{ createdAt, id }`. Devuelve `null` si
+ * el cursor es inválido — la vista simplemente ignora el cursor y
+ * arranca desde la página 1.
+ */
+const CursorPayloadSchema = z.object({
+  createdAt: DateStringToDate,
+  id: z.number().int().positive(),
+});
+
+export function decodeCursor(raw: string | undefined): { createdAt: string; id: number } | null {
+  if (!raw) return null;
+  try {
+    const decoded = Buffer.from(raw, 'base64url').toString('utf8');
+    const json = JSON.parse(decoded) as unknown;
+    const parsed = CursorPayloadSchema.safeParse(json);
+    if (!parsed.success) return null;
+    return { createdAt: parsed.data.createdAt.toISOString(), id: parsed.data.id };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Sanea searchParams "en bruto" a valores tipados. Nunca lanza — si algún
+ * campo es inválido, se prueba campo por campo y se retiene solo lo válido.
+ */
+export function parseAuditSearch(raw: Readonly<Record<string, string | undefined>>): AuditSearchParams {
+  const parsed = AuditSearchParamsSchema.safeParse(raw);
+  if (parsed.success) return parsed.data;
+
+  // Fallback tolerante: probar cada campo por separado con el schema completo
+  // (pasando solo esa clave). Descarta claves inválidas silenciosamente.
+  const clean: Record<string, string> = {};
+  for (const [k, v] of Object.entries(raw)) {
+    if (typeof v !== 'string') continue;
+    const single = AuditSearchParamsSchema.safeParse({ [k]: v });
+    if (single.success && k in single.data) {
+      clean[k] = v;
+    }
+  }
+  return AuditSearchParamsSchema.parse(clean);
+}


### PR DESCRIPTION
> **Nota de ruta (leer primero)**: el brief pidio `/admin/sorteos/auditoria` con la mencion "si no existe otra mejor". Monte bajo **`/admin/giveaways/auditoria`** para consistencia con el modulo admin existente (`/admin/giveaways/*`). Facil de renombrar si prefieres el otro path.

## Summary

Fase 1 PR2 sobre la base ya en produccion (Fase 0 + Fase 1 PR1, master `fee00cca`). Cierra tres bloques principales + un bonus autorizado. **Cero migracion de schema.**

### Bloque 1 - Audit UI admin
- Ruta: `/admin/giveaways/auditoria`.
- Nuevo permiso `sorteos:audit` en `src/lib/permissions.ts` - solo `admin`, `admin_limited_tasks`, `manager`. **Excluye `staff` y `ops`** explicitamente.
- Filtros server-side por Zod (`src/lib/schemas/giveawayAudit.ts`): `from`, `to`, `action`, `outcome`, `userId`, `refType`, `country`. Cursor paginado base64url estable.
- Query `listAuditEvents()` en `src/lib/queries/giveawayAudit.ts` con join a `user` para nombre (nunca email).
- Render via `AuditoriaRow.tsx` con saneamiento explicito (`src/lib/audit/redactMetadata.ts`):
  - `ipHash` truncado a **12 chars** visibles.
  - `userAgent` resumido a ~60 chars.
  - Metadata whitelist: solo claves conocidas (`giveawayId`, `coinsEarned`, `category`, etc.). Claves que matcheen `email|token|secret|password|apiKey|authorization|cookie|jwt|refresh|access|steamId|tradeUrl|address|phone|nif|dni|iban|card|cvv` -> `[redacted]`.

### Bloque 2 - Retencion de `sp_audit_events`
- **Script manual**, no cron (segun brief).
- `scripts/purge-audit-events.ts` - dry-run por defecto.
- Guard estricto: `CONFIRM_PURGE_AUDIT_EVENTS=I_ACCEPT_PURGE_AUDIT_EVENTS` (valor exacto, sin trim, sin case-insensitive).
- Retencion default **730 dias** (rango permitido 30-3650).
- Salida agrupada por `action` + total.
- Docs: `docs/legal/audit-retention.md`.
- Dry-run ejecutado contra prod: `Sin eventos en el rango` (correcto - tabla joven).

### Bloque 3 - Blindaje portal marca (tests defensivos)
- **Sin cambios en queries** - `getBrandCampaigns` y `getBrandProposals` ya filtran por `brandUserId` correctamente.
- Tests IDOR nuevos + test estatico del `where clause`. Regresion bloqueada si alguien elimina el filtro.

### Bloque bonus (autorizado)
- `raffle_winner_picked` - `pickRaffleWinnerAction` emite audit con metadata `{ giveawayId, winnerCount, entriesCount, adminUserId }`. El `adminUserId` viene de `requirePermission('sorteos','write')`.
- **Blocked coin sources** - nuevo helper `assertAllowedCoinSourceOrLog()` en `src/lib/audit/logBlockedCoinSource.ts`. Sustituye `assertAllowedCoinSource()` en 5 callsites (participate, streak, redeem, mission x3). Si la fuente esta bloqueada, emite audit con `outcome:'blocked'` reutilizando el `action` del contexto. **NO extiende el set cerrado**, sin migracion.

## Archivos tocados

**Nuevos (17)**:
- `docs/legal/audit-retention.md`
- `scripts/purge-audit-events.ts`
- `src/lib/audit/logBlockedCoinSource.ts`
- `src/lib/audit/redactMetadata.ts`
- `src/lib/queries/giveawayAudit.ts`
- `src/lib/schemas/giveawayAudit.ts`
- `src/app/admin/(dashboard)/giveaways/auditoria/page.tsx`
- `src/app/admin/(dashboard)/giveaways/auditoria/AuditoriaFilters.tsx`
- `src/app/admin/(dashboard)/giveaways/auditoria/AuditoriaRow.tsx`
- 8 archivos de tests server

**Modificados (7)**:
- `docs/tech-debt.md` - TD-15 (Preview DB/Blob), TD-16 (UNIQUE txId), TD-17 (proyectozack/ dup)
- `src/lib/permissions.ts` - anade `sorteos:audit`
- `src/app/admin/(dashboard)/giveaways/actions.ts` - audit `raffle_winner_picked`
- `src/app/sorteos/plataforma/actions.ts` - wrap 3 callsites
- `src/app/sorteos/plataforma/discord-mission-action.ts` - wrap 1 callsite
- `src/app/sorteos/plataforma/twitch-mission-action.ts` - wrap 1 callsite
- `src/lib/giveaway-platform/missions.ts` - wrap 1 callsite
- `src/__tests__/server/assert-allowed-coin-source-hooks.test.ts` - actualizado para aceptar el wrapper

## Confirmaciones del brief

- Sin migracion. Test estatico vigila que la ultima migration siga siendo `0109`.
- Sin cambios de economia / puntos / rewards. Solo audit + guardrails.
- Sin cron automatico. Script manual con guard.
- Sin borrar audit_events reales. Dry-run + guard.
- Sin exponer IP real. Solo hash SHA-256 truncado a 12 chars.
- No amplia acceso a staff/ops. `sorteos:audit` excluye ambos.
- No mergear sin OK del usuario.

## Roles con acceso a `sorteos:audit`
`admin`, `admin_limited_tasks`, `manager`.

## Roles excluidos
`staff`, `ops`, `brand`, `creator`, `editor`, `talent_manager`, `finance`, `analyst`.

## Tests

**+67 nuevos** (uno redundante eliminado por Regla 1 typescript.md):
- `sorteos-audit-permissions.test.ts` - 6 tests.
- `sorteos-audit-redact-metadata.test.ts` - 12 tests.
- `sorteos-auditoria-page-guard.test.ts` - 7 tests estaticos.
- `purge-audit-events-guard.test.ts` - 18 tests.
- `brand-portal-idor.test.ts` - 8 tests (5 IDOR runtime + 3 contrato estatico).
- `raffle-winner-audit.test.ts` - 6 tests estaticos.
- `blocked-coin-source-audit.test.ts` - 6 tests.
- `sorteos-fase1-pr2-no-migration.test.ts` - 3 tests estaticos.

**Suite completa**: `3834 passed, 194 suites, 5.7 s`. Cero regresiones.

## Checks locales
- `npx tsc --noEmit` - sin errores en el diff.
- `npx eslint` - sin errores en el diff.
- `npx jest` - 3834/3834 verdes.
- `scripts/purge-audit-events.ts` - dry-run OK.

## Reglas typescript.md (excepciones documentadas)
- **Regla 14** (>3 useState en form): `AuditoriaFilters.tsx` tiene 7 campos con `useState`. Excepcion documentada in-file: es filter form URL-driven, no data-entry. Validacion fuerte vive server-side en `parseAuditSearch` con Zod (Regla 4).

## Blind spot conocido
- Tests de `sorteos:audit` verifican el mapa `PERMISSIONS` (proxy estatico). No hay test end-to-end de que `requirePermission` rechaza una sesion `staff` en runtime. `requirePermission` esta cubierto upstream. El guard estatico en `sorteos-auditoria-page-guard.test.ts` confirma que la pagina llama `requirePermission('sorteos','audit')`.
- **Sin browser QA** - no arranque dev server. Verificado por tests estaticos + unitarios. Recomiendo smoke-test en Preview de Vercel.

## Riesgos pendientes
- TD-15 (Preview DB/Blob aislados) sigue abierto.
- VRF/RANDAO para raffles fuera de scope (decision legal).
- `mission_verify` en el set cerrado sin callsite. Sin cambios esta PR.
- `admin_identity` en otras acciones admin - solo cubierto en `pickRaffleWinnerAction`.

## Test plan
- [ ] En Preview, `/admin/giveaways/auditoria` como `admin` -> 200, tabla + filtros + KPIs.
- [ ] Como `staff` u `ops` -> redirect a home.
- [ ] Filtro por `action=raffle_winner_picked` -> tras probar el bonus, aparece el evento.
- [ ] `ipHash` visible <= 12 chars; hover del `userAgent` muestra el completo pero visible sale truncado.
- [ ] Metadata con `email` o `token` (si algun callsite futuro los inyectase) -> `[redacted]`.
- [ ] `scripts/purge-audit-events.ts` sin guard -> dry-run, no borra. Con guard `--older-than-days=730` -> confirma cutoff.

Generated with [Claude Code](https://claude.com/claude-code)
