### PR TITLE
Tratos · PR1 · Entregables editables + limpieza drawer

### DIFF
--- a/drizzle/0110_add_preroll_to_deliverable_type.sql
+++ b/drizzle/0110_add_preroll_to_deliverable_type.sql
@@ -1,0 +1,14 @@
+-- Migración aditiva: añade `preroll` al enum `deliverable_type`.
+--
+-- Justificación (PR: tratos-entregables-editables): el módulo Tratos necesita
+-- distinguir "Preroll" como tipo de entregable independiente para editar
+-- cantidades objetivo en dealDeliverableTrackers y para replicar la plantilla
+-- de seguimiento tipo "Jolu - KD" que separa Preroll y Video.
+--
+-- NO destructivo:
+--   · Sólo AÑADE un valor al enum existente.
+--   · No modifica ni borra ningún dato.
+--   · IF NOT EXISTS para idempotencia si ya se aplicó.
+--   · Mismo patrón que 0017/0018/0030/0033.
+
+ALTER TYPE "public"."deliverable_type" ADD VALUE IF NOT EXISTS 'preroll';

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -771,6 +771,13 @@
       "when": 1783435200000,
       "tag": "0109_billing_clients_pdf_language",
       "breakpoints": true
+    },
+    {
+      "idx": 110,
+      "version": "7",
+      "when": 1783608000000,
+      "tag": "0110_add_preroll_to_deliverable_type",
+      "breakpoints": true
     }
   ]
 }

--- a/src/__tests__/server/finanzas-rentabilidad-6b.test.ts
+++ b/src/__tests__/server/finanzas-rentabilidad-6b.test.ts
@@ -44,11 +44,12 @@ describe('Rentabilidad 6B — invariantes de PR 6A preservadas', () => {
     expect(src).toMatch(/requirePermission\(['"]facturacion['"],\s*['"]read['"]\)/);
   });
 
-  it('no crea migración nueva 011X', () => {
+  it('no crea migración nueva del ámbito rentabilidad', () => {
+    // Refactorizado tras 0110 (aditiva, otra PR): esta PR (rentabilidad 6B)
+    // sólo añade rankings y charts — no debería introducir migraciones de su
+    // ámbito. Comprobación por naming.
     const journal = read('drizzle/meta/_journal.json');
-    expect(journal).toMatch(/"tag":\s*"0109_billing_clients_pdf_language"/);
-    expect(journal).not.toMatch(/"tag":\s*"0110_/);
-    expect(journal).not.toMatch(/"tag":\s*"0111_/);
+    expect(journal).not.toMatch(/"tag":\s*"\d{4}_[^"]*(rentab|pnl|margin|profit|ranking)[^"]*"/i);
   });
 });
 

--- a/src/__tests__/server/finanzas-rentabilidad.test.ts
+++ b/src/__tests__/server/finanzas-rentabilidad.test.ts
@@ -215,12 +215,11 @@ describe('PR 6A — sin scope creep', () => {
     }
   });
 
-  it('no crea migración nueva 011X', () => {
-    // Comprobamos que el último journal entry sigue siendo el conocido del PR anterior.
-    // Si en el futuro se hace una migración legítima, este test debe actualizarse.
+  it('no crea migración nueva del ámbito rentabilidad/pnl', () => {
+    // Refactorizado tras 0110 (aditiva, otra PR): esta PR (rentabilidad 6A)
+    // sólo debía ser query + UI — comprobamos que no aparece migración
+    // relacionada con rentabilidad/pnl/margin en el journal.
     const journal = read('drizzle/meta/_journal.json');
-    expect(journal).toMatch(/"tag":\s*"0109_billing_clients_pdf_language"/);
-    // No hay 0110 aún en PR 6A
-    expect(journal).not.toMatch(/"tag":\s*"0110_/);
+    expect(journal).not.toMatch(/"tag":\s*"\d{4}_[^"]*(rentab|pnl|margin|profit)[^"]*"/i);
   });
 });

--- a/src/__tests__/server/social-missions-coming-soon.test.ts
+++ b/src/__tests__/server/social-missions-coming-soon.test.ts
@@ -194,17 +194,16 @@ describe('PlatformCreatorLanding — cableado del flag coming_soon', () => {
 });
 
 describe('Regresión — sin migración ni server actions nuevas', () => {
-  it('última migration sigue siendo 0109', () => {
-    const files = fs.readdirSync(path.join(ROOT, 'drizzle')).filter((f) => /^\d{4}_.*\.sql$/.test(f));
-    const last = files.sort()[files.length - 1];
-    expect(last).toBeDefined();
-    expect(last!).toMatch(/^0109_/);
-  });
+  // Refactorizado tras 0110 (aditiva, otra PR): comprobamos que no hay
+  // migración nueva del ámbito de esta PR (social missions coming soon).
+  const SCOPE_RE = /^\d{4}_.*(social[_-]?mission|discord|twitch|youtube|coming[_-]?soon|placeholder)/i;
 
-  it('no aparece migration 0110/0111', () => {
-    const files = fs.readdirSync(path.join(ROOT, 'drizzle'));
-    expect(files.find((f) => f.startsWith('0110_'))).toBeUndefined();
-    expect(files.find((f) => f.startsWith('0111_'))).toBeUndefined();
+  it('no aparecen migraciones nuevas del ámbito social missions', () => {
+    const files = fs.readdirSync(path.join(ROOT, 'drizzle')).filter((f) => /^\d{4}_.*\.sql$/.test(f));
+    for (const f of files.filter((x) => SCOPE_RE.test(x))) {
+      const idx = Number(f.substring(0, 4));
+      expect(idx).toBeLessThanOrEqual(109);
+    }
   });
 
   it('discord-mission-action.ts sigue con 1 export (verifyDiscordMission)', () => {

--- a/src/__tests__/server/social-missions-ux-polish.test.ts
+++ b/src/__tests__/server/social-missions-ux-polish.test.ts
@@ -120,17 +120,18 @@ describe('CSS — clases añadidas por polish', () => {
 });
 
 describe('Sin migración ni server actions nuevas', () => {
-  it('la última migration sigue siendo 0109', () => {
-    const files = fs.readdirSync(path.join(ROOT, 'drizzle')).filter((f) => /^\d{4}_.*\.sql$/.test(f));
-    const last = files.sort()[files.length - 1];
-    expect(last).toBeDefined();
-    expect(last!).toMatch(/^0109_/);
-  });
+  // Verificamos que esta PR (UX puro social missions) no introdujo ninguna
+  // migración de su ámbito. Test refactorizado tras 0110 (aditiva, otra PR).
+  const SCOPE_RE = /^\d{4}_.*(social[_-]?mission|discord|twitch|youtube|coin|reward)/i;
 
-  it('no aparece migration 0110/0111 (esta PR es UX puro)', () => {
-    const files = fs.readdirSync(path.join(ROOT, 'drizzle'));
-    expect(files.find((f) => f.startsWith('0110_'))).toBeUndefined();
-    expect(files.find((f) => f.startsWith('0111_'))).toBeUndefined();
+  it('no aparecen migraciones nuevas del ámbito social missions', () => {
+    const files = fs.readdirSync(path.join(ROOT, 'drizzle')).filter((f) => /^\d{4}_.*\.sql$/.test(f));
+    for (const f of files.filter((x) => SCOPE_RE.test(x))) {
+      const idx = Number(f.substring(0, 4));
+      // La migración legítima previa de social missions ya existe; no debe
+      // aparecer ninguna nueva por encima del corte de la PR original.
+      expect(idx).toBeLessThanOrEqual(109);
+    }
   });
 
   it('discord-mission-action.ts sigue exportando solo verifyDiscordMission (no nuevas actions)', () => {

--- a/src/__tests__/server/sorteos-fase1-pr2-no-migration.test.ts
+++ b/src/__tests__/server/sorteos-fase1-pr2-no-migration.test.ts
@@ -12,29 +12,32 @@ import * as path from 'path';
 const DRIZZLE_DIR = path.join(process.cwd(), 'drizzle');
 
 describe('Fase 1 PR2 — sin migración nueva', () => {
-  it('la última migration en el journal es 0109_*', () => {
+  // Nota histórica: este test verificaba que la última migration fuera 0109.
+  // Cuando una PR ajena (tratos-entregables-editables) añade una migration
+  // aditiva, la aserción se refactoriza a "ninguna migración del ámbito
+  // sorteos/raffle nueva" — que es la intención real del test.
+  const SCOPE_RE = /^\d{4}_.*(sorteo|raffle|prize|coin|social[_-]?mission|consent[_-]?gate)/i;
+
+  it('no aparecen migraciones nuevas del ámbito sorteos/raffle', () => {
     const files = fs.readdirSync(DRIZZLE_DIR).filter((f) => f.endsWith('.sql'));
-    const migrations = files
-      .filter((f) => /^\d{4}_/.test(f))
-      .sort();
-    const last = migrations[migrations.length - 1];
-    expect(last).toBeDefined();
-    expect(last!).toMatch(/^0109_/);
+    const scoped = files.filter((f) => SCOPE_RE.test(f) && !f.startsWith('_legacy_'));
+    // Solo la migration 0106 legítima de Fase 1 PR1 (consent gate) debe quedar.
+    // La Fase 1 PR2 confirmó "sin nueva migración de este ámbito".
+    for (const f of scoped) {
+      const idx = Number(f.substring(0, 4));
+      expect(idx).toBeLessThanOrEqual(108);
+    }
   });
 
-  it('no existe migration 0110 ni 0111', () => {
-    const files = fs.readdirSync(DRIZZLE_DIR);
-    expect(files.find((f) => f.startsWith('0110_'))).toBeUndefined();
-    expect(files.find((f) => f.startsWith('0111_'))).toBeUndefined();
-  });
-
-  it('el journal de meta refleja 0109 como último', () => {
+  it('el journal no contiene tags de sorteos/raffle posteriores a 0106', () => {
     const journalPath = path.join(DRIZZLE_DIR, 'meta', '_journal.json');
     const raw = fs.readFileSync(journalPath, 'utf8');
-    const parsed = JSON.parse(raw) as { entries?: Array<{ tag: string }> };
+    const parsed = JSON.parse(raw) as { entries?: Array<{ idx: number; tag: string }> };
     const entries = parsed.entries ?? [];
-    const last = entries[entries.length - 1];
-    expect(last).toBeDefined();
-    expect(last!.tag).toMatch(/^0109_/);
+    for (const e of entries) {
+      if (SCOPE_RE.test(`${e.idx.toString().padStart(4, '0')}_${e.tag.replace(/^\d+_/, '')}`)) {
+        expect(e.idx).toBeLessThanOrEqual(108);
+      }
+    }
   });
 });

--- a/src/__tests__/server/tratos-entregables-drawer.test.ts
+++ b/src/__tests__/server/tratos-entregables-drawer.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Tests estáticos del drawer/formulario de Tratos tras PR
+ * `tratos-entregables-editables`.
+ *
+ * Cubre:
+ *   1. El drawer NO renderiza inputs con name briefingUrl/contentUrl/
+ *      estimatedCostAgency/estimatedMarginPct (ocultos, columnas DB conservadas).
+ *   2. SummaryCard NO renderiza los links briefingUrl/contentUrl.
+ *   3. El drawer incluye el nuevo bloque DeliverablesEditor.
+ *   4. DeliverablesEditor tiene botón "Generar plantilla" disabled con tooltip.
+ *   5. DeliverablesEditor serializa a un hidden input `deliverables_json`.
+ *   6. Ningún archivo del feature llama a Google APIs.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const ROOT = path.resolve(__dirname, '..', '..', '..');
+
+const DRAWER_PARTS = path.join(ROOT, 'src/features/admin/campaigns/components/CampaignDrawer.parts.tsx');
+const SUMMARY_CARD = path.join(ROOT, 'src/features/admin/campaigns/components/CampaignSummaryCard.tsx');
+const EDITOR       = path.join(ROOT, 'src/features/admin/campaigns/components/DeliverablesEditor.tsx');
+const ACTIONS      = path.join(ROOT, 'src/app/admin/(dashboard)/campanas/actions.ts');
+const SYNC         = path.join(ROOT, 'src/lib/queries/campaign-deliverables-sync.ts');
+
+function read(p: string): string {
+  return fs.readFileSync(p, 'utf-8');
+}
+
+describe('drawer sin campos ocultos', () => {
+  const src = read(DRAWER_PARTS);
+
+  it('NO renderiza input name="briefingUrl"', () => {
+    expect(src).not.toMatch(/name=["']briefingUrl["']/);
+  });
+
+  it('NO renderiza input name="contentUrl"', () => {
+    expect(src).not.toMatch(/name=["']contentUrl["']/);
+  });
+
+  it('NO renderiza input name="estimatedCostAgency"', () => {
+    expect(src).not.toMatch(/name=["']estimatedCostAgency["']/);
+  });
+
+  it('NO renderiza input name="estimatedMarginPct"', () => {
+    expect(src).not.toMatch(/name=["']estimatedMarginPct["']/);
+  });
+
+  it('NO renderiza label "Estimaciones internas" ni "URL briefing" ni "URL contenido"', () => {
+    // El label del bloque "Estimaciones internas" se retiró junto con los inputs.
+    // Puede aparecer en comentarios explicando por qué se ocultó; buscamos texto
+    // renderizable (dentro de un JSX text node o de un label).
+    expect(src).not.toMatch(/>[^<]*Estimaciones internas[^<]*</);
+    expect(src).not.toMatch(/label="URL briefing"/);
+    expect(src).not.toMatch(/label="URL contenido"/);
+  });
+
+  it('SÍ incluye <DeliverablesEditor', () => {
+    expect(src).toMatch(/<DeliverablesEditor\s/);
+  });
+});
+
+describe('SummaryCard sin links de briefing/contenido', () => {
+  const src = read(SUMMARY_CARD);
+
+  it('NO renderiza label "Briefing" ni link "Ver briefing"', () => {
+    expect(src).not.toMatch(/label="Briefing"/);
+    expect(src).not.toMatch(/Ver briefing/);
+  });
+
+  it('NO renderiza label "Contenido" ni link "Ver contenido"', () => {
+    expect(src).not.toMatch(/label="Contenido"/);
+    expect(src).not.toMatch(/Ver contenido/);
+  });
+
+  it('NO renderiza campaign.briefingUrl ni campaign.contentUrl en JSX', () => {
+    // Los accesos siguen existiendo en queries; aquí verificamos que no se
+    // renderiza contenido en el componente.
+    expect(src).not.toMatch(/href=\{campaign\.briefingUrl/);
+    expect(src).not.toMatch(/href=\{campaign\.contentUrl/);
+  });
+});
+
+describe('DeliverablesEditor', () => {
+  const src = read(EDITOR);
+
+  it('renderiza el hidden input name="deliverables_json"', () => {
+    expect(src).toMatch(/name=["']deliverables_json["']/);
+  });
+
+  it('permite añadir filas (botón "Añadir entregable")', () => {
+    expect(src).toMatch(/Añadir entregable/);
+  });
+
+  it('permite eliminar filas (botón "Quitar")', () => {
+    expect(src).toMatch(/aria-label=["']Eliminar entregable["']/);
+  });
+
+  it('el botón "Generar plantilla de seguimiento" está disabled con tooltip', () => {
+    expect(src).toMatch(/Generar plantilla de seguimiento/);
+    // Debe estar disabled y tener un title explicativo.
+    expect(src).toMatch(/disabled/);
+    expect(src).toMatch(/Próximamente[\s\S]{0,60}PR2/);
+  });
+
+  it('NO llama a Google APIs ni menciona GOOGLE_SHEETS/drive/oauth', () => {
+    expect(src).not.toMatch(/GOOGLE_SHEETS_API_KEY/);
+    expect(src).not.toMatch(/google\.sheets/i);
+    expect(src).not.toMatch(/oauth/i);
+    expect(src).not.toMatch(/drive\.google/i);
+    expect(src).not.toMatch(/spreadsheets\.google/i);
+  });
+
+  it('usa el enum de tipos existente (importa de @/lib/schemas/deliverable)', () => {
+    expect(src).toMatch(/from\s+['"]@\/lib\/schemas\/deliverable['"]/);
+    expect(src).toMatch(/DELIVERABLE_TYPES/);
+    expect(src).toMatch(/DELIVERABLE_TYPE_LABELS/);
+  });
+});
+
+describe('Server action integra deliverables_json', () => {
+  const src = read(ACTIONS);
+
+  it('importa parseDeliverablesJson', () => {
+    expect(src).toMatch(/parseDeliverablesJson/);
+  });
+
+  it('importa syncCampaignDeliverables', () => {
+    expect(src).toMatch(/syncCampaignDeliverables/);
+  });
+
+  it('createCampaignAction sincroniza trackers cuando llegan filas', () => {
+    // Buscamos la llamada dentro de la función create.
+    const createBlock = src.match(/createCampaignAction[\s\S]+?^\}/m)?.[0] ?? '';
+    expect(createBlock).toMatch(/parseDeliverablesJson\(formData\.get\('deliverables_json'\)\)/);
+    expect(createBlock).toMatch(/syncCampaignDeliverables\(campaign\.id/);
+  });
+
+  it('updateCampaignAction sincroniza trackers cuando llegan filas', () => {
+    const updateBlock = src.match(/updateCampaignAction[\s\S]+?^\}/m)?.[0] ?? '';
+    expect(updateBlock).toMatch(/parseDeliverablesJson\(formData\.get\('deliverables_json'\)\)/);
+    expect(updateBlock).toMatch(/syncCampaignDeliverables\(id/);
+  });
+});
+
+describe('sync util — soft-delete y sin borrado destructivo', () => {
+  const src = read(SYNC);
+
+  it('marca como cancelled los trackers que ya no aparecen (soft-delete)', () => {
+    expect(src).toMatch(/status:\s*['"]cancelled['"]/);
+  });
+
+  it('NO ejecuta db.delete', () => {
+    expect(src).not.toMatch(/\bdb\.delete\s*\(/);
+  });
+
+  it('trackingSourceType siempre "manual" al insertar desde el drawer', () => {
+    expect(src).toMatch(/trackingSourceType:\s*['"]manual['"]/);
+  });
+});
+
+describe('no hay llamadas a Google APIs en el feature', () => {
+  const files = [DRAWER_PARTS, EDITOR, ACTIONS, SYNC];
+  it('ninguno importa @/lib/integrations/google-sheets o drive-auth', () => {
+    for (const f of files) {
+      const src = read(f);
+      expect(src).not.toMatch(/from\s+['"]@\/lib\/integrations\/google-sheets/);
+      expect(src).not.toMatch(/from\s+['"]@\/lib\/backup\/drive-auth/);
+    }
+  });
+});

--- a/src/__tests__/server/tratos-entregables-migration.test.ts
+++ b/src/__tests__/server/tratos-entregables-migration.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Contratos de la migración 0110 (aditiva, no destructiva).
+ *
+ * La migración solo AÑADE 'preroll' al enum deliverable_type existente.
+ * No borra ni renombra nada.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const ROOT = path.resolve(__dirname, '..', '..', '..');
+const MIGRATION = path.join(ROOT, 'drizzle/0110_add_preroll_to_deliverable_type.sql');
+const JOURNAL = path.join(ROOT, 'drizzle/meta/_journal.json');
+const SCHEMA = path.join(ROOT, 'src/db/schema/deliverables.ts');
+
+describe('migración 0110 — aditiva, no destructiva', () => {
+  it('el archivo SQL existe', () => {
+    expect(fs.existsSync(MIGRATION)).toBe(true);
+  });
+
+  it('SÓLO usa ALTER TYPE ADD VALUE — nada de DROP/DELETE/RENAME', () => {
+    const src = fs.readFileSync(MIGRATION, 'utf-8');
+    expect(src).toMatch(/ALTER TYPE .+ADD VALUE .+preroll/i);
+    expect(src).not.toMatch(/\bDROP\b/i);
+    expect(src).not.toMatch(/\bDELETE\b/i);
+    expect(src).not.toMatch(/\bRENAME\b/i);
+    expect(src).not.toMatch(/\bTRUNCATE\b/i);
+  });
+
+  it('usa IF NOT EXISTS para idempotencia', () => {
+    const src = fs.readFileSync(MIGRATION, 'utf-8');
+    expect(src).toMatch(/IF NOT EXISTS/i);
+  });
+
+  it('el journal referencia la migración con idx 110', () => {
+    const journal = JSON.parse(fs.readFileSync(JOURNAL, 'utf-8')) as {
+      entries: Array<{ idx: number; tag: string }>;
+    };
+    const entry = journal.entries.find((e) => e.idx === 110);
+    expect(entry).toBeDefined();
+    expect(entry?.tag).toBe('0110_add_preroll_to_deliverable_type');
+  });
+
+  it('el enum del schema Drizzle incluye preroll', () => {
+    const src = fs.readFileSync(SCHEMA, 'utf-8');
+    expect(src).toMatch(/pgEnum\(['"]deliverable_type['"][\s\S]+?['"]preroll['"]/);
+  });
+});

--- a/src/__tests__/server/tratos-entregables-parser.test.ts
+++ b/src/__tests__/server/tratos-entregables-parser.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Tests unitarios del parser `parseDeliverablesJson` y del schema Zod.
+ * No toca DB.
+ */
+
+import { parseDeliverablesJson, deliverableEditorPayloadSchema } from '@/lib/schemas/campaign-deliverables';
+
+describe('parseDeliverablesJson', () => {
+  it('retorna [] cuando el input es null/undefined/vacío', () => {
+    expect(parseDeliverablesJson(null)).toEqual([]);
+    expect(parseDeliverablesJson(undefined)).toEqual([]);
+    expect(parseDeliverablesJson('')).toEqual([]);
+    expect(parseDeliverablesJson('   ')).toEqual([]);
+    expect(parseDeliverablesJson('[]')).toEqual([]);
+  });
+
+  it('parsea payload válido', () => {
+    const json = JSON.stringify([
+      { deliverableType: 'stream_integration', targetCount: 15 },
+      { id: 42, deliverableType: 'preroll', targetCount: 12, notes: 'test' },
+    ]);
+    const out = parseDeliverablesJson(json);
+    expect(out).toHaveLength(2);
+    expect(out[0]).toEqual({ deliverableType: 'stream_integration', targetCount: 15 });
+    expect(out[1]).toEqual({ id: 42, deliverableType: 'preroll', targetCount: 12, notes: 'test' });
+  });
+
+  it('acepta preroll como tipo (añadido al enum en esta PR)', () => {
+    const out = parseDeliverablesJson(JSON.stringify([
+      { deliverableType: 'preroll', targetCount: 5 },
+    ]));
+    expect(out).toHaveLength(1);
+    expect(out[0]?.deliverableType).toBe('preroll');
+  });
+
+  it('NUNCA lanza en JSON inválido — retorna []', () => {
+    expect(parseDeliverablesJson('not json')).toEqual([]);
+    expect(parseDeliverablesJson('{"invalid":"shape"}')).toEqual([]);
+    expect(parseDeliverablesJson(JSON.stringify([{ deliverableType: 'INVALID', targetCount: 1 }]))).toEqual([]);
+    expect(parseDeliverablesJson(JSON.stringify([{ deliverableType: 'preroll', targetCount: 0 }]))).toEqual([]);
+    expect(parseDeliverablesJson(JSON.stringify([{ deliverableType: 'preroll', targetCount: -1 }]))).toEqual([]);
+  });
+
+  it('descarta filas con targetCount fuera de rango', () => {
+    const parsed = deliverableEditorPayloadSchema.safeParse([
+      { deliverableType: 'stream_integration', targetCount: 1000 },
+    ]);
+    expect(parsed.success).toBe(false);
+  });
+
+  it('trim + limpia notas vacías', () => {
+    const out = parseDeliverablesJson(JSON.stringify([
+      { deliverableType: 'stream_integration', targetCount: 5, notes: '   ' },
+    ]));
+    expect(out[0]?.notes).toBeUndefined();
+  });
+});
+
+describe('no impacta en el resto del CRM', () => {
+  it('los tipos DELIVERABLE_TYPES incluyen preroll', () => {
+    const { DELIVERABLE_TYPES } = jest.requireActual('@/lib/schemas/deliverable') as { DELIVERABLE_TYPES: readonly string[] };
+    expect(DELIVERABLE_TYPES).toContain('preroll');
+    expect(DELIVERABLE_TYPES).toContain('stream_integration');
+    expect(DELIVERABLE_TYPES).toContain('otro');
+  });
+});

--- a/src/app/admin/(dashboard)/campanas/actions.ts
+++ b/src/app/admin/(dashboard)/campanas/actions.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from 'next/cache';
 
 import { requirePermission } from '@/lib/permissions';
 import { createCampaignSchema, updateCampaignSchema } from '@/lib/schemas/campaign';
+import { parseDeliverablesJson } from '@/lib/schemas/campaign-deliverables';
 import {
   createCampaign,
   updateCampaign,
@@ -11,6 +12,7 @@ import {
   unarchiveCampaign,
   assertCanEditCampaign,
 } from '@/lib/queries/campaigns';
+import { syncCampaignDeliverables } from '@/lib/queries/campaign-deliverables-sync';
 
 import { compact } from '@/lib/utils/objects';
 
@@ -38,6 +40,14 @@ export async function createCampaignAction(
 
     const campaign = await createCampaign(input);
 
+    // Entregables (dealDeliverableTrackers) — se sincronizan post-create con
+    // el id ya conocido. parseDeliverablesJson nunca lanza; retorna [] si el
+    // payload está ausente o malformado, así no rompe el create básico.
+    const deliverables = parseDeliverablesJson(formData.get('deliverables_json'));
+    if (deliverables.length > 0) {
+      await syncCampaignDeliverables(campaign.id, deliverables);
+    }
+
     revalidatePath('/admin/campanas');
     return { success: true, id: campaign.id };
   } catch (err) {
@@ -63,6 +73,15 @@ export async function updateCampaignAction(
     await assertCanEditCampaign(id, { userId: session.user.id, role: session.user.role });
 
     await updateCampaign(id, compact(rest) as Partial<CreateCampaignInput>);
+
+    // Entregables — sincroniza siempre (incluso array vacío) para que quitar
+    // todas las filas cancele los trackers activos.
+    const deliverables = parseDeliverablesJson(formData.get('deliverables_json'));
+    // Solo procesa si el input trajo el campo (para no cancelar en actualizaciones
+    // parciales que ni siquiera envían deliverables_json).
+    if (formData.has('deliverables_json')) {
+      await syncCampaignDeliverables(id, deliverables);
+    }
 
     revalidatePath('/admin/campanas');
     return { success: true };

--- a/src/app/admin/(dashboard)/campanas/page.tsx
+++ b/src/app/admin/(dashboard)/campanas/page.tsx
@@ -8,6 +8,7 @@ import { listCampaigns } from '@/lib/queries/campaigns';
 import { listCrmBrands, getBrandContacts } from '@/lib/queries/crmBrands';
 import { getAllTalents } from '@/lib/queries/talents';
 import { listInvoices } from '@/lib/queries/invoices';
+import { listActiveDeliverablesForCampaigns } from '@/lib/queries/campaign-deliverables-sync';
 import { getUsdEurRate } from '@/lib/exchangeRate';
 import { CampaignsList } from '@/features/admin/campaigns/components/CampaignsList';
 
@@ -65,6 +66,10 @@ export default async function AdminCampanasPage(): Promise<React.ReactElement> {
     };
   });
 
+  const deliverablesByCampaign = await listActiveDeliverablesForCampaigns(
+    campaigns.map((c) => c.id),
+  );
+
   return (
     <CampaignsList
       campaigns={campaigns}
@@ -76,6 +81,7 @@ export default async function AdminCampanasPage(): Promise<React.ReactElement> {
       rate={exchangeRate.rate}
       rateDate={exchangeRate.date}
       rateIsEstimated={exchangeRate.isEstimated}
+      deliverablesByCampaign={deliverablesByCampaign}
     />
   );
 }

--- a/src/db/schema/deliverables.ts
+++ b/src/db/schema/deliverables.ts
@@ -46,6 +46,7 @@ export const deliverableTypeEnum = pgEnum('deliverable_type', [
   'post_instagram',
   'pack_mensual',
   'pack_trimestral',
+  'preroll',
   'otro',
 ]);
 

--- a/src/features/admin/campaigns/components/CampaignDrawer.parts.tsx
+++ b/src/features/admin/campaigns/components/CampaignDrawer.parts.tsx
@@ -17,6 +17,7 @@ import {
   archiveCampaignAction,
 } from '@/app/admin/(dashboard)/campanas/actions';
 import type { CampaignRow, CrmBrandContact } from '@/types';
+import { DeliverablesEditor, type DeliverableEditorRow } from './DeliverablesEditor';
 
 // ── Shared types ───────────────────────────────────────────────────────────────
 
@@ -84,6 +85,11 @@ export type CampaignFormProps = {
   readonly staffUsers: readonly StaffOption[];
   readonly contactsByBrand: Readonly<Record<number, readonly CrmBrandContact[]>>;
   readonly isManager: boolean;
+  /**
+   * Entregables (dealDeliverableTrackers) existentes para el trato — solo
+   * relevante en modo edición. `[]` al crear.
+   */
+  readonly initialDeliverables?: readonly DeliverableEditorRow[];
 };
 
 export function CampaignForm({
@@ -95,6 +101,7 @@ export function CampaignForm({
   staffUsers,
   contactsByBrand,
   isManager,
+  initialDeliverables = [],
 }: CampaignFormProps): React.ReactElement {
   const router = useRouter();
   const [, startTransition] = useTransition();
@@ -247,7 +254,10 @@ export function CampaignForm({
       )}
 
       {/* Tipo de acción */}
-      <Field label="Tipo de acción *">
+      <Field
+        label="Tipo de acción *"
+        hint="Categoría principal. Los entregables concretos se detallan más abajo."
+      >
         <select
           name="actionType"
           required
@@ -331,26 +341,10 @@ export function CampaignForm({
         />
       </Field>
 
-      {/* URLs */}
-      <Field label="URL briefing">
-        <input
-          type="url"
-          name="briefingUrl"
-          defaultValue={campaign?.briefingUrl ?? ''}
-          placeholder="https://…"
-          className={inputCls}
-        />
-      </Field>
-
-      <Field label="URL contenido">
-        <input
-          type="url"
-          name="contentUrl"
-          defaultValue={campaign?.contentUrl ?? ''}
-          placeholder="https://…"
-          className={inputCls}
-        />
-      </Field>
+      {/* URLs briefing/contenido — OCULTOS (PR: tratos-entregables-editables).
+          Columnas DB conservadas; solo se retiran del formulario porque el
+          equipo ya no las usa activamente. Los valores existentes siguen
+          consultables desde queries y SummaryCard (también oculto). */}
 
       {/* Moneda + importes */}
       <input type="hidden" name="currency" value={currency} />
@@ -509,37 +503,12 @@ export function CampaignForm({
         </select>
       </Field>
 
-      {/* Estimates — coste interno estimado y margen previsto */}
-      <div className="border-t border-sp-admin-border/50 pt-3">
-        <p className="text-[11px] uppercase tracking-wider font-semibold text-sp-admin-muted mb-3">
-          Estimaciones internas
-        </p>
-        <div className="grid grid-cols-2 gap-3">
-          <Field label="Coste estimado agencia (€)" hint="Horas + gastos internos previstos">
-            <input
-              type="number"
-              name="estimatedCostAgency"
-              min="0"
-              step="10"
-              defaultValue={campaign?.estimatedCostAgency ?? ''}
-              placeholder="0"
-              className={inputCls}
-            />
-          </Field>
-          <Field label="Margen previsto (%)" hint="Comisión estimada sobre el deal">
-            <input
-              type="number"
-              name="estimatedMarginPct"
-              min="0"
-              max="100"
-              step="0.5"
-              defaultValue={campaign?.estimatedMarginPct ?? ''}
-              placeholder="20"
-              className={inputCls}
-            />
-          </Field>
-        </div>
-      </div>
+      {/* Bloque estimaciones ocultado (PR tratos-entregables-editables).
+          Columnas DB conservadas. AI assistant sigue leyendo valores previos. */}
+
+      {/* Entregables del trato — se persisten en dealDeliverableTrackers via
+          Server Action. Ver DeliverablesEditor.tsx. */}
+      <DeliverablesEditor initialRows={initialDeliverables} />
 
       {/* Notas */}
       <Field label="Notas">

--- a/src/features/admin/campaigns/components/CampaignDrawer.tsx
+++ b/src/features/admin/campaigns/components/CampaignDrawer.tsx
@@ -4,6 +4,7 @@ import { EditDrawer } from '@/features/admin/_shared/components/EditDrawer';
 import type { CampaignRow, CrmBrandContact } from '@/types';
 
 import { CampaignForm, type BrandOption, type TalentOption, type StaffOption } from './CampaignDrawer.parts';
+import type { DeliverableEditorRow } from './DeliverablesEditor';
 
 type Props = {
   readonly campaign: CampaignRow | null;
@@ -14,6 +15,7 @@ type Props = {
   readonly staffUsers: readonly StaffOption[];
   readonly contactsByBrand: Readonly<Record<number, readonly CrmBrandContact[]>>;
   readonly isManager: boolean;
+  readonly initialDeliverables?: readonly DeliverableEditorRow[];
 };
 
 /**
@@ -31,6 +33,7 @@ export function CampaignDrawer({
   staffUsers,
   contactsByBrand,
   isManager,
+  initialDeliverables = [],
 }: Props): React.ReactElement {
   // Use campaign id (or 'new') as key so the form remounts on each open/switch
   const formKey = isOpen ? (campaign ? String(campaign.id) : 'new') : 'closed';
@@ -51,6 +54,7 @@ export function CampaignDrawer({
         staffUsers={staffUsers}
         contactsByBrand={contactsByBrand}
         isManager={isManager}
+        initialDeliverables={initialDeliverables}
       />
     </EditDrawer>
   );

--- a/src/features/admin/campaigns/components/CampaignSummaryCard.tsx
+++ b/src/features/admin/campaigns/components/CampaignSummaryCard.tsx
@@ -272,36 +272,9 @@ export function CampaignSummaryCard({ campaign }: Props): React.ReactElement {
           {campaign.deliveryDeadline !== null && (
             <InfoRow label="Fecha entrega" value={formatDate(campaign.deliveryDeadline)} />
           )}
-          {campaign.briefingUrl !== null && campaign.briefingUrl !== '' && (
-            <InfoRow
-              label="Briefing"
-              value={
-                <a
-                  href={campaign.briefingUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-sp-admin-accent hover:underline"
-                >
-                  Ver briefing ↗
-                </a>
-              }
-            />
-          )}
-          {campaign.contentUrl !== null && campaign.contentUrl !== '' && (
-            <InfoRow
-              label="Contenido"
-              value={
-                <a
-                  href={campaign.contentUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-sp-admin-accent hover:underline"
-                >
-                  Ver contenido ↗
-                </a>
-              }
-            />
-          )}
+          {/* briefingUrl y contentUrl OCULTOS (PR: tratos-entregables-editables).
+              Columnas DB conservadas; los valores guardados siguen accesibles
+              vía queries. */}
           <InfoRow
             label="Creada"
             value={formatDate(campaign.createdAt.toISOString())}

--- a/src/features/admin/campaigns/components/CampaignsList.tsx
+++ b/src/features/admin/campaigns/components/CampaignsList.tsx
@@ -15,6 +15,8 @@ import {
 import type { CampaignWithRelations } from '@/types';
 import type { CampaignFilterState } from '@/features/admin/campaigns/components/CampaignFilters';
 import type { CrmBrandContact }     from '@/types';
+import type { DeliverableType }     from '@/lib/schemas/deliverable';
+import type { DeliverableEditorRow } from '@/features/admin/campaigns/components/DeliverablesEditor';
 
 import {
   EUR,
@@ -49,6 +51,17 @@ type Props = {
   readonly rate?:            number;
   readonly rateDate?:        string;
   readonly rateIsEstimated?: boolean;
+  /**
+   * Trackers activos (`dealDeliverableTrackers`) precargados por campaign.
+   * Se pasan al drawer cuando se abre en modo edición para poblar el editor
+   * de entregables sin fetch adicional.
+   */
+  readonly deliverablesByCampaign?: Readonly<Record<number, ReadonlyArray<{
+    readonly id: number;
+    readonly deliverableType: string;
+    readonly targetCount: number;
+    readonly notes: string | null;
+  }>>>;
 };
 
 // ── KPI Card ─────────────────────────────────────────────────────────────────
@@ -110,6 +123,7 @@ function isActive(f: CampaignFilterState): boolean {
 export function CampaignsList({
   campaigns, isManager, brands, talents, staffUsers, contactsByBrand,
   rate = USD_EUR_RATE, rateDate = '', rateIsEstimated = true,
+  deliverablesByCampaign = {},
 }: Props): React.ReactElement {
   const [filters, setFilters]       = useState<CampaignFilterState>(EMPTY_FILTERS);
   const [drawerOpen, setDrawerOpen] = useState(false);
@@ -409,6 +423,24 @@ export function CampaignsList({
         staffUsers={staffUsers}
         contactsByBrand={contactsByBrand}
         isManager={isManager}
+        initialDeliverables={
+          selected !== null
+            // El prop viene tipado como string genérico; DeliverableEditor lo
+            // valida y el server sólo devuelve valores del enum, así que el
+            // cast es seguro. exactOptionalPropertyTypes exige omitir la
+            // propiedad notes cuando es null en lugar de asignar undefined.
+            ? (deliverablesByCampaign[selected.id] ?? []).map((d): DeliverableEditorRow => {
+                const base: DeliverableEditorRow = {
+                  id: d.id,
+                  deliverableType: d.deliverableType as DeliverableType,
+                  targetCount: d.targetCount,
+                };
+                return d.notes !== null && d.notes !== ''
+                  ? { ...base, notes: d.notes }
+                  : base;
+              })
+            : []
+        }
       />
     </div>
   );

--- a/src/features/admin/campaigns/components/DeliverablesEditor.tsx
+++ b/src/features/admin/campaigns/components/DeliverablesEditor.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { DELIVERABLE_TYPES, DELIVERABLE_TYPE_LABELS, type DeliverableType } from '@/lib/schemas/deliverable';
+
+/**
+ * Bloque editable de entregables ("Entregables" en el drawer de crear/editar trato).
+ *
+ * Cada fila representa una cantidad objetivo por tipo de entregable
+ * (p. ej. "15 streams", "5 vídeos dedicados", "12 prerolls"). Se sincroniza
+ * en un input hidden con name="deliverables_json" para que se envíe con el
+ * FormData del drawer. El server action decodifica ese JSON y hace
+ * INSERT/UPDATE/soft-delete en `dealDeliverableTrackers` con `campaignId`.
+ *
+ * Regla dura de PR1: NO llama a Google APIs, NO genera plantilla real. El
+ * botón "Generar plantilla de seguimiento" está disabled con tooltip.
+ */
+
+export type DeliverableEditorRow = {
+  readonly id?: number;
+  readonly deliverableType: DeliverableType;
+  readonly targetCount: number;
+  readonly notes?: string;
+};
+
+type Props = {
+  readonly initialRows: readonly DeliverableEditorRow[];
+};
+
+// Orden de los tipos en el select — Preroll y Stream primero por frecuencia
+// en los deals que vemos.
+const TYPE_OPTIONS: readonly DeliverableType[] = [
+  'stream_integration',
+  'preroll',
+  'video_youtube',
+  'short_reel_tiktok',
+  'story_instagram',
+  'tweet_x',
+  'post_instagram',
+  'pack_mensual',
+  'pack_trimestral',
+  ...(DELIVERABLE_TYPES.filter((t) => t === 'otro') as DeliverableType[]),
+];
+
+const inputCls =
+  'rounded-md border border-sp-admin-border bg-sp-admin-bg px-3 py-2 text-sm text-sp-admin-text placeholder:text-sp-admin-muted focus:outline-none focus:ring-1 focus:ring-sp-admin-accent w-full';
+
+const selectCls =
+  'rounded-md border border-sp-admin-border bg-sp-admin-bg px-3 py-2 text-sm text-sp-admin-text focus:outline-none focus:ring-1 focus:ring-sp-admin-accent w-full';
+
+export function DeliverablesEditor({ initialRows }: Props): React.ReactElement {
+  const [rows, setRows] = useState<DeliverableEditorRow[]>([...initialRows]);
+
+  const payload = useMemo(() => JSON.stringify(rows), [rows]);
+
+  function updateRow(idx: number, patch: Partial<DeliverableEditorRow>): void {
+    setRows((prev) => prev.map((r, i) => (i === idx ? { ...r, ...patch } : r)));
+  }
+
+  function removeRow(idx: number): void {
+    setRows((prev) => prev.filter((_, i) => i !== idx));
+  }
+
+  function addRow(): void {
+    setRows((prev) => [
+      ...prev,
+      { deliverableType: 'stream_integration', targetCount: 1 },
+    ]);
+  }
+
+  return (
+    <div
+      className="border-t border-sp-admin-border/50 pt-3"
+      data-testid="deliverables-editor"
+    >
+      <div className="flex items-baseline justify-between mb-3">
+        <p className="text-[11px] uppercase tracking-wider font-semibold text-sp-admin-muted">
+          Entregables del trato
+        </p>
+        {rows.length > 0 ? (
+          <p className="text-[10px] text-sp-admin-muted">
+            {rows.length} tipo{rows.length === 1 ? '' : 's'}
+          </p>
+        ) : null}
+      </div>
+
+      {rows.length === 0 ? (
+        <p className="text-xs text-sp-admin-muted mb-3">
+          Sin entregables definidos. Añade filas para indicar cantidad por tipo
+          (streams, prerolls, vídeos dedicados, shorts…).
+        </p>
+      ) : (
+        <ul className="flex flex-col gap-2 mb-2">
+          {rows.map((row, idx) => (
+            <li
+              key={row.id ?? `new-${idx}`}
+              className="grid grid-cols-[minmax(0,1.5fr)_80px_minmax(0,1.5fr)_auto] gap-2 items-center"
+            >
+              <select
+                aria-label="Tipo de entregable"
+                value={row.deliverableType}
+                onChange={(e) => updateRow(idx, { deliverableType: e.target.value as DeliverableType })}
+                className={selectCls}
+              >
+                {TYPE_OPTIONS.map((t) => (
+                  <option key={t} value={t}>
+                    {DELIVERABLE_TYPE_LABELS[t]}
+                  </option>
+                ))}
+              </select>
+              <input
+                aria-label="Cantidad"
+                type="number"
+                min={1}
+                step={1}
+                value={row.targetCount}
+                onChange={(e) => updateRow(idx, { targetCount: Math.max(1, Number(e.target.value) || 1) })}
+                className={inputCls}
+              />
+              <input
+                aria-label="Notas del entregable"
+                type="text"
+                value={row.notes ?? ''}
+                onChange={(e) => updateRow(idx, { notes: e.target.value })}
+                placeholder="Notas (opcional)"
+                className={inputCls}
+              />
+              <button
+                type="button"
+                onClick={() => removeRow(idx)}
+                className="rounded-md border border-sp-admin-border px-2 py-1 text-xs text-sp-admin-muted hover:text-red-400 hover:border-red-500/50 transition-colors"
+                aria-label="Eliminar entregable"
+              >
+                Quitar
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="flex items-center gap-2 flex-wrap">
+        <button
+          type="button"
+          onClick={addRow}
+          className="rounded-md border border-sp-admin-border px-3 py-1.5 text-xs text-sp-admin-text hover:border-sp-admin-accent transition-colors"
+        >
+          + Añadir entregable
+        </button>
+
+        <button
+          type="button"
+          disabled
+          title="Próximamente: generación de plantilla en PR2"
+          aria-label="Generar plantilla de seguimiento (próximamente)"
+          className="rounded-md border border-sp-admin-border px-3 py-1.5 text-xs text-sp-admin-muted opacity-60 cursor-not-allowed"
+          data-testid="generate-sheet-template-btn"
+        >
+          Generar plantilla de seguimiento
+        </button>
+
+        <span className="text-[10px] text-sp-admin-muted">
+          El botón de plantilla se activa en PR2.
+        </span>
+      </div>
+
+      {/* Hidden input serializado — lo consume la Server Action al enviar. */}
+      <input type="hidden" name="deliverables_json" value={payload} />
+    </div>
+  );
+}

--- a/src/lib/queries/campaign-deliverables-sync.ts
+++ b/src/lib/queries/campaign-deliverables-sync.ts
@@ -1,0 +1,211 @@
+import { and, eq, inArray, ne } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import { dealDeliverableTrackers } from '@/db/schema/dealDeliverableTrackers';
+import { campaigns } from '@/db/schema/campaigns';
+import { crmBrands } from '@/db/schema/crmBrands';
+import type { DeliverableType } from '@/lib/schemas/deliverable';
+
+/**
+ * Sincroniza los entregables de un trato (`campaigns.id`) contra la tabla
+ * `dealDeliverableTrackers`. NO borra filas físicamente — hace soft-delete
+ * poniendo `status = 'cancelled'` cuando el usuario retira una fila del editor.
+ *
+ * Reglas:
+ *   1. Fila con `id`:
+ *      - Si el id existe y pertenece al campaign → UPDATE targetCount + notes.
+ *      - Si no pertenece o no existe → se ignora (defensa contra manipulación).
+ *   2. Fila sin `id` → INSERT nuevo tracker en `dealDeliverableTrackers` con
+ *      `trackingSourceType='manual'`, `status='active'`, `currentCount=0`.
+ *   3. Trackers que existían y ya no están en el input → UPDATE status='cancelled'.
+ *      El tracking histórico se conserva (currentCount, items, etc.).
+ *
+ * No borra invocations si el tracker está enlazado a items (los items no se
+ * tocan). Los currentCount se preservan cuando se hace UPDATE de targetCount.
+ */
+export type DeliverableSyncInput = {
+  readonly id?: number | undefined;
+  readonly deliverableType: DeliverableType;
+  readonly targetCount: number;
+  readonly notes?: string | null | undefined;
+};
+
+export type DeliverableSyncResult = {
+  readonly inserted: number;
+  readonly updated: number;
+  readonly cancelled: number;
+};
+
+export async function syncCampaignDeliverables(
+  campaignId: number,
+  rows: readonly DeliverableSyncInput[],
+): Promise<DeliverableSyncResult> {
+  // Recuperar contexto del campaign para brandName/dealName/talentId
+  // (dealDeliverableTrackers exige esas columnas notNull).
+  const [campaign] = await db
+    .select({
+      id: campaigns.id,
+      name: campaigns.name,
+      brandId: campaigns.brandId,
+      talentId: campaigns.talentId,
+    })
+    .from(campaigns)
+    .where(eq(campaigns.id, campaignId))
+    .limit(1);
+  if (!campaign) throw new Error(`syncCampaignDeliverables: campaign ${campaignId} not found`);
+
+  const [brand] = await db
+    .select({ id: crmBrands.id, name: crmBrands.name })
+    .from(crmBrands)
+    .where(eq(crmBrands.id, campaign.brandId))
+    .limit(1);
+  const brandName = brand?.name ?? 'SIN MARCA';
+
+  // Existentes actuales (no cancelled) de este campaign.
+  const existing = await db
+    .select({
+      id: dealDeliverableTrackers.id,
+      deliverableType: dealDeliverableTrackers.deliverableType,
+    })
+    .from(dealDeliverableTrackers)
+    .where(
+      and(
+        eq(dealDeliverableTrackers.campaignId, campaignId),
+        ne(dealDeliverableTrackers.status, 'cancelled'),
+      ),
+    );
+
+  const existingIds = new Set(existing.map((e) => e.id));
+  const keepIds = new Set<number>();
+
+  let inserted = 0;
+  let updated = 0;
+
+  // 1) Procesar INSERT + UPDATE
+  for (const r of rows) {
+    if (r.targetCount <= 0) continue;
+    if (r.id !== undefined && existingIds.has(r.id)) {
+      // UPDATE — solo si pertenece al campaign
+      await db
+        .update(dealDeliverableTrackers)
+        .set({
+          targetCount: r.targetCount,
+          notes: r.notes ?? null,
+          deliverableType: r.deliverableType,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(dealDeliverableTrackers.id, r.id),
+            eq(dealDeliverableTrackers.campaignId, campaignId),
+          ),
+        );
+      keepIds.add(r.id);
+      updated++;
+    } else if (r.id === undefined) {
+      // INSERT
+      await db.insert(dealDeliverableTrackers).values({
+        campaignId,
+        talentId: campaign.talentId,
+        brandName,
+        dealName: campaign.name,
+        deliverableType: r.deliverableType,
+        targetCount: r.targetCount,
+        currentCount: 0,
+        status: 'active',
+        trackingSourceType: 'manual',
+        notes: r.notes ?? null,
+      });
+      inserted++;
+    }
+    // else: id presente pero no pertenece al campaign → ignoramos (defensa)
+  }
+
+  // 2) Cancelar los que ya no aparecen
+  const toCancel = [...existingIds].filter((id) => !keepIds.has(id));
+  let cancelled = 0;
+  if (toCancel.length > 0) {
+    await db
+      .update(dealDeliverableTrackers)
+      .set({ status: 'cancelled', updatedAt: new Date() })
+      .where(inArray(dealDeliverableTrackers.id, toCancel));
+    cancelled = toCancel.length;
+  }
+
+  return { inserted, updated, cancelled };
+}
+
+export type ActiveDeliverableRow = {
+  readonly id: number;
+  readonly deliverableType: DeliverableType;
+  readonly targetCount: number;
+  readonly notes: string | null;
+};
+
+/**
+ * Devuelve los trackers activos de un campaign para pintarlos en el editor.
+ * No incluye los `cancelled` (histórico soft-deleted).
+ */
+export async function getCampaignActiveDeliverables(campaignId: number): Promise<ActiveDeliverableRow[]> {
+  const rows = await db
+    .select({
+      id: dealDeliverableTrackers.id,
+      deliverableType: dealDeliverableTrackers.deliverableType,
+      targetCount: dealDeliverableTrackers.targetCount,
+      notes: dealDeliverableTrackers.notes,
+    })
+    .from(dealDeliverableTrackers)
+    .where(
+      and(
+        eq(dealDeliverableTrackers.campaignId, campaignId),
+        ne(dealDeliverableTrackers.status, 'cancelled'),
+      ),
+    )
+    .orderBy(dealDeliverableTrackers.createdAt);
+  return rows.map((r) => ({
+    id: r.id,
+    deliverableType: r.deliverableType as DeliverableType,
+    targetCount: r.targetCount,
+    notes: r.notes,
+  }));
+}
+
+/**
+ * Versión bulk: devuelve Map<campaignId, ActiveDeliverableRow[]> para varios
+ * campaigns a la vez. Usada por el listado de Tratos que precarga todos los
+ * deliverables activos y los pasa al drawer cuando se abre en modo edición.
+ */
+export async function listActiveDeliverablesForCampaigns(
+  campaignIds: readonly number[],
+): Promise<Record<number, ActiveDeliverableRow[]>> {
+  if (campaignIds.length === 0) return {};
+  const rows = await db
+    .select({
+      id: dealDeliverableTrackers.id,
+      campaignId: dealDeliverableTrackers.campaignId,
+      deliverableType: dealDeliverableTrackers.deliverableType,
+      targetCount: dealDeliverableTrackers.targetCount,
+      notes: dealDeliverableTrackers.notes,
+    })
+    .from(dealDeliverableTrackers)
+    .where(
+      and(
+        inArray(dealDeliverableTrackers.campaignId, campaignIds as number[]),
+        ne(dealDeliverableTrackers.status, 'cancelled'),
+      ),
+    )
+    .orderBy(dealDeliverableTrackers.createdAt);
+  const acc: Record<number, ActiveDeliverableRow[]> = {};
+  for (const r of rows) {
+    if (r.campaignId === null) continue;
+    const list = acc[r.campaignId] ?? [];
+    list.push({
+      id: r.id,
+      deliverableType: r.deliverableType as DeliverableType,
+      targetCount: r.targetCount,
+      notes: r.notes,
+    });
+    acc[r.campaignId] = list;
+  }
+  return acc;
+}
+

--- a/src/lib/schemas/campaign-deliverables.ts
+++ b/src/lib/schemas/campaign-deliverables.ts
@@ -1,0 +1,45 @@
+import { z } from 'zod';
+import { DELIVERABLE_TYPES } from './deliverable';
+
+/**
+ * Schema Zod para el payload `deliverables_json` que envía el drawer de
+ * Tratos. Cada fila es una cantidad objetivo por tipo de entregable.
+ *
+ * `id` presente = tracker existente (UPDATE).
+ * `id` ausente  = nuevo tracker (INSERT).
+ *
+ * targetCount debe ser >= 1. Filas con targetCount 0 se descartan al sincronizar.
+ */
+export const deliverableEditorRowSchema = z.object({
+  id: z.coerce.number().int().positive().optional(),
+  deliverableType: z.enum(DELIVERABLE_TYPES),
+  targetCount: z.coerce.number().int().min(1).max(999),
+  notes: z.preprocess(
+    (v) => (typeof v === 'string' && v.trim() === '' ? undefined : v),
+    z.string().max(500).optional(),
+  ),
+});
+
+export type DeliverableEditorRowInput = z.infer<typeof deliverableEditorRowSchema>;
+
+export const deliverableEditorPayloadSchema = z.array(deliverableEditorRowSchema);
+
+/**
+ * Parsea un `deliverables_json` que viene del FormData (o retorna array vacío
+ * si el string está vacío/ausente/inválido). NUNCA lanza — filtra silencioso
+ * lo malformado para que la Server Action no pete por un JSON roto del cliente.
+ */
+export function parseDeliverablesJson(raw: unknown): DeliverableEditorRowInput[] {
+  if (raw === undefined || raw === null) return [];
+  if (typeof raw !== 'string') return [];
+  const trimmed = raw.trim();
+  if (trimmed === '' || trimmed === '[]') return [];
+  let json: unknown;
+  try {
+    json = JSON.parse(trimmed);
+  } catch {
+    return [];
+  }
+  const parsed = deliverableEditorPayloadSchema.safeParse(json);
+  return parsed.success ? parsed.data : [];
+}

--- a/src/lib/schemas/deliverable.ts
+++ b/src/lib/schemas/deliverable.ts
@@ -41,6 +41,7 @@ export const DELIVERABLE_TYPES = [
   'post_instagram',
   'pack_mensual',
   'pack_trimestral',
+  'preroll',
   'otro',
 ] as const;
 
@@ -55,6 +56,7 @@ export const DELIVERABLE_TYPE_LABELS: Record<DeliverableType, string> = {
   post_instagram: 'Post Instagram',
   pack_mensual: 'Pack mensual',
   pack_trimestral: 'Pack trimestral',
+  preroll: 'Preroll',
   otro: 'Otro',
 };
 


### PR DESCRIPTION
## ⚠️ Divulgaciones importantes antes de mergear

Tres decisiones que quiero destacar **antes** de la revisión, para que no queden enterradas en el diff:

### 1) Migración 0110 aditiva — decisión mía, reversible
Añadí `preroll` al enum `deliverable_type` porque la plantilla de referencia (`Jolu - KD`) distingue Preroll y Video, y no encontré valor equivalente. La migración es **aditiva no destructiva** (`ADD VALUE IF NOT EXISTS`), mismo patrón que 0017/0018/0030/0033.

**Alternativa si prefieres cero migración en este PR:** mapear "Preroll" a `stream_integration` en UI y revertir 0110. Dime y lo cambio antes del merge.

### 2) 5 archivos de tests ajenos tocados (colateral inevitable)
Cinco tests estáticos de PRs previas hardcodeaban "última migración = 0109". Al añadir 0110 se rompían. Los reescribí para que verifiquen **la intención real de cada test** (no aparecen migraciones del ámbito de su PR — sorteos/raffle/coin, social_mission, rentabilidad/pnl/margin) en lugar del índice absoluto. Ficheros:
- `sorteos-fase1-pr2-no-migration.test.ts`
- `social-missions-ux-polish.test.ts`
- `social-missions-coming-soon.test.ts`
- `finanzas-rentabilidad.test.ts`
- `finanzas-rentabilidad-6b.test.ts`

### 3) Permisos: reutiliza el `read` existente
Los Server Actions `createCampaignAction` / `updateCampaignAction` ya validan `requirePermission('campanas', 'read')` heredado. **No introduzco escritura nueva** — el sync se ejecuta bajo la sesión que ya está autorizada. Si quieres que este PR promocione a `campanas.write` te lo dejo en PR2.

---

## Archivos tocados

**Migración (aditiva):**
- `drizzle/0110_add_preroll_to_deliverable_type.sql` — `ALTER TYPE ... ADD VALUE IF NOT EXISTS 'preroll'`
- `drizzle/meta/_journal.json`

**Schema + Zod:**
- `src/db/schema/deliverables.ts` — enum extendido con `preroll`
- `src/lib/schemas/deliverable.ts` — constant + label
- `src/lib/schemas/campaign-deliverables.ts` (NUEVO) — `parseDeliverablesJson`, nunca throws, retorna `[]` en input inválido

**Query (sync + fetch):**
- `src/lib/queries/campaign-deliverables-sync.ts` (NUEVO)
    - `syncCampaignDeliverables(campaignId, rows)`: INSERT nuevos / UPDATE existentes que pertenecen al campaign / soft-delete `status='cancelled'` de los retirados. Defensivo — id ajeno al campaign se ignora.
    - `getCampaignActiveDeliverables(campaignId)`
    - `listActiveDeliverablesForCampaigns(campaignIds)` — bulk para el listado

**UI:**
- `src/features/admin/campaigns/components/DeliverablesEditor.tsx` (NUEVO)
    - Client component
    - Add/remove filas, tipo + cantidad + notas
    - Serializa a `<input name="deliverables_json" hidden>`
    - Botón "Generar plantilla de seguimiento" **disabled** con tooltip "Próximamente"
- `CampaignDrawer.parts.tsx` — ocultos `briefingUrl`, `contentUrl`, `estimatedCostAgency`, `estimatedMarginPct`. Editor insertado antes de notas. Hint en `actionType` para diferenciar del editor.
- `CampaignDrawer.tsx` + `CampaignsList.tsx` — threading del prop `initialDeliverables`
- `CampaignSummaryCard.tsx` — ocultos `briefingUrl` + `contentUrl`

**Server Actions:**
- `src/app/admin/(dashboard)/campanas/actions.ts` — `createCampaignAction` llama al sync tras crear; `updateCampaignAction` sincroniza sólo si `formData.has('deliverables_json')`
- `src/app/admin/(dashboard)/campanas/page.tsx` — precarga bulk de deliverables

**Tests (35 nuevos):**
- `tratos-entregables-drawer.test.ts` — 4 campos fuera del drawer, 2 fuera de summary, editor presente, botón disabled, sin imports Google/OAuth
- `tratos-entregables-parser.test.ts` — Zod boundary (input inválido → `[]`)
- `tratos-entregables-migration.test.ts` — additive + `IF NOT EXISTS`

## Cómo se crean/actualizan/borran trackers

| Escenario | Acción |
|---|---|
| Fila del editor sin `id` | INSERT en `dealDeliverableTrackers` con `trackingSourceType='manual'`, `status='active'`, `currentCount=0` |
| Fila con `id` que pertenece al campaign | UPDATE `targetCount` + `notes` + `deliverableType` |
| Fila con `id` que NO pertenece al campaign | **Ignorado** — defensa contra manipulación cliente |
| Tracker existente ausente del nuevo input | UPDATE `status='cancelled'` (soft-delete). `currentCount` y `items` se preservan |

## Qué queda para PR2
- Botón "Generar plantilla de seguimiento" activo (integración pendiente — Sheets/interno TBD)
- Escritura promocionada a `campanas.write` si lo decides
- Historial visible de trackers `cancelled` (auditoría)

## Checks

- `npx drizzle-kit check` → limpio
- `npx tsc --noEmit` → sin errores en archivos del PR (los que aparecen son pre-existentes en `proyectozack/` y `create-invoice-from-deal.ts`)
- `npx eslint <archivos del PR>` → limpio
- Tests suites afectadas: **9 passed, 188 tests**

## Riesgos

- **Bajo:** migración aditiva idempotente, no destructiva
- **Bajo:** UI oculta campos pero no borra columnas — reversibilidad total
- **Medio (mitigado):** el sync ignora IDs ajenos al campaign — no permite editar trackers de otros deals aunque el cliente manipule el hidden input
- **Cero regresión de tracking:** `currentCount`, `items` e histórico no se tocan en UPDATE ni en soft-delete

**No mergear sin tu OK.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)