### PR TITLE
feat(sorteos): social missions UX polish — empty state + Discord hint + rate limit copy

### DIFF
--- a/src/__tests__/server/social-missions-ux-polish.test.ts
+++ b/src/__tests__/server/social-missions-ux-polish.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Social missions UX polish — tests estáticos de contrato.
+ *
+ * Cambios cubiertos:
+ *   1. Empty state explícito en MissionsGrid cuando no hay cards visibles.
+ *   2. Copy Discord "Entra al servidor y después verifica la misión" en el
+ *      estado connected.
+ *   3. Rate limit copy más útil en Discord y Twitch (menciona "unos segundos"
+ *      + hint específico por provider).
+ *   4. Confirmación de que NO hay migración nueva ni server actions nuevas.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(__dirname, '..', '..', '..');
+const read = (rel: string): string => fs.readFileSync(path.join(ROOT, rel), 'utf-8');
+
+describe('MissionsGrid — empty state explícito', () => {
+  const source = read('src/features/giveaway-platform/components/MissionsGrid.tsx');
+
+  it('renderiza contenedor gp-mission-empty con role="status" y aria-live', () => {
+    expect(source).toMatch(/className="gp-mission-empty"/);
+    expect(source).toMatch(/role="status"/);
+    expect(source).toMatch(/aria-live="polite"/);
+  });
+
+  it('empty state incluye título y subtítulo diferenciados', () => {
+    expect(source).toMatch(/gp-mission-empty-title/);
+    expect(source).toMatch(/gp-mission-empty-sub/);
+  });
+
+  it('copy "Aún no hay misiones activas para este creador"', () => {
+    expect(source).toContain('Aún no hay misiones activas para este creador');
+  });
+
+  it('copy "Vuelve pronto — se añaden a lo largo del mes"', () => {
+    expect(source).toContain('Vuelve pronto');
+    expect(source).toContain('se añaden a lo largo del mes');
+  });
+
+  it('empty state considera cards Discord/Twitch reales, no solo missions.length', () => {
+    expect(source).toMatch(/hasDiscordCard/);
+    expect(source).toMatch(/hasTwitchCard/);
+    expect(source).toMatch(/hasInternalCard/);
+    expect(source).toMatch(/hasAnyCard/);
+  });
+
+  it('NO conserva el texto vago anterior "No hay misiones activas este mes"', () => {
+    expect(source).not.toMatch(/No hay misiones activas este mes/);
+  });
+});
+
+describe('DiscordMissionCard — hint secuencial', () => {
+  const source = read('src/features/giveaway-platform/components/DiscordMissionCard.tsx');
+
+  it('renderiza <p className="gp-mission-discord-hint">', () => {
+    expect(source).toMatch(/className="gp-mission-discord-hint"/);
+  });
+
+  it('copy exacto: "Entra al servidor y después verifica la misión"', () => {
+    expect(source).toContain('Entra al servidor y después verifica la misión');
+  });
+
+  it('hint solo aparece cuando connected && !showError && !isDone', () => {
+    // Test estructural: el hint está dentro de un condicional `connected && !showError`.
+    expect(source).toMatch(/connected && !showError \? \([\s\S]*?gp-mission-discord-hint/);
+  });
+});
+
+describe('Rate limit copy — Discord', () => {
+  const source = read('src/app/sorteos/plataforma/discord-mission-action.ts');
+
+  it('menciona "unos segundos" como texto amable', () => {
+    expect(source).toContain('Espera unos segundos antes de volver a verificar');
+  });
+
+  it('menciona hint específico Discord "acabas de unirte al servidor"', () => {
+    expect(source).toContain('acabas de unirte al servidor');
+  });
+
+  it('sigue conservando el número de segundos concretos como confirmación', () => {
+    expect(source).toMatch(/\$\{RATE_LIMIT_SECONDS\}s/);
+  });
+
+  it('NO conserva el texto anterior corto "Espera 30s antes de volver a verificar"', () => {
+    expect(source).not.toMatch(/^\s*message:\s*`Espera 30s antes de volver a verificar`/m);
+  });
+});
+
+describe('Rate limit copy — Twitch', () => {
+  const source = read('src/app/sorteos/plataforma/twitch-mission-action.ts');
+
+  it('menciona "unos segundos" como texto amable', () => {
+    expect(source).toContain('Espera unos segundos antes de volver a verificar');
+  });
+
+  it('menciona hint específico Twitch "acabas de seguir el canal"', () => {
+    expect(source).toContain('acabas de seguir el canal');
+  });
+
+  it('sigue conservando el número de segundos concretos como confirmación', () => {
+    expect(source).toMatch(/\$\{RATE_LIMIT_SECONDS\}s/);
+  });
+});
+
+describe('CSS — clases añadidas por polish', () => {
+  const widgetsCss = read('src/app/sorteos/plataforma/platform-widgets.css');
+  const discordCss = read('src/app/sorteos/plataforma/platform-discord-mission.css');
+
+  it('.gp-mission-empty existe en platform-widgets.css', () => {
+    expect(widgetsCss).toMatch(/\.giveaway-platform \.gp-mission-empty\s*\{/);
+    expect(widgetsCss).toMatch(/\.giveaway-platform \.gp-mission-empty-title\s*\{/);
+    expect(widgetsCss).toMatch(/\.giveaway-platform \.gp-mission-empty-sub\s*\{/);
+  });
+
+  it('.gp-mission-discord-hint existe en platform-discord-mission.css', () => {
+    expect(discordCss).toMatch(/\.giveaway-platform \.gp-mission-discord-hint\s*\{/);
+  });
+});
+
+describe('Sin migración ni server actions nuevas', () => {
+  it('la última migration sigue siendo 0109', () => {
+    const files = fs.readdirSync(path.join(ROOT, 'drizzle')).filter((f) => /^\d{4}_.*\.sql$/.test(f));
+    const last = files.sort()[files.length - 1];
+    expect(last).toBeDefined();
+    expect(last!).toMatch(/^0109_/);
+  });
+
+  it('no aparece migration 0110/0111 (esta PR es UX puro)', () => {
+    const files = fs.readdirSync(path.join(ROOT, 'drizzle'));
+    expect(files.find((f) => f.startsWith('0110_'))).toBeUndefined();
+    expect(files.find((f) => f.startsWith('0111_'))).toBeUndefined();
+  });
+
+  it('discord-mission-action.ts sigue exportando solo verifyDiscordMission (no nuevas actions)', () => {
+    const source = read('src/app/sorteos/plataforma/discord-mission-action.ts');
+    const exportMatches = source.match(/^export\s+async\s+function\s+\w+/gm) ?? [];
+    // Un solo export async function verifyDiscordMission
+    expect(exportMatches).toHaveLength(1);
+    expect(exportMatches[0]).toMatch(/verifyDiscordMission/);
+  });
+
+  it('twitch-mission-action.ts sigue exportando solo verifyTwitchMission', () => {
+    const source = read('src/app/sorteos/plataforma/twitch-mission-action.ts');
+    const exportMatches = source.match(/^export\s+async\s+function\s+\w+/gm) ?? [];
+    expect(exportMatches).toHaveLength(1);
+    expect(exportMatches[0]).toMatch(/verifyTwitchMission/);
+  });
+});

--- a/src/app/sorteos/plataforma/discord-mission-action.ts
+++ b/src/app/sorteos/plataforma/discord-mission-action.ts
@@ -120,7 +120,11 @@ export async function verifyDiscordMission(input: unknown): Promise<DiscordVerif
     ))
     .limit(1);
   if (recent) {
-    return { ok: false, code: 'rate_limited', message: `Espera ${RATE_LIMIT_SECONDS}s antes de volver a verificar` };
+    return {
+      ok: false,
+      code: 'rate_limited',
+      message: `Espera unos segundos antes de volver a verificar. Si acabas de unirte al servidor, espera ${RATE_LIMIT_SECONDS}s y vuelve a probar.`,
+    };
   }
 
   // Cuenta Discord conectada.

--- a/src/app/sorteos/plataforma/platform-discord-mission.css
+++ b/src/app/sorteos/plataforma/platform-discord-mission.css
@@ -35,6 +35,13 @@
   margin-right: 4px;
 }
 
+.giveaway-platform .gp-mission-discord-hint {
+  margin: 12px 0 -2px;
+  font-size: 12px;
+  line-height: 1.5;
+  color: rgba(88, 101, 242, 0.95);
+  font-weight: 600;
+}
 .giveaway-platform .gp-mission-discord-actions {
   display: flex;
   flex-wrap: wrap;

--- a/src/app/sorteos/plataforma/platform-widgets.css
+++ b/src/app/sorteos/plataforma/platform-widgets.css
@@ -87,6 +87,26 @@
   color: var(--muted);
   margin: 0 0 16px;
 }
+.giveaway-platform .gp-mission-empty {
+  border-radius: 14px;
+  border: 1px dashed rgba(196, 40, 128, 0.25);
+  background: linear-gradient(160deg, rgba(21,16,36,0.6), rgba(11,9,23,0.6));
+  padding: 28px 20px;
+  text-align: center;
+}
+.giveaway-platform .gp-mission-empty-title {
+  font-family: var(--font-display), var(--font-rajdhani), sans-serif;
+  font-size: 15px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  color: var(--txt);
+  margin: 0 0 6px;
+}
+.giveaway-platform .gp-mission-empty-sub {
+  font-size: 13px;
+  color: var(--muted);
+  margin: 0;
+}
 .giveaway-platform .gp-missions-grid {
   display: grid;
   gap: 16px;

--- a/src/app/sorteos/plataforma/twitch-mission-action.ts
+++ b/src/app/sorteos/plataforma/twitch-mission-action.ts
@@ -137,7 +137,11 @@ export async function verifyTwitchMission(input: unknown): Promise<TwitchVerifyR
     ))
     .limit(1);
   if (recent) {
-    return { ok: false, code: 'rate_limited', message: `Espera ${RATE_LIMIT_SECONDS}s antes de volver a verificar` };
+    return {
+      ok: false,
+      code: 'rate_limited',
+      message: `Espera unos segundos antes de volver a verificar. Si acabas de seguir el canal, espera ${RATE_LIMIT_SECONDS}s y vuelve a probar.`,
+    };
   }
 
   // Cuenta Twitch conectada.

--- a/src/features/giveaway-platform/components/DiscordMissionCard.tsx
+++ b/src/features/giveaway-platform/components/DiscordMissionCard.tsx
@@ -68,7 +68,13 @@ export function DiscordMissionCard({ mission, connected, inviteUrl }: Props) {
       <p className="gp-mission-desc">{mission.description}</p>
 
       {isDone ? null : (
-        <div className="gp-mission-discord-actions">
+        <>
+          {connected && !showError ? (
+            <p className="gp-mission-discord-hint">
+              Entra al servidor y después verifica la misión.
+            </p>
+          ) : null}
+          <div className="gp-mission-discord-actions">
           {connected ? (
             <>
               {inviteUrl ? (
@@ -112,7 +118,8 @@ export function DiscordMissionCard({ mission, connected, inviteUrl }: Props) {
               </Link>
             </>
           )}
-        </div>
+          </div>
+        </>
       )}
 
       {showError ? (

--- a/src/features/giveaway-platform/components/MissionsGrid.tsx
+++ b/src/features/giveaway-platform/components/MissionsGrid.tsx
@@ -38,14 +38,29 @@ interface Props {
 export function MissionsGrid({ missions, discord, twitch }: Props) {
   const [expanded, setExpanded] = useState(false);
 
-  if (missions.length === 0) {
-    return <p className="gp-mission-head">No hay misiones activas este mes.</p>;
-  }
-
   // Split por provider: Discord y Twitch aparte para renderizado con card específica.
   const discordMissions = missions.filter((m) => m.provider === 'discord');
   const twitchMissions = missions.filter((m) => m.provider === 'twitch');
   const otherMissions = missions.filter((m) => m.provider !== 'discord' && m.provider !== 'twitch');
+
+  // Empty state real: cero cards visibles de ningún tipo. El check previo
+  // `missions.length === 0` era demasiado restrictivo — si había misiones
+  // Discord/Twitch en el array pero sin `discord`/`twitch` props (fail-safe
+  // de env vars), el usuario veía "no hay misiones" incluso con otras
+  // internas potenciales. Aquí calculamos exactamente qué SE VA A RENDERIZAR.
+  const hasDiscordCard = discordMissions.length > 0 && Boolean(discord);
+  const hasTwitchCard = twitchMissions.length > 0 && Boolean(twitch);
+  const hasInternalCard = otherMissions.length > 0;
+  const hasAnyCard = hasDiscordCard || hasTwitchCard || hasInternalCard;
+
+  if (!hasAnyCard) {
+    return (
+      <div className="gp-mission-empty" role="status" aria-live="polite">
+        <p className="gp-mission-empty-title">Aún no hay misiones activas para este creador.</p>
+        <p className="gp-mission-empty-sub">Vuelve pronto — se añaden a lo largo del mes.</p>
+      </div>
+    );
+  }
 
   // Cobradas al final, resto en el orden que llega del server (sortOrder ASC).
   const sortedOther = [...otherMissions].sort((a, b) => Number(a.claimed) - Number(b.claimed));


### PR DESCRIPTION
## Summary

Tres micro-mejoras UX sobre las cards de social missions detectadas en la preview local (`/dev/preview-social-missions`, ya limpiada) antes de activar Discord/Twitch en producción.

**Cero cambios de lógica de negocio.** Solo copy + un empty state + un hint condicional.

## Bloques

### 1 — Empty state explícito (`MissionsGrid.tsx`)

Cuando no hay ninguna card visible (ni Discord, ni Twitch, ni internas), muestra un bloque diferenciado:

```
Aún no hay misiones activas para este creador.
Vuelve pronto — se añaden a lo largo del mes.
```

Con `role="status"` y `aria-live="polite"` para lectores de pantalla. Sustituye al viejo `<p>` inline con texto vago `"No hay misiones activas este mes."`.

**Corrección lateral**: el check anterior era `if (missions.length === 0)` — retornaba antes de valorar props `discord`/`twitch`. Ahora considera si van a renderizarse cards de cualquier tipo (`hasDiscordCard || hasTwitchCard || hasInternalCard`).

### 2 — Copy Discord secuencial (`DiscordMissionCard.tsx`)

Cuando el user está conectado a Discord y aún no ha verificado (ni error visible), añade un hint encima de los botones:

```
Entra al servidor y después verifica la misión.
```

Estilizado con `.gp-mission-discord-hint` en color Discord (#5865F2). Evita que el usuario clique "Verificar" sin haber entrado al servidor y caiga en `not_verified` con error confuso.

### 3 — Rate limit copy útil (2 actions)

Discord y Twitch cambian el mensaje de `outcome: 'rate_limited'`:

**Antes:** `"Espera 30s antes de volver a verificar"`

**Después:**
- Discord: `"Espera unos segundos antes de volver a verificar. Si acabas de unirte al servidor, espera 30s y vuelve a probar."`
- Twitch: `"Espera unos segundos antes de volver a verificar. Si acabas de seguir el canal, espera 30s y vuelve a probar."`

Da al usuario la información que necesita (por qué esperar, qué acción concreta acaba de hacer). Cero cambio de valor `RATE_LIMIT_SECONDS`.

## Archivos tocados (7)

**Modificados (6):**
- `src/features/giveaway-platform/components/MissionsGrid.tsx` — nuevo empty state + refactor del check
- `src/features/giveaway-platform/components/DiscordMissionCard.tsx` — hint condicional
- `src/app/sorteos/plataforma/discord-mission-action.ts` — rate limit copy
- `src/app/sorteos/plataforma/twitch-mission-action.ts` — rate limit copy
- `src/app/sorteos/plataforma/platform-widgets.css` — clases `.gp-mission-empty*`
- `src/app/sorteos/plataforma/platform-discord-mission.css` — clase `.gp-mission-discord-hint`

**Nuevo (1):**
- `src/__tests__/server/social-missions-ux-polish.test.ts` — 22 tests estáticos

## Confirmaciones (fuera de scope)

- ✅ **Sin migración**. Última migration sigue en `0109_billing_clients_pdf_language.sql`. Test estático lo vigila.
- ✅ **Sin server actions nuevas**. `discord-mission-action.ts` y `twitch-mission-action.ts` mantienen 1 export cada uno (`verifyDiscordMission` / `verifyTwitchMission`). Test estático lo vigila.
- ✅ **Sin cambios de lógica verify+claim**. El flujo atómico dentro de las actions no cambia.
- ✅ **Sin cambios de rewards, puntos, seeds, env vars**.
- ✅ **Sin tocar OAuth**. Los redirects y scopes son idénticos.
- ✅ **Sin tocar `assertAllowedCoinSource`** ni el wrapper `assertAllowedCoinSourceOrLog`.
- ✅ **Sin tocar `sp_audit_events`** ni sus emisores.
- ✅ **Sin tocar `platform_missions`** ni `mission_verification_attempts` ni `mission_claims`.
- ✅ **Sin PR fuera de scope**. Solo el brief aprobado.

## Tests (22 nuevos)

`social-missions-ux-polish.test.ts` cubre:

**Empty state (6):**
- Contenedor `gp-mission-empty` con `role="status"` + `aria-live`
- Título y subtítulo diferenciados
- Copy exacto ("Aún no hay misiones…" + "Vuelve pronto — se añaden…")
- Check considera cards sociales, no solo `missions.length`
- NO conserva el texto vago anterior

**Discord hint (3):**
- Renderiza `<p className="gp-mission-discord-hint">`
- Copy exacto ("Entra al servidor y después verifica la misión")
- Condicional `connected && !showError`

**Rate limit Discord (4):**
- Menciona "unos segundos"
- Hint específico "acabas de unirte al servidor"
- Sigue mostrando `${RATE_LIMIT_SECONDS}s`
- NO conserva la versión corta anterior

**Rate limit Twitch (3):**
- Menciona "unos segundos"
- Hint específico "acabas de seguir el canal"
- Sigue mostrando `${RATE_LIMIT_SECONDS}s`

**CSS (2):**
- `.gp-mission-empty*` en `platform-widgets.css`
- `.gp-mission-discord-hint` en `platform-discord-mission.css`

**Regresión "esta PR no toca infra" (4):**
- Última migration = 0109
- Sin 0110/0111
- 1 export en discord-mission-action.ts (`verifyDiscordMission`)
- 1 export en twitch-mission-action.ts (`verifyTwitchMission`)

## Checks locales

- `npx tsc --noEmit` — limpio en el diff
- `npx eslint <archivos tocados>` — limpio
- `npx jest` — **3856 passed** (3834 → 3856, +22 nuevos, 195 suites, 7.0 s)

## Riesgos pendientes

Ninguno nuevo. Los riesgos anteriores (TD-15 Preview aislado, VRF/RANDAO raffles, `mission_verify` fantasma) siguen abiertos pero no aplican a esta PR.

**Nota**: no hago browser QA aquí porque la preview local ya validó los estados visuales. Recomiendo un vistazo en Vercel Preview (SSO) tras CI verde, sobre todo el nuevo `.gp-mission-discord-hint` con el color Discord.

## Test plan (post-merge, Production)

- [ ] `/sorteos/[creatorSlug]` como usuario loggeado sin misiones activas → aparece bloque empty state con role="status".
- [ ] Al conectar Discord (cuando Discord esté activado), aparece el hint "Entra al servidor y después verifica la misión" encima de los botones.
- [ ] Al hacer verify dos veces seguidas → mensaje rate_limited menciona "unos segundos" + hint específico Discord/Twitch.
- [ ] Copy de privacidad Discord y Twitch inalterado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
