### PR TITLE
feat(sorteos): mostrar social missions en modo próximamente

### DIFF
--- a/src/__tests__/server/social-missions-coming-soon.test.ts
+++ b/src/__tests__/server/social-missions-coming-soon.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Social missions "Próximamente" — tests estáticos.
+ *
+ * Cambios cubiertos:
+ *   - Flags isDiscordComingSoon / isTwitchComingSoon (solo 'zacketizor').
+ *   - Placeholders Discord + Twitch en MissionsGrid renderizados con
+ *     copy exacto del brief.
+ *   - Discord placeholder SIN ningún enlace ni botón OAuth.
+ *   - Twitch placeholder incluye enlace público (twitch.tv/zacketizor)
+ *     con target="_blank" y rel="noopener noreferrer".
+ *   - Card real sigue teniendo prioridad cuando target y OAuth existen.
+ *   - Sin migración, sin server actions nuevas.
+ */
+
+// Mock de env para poder importar los constants sin cargar Better Auth.
+jest.mock('@/lib/env', () => ({
+  env: new Proxy({}, { get: (_t, key: string) => process.env[key] }),
+}));
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(__dirname, '..', '..', '..');
+const read = (rel: string): string => fs.readFileSync(path.join(ROOT, rel), 'utf-8');
+
+import { isDiscordComingSoon } from '@/features/giveaway-platform/constants/discord-missions';
+import { isTwitchComingSoon, getTwitchPublicChannelUrl } from '@/features/giveaway-platform/constants/twitch-missions';
+
+describe('isDiscordComingSoon', () => {
+  it('devuelve true para zacketizor', () => {
+    expect(isDiscordComingSoon('zacketizor')).toBe(true);
+  });
+
+  it('devuelve false para cualquier otro slug', () => {
+    expect(isDiscordComingSoon('imantado')).toBe(false);
+    expect(isDiscordComingSoon('naow')).toBe(false);
+    expect(isDiscordComingSoon('random-creator')).toBe(false);
+    expect(isDiscordComingSoon('')).toBe(false);
+  });
+});
+
+describe('isTwitchComingSoon', () => {
+  it('devuelve true para zacketizor', () => {
+    expect(isTwitchComingSoon('zacketizor')).toBe(true);
+  });
+
+  it('devuelve false para cualquier otro slug', () => {
+    expect(isTwitchComingSoon('imantado')).toBe(false);
+    expect(isTwitchComingSoon('naow')).toBe(false);
+    expect(isTwitchComingSoon('random-creator')).toBe(false);
+    expect(isTwitchComingSoon('')).toBe(false);
+  });
+});
+
+describe('getTwitchPublicChannelUrl', () => {
+  it('devuelve https://www.twitch.tv/zacketizor para zacketizor', () => {
+    expect(getTwitchPublicChannelUrl('zacketizor')).toBe('https://www.twitch.tv/zacketizor');
+  });
+
+  it('devuelve null para slug desconocido', () => {
+    expect(getTwitchPublicChannelUrl('imantado')).toBeNull();
+    expect(getTwitchPublicChannelUrl('random')).toBeNull();
+  });
+
+  it('la URL es HTTPS y no contiene credenciales', () => {
+    const url = getTwitchPublicChannelUrl('zacketizor');
+    expect(url).toMatch(/^https:\/\/www\.twitch\.tv\//);
+    expect(url).not.toMatch(/@/); // sin user:pass@host
+    expect(url).not.toMatch(/[?&]token=|[?&]auth=/i);
+  });
+});
+
+describe('MissionsGrid — placeholders sociales sin OAuth', () => {
+  const source = read('src/features/giveaway-platform/components/MissionsGrid.tsx');
+
+  it('DiscordMissionsPlaceholder tiene role="note"', () => {
+    expect(source).toMatch(/function DiscordMissionsPlaceholder\(\)[\s\S]*?role="note"/);
+  });
+
+  it('DiscordMissionsPlaceholder NO contiene "Conectar Discord"', () => {
+    const discordFn = source.split('function DiscordMissionsPlaceholder')[1]?.split('function ')[0] ?? '';
+    expect(discordFn).not.toMatch(/Conectar Discord/);
+  });
+
+  it('DiscordMissionsPlaceholder NO enlaza a /api/auth/social/discord/connect', () => {
+    const discordFn = source.split('function DiscordMissionsPlaceholder')[1]?.split('function ')[0] ?? '';
+    expect(discordFn).not.toMatch(/\/api\/auth\/social\/discord\//);
+  });
+
+  it('DiscordMissionsPlaceholder NO tiene ningún <a> ni <Link> (cero salida)', () => {
+    const discordFn = source.split('function DiscordMissionsPlaceholder')[1]?.split('function ')[0] ?? '';
+    expect(discordFn).not.toMatch(/<a\s/i);
+    expect(discordFn).not.toMatch(/<Link\s/i);
+  });
+
+  it('DiscordMissionsPlaceholder NO tiene ningún <button>', () => {
+    const discordFn = source.split('function DiscordMissionsPlaceholder')[1]?.split('function ')[0] ?? '';
+    expect(discordFn).not.toMatch(/<button/i);
+  });
+
+  it('DiscordMissionsPlaceholder incluye copy exacto del brief', () => {
+    expect(source).toContain('Únete al Discord de ZACKETIZOR y consigue puntos cuando activemos esta misión');
+  });
+
+  it('DiscordMissionsPlaceholder marca "Próximamente"', () => {
+    const discordFn = source.split('function DiscordMissionsPlaceholder')[1]?.split('function ')[0] ?? '';
+    expect(discordFn).toMatch(/Próximamente/);
+  });
+
+  it('TwitchMissionsPlaceholder tiene role="note"', () => {
+    expect(source).toMatch(/function TwitchMissionsPlaceholder\([\s\S]*?role="note"/);
+  });
+
+  it('TwitchMissionsPlaceholder NO contiene "Conectar Twitch"', () => {
+    const twitchFn = source.split('function TwitchMissionsPlaceholder')[1]?.split('function ')[0] ?? '';
+    expect(twitchFn).not.toMatch(/Conectar Twitch/);
+  });
+
+  it('TwitchMissionsPlaceholder NO enlaza a /api/auth/social/twitch/connect', () => {
+    const twitchFn = source.split('function TwitchMissionsPlaceholder')[1]?.split('function ')[0] ?? '';
+    expect(twitchFn).not.toMatch(/\/api\/auth\/social\/twitch\//);
+  });
+
+  it('TwitchMissionsPlaceholder NO contiene "Verificar misión"', () => {
+    const twitchFn = source.split('function TwitchMissionsPlaceholder')[1]?.split('function ')[0] ?? '';
+    expect(twitchFn).not.toMatch(/Verificar misi[oó]n/);
+  });
+
+  it('TwitchMissionsPlaceholder tiene link "Ver Twitch →" con target=_blank y rel=noopener noreferrer', () => {
+    const twitchFn = source.split('function TwitchMissionsPlaceholder')[1]?.split('function ')[0] ?? '';
+    expect(twitchFn).toMatch(/Ver Twitch/);
+    expect(twitchFn).toMatch(/target="_blank"/);
+    expect(twitchFn).toMatch(/rel="noopener noreferrer"/);
+  });
+
+  it('TwitchMissionsPlaceholder link solo aparece si channelUrl no es null', () => {
+    const twitchFn = source.split('function TwitchMissionsPlaceholder')[1]?.split('function ')[0] ?? '';
+    expect(twitchFn).toMatch(/channelUrl \?/);
+  });
+
+  it('TwitchMissionsPlaceholder incluye copy exacto del brief', () => {
+    expect(source).toContain('Sigue el canal de ZACKETIZOR y consigue puntos cuando activemos esta misión');
+  });
+});
+
+describe('MissionsGrid — prioridad de card real sobre placeholder', () => {
+  const source = read('src/features/giveaway-platform/components/MissionsGrid.tsx');
+
+  it('renderiza card real cuando discordMissions > 0 && discord — placeholder es fallback', () => {
+    // El JSX evalúa primero la condición de la card real:
+    //   discordMissions.length > 0 && discord ? <DiscordMissionCard /> : hasDiscordPlaceholder ? <DiscordMissionsPlaceholder /> : null
+    expect(source).toMatch(/discordMissions\.length > 0 && discord \? \(/);
+    expect(source).toMatch(/\) : hasDiscordPlaceholder \? \(/);
+    expect(source).toMatch(/<DiscordMissionsPlaceholder \/>/);
+  });
+
+  it('renderiza card real Twitch cuando twitchMissions > 0 && twitch — placeholder es fallback', () => {
+    expect(source).toMatch(/twitchMissions\.length > 0 && twitch \? \(/);
+    expect(source).toMatch(/\) : hasTwitchPlaceholder \? \(/);
+    expect(source).toMatch(/<TwitchMissionsPlaceholder channelUrl=/);
+  });
+
+  it('empty state considera también los placeholders (no aparece si hay al menos uno)', () => {
+    expect(source).toMatch(/hasDiscordPlaceholder/);
+    expect(source).toMatch(/hasTwitchPlaceholder/);
+    expect(source).toMatch(/hasAnyCard = hasDiscordCard \|\| hasTwitchCard \|\| hasInternalCard \|\| hasDiscordPlaceholder \|\| hasTwitchPlaceholder/);
+  });
+});
+
+describe('PlatformCreatorLanding — cableado del flag coming_soon', () => {
+  const source = read('src/features/giveaway-platform/components/PlatformCreatorLanding.tsx');
+
+  it('importa isDiscordComingSoon', () => {
+    expect(source).toMatch(/isDiscordComingSoon/);
+  });
+
+  it('importa isTwitchComingSoon y getTwitchPublicChannelUrl', () => {
+    expect(source).toMatch(/isTwitchComingSoon/);
+    expect(source).toMatch(/getTwitchPublicChannelUrl/);
+  });
+
+  it('discordComingSoon solo se activa cuando discordProp está undefined Y el creador es coming_soon', () => {
+    expect(source).toMatch(/const discordComingSoon = !discordProp && isDiscordComingSoon\(active\.slug\)/);
+  });
+
+  it('twitchComingSoon solo se activa cuando twitchProp está undefined Y el creador es coming_soon', () => {
+    expect(source).toMatch(/const twitchComingSoon = !twitchProp && isTwitchComingSoon\(active\.slug\)/);
+  });
+
+  it('pasa los flags a MissionsGrid', () => {
+    expect(source).toMatch(/discordComingSoon=\{discordComingSoon\}/);
+    expect(source).toMatch(/twitchComingSoon=\{twitchComingSoon\}/);
+  });
+});
+
+describe('Regresión — sin migración ni server actions nuevas', () => {
+  it('última migration sigue siendo 0109', () => {
+    const files = fs.readdirSync(path.join(ROOT, 'drizzle')).filter((f) => /^\d{4}_.*\.sql$/.test(f));
+    const last = files.sort()[files.length - 1];
+    expect(last).toBeDefined();
+    expect(last!).toMatch(/^0109_/);
+  });
+
+  it('no aparece migration 0110/0111', () => {
+    const files = fs.readdirSync(path.join(ROOT, 'drizzle'));
+    expect(files.find((f) => f.startsWith('0110_'))).toBeUndefined();
+    expect(files.find((f) => f.startsWith('0111_'))).toBeUndefined();
+  });
+
+  it('discord-mission-action.ts sigue con 1 export (verifyDiscordMission)', () => {
+    const source = read('src/app/sorteos/plataforma/discord-mission-action.ts');
+    const exports = source.match(/^export\s+async\s+function\s+\w+/gm) ?? [];
+    expect(exports).toHaveLength(1);
+    expect(exports[0]).toMatch(/verifyDiscordMission/);
+  });
+
+  it('twitch-mission-action.ts sigue con 1 export (verifyTwitchMission)', () => {
+    const source = read('src/app/sorteos/plataforma/twitch-mission-action.ts');
+    const exports = source.match(/^export\s+async\s+function\s+\w+/gm) ?? [];
+    expect(exports).toHaveLength(1);
+    expect(exports[0]).toMatch(/verifyTwitchMission/);
+  });
+});
+
+describe('CSS placeholder social', () => {
+  it('platform-missions-social-placeholder.css existe y define variantes Discord/Twitch', () => {
+    const cssPath = 'src/app/sorteos/plataforma/platform-missions-social-placeholder.css';
+    expect(fs.existsSync(path.join(ROOT, cssPath))).toBe(true);
+    const css = read(cssPath);
+    expect(css).toMatch(/\.giveaway-platform \.gp-missions-social-placeholder/);
+    expect(css).toMatch(/\.is-discord/);
+    expect(css).toMatch(/\.is-twitch/);
+  });
+
+  it('el CSS se carga desde el layout de sorteos', () => {
+    const layout = read('src/app/sorteos/layout.tsx');
+    expect(layout).toMatch(/platform-missions-social-placeholder\.css/);
+  });
+});

--- a/src/app/sorteos/layout.tsx
+++ b/src/app/sorteos/layout.tsx
@@ -15,6 +15,7 @@ import './plataforma/platform-widgets.css';
 import './plataforma/platform-rewards-upcoming.css';
 import './plataforma/platform-rewards-hub.css';
 import './plataforma/platform-missions-yt-placeholder.css';
+import './plataforma/platform-missions-social-placeholder.css';
 import './plataforma/platform-discord-mission.css';
 import './plataforma/platform-twitch-mission.css';
 import './plataforma/platform-external-giveaways.css';

--- a/src/app/sorteos/plataforma/platform-missions-social-placeholder.css
+++ b/src/app/sorteos/plataforma/platform-missions-social-placeholder.css
@@ -1,0 +1,116 @@
+/*
+ * Placeholders informativos — misiones sociales "Próximamente".
+ *
+ * Discord y Twitch. Se retiran automáticamente cuando la card real puede
+ * renderizarse (env vars pobladas + seed insertado). Sin lógica, sin
+ * botones OAuth, cero contacto con DB. Solo información pública.
+ *
+ * Basado en el patrón `.gp-missions-yt-placeholder` — misma cardinalidad
+ * y estilo de "próximamente" que ya está en producción para YouTube.
+ *
+ * Scoped bajo `.giveaway-platform`. Cargado desde el layout raíz.
+ */
+
+.giveaway-platform .gp-missions-social-placeholder {
+  margin-top: 20px;
+  padding: 18px 20px;
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  border-radius: 14px;
+  border: 1px dashed;
+}
+
+/* Variante Discord — color Discord (#5865F2 blurple). */
+.giveaway-platform .gp-missions-social-placeholder.is-discord {
+  background:
+    radial-gradient(400px 220px at 100% 0%, rgba(88, 101, 242, 0.14), transparent 65%),
+    rgba(11, 8, 20, 0.55);
+  border-color: rgba(88, 101, 242, 0.4);
+}
+
+/* Variante Twitch — color Twitch (#9146FF violeta). */
+.giveaway-platform .gp-missions-social-placeholder.is-twitch {
+  background:
+    radial-gradient(400px 220px at 100% 0%, rgba(145, 70, 255, 0.14), transparent 65%),
+    rgba(11, 8, 20, 0.55);
+  border-color: rgba(145, 70, 255, 0.4);
+}
+
+.giveaway-platform .gp-missions-social-icon {
+  font-size: 26px;
+  line-height: 1;
+  flex-shrink: 0;
+}
+.giveaway-platform .gp-missions-social-placeholder.is-discord .gp-missions-social-icon {
+  filter: drop-shadow(0 0 8px rgba(88, 101, 242, 0.45));
+}
+.giveaway-platform .gp-missions-social-placeholder.is-twitch .gp-missions-social-icon {
+  filter: drop-shadow(0 0 8px rgba(145, 70, 255, 0.45));
+}
+
+.giveaway-platform .gp-missions-social-body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.giveaway-platform .gp-missions-social-title {
+  font-family: var(--font-display), var(--font-rajdhani), sans-serif;
+  font-weight: 800;
+  font-size: 15px;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+  color: #fff;
+}
+
+.giveaway-platform .gp-missions-social-soon {
+  font-weight: 800;
+  letter-spacing: 1px;
+  margin-left: 4px;
+}
+.giveaway-platform .gp-missions-social-placeholder.is-discord .gp-missions-social-soon {
+  color: rgba(153, 165, 255, 0.95);
+}
+.giveaway-platform .gp-missions-social-placeholder.is-twitch .gp-missions-social-soon {
+  color: rgba(199, 172, 255, 0.95);
+}
+
+.giveaway-platform .gp-missions-social-desc {
+  margin: 0;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.55;
+  max-width: 720px;
+}
+
+.giveaway-platform .gp-missions-social-link {
+  align-self: flex-start;
+  margin-top: 8px;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.4px;
+  text-decoration: none;
+  padding: 6px 12px;
+  border-radius: 8px;
+  transition: background 0.15s ease;
+}
+.giveaway-platform .gp-missions-social-placeholder.is-twitch .gp-missions-social-link {
+  color: #d9c6ff;
+  background: rgba(145, 70, 255, 0.14);
+  border: 1px solid rgba(145, 70, 255, 0.4);
+}
+.giveaway-platform .gp-missions-social-placeholder.is-twitch .gp-missions-social-link:hover {
+  background: rgba(145, 70, 255, 0.22);
+}
+
+@media (max-width: 480px) {
+  .giveaway-platform .gp-missions-social-placeholder {
+    padding: 14px 16px;
+    gap: 12px;
+  }
+  .giveaway-platform .gp-missions-social-icon { font-size: 22px; }
+  .giveaway-platform .gp-missions-social-title { font-size: 13.5px; }
+  .giveaway-platform .gp-missions-social-desc { font-size: 12.5px; }
+}

--- a/src/features/giveaway-platform/components/MissionsGrid.tsx
+++ b/src/features/giveaway-platform/components/MissionsGrid.tsx
@@ -25,6 +25,20 @@ interface Props {
     connected: boolean;
     channelUrl: string | null;
   } | undefined;
+  /**
+   * Cuando `discord` (real) está undefined pero sabemos que ese creador
+   * tendrá misión Discord — se muestra placeholder "Próximamente" sin
+   * botones OAuth. Cero contacto con DB / seeds / server actions.
+   */
+  discordComingSoon?: boolean;
+  /**
+   * Cuando `twitch` (real) está undefined pero sabemos que ese creador
+   * tendrá misión Twitch — se muestra placeholder "Próximamente" con
+   * link opcional al canal público (info abierta, no env var).
+   */
+  twitchComingSoon?: {
+    channelUrl: string | null;
+  } | null;
 }
 
 /**
@@ -35,7 +49,7 @@ interface Props {
  *
  * Cobradas se envían al final dentro de cada grupo — no ocupan el top.
  */
-export function MissionsGrid({ missions, discord, twitch }: Props) {
+export function MissionsGrid({ missions, discord, twitch, discordComingSoon, twitchComingSoon }: Props) {
   const [expanded, setExpanded] = useState(false);
 
   // Split por provider: Discord y Twitch aparte para renderizado con card específica.
@@ -51,7 +65,12 @@ export function MissionsGrid({ missions, discord, twitch }: Props) {
   const hasDiscordCard = discordMissions.length > 0 && Boolean(discord);
   const hasTwitchCard = twitchMissions.length > 0 && Boolean(twitch);
   const hasInternalCard = otherMissions.length > 0;
-  const hasAnyCard = hasDiscordCard || hasTwitchCard || hasInternalCard;
+  // Los placeholders "Próximamente" también cuentan como "algo visible" —
+  // no queremos mostrar empty state si vamos a renderizar al menos un
+  // placeholder social.
+  const hasDiscordPlaceholder = !hasDiscordCard && Boolean(discordComingSoon);
+  const hasTwitchPlaceholder = !hasTwitchCard && Boolean(twitchComingSoon);
+  const hasAnyCard = hasDiscordCard || hasTwitchCard || hasInternalCard || hasDiscordPlaceholder || hasTwitchPlaceholder;
 
   if (!hasAnyCard) {
     return (
@@ -85,6 +104,8 @@ export function MissionsGrid({ missions, discord, twitch }: Props) {
             />
           ))}
         </div>
+      ) : hasDiscordPlaceholder ? (
+        <DiscordMissionsPlaceholder />
       ) : null}
 
       {twitchMissions.length > 0 && twitch ? (
@@ -98,6 +119,8 @@ export function MissionsGrid({ missions, discord, twitch }: Props) {
             />
           ))}
         </div>
+      ) : hasTwitchPlaceholder ? (
+        <TwitchMissionsPlaceholder channelUrl={twitchComingSoon?.channelUrl ?? null} />
       ) : null}
 
       <div className="gp-missions-grid">
@@ -141,6 +164,74 @@ export function MissionsGrid({ missions, discord, twitch }: Props) {
       ) : null}
       <YoutubeMissionsPlaceholder />
     </>
+  );
+}
+
+/**
+ * Placeholder informativo — misión Discord "Próximamente".
+ *
+ * Se muestra cuando el creador tiene `isDiscordComingSoon(slug) === true`
+ * pero la card real todavía no puede renderizarse (falta env var, seed,
+ * OAuth o TOKEN_ENCRYPTION_KEY). Sin botones OAuth, sin server actions,
+ * sin puntos, sin claims. Cero contacto con DB.
+ *
+ * Cuando la config esté completa, `MissionsGrid` renderiza la card real
+ * (`DiscordMissionCard`) y este placeholder deja de aparecer.
+ */
+function DiscordMissionsPlaceholder() {
+  return (
+    <div
+      className="gp-missions-social-placeholder is-discord"
+      role="note"
+      aria-label="Misión Discord próximamente"
+    >
+      <div className="gp-missions-social-icon" aria-hidden>🎮</div>
+      <div className="gp-missions-social-body">
+        <div className="gp-missions-social-title">
+          Discord <span className="gp-missions-social-soon">· Próximamente</span>
+        </div>
+        <p className="gp-missions-social-desc">
+          Únete al Discord de ZACKETIZOR y consigue puntos cuando activemos esta misión.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Placeholder informativo — misión Twitch "Próximamente".
+ *
+ * Igual que el de Discord, pero con enlace opcional al canal público
+ * (info abierta — twitch.tv/<login>, no requiere env var). El link es
+ * seguro: no dispara OAuth, no crea sesión, solo redirige al canal.
+ */
+function TwitchMissionsPlaceholder({ channelUrl }: { channelUrl: string | null }) {
+  return (
+    <div
+      className="gp-missions-social-placeholder is-twitch"
+      role="note"
+      aria-label="Misión Twitch próximamente"
+    >
+      <div className="gp-missions-social-icon" aria-hidden>🎥</div>
+      <div className="gp-missions-social-body">
+        <div className="gp-missions-social-title">
+          Twitch <span className="gp-missions-social-soon">· Próximamente</span>
+        </div>
+        <p className="gp-missions-social-desc">
+          Sigue el canal de ZACKETIZOR y consigue puntos cuando activemos esta misión.
+        </p>
+        {channelUrl ? (
+          <a
+            href={channelUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="gp-missions-social-link"
+          >
+            Ver Twitch →
+          </a>
+        ) : null}
+      </div>
+    </div>
   );
 }
 

--- a/src/features/giveaway-platform/components/PlatformCreatorLanding.tsx
+++ b/src/features/giveaway-platform/components/PlatformCreatorLanding.tsx
@@ -21,8 +21,8 @@ import {
   todayInPlatformTz,
 } from '@/lib/giveaway-platform/constants';
 import { getCreatorVisual } from '@/features/giveaway-platform/constants/creators';
-import { getDiscordMissionTarget, isDiscordOauthConfigured } from '@/features/giveaway-platform/constants/discord-missions';
-import { getTwitchMissionTarget, isTwitchOauthConfigured } from '@/features/giveaway-platform/constants/twitch-missions';
+import { getDiscordMissionTarget, isDiscordOauthConfigured, isDiscordComingSoon } from '@/features/giveaway-platform/constants/discord-missions';
+import { getTwitchMissionTarget, isTwitchOauthConfigured, isTwitchComingSoon, getTwitchPublicChannelUrl } from '@/features/giveaway-platform/constants/twitch-missions';
 import { isTokenEncryptionConfigured } from '@/lib/crypto/token-encryption';
 import { getConnectedAccount } from '@/lib/queries/connectedSocialAccounts';
 import { PlatformNav } from '@/features/giveaway-platform/components/PlatformNav';
@@ -130,6 +130,12 @@ export async function PlatformCreatorLanding({ slug }: Props) {
         }
       : undefined;
 
+  // Modo "Próximamente" Discord — se muestra un placeholder anunciando la
+  // misión SOLO si el creador tiene el flag `isDiscordComingSoon` Y la card
+  // real todavía no puede renderizarse. Cuando la config se complete, el
+  // placeholder desaparece automáticamente y aparece la card real.
+  const discordComingSoon = !discordProp && isDiscordComingSoon(active.slug);
+
   // Config Twitch — misma lógica fail-safe que Discord. La card Twitch
   // solo aparece si target del creador + OAuth + cifrado están todos
   // configurados.
@@ -141,6 +147,12 @@ export async function PlatformCreatorLanding({ slug }: Props) {
           channelUrl: twitchTarget.channelUrl ?? null,
         }
       : undefined;
+
+  // Placeholder Twitch — como Discord, pero además incluye el channel URL
+  // público (info abierta, no env) para el CTA "Ver Twitch".
+  const twitchComingSoon = !twitchProp && isTwitchComingSoon(active.slug)
+    ? { channelUrl: getTwitchPublicChannelUrl(active.slug) }
+    : null;
 
   const hasSteamTradeUrl = Boolean(playerProfile?.steamTradeUrl && playerProfile.steamTradeUrl.trim().length > 0);
 
@@ -195,7 +207,13 @@ export async function PlatformCreatorLanding({ slug }: Props) {
             <section id="misiones">
               <div className="gp-legacy-block">
                 <h2>Misiones · gana puntos</h2>
-                <MissionsGrid missions={missions} discord={discordProp} twitch={twitchProp} />
+                <MissionsGrid
+                  missions={missions}
+                  discord={discordProp}
+                  twitch={twitchProp}
+                  discordComingSoon={discordComingSoon}
+                  twitchComingSoon={twitchComingSoon}
+                />
               </div>
             </section>
           </>

--- a/src/features/giveaway-platform/constants/discord-missions.ts
+++ b/src/features/giveaway-platform/constants/discord-missions.ts
@@ -48,3 +48,21 @@ export const DISCORD_OAUTH_SCOPES = 'identify guilds' as const;
 
 /** verificationMode canónico que persiste en `platform_missions`. */
 export const DISCORD_GUILD_MEMBER_MODE = 'discord_guild_member' as const;
+
+/**
+ * Creators cuya misión Discord queremos anunciar públicamente en modo
+ * "Próximamente" mientras terminamos de configurar env vars / seeds.
+ *
+ * El placeholder solo aparece si `getDiscordMissionTarget(slug)` devuelve
+ * `null` (es decir, la card real todavía NO puede renderizarse). Cuando la
+ * config esté completa, `getDiscordMissionTarget` devolverá el target y
+ * el placeholder desaparece automáticamente.
+ *
+ * Añadir un creador nuevo aquí requiere que sepas que ese creador tendrá
+ * misión Discord confirmada — sino, no lo pongas.
+ */
+const DISCORD_COMING_SOON_CREATORS: readonly string[] = ['zacketizor'];
+
+export function isDiscordComingSoon(creatorSlug: string): boolean {
+  return DISCORD_COMING_SOON_CREATORS.includes(creatorSlug);
+}

--- a/src/features/giveaway-platform/constants/twitch-missions.ts
+++ b/src/features/giveaway-platform/constants/twitch-missions.ts
@@ -58,3 +58,32 @@ export const TWITCH_OAUTH_SCOPES = 'user:read:follows' as const;
 
 /** verificationMode canónico que persiste en `platform_missions`. */
 export const TWITCH_FOLLOW_CHANNEL_MODE = 'twitch_follow_channel' as const;
+
+/**
+ * Creators cuya misión Twitch queremos anunciar públicamente en modo
+ * "Próximamente" mientras terminamos de configurar env vars / seeds.
+ *
+ * Ver comentario gemelo en `discord-missions.ts` — mismo criterio.
+ */
+const TWITCH_COMING_SOON_CREATORS: readonly string[] = ['zacketizor'];
+
+export function isTwitchComingSoon(creatorSlug: string): boolean {
+  return TWITCH_COMING_SOON_CREATORS.includes(creatorSlug);
+}
+
+/**
+ * URL pública del canal Twitch por creador — se usa solo en el placeholder
+ * "Próximamente" como enlace "Ver Twitch". No requiere env var porque el
+ * canal es información pública (twitch.tv/<login>).
+ *
+ * Cuando la misión real esté activa, el `channelUrl` viene de
+ * `env.TWITCH_ZACKETIZOR_CHANNEL_URL` vía `getTwitchMissionTarget`.
+ */
+export function getTwitchPublicChannelUrl(creatorSlug: string): string | null {
+  switch (creatorSlug) {
+    case 'zacketizor':
+      return 'https://www.twitch.tv/zacketizor';
+    default:
+      return null;
+  }
+}


### PR DESCRIPTION
## Summary

Placeholders públicos Discord + Twitch en `/sorteos/zacketizor` para anunciar las misiones sociales sin activar OAuth ni claims. Se muestran automáticamente cuando el fail-safe oculta las cards reales (env vars incompletas, seed no ejecutado, `TOKEN_ENCRYPTION_KEY` ausente). Cero cambio de comportamiento cuando la config esté completa — la card real toma precedencia sobre el placeholder.

## Comportamiento

| Escenario | Antes | Después |
|---|---|---|
| Env vars + seed completos | Card real interactiva | Card real interactiva (sin cambio) |
| Falta config **y** creador tiene flag coming-soon | Cero visible | **Placeholder "Próximamente"** ← nuevo |
| Falta config **y** creador NO tiene flag | Cero visible | Cero visible (sin cambio) |

Flag hardcoded solo para `'zacketizor'` en primera iteración.

## Archivos tocados (7)

**Modificados (5):**
- `src/features/giveaway-platform/constants/discord-missions.ts` — export `isDiscordComingSoon()`
- `src/features/giveaway-platform/constants/twitch-missions.ts` — export `isTwitchComingSoon()` + `getTwitchPublicChannelUrl()`
- `src/features/giveaway-platform/components/PlatformCreatorLanding.tsx` — calcula `discordComingSoon` / `twitchComingSoon` y los pasa a `MissionsGrid`
- `src/features/giveaway-platform/components/MissionsGrid.tsx` — props nuevos + `DiscordMissionsPlaceholder` + `TwitchMissionsPlaceholder`
- `src/app/sorteos/layout.tsx` — carga el nuevo CSS

**Nuevos (2):**
- `src/app/sorteos/plataforma/platform-missions-social-placeholder.css` — variantes `.is-discord` (blurple #5865F2) y `.is-twitch` (violeta #9146FF)
- `src/__tests__/server/social-missions-coming-soon.test.ts` — 35 tests estáticos

## Diff resumido

### Constants
```diff
// discord-missions.ts
+ const DISCORD_COMING_SOON_CREATORS: readonly string[] = ['zacketizor'];
+ export function isDiscordComingSoon(creatorSlug: string): boolean {
+   return DISCORD_COMING_SOON_CREATORS.includes(creatorSlug);
+ }

// twitch-missions.ts
+ const TWITCH_COMING_SOON_CREATORS: readonly string[] = ['zacketizor'];
+ export function isTwitchComingSoon(creatorSlug: string): boolean {
+   return TWITCH_COMING_SOON_CREATORS.includes(creatorSlug);
+ }
+ export function getTwitchPublicChannelUrl(creatorSlug: string): string | null {
+   switch (creatorSlug) {
+     case 'zacketizor': return 'https://www.twitch.tv/zacketizor';
+     default: return null;
+   }
+ }
```

### PlatformCreatorLanding.tsx
```diff
+ const discordComingSoon = !discordProp && isDiscordComingSoon(active.slug);
+ const twitchComingSoon = !twitchProp && isTwitchComingSoon(active.slug)
+   ? { channelUrl: getTwitchPublicChannelUrl(active.slug) }
+   : null;

  <MissionsGrid
    missions={missions}
    discord={discordProp}
    twitch={twitchProp}
+   discordComingSoon={discordComingSoon}
+   twitchComingSoon={twitchComingSoon}
  />
```

### MissionsGrid.tsx — placeholders + prioridad card > placeholder
```diff
- {discordMissions.length > 0 && discord ? (
-   <div className="gp-missions-grid">... card real ...</div>
- ) : null}
+ {discordMissions.length > 0 && discord ? (
+   <div className="gp-missions-grid">... card real ...</div>
+ ) : hasDiscordPlaceholder ? (
+   <DiscordMissionsPlaceholder />
+ ) : null}

  // idem para Twitch
+ function DiscordMissionsPlaceholder() { ... }  // role="note", sin <a>, sin <button>
+ function TwitchMissionsPlaceholder({ channelUrl }) { ... }  // role="note" + link "Ver Twitch →" opcional
```

## Copy exacto (verificado por tests)

**Discord:**
> **Discord · Próximamente**
>
> Únete al Discord de ZACKETIZOR y consigue puntos cuando activemos esta misión.

**Twitch:**
> **Twitch · Próximamente**
>
> Sigue el canal de ZACKETIZOR y consigue puntos cuando activemos esta misión.
>
> [Ver Twitch →](https://www.twitch.tv/zacketizor)

## Confirmaciones

- ✅ **Sin DB** — cero queries, cero schema, cero seeds nuevos
- ✅ **Sin OAuth** — endpoints intactos. Placeholders NO enlazan a `/api/auth/social/discord/connect` ni Twitch (test estático)
- ✅ **Sin env vars nuevas** — flags hardcoded en constants
- ✅ **Sin migración** — journal en `0109`. Test estático vigila
- ✅ **Sin server actions nuevas** — 1 export por action file (test estático)
- ✅ **Sin cambios de rewards, puntos, claims, rate limit**
- ✅ **Sin rediseño grande** — 2 placeholders siguiendo patrón YouTube ya en producción
- ✅ **Discord placeholder SIN enlace** — decisión del brief. Test verifica cero `<a>`, cero `<Link>`, cero `<button>`, cero `"Conectar Discord"`, cero `/api/auth/social/discord/`
- ✅ **Twitch placeholder SÍ enlace público** — `https://www.twitch.tv/zacketizor` con `target="_blank"` + `rel="noopener noreferrer"`. Info abierta, no env var

## Tests (+35 nuevos)

Grupos cubiertos:
- Flags `isDiscordComingSoon` / `isTwitchComingSoon` (6 asserts)
- `getTwitchPublicChannelUrl` — URL correcta + HTTPS + sin credenciales (3)
- Discord placeholder — sin `<a>` / `<Link>` / `<button>` / OAuth link / "Conectar Discord" (5)
- Discord copy exacto (2)
- Twitch placeholder — sin OAuth link, sin "Conectar Twitch", sin "Verificar" (3)
- Twitch link `target=_blank` + `rel=noopener noreferrer` + condicional (3)
- Twitch copy exacto (1)
- Prioridad card real > placeholder (3)
- Empty state considera los placeholders (1)
- `PlatformCreatorLanding` cableado correcto (5)
- Regresión sin migración / sin server actions nuevas (4)
- CSS y layout wiring (2)

**Suite completa: 3891 passed** (3856 → 3891, 196 suites, 6.7 s). Cero regresión.

## Checks locales

- `npx tsc --noEmit` — limpio en el diff
- `npx eslint` — limpio en los 5 archivos tocados
- `npx jest` — 3891/3891 verdes

## Riesgos pendientes

Ninguno nuevo. Los conocidos siguen:
- TD-15 Preview DB/Blob aislados
- TD-16 UNIQUE en `invoices.txId`
- TD-17 carpeta `proyectozack/` duplicada
- VRF/RANDAO raffles legales (fuera de scope)
- `mission_verify` fantasma en set cerrado

## Riesgo UX detectado (menor)

Al activar env vars + seed real, el placeholder desaparece y aparece la card real con botones "Conectar Discord". Cambio visual perceptible, esperado. Comunicable como "lanzamos hoy Discord missions" cuando pase.

## Test plan (post-merge, Production)

- [ ] `/sorteos/zacketizor` como usuario loggeado → placeholders Discord/Twitch visibles bajo "Misiones · gana puntos".
- [ ] Otros creadores (`/sorteos/imantado`, `/sorteos/naow`) → sin placeholders sociales.
- [ ] Click "Ver Twitch →" → abre `https://www.twitch.tv/zacketizor` en pestaña nueva.
- [ ] Discord placeholder no tiene botón "Conectar".
- [ ] Cuando se pueble `DISCORD_ZACKETIZOR_GUILD_ID` + seed → placeholder Discord desaparece, aparece card real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
